### PR TITLE
refactor: modularize quote page — 749→163 lines, responsive

### DIFF
--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -3,39 +3,14 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { fetchQuote, streamChat, markQuoteAsRead, type QuoteDetail } from "@/lib/api";
-import MessageBubble from "@/components/chat/MessageBubble";
-
-export interface UIMessage {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-  isStreaming?: boolean;
-  attachmentName?: string;
-}
-
-// ── HELPERS ──────────────────────────────────────────────────────────────────
-
-const fmtARS = (n: number | null | undefined) => {
-  if (n == null || isNaN(n)) return "—";
-  return `$${Math.round(n).toLocaleString("es-AR")}`;
-};
-const fmtUSD = (n: number | null | undefined) => {
-  if (n == null || isNaN(n)) return "—";
-  return `USD ${Math.round(n).toLocaleString("es-AR")}`;
-};
-const fmtQty = (n: number | null | undefined) => {
-  if (n == null || isNaN(n)) return "—";
-  if (Math.abs(n - Math.round(n)) < 0.05) return String(Math.round(n));
-  return n.toFixed(2).replace(".", ",");
-};
-
-const STATUS: Record<string, { label: string; bg: string; color: string }> = {
-  draft: { label: "Borrador", bg: "var(--amb2)", color: "var(--amb)" },
-  validated: { label: "Validado", bg: "var(--grn2)", color: "var(--grn)" },
-  sent: { label: "Enviado", bg: "var(--acc2)", color: "var(--acc)" },
-};
-
-// ── MAIN ─────────────────────────────────────────────────────────────────────
+import type { UIMessage } from "@/lib/types";
+import { useBreakpoints } from "@/lib/useMediaQuery";
+import QuoteHeader from "@/components/quote/QuoteHeader";
+import QuoteTabBar from "@/components/quote/QuoteTabBar";
+import DetailView from "@/components/quote/DetailView";
+import ChatView from "@/components/quote/ChatView";
+import Section from "@/components/quote/Section";
+import ChatInput from "@/components/chat/ChatInput";
 
 export default function QuotePage() {
   const router = useRouter();
@@ -55,12 +30,10 @@ export default function QuotePage() {
 
   const endRef = useRef<HTMLDivElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
-  const taRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
     fetchQuote(quoteId).then(q => {
       setQuote(q);
-      // Mark as read if unread (web quotes)
       if (!q.is_read) {
         markQuoteAsRead(quoteId).catch(() => {});
       }
@@ -74,7 +47,6 @@ export default function QuotePage() {
             : (m.content as any[]).filter(c => c.type === "text").map(c => c.text || "").join(""),
         }));
       setMessages(uiMsgs);
-      // Show detail tab only for validated/sent quotes
       if (q.status === "validated" || q.status === "sent") {
         setTab("detail");
       }
@@ -141,9 +113,11 @@ export default function QuotePage() {
     }
   }, [input, attachedFiles, sending, quoteId, tab]);
 
-  const onKey = (e: React.KeyboardEvent) => {
+  const { isMobile } = useBreakpoints();
+
+  const onKey = useCallback((e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); send(); }
-  };
+  }, [send]);
 
   if (loading) return (
     <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100%", color: "var(--t3)", fontSize: 13 }}>
@@ -151,66 +125,28 @@ export default function QuotePage() {
     </div>
   );
 
-  const st = STATUS[quote?.status || "draft"];
-  const bd = quote?.quote_breakdown || null;
+  const chatInputProps = {
+    input, setInput,
+    files: attachedFiles, setFiles: setAttachedFiles,
+    dragActive, setDragActive,
+    dragCounterRef: dragCounter,
+    sending, send, onKey,
+    fileRef,
+  };
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      {/* ── HEADER ──────────────────────────────────────────── */}
-      <div style={{
-        display: "flex", alignItems: "center", justifyContent: "space-between",
-        padding: "14px 28px", borderBottom: "1px solid var(--b1)",
-        flexShrink: 0, background: "var(--s1)",
-      }}>
-        <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
-          <button onClick={() => router.push("/")} style={backBtnStyle}>
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="15 18 9 12 15 6" /></svg>
-          </button>
-          <div>
-            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-              <span style={{ fontSize: 16, fontWeight: 600, color: "var(--t1)" }}>{quote?.client_name || "Nuevo presupuesto"}</span>
-              <span style={{ ...badgeStyle, background: st.bg, color: st.color }}>● {st.label}</span>
-              {quote?.source === "web" && <span style={{ ...badgeStyle, background: "rgba(138,43,226,.15)", color: "#a855f7" }}>WEB</span>}
-            </div>
-            <div style={{ fontSize: 12, color: "var(--t3)", marginTop: 2 }}>
-              {quote?.project}{quote?.material ? ` · ${quote.material}` : ""}
-            </div>
-          </div>
-        </div>
-        <div style={{ display: "flex", gap: 8 }}>
-          {quote?.pdf_url && <FileLink href={quote.pdf_url} label="PDF" color="#ff6b63" />}
-          {quote?.excel_url && <FileLink href={quote.excel_url} label="Excel" color="var(--grn)" />}
-          {quote?.drive_url && <FileLink href={quote.drive_url} label="Drive" color="var(--acc)" />}
-        </div>
-      </div>
+      <QuoteHeader quote={quote} onBack={() => router.push("/")} />
+      <QuoteTabBar tab={tab} setTab={setTab} canShowDetail={!!quote && quote.status !== "draft"} />
 
-      {/* ── TABS ────────────────────────────────────────────── */}
-      <div style={{
-        display: "flex", gap: 0, borderBottom: "1px solid var(--b1)",
-        background: "var(--s1)", paddingLeft: 28,
-      }}>
-        <TabBtn active={tab === "detail"} onClick={() => setTab("detail")} disabled={!quote || quote.status === "draft"}>Detalle</TabBtn>
-        <TabBtn active={tab === "chat"} onClick={() => setTab("chat")}>Chat</TabBtn>
-      </div>
-
-      {/* ── CONTENT ─────────────────────────────────────────── */}
       {tab === "detail" ? (
-        <div style={{ flex: 1, overflowY: "auto", padding: "24px 28px" }}>
-          <DetailView quote={quote} breakdown={bd} onSwitchToChat={() => setTab("chat")} />
-
-          {/* Quick chat at bottom */}
+        <div style={{ flex: 1, overflowY: "auto", padding: isMobile ? "16px 14px" : "24px 28px" }}>
+          <DetailView quote={quote} breakdown={quote?.quote_breakdown || null} onSwitchToChat={() => setTab("chat")} />
           <Section title="Modificaciones" style={{ marginTop: 20 }}>
             <div style={{ fontSize: 12, color: "var(--t3)", marginBottom: 10 }}>
               Escribí un cambio y Valentina regenera los documentos automáticamente.
             </div>
-            <ChatInput
-              input={input} setInput={setInput}
-              files={attachedFiles} setFiles={setAttachedFiles}
-              dragActive={dragActive} setDragActive={setDragActive}
-              dragCounterRef={dragCounter}
-              sending={sending} send={send} onKey={onKey}
-              fileRef={fileRef}
-            />
+            <ChatInput {...chatInputProps} />
             <button onClick={() => setTab("chat")} style={{
               marginTop: 8, background: "none", border: "none", color: "var(--acc)",
               fontSize: 12, cursor: "pointer", fontFamily: "inherit", padding: 0,
@@ -220,530 +156,8 @@ export default function QuotePage() {
           </Section>
         </div>
       ) : (
-        <>
-          <div style={{ flex: 1, overflowY: "auto", padding: "28px 28px 16px", display: "flex", flexDirection: "column", gap: 20 }}>
-            {messages.length === 0 && (
-              <div style={{ padding: "14px 18px", background: "var(--s2)", borderRadius: 12, fontSize: 13, color: "var(--t2)" }}>
-                Hola 👋 Soy Valentina. Pasame el enunciado del trabajo y/o el plano.
-              </div>
-            )}
-            {messages.map(msg => <MessageBubble key={msg.id} message={msg} actionText={msg.isStreaming ? actionText : undefined} />)}
-            <div ref={endRef} />
-          </div>
-          <div style={{ flexShrink: 0, padding: "14px 28px 18px", borderTop: "1px solid var(--b1)", background: "var(--s1)" }}>
-            <ChatInput
-              input={input} setInput={setInput}
-              files={attachedFiles} setFiles={setAttachedFiles}
-              dragActive={dragActive} setDragActive={setDragActive}
-              dragCounterRef={dragCounter}
-              sending={sending} send={send} onKey={onKey}
-              fileRef={fileRef}
-            />
-            <div style={{ fontSize: 10, color: "var(--t4)", textAlign: "center", marginTop: 7 }}>
-              Enter para enviar · Shift+Enter para nueva línea
-            </div>
-          </div>
-        </>
+        <ChatView messages={messages} actionText={actionText} endRef={endRef} chatInputProps={chatInputProps} />
       )}
     </div>
   );
 }
-
-// ── DETAIL VIEW ─────────────────────────────────────────────────────────────
-
-function DetailView({ quote, breakdown, onSwitchToChat }: {
-  quote: QuoteDetail | null;
-  breakdown: Record<string, any> | null;
-  onSwitchToChat: () => void;
-}) {
-  if (!quote) return null;
-
-  const pieces = breakdown?.sectors?.flatMap((s: any) => s.pieces || []) || [];
-  const moItems = (breakdown?.mo_items || []).map((m: any) => ({
-    ...m,
-    total: m.total ?? (m.quantity ?? 0) * (m.unit_price ?? 0),
-  }));
-  const merma = breakdown?.merma;
-  const totalM2 = breakdown?.material_m2 || 0;
-  const discountPct = breakdown?.discount_pct || 0;
-  const totalMO = moItems.reduce((s: number, m: any) => s + (m.total || 0), 0);
-
-  return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
-
-      {/* A. RESUMEN */}
-      <Section title="Resumen">
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr 1fr", gap: 16 }}>
-          <MetaItem label="Cliente" value={quote.client_name || "—"} />
-          <MetaItem label="Proyecto" value={quote.project || "—"} />
-          <MetaItem label="Material" value={quote.material || "—"} />
-          <MetaItem label="Fecha" value={new Date(quote.created_at).toLocaleDateString("es-AR")} />
-          <MetaItem label="Demora" value={breakdown?.delivery_days || "—"} />
-          <MetaItem label="Origen" value={quote.source === "web" ? "Web (chatbot)" : "Operador"} />
-          <MetaItem label="Total ARS" value={quote.total_ars ? fmtARS(quote.total_ars) : "—"} highlight />
-          <MetaItem label="Total USD" value={quote.total_usd ? fmtUSD(quote.total_usd) : "—"} highlight />
-        </div>
-      </Section>
-
-      {/* A2. SOURCE FILES */}
-      {quote.source_files && quote.source_files.length > 0 && (
-        <Section title="Archivos Fuente">
-          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-            {quote.source_files.map((f: any, i: number) => (
-              <div key={i} style={{
-                display: "flex", alignItems: "center", gap: 12,
-                padding: "12px 16px", borderRadius: 8,
-                background: i % 2 === 0 ? "rgba(255,255,255,.02)" : "transparent",
-                border: "1px solid var(--b1)",
-              }}>
-                <span style={{ fontSize: 20, flexShrink: 0 }}>
-                  {f.type?.includes("pdf") ? "📄" : f.type?.includes("image") ? "🖼️" : "📎"}
-                </span>
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ fontSize: 13, fontWeight: 500, color: "var(--t1)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                    {f.filename}
-                  </div>
-                  <div style={{ fontSize: 11, color: "var(--t3)", marginTop: 2 }}>
-                    {f.type?.includes("pdf") ? "PDF" : f.type?.includes("jpeg") || f.type?.includes("jpg") ? "JPG" : f.type?.includes("png") ? "PNG" : "Archivo"}
-                    {f.size ? ` · ${f.size < 1024 ? f.size + " B" : f.size < 1048576 ? (f.size / 1024).toFixed(1) + " KB" : (f.size / 1048576).toFixed(1) + " MB"}` : ""}
-                  </div>
-                </div>
-                <a href={f.url} download style={{
-                  display: "flex", alignItems: "center", gap: 5,
-                  padding: "6px 14px", borderRadius: 6,
-                  fontSize: 11, fontWeight: 500, textDecoration: "none",
-                  border: "1px solid var(--acc3)", background: "transparent",
-                  color: "var(--acc)", cursor: "pointer", flexShrink: 0,
-                }}>
-                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                    <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
-                    <polyline points="7 10 12 15 17 10" />
-                    <line x1="12" y1="15" x2="12" y2="3" />
-                  </svg>
-                  Descargar
-                </a>
-              </div>
-            ))}
-          </div>
-        </Section>
-      )}
-
-      {/* B. SOLICITUD (only if breakdown available) */}
-      {breakdown && (
-        <Section title="Solicitud">
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
-            <ReqField label="Material" value={breakdown.material_name || "—"} />
-            <ReqField label="Superficie" value={totalM2 ? `${fmtQty(totalM2)} m²` : "—"} />
-            <ReqField label="Moneda" value={breakdown.material_currency || "—"} />
-            <ReqField label="Precio/m²" value={breakdown.material_price_unit ? (breakdown.material_currency === "USD" ? fmtUSD(breakdown.material_price_unit) : fmtARS(breakdown.material_price_unit)) : "—"} />
-            <ReqField label="Plazo" value={breakdown.delivery_days || "—"} />
-            <ReqField label="Proyecto" value={breakdown.project || "—"} />
-          </div>
-        </Section>
-      )}
-
-      {/* C. DESGLOSE */}
-      {breakdown && (pieces.length > 0 || moItems.length > 0) ? (
-        <Section title="Desglose del Presupuesto">
-          {/* Pieces */}
-          {pieces.length > 0 && (
-            <div style={{ marginBottom: 16 }}>
-              <div style={{ fontSize: 13, fontWeight: 600, color: "var(--t1)", marginBottom: 8 }}>
-                Material — {fmtQty(totalM2)} m²
-              </div>
-              <table style={tableStyle}>
-                <thead>
-                  <tr>
-                    <th style={thStyle}>Pieza</th>
-                    <th style={{ ...thStyle, textAlign: "right" }}>Detalle</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {pieces.map((p: string, i: number) => (
-                    <tr key={i} style={{ background: i % 2 === 1 ? "rgba(255,255,255,.03)" : "transparent" }}>
-                      <td style={tdStyle}>{p}</td>
-                      <td style={{ ...tdStyle, textAlign: "right", color: "var(--t3)" }}></td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-
-          {/* Merma */}
-          {merma && (
-            <InfoBar
-              icon="📐"
-              label="Merma"
-              status={merma.aplica ? "APLICA" : "NO APLICA"}
-              detail={merma.motivo || ""}
-            />
-          )}
-
-          {/* MO */}
-          {moItems.length > 0 && (
-            <div style={{ marginTop: 16, marginBottom: 16 }}>
-              <div style={{ fontSize: 13, fontWeight: 600, color: "var(--t1)", marginBottom: 8 }}>Mano de Obra</div>
-              <table style={tableStyle}>
-                <thead>
-                  <tr>
-                    <th style={thStyle}>Ítem</th>
-                    <th style={{ ...thStyle, textAlign: "right" }}>Cant</th>
-                    <th style={{ ...thStyle, textAlign: "right" }}>Precio</th>
-                    <th style={{ ...thStyle, textAlign: "right" }}>Total</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {moItems.map((m: any, i: number) => (
-                    <tr key={i} style={{ background: i % 2 === 1 ? "rgba(255,255,255,.03)" : "transparent" }}>
-                      <td style={tdStyle}>{m.description}</td>
-                      <td style={{ ...tdStyle, textAlign: "right" }}>{fmtQty(m.quantity)}</td>
-                      <td style={{ ...tdStyle, textAlign: "right" }}>{fmtARS(m.unit_price)}</td>
-                      <td style={{ ...tdStyle, textAlign: "right" }}>{fmtARS(m.total)}</td>
-                    </tr>
-                  ))}
-                  <tr style={{ background: "rgba(255,255,255,.05)" }}>
-                    <td style={{ ...tdStyle, fontWeight: 600 }}>TOTAL MO</td>
-                    <td style={tdStyle}></td>
-                    <td style={tdStyle}></td>
-                    <td style={{ ...tdStyle, textAlign: "right", fontWeight: 600 }}>{fmtARS(totalMO)}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          )}
-
-          {/* Discount */}
-          <InfoBar
-            icon="🏷️"
-            label="Descuentos"
-            status={discountPct > 0 ? `APLICA ${discountPct}%` : "NO APLICA"}
-            detail={discountPct > 0 ? `${discountPct}% sobre material` : "Particular sin umbral de m²"}
-          />
-
-          {/* Grand total */}
-          {(quote.total_ars || quote.total_usd) && (
-            <div style={{
-              marginTop: 20, padding: "16px 20px", borderRadius: 10,
-              background: "var(--s3)", border: "1px solid var(--b2)",
-              display: "flex", justifyContent: "space-between", alignItems: "center",
-            }}>
-              <span style={{ fontSize: 14, fontWeight: 600, color: "var(--t1)" }}>PRESUPUESTO TOTAL</span>
-              <div style={{ textAlign: "right" }}>
-                {quote.total_ars && (
-                  <div style={{ fontSize: 18, fontWeight: 700, color: "var(--t1)" }}>
-                    {fmtARS(quote.total_ars)} <span style={{ color: "var(--t3)", fontWeight: 400, fontSize: 13 }}>mano de obra</span>
-                  </div>
-                )}
-                {quote.total_usd && (
-                  <div style={{ fontSize: 15, fontWeight: 600, color: "var(--acc)", marginTop: 2 }}>
-                    + {fmtUSD(quote.total_usd)} <span style={{ color: "var(--t3)", fontWeight: 400, fontSize: 13 }}>material</span>
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
-        </Section>
-      ) : (
-        /* Fallback for legacy quotes without breakdown */
-        <Section title="Desglose">
-          <div style={{ fontSize: 13, color: "var(--t3)" }}>
-            Este presupuesto no tiene datos de desglose estructurados. Consultá el historial de chat para ver los detalles.
-          </div>
-          <button onClick={onSwitchToChat} style={{
-            marginTop: 10, background: "none", border: "none", color: "var(--acc)",
-            fontSize: 12, cursor: "pointer", fontFamily: "inherit", padding: 0,
-          }}>
-            Ver chat →
-          </button>
-        </Section>
-      )}
-    </div>
-  );
-}
-
-// ── CHAT INPUT ──────────────────────────────────────────────────────────────
-
-const VALID_TYPES = ["application/pdf", "image/jpeg", "image/jpg", "image/png", "image/webp"];
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
-const MAX_FILES = 5;
-
-function ChatInput({ input, setInput, files, setFiles, dragActive, setDragActive, dragCounterRef, sending, send, onKey, fileRef }: {
-  input: string; setInput: (v: string) => void;
-  files: File[]; setFiles: (f: File[]) => void;
-  dragActive: boolean; setDragActive: (v: boolean) => void;
-  dragCounterRef: React.MutableRefObject<number>;
-  sending: boolean; send: () => void; onKey: (e: React.KeyboardEvent) => void;
-  fileRef: React.RefObject<HTMLInputElement>;
-}) {
-  const [fileError, setFileError] = useState<string | null>(null);
-
-  const addFiles = (newFiles: FileList | File[]) => {
-    const arr = Array.from(newFiles);
-    for (const f of arr) {
-      if (!VALID_TYPES.some(t => f.type.includes(t.split("/")[1]))) {
-        setFileError(`"${f.name}" — tipo no soportado`);
-        setTimeout(() => setFileError(null), 3000);
-        continue;
-      }
-      if (f.size > MAX_FILE_SIZE) {
-        setFileError(`"${f.name}" — máximo 10MB`);
-        setTimeout(() => setFileError(null), 3000);
-        continue;
-      }
-      if (files.length >= MAX_FILES) {
-        setFileError("Máximo 5 archivos");
-        setTimeout(() => setFileError(null), 3000);
-        break;
-      }
-      if (files.some(ef => ef.name === f.name && ef.size === f.size)) continue;
-      setFiles([...files, f]);
-    }
-  };
-
-  const removeFile = (idx: number) => setFiles(files.filter((_, i) => i !== idx));
-
-  const handleDragEnter = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current++;
-    setDragActive(true);
-  };
-  const handleDragLeave = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current--;
-    if (dragCounterRef.current <= 0) { dragCounterRef.current = 0; setDragActive(false); }
-  };
-  const handleDragOver = (e: React.DragEvent) => e.preventDefault();
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current = 0;
-    setDragActive(false);
-    if (e.dataTransfer.files.length > 0) addFiles(e.dataTransfer.files);
-  };
-
-  const fmtSize = (b: number) => b < 1024 ? `${b} B` : b < 1048576 ? `${(b/1024).toFixed(1)} KB` : `${(b/1048576).toFixed(1)} MB`;
-  const fmtType = (t: string) => t.includes("pdf") ? "PDF" : t.includes("jpeg") || t.includes("jpg") ? "JPG" : t.includes("png") ? "PNG" : "WEBP";
-  const fileIcon = (t: string) => t.includes("pdf") ? "📄" : "🖼️";
-
-  return (
-    <div
-      onDragEnter={handleDragEnter} onDragLeave={handleDragLeave}
-      onDragOver={handleDragOver} onDrop={handleDrop}
-      style={{ position: "relative" }}
-    >
-      {/* Drag overlay */}
-      {dragActive && (
-        <div style={{
-          position: "absolute", inset: 0, zIndex: 10,
-          background: "rgba(79,143,255,0.08)", border: "2px dashed var(--acc)",
-          borderRadius: 12, display: "flex", flexDirection: "column",
-          alignItems: "center", justifyContent: "center", gap: 6,
-          pointerEvents: "none",
-        }}>
-          <span style={{ fontSize: 28 }}>📁</span>
-          <span style={{ fontSize: 14, fontWeight: 500, color: "var(--acc)" }}>Soltá tu plano PDF o imagen acá</span>
-          <span style={{ fontSize: 11, color: "var(--t3)" }}>PDF, JPG, PNG · Máximo 10MB</span>
-        </div>
-      )}
-
-      {/* File chips */}
-      {(files.length > 0 || fileError) && (
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 8 }}>
-          {files.map((f, i) => (
-            <div key={`${f.name}-${i}`} style={{
-              display: "flex", alignItems: "center", gap: 6,
-              padding: "5px 10px", borderRadius: 6,
-              background: "var(--s3)", border: "1px solid var(--b1)",
-              fontSize: 11, color: "var(--t2)", maxWidth: 280,
-            }}>
-              <span style={{ fontSize: 14 }}>{fileIcon(f.type)}</span>
-              <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1 }}>{f.name}</span>
-              <span style={{ color: "var(--t3)", flexShrink: 0 }}>{fmtType(f.type)} · {fmtSize(f.size)}</span>
-              <button onClick={() => removeFile(i)} style={{ background: "none", border: "none", color: "var(--t3)", cursor: "pointer", fontSize: 13, padding: "0 2px" }}>✕</button>
-            </div>
-          ))}
-          {fileError && (
-            <div style={{
-              display: "flex", alignItems: "center", gap: 6,
-              padding: "5px 10px", borderRadius: 6,
-              background: "rgba(255,69,58,0.08)", border: "1px solid rgba(255,69,58,0.3)",
-              fontSize: 11, color: "var(--red)",
-            }}>
-              ⚠️ {fileError}
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Input row */}
-      <div style={{
-        display: "flex", alignItems: "flex-end", gap: 8,
-        background: "var(--s3)",
-        border: dragActive ? "1px solid var(--acc)" : "1px solid var(--b2)",
-        boxShadow: dragActive ? "0 0 20px rgba(79,143,255,0.15)" : "none",
-        borderRadius: 12, padding: "10px 10px 10px 16px",
-        transition: "border-color 0.15s, box-shadow 0.15s",
-      }}>
-        <textarea value={input} onChange={e => setInput(e.target.value)}
-          onKeyDown={onKey} rows={1} disabled={sending}
-          placeholder="Escribí el enunciado o arrastrá el plano acá..."
-          style={{
-            flex: 1, background: "transparent", border: "none", outline: "none",
-            fontFamily: "inherit", fontSize: 13, color: "var(--t1)",
-            resize: "none", lineHeight: 1.5, maxHeight: 110,
-          }}
-        />
-        <div style={{ display: "flex", alignItems: "center", gap: 5, flexShrink: 0 }}>
-          <input ref={fileRef} type="file" accept=".pdf,.jpg,.jpeg,.png,.webp" multiple style={{ display: "none" }}
-            onChange={e => { if (e.target.files) addFiles(e.target.files); e.target.value = ""; }}
-          />
-          <IconBtn onClick={() => fileRef.current?.click()} title="Adjuntar plano">
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
-              <path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48" />
-            </svg>
-          </IconBtn>
-          <IconBtn onClick={send} primary disabled={sending || (!input.trim() && files.length === 0)}>
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2">
-              <line x1="22" y1="2" x2="11" y2="13" /><polygon points="22 2 15 22 11 13 2 9 22 2" />
-            </svg>
-          </IconBtn>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ── SUB-COMPONENTS ──────────────────────────────────────────────────────────
-
-function Section({ title, children, style: extraStyle }: { title: string; children: React.ReactNode; style?: React.CSSProperties }) {
-  return (
-    <div style={{
-      background: "var(--s1)", border: "1px solid var(--b1)",
-      borderRadius: 12, padding: "18px 22px", ...extraStyle,
-    }}>
-      <div style={{
-        fontSize: 13, fontWeight: 600, color: "var(--t1)",
-        textTransform: "uppercase", letterSpacing: "0.06em",
-        marginBottom: 14, paddingBottom: 8, borderBottom: "1px solid var(--b1)",
-      }}>
-        {title}
-      </div>
-      {children}
-    </div>
-  );
-}
-
-function MetaItem({ label, value, highlight }: { label: string; value: string; highlight?: boolean }) {
-  return (
-    <div>
-      <div style={{ fontSize: 10, color: "var(--t3)", textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 3 }}>{label}</div>
-      <div style={{ fontSize: 14, fontWeight: highlight ? 600 : 400, color: highlight ? "var(--t1)" : "var(--t2)" }}>{value}</div>
-    </div>
-  );
-}
-
-function ReqField({ label, value }: { label: string; value: string }) {
-  return (
-    <div style={{ display: "flex", gap: 8, fontSize: 13 }}>
-      <span style={{ color: "var(--t3)", minWidth: 110, flexShrink: 0 }}>{label}</span>
-      <span style={{ color: "var(--t1)" }}>{value}</span>
-    </div>
-  );
-}
-
-function InfoBar({ icon, label, status, detail }: { icon: string; label: string; status: string; detail: string }) {
-  const isNo = status.includes("NO");
-  return (
-    <div style={{
-      display: "flex", alignItems: "center", gap: 10,
-      padding: "10px 14px", borderRadius: 8,
-      background: isNo ? "rgba(255,255,255,.02)" : "rgba(245,166,35,.06)",
-      border: `1px solid ${isNo ? "var(--b1)" : "rgba(245,166,35,.16)"}`,
-      fontSize: 12,
-    }}>
-      <span>{icon}</span>
-      <span style={{ fontWeight: 600, color: "var(--t1)" }}>{label} — {status}</span>
-      <span style={{ color: "var(--t3)" }}>{detail}</span>
-    </div>
-  );
-}
-
-function TabBtn({ active, children, onClick, disabled }: { active: boolean; children: React.ReactNode; onClick: () => void; disabled?: boolean }) {
-  return (
-    <button onClick={disabled ? undefined : onClick} style={{
-      padding: "10px 20px", fontSize: 13, fontWeight: 500,
-      border: "none", borderBottom: active ? "2px solid var(--acc)" : "2px solid transparent",
-      background: "transparent",
-      color: disabled ? "var(--t4)" : active ? "var(--acc)" : "var(--t3)",
-      cursor: disabled ? "default" : "pointer",
-      fontFamily: "inherit",
-      opacity: disabled ? 0.5 : 1,
-    }}>
-      {children}
-    </button>
-  );
-}
-
-function FileLink({ href, label, color }: { href: string; label: string; color: string }) {
-  const emoji = label === "PDF" ? "📄" : label === "Excel" ? "📊" : "☁";
-  return (
-    <a href={href} target="_blank" rel="noopener noreferrer" style={{
-      display: "flex", alignItems: "center", gap: 5,
-      padding: "6px 12px", borderRadius: 6,
-      fontSize: 11, fontWeight: 500, textDecoration: "none",
-      border: `1px solid ${color}33`, background: "transparent", color,
-    }}>
-      {emoji} {label}
-    </a>
-  );
-}
-
-function IconBtn({ onClick, children, primary, disabled, title }: {
-  onClick: () => void; children: React.ReactNode;
-  primary?: boolean; disabled?: boolean; title?: string;
-}) {
-  return (
-    <button onClick={onClick} disabled={disabled} title={title} style={{
-      width: 32, height: 32, borderRadius: "50%",
-      border: primary ? "none" : "1px solid var(--b1)",
-      background: primary ? "var(--acc)" : "transparent",
-      color: primary ? "#fff" : "var(--t2)",
-      cursor: disabled ? "not-allowed" : "pointer",
-      display: "flex", alignItems: "center", justifyContent: "center",
-      transition: "all .1s", opacity: disabled ? 0.4 : 1,
-    }}>
-      {children}
-    </button>
-  );
-}
-
-// ── STYLES ───────────────────────────────────────────────────────────────────
-
-const backBtnStyle: React.CSSProperties = {
-  width: 30, height: 30, borderRadius: 6,
-  border: "1px solid var(--b1)", background: "transparent",
-  color: "var(--t2)", cursor: "pointer",
-  display: "flex", alignItems: "center", justifyContent: "center",
-};
-
-const badgeStyle: React.CSSProperties = {
-  display: "inline-flex", alignItems: "center", gap: 4,
-  padding: "2px 8px", borderRadius: 999, fontSize: 10, fontWeight: 600,
-};
-
-const tableStyle: React.CSSProperties = {
-  width: "100%", borderCollapse: "collapse",
-  border: "1px solid var(--b1)", borderRadius: 8, overflow: "hidden",
-};
-
-const thStyle: React.CSSProperties = {
-  padding: "8px 12px", fontSize: 11, fontWeight: 600,
-  color: "var(--t3)", textTransform: "uppercase", letterSpacing: "0.05em",
-  background: "rgba(255,255,255,.03)", borderBottom: "1px solid var(--b1)",
-  textAlign: "left",
-};
-
-const tdStyle: React.CSSProperties = {
-  padding: "9px 12px", fontSize: 13, color: "var(--t2)",
-  borderBottom: "1px solid rgba(255,255,255,.04)",
-};

--- a/web/src/components/chat/ChatInput.tsx
+++ b/web/src/components/chat/ChatInput.tsx
@@ -1,0 +1,158 @@
+import { useState } from "react";
+import IconBtn from "@/components/ui/IconBtn";
+
+const VALID_TYPES = ["application/pdf", "image/jpeg", "image/jpg", "image/png", "image/webp"];
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const MAX_FILES = 5;
+
+export interface ChatInputProps {
+  input: string;
+  setInput: (v: string) => void;
+  files: File[];
+  setFiles: (f: File[]) => void;
+  dragActive: boolean;
+  setDragActive: (v: boolean) => void;
+  dragCounterRef: React.MutableRefObject<number>;
+  sending: boolean;
+  send: () => void;
+  onKey: (e: React.KeyboardEvent) => void;
+  fileRef: React.RefObject<HTMLInputElement>;
+}
+
+export default function ChatInput({ input, setInput, files, setFiles, dragActive, setDragActive, dragCounterRef, sending, send, onKey, fileRef }: ChatInputProps) {
+  const [fileError, setFileError] = useState<string | null>(null);
+
+  const addFiles = (newFiles: FileList | File[]) => {
+    const arr = Array.from(newFiles);
+    for (const f of arr) {
+      if (!VALID_TYPES.some(t => f.type.includes(t.split("/")[1]))) {
+        setFileError(`"${f.name}" — tipo no soportado`);
+        setTimeout(() => setFileError(null), 3000);
+        continue;
+      }
+      if (f.size > MAX_FILE_SIZE) {
+        setFileError(`"${f.name}" — máximo 10MB`);
+        setTimeout(() => setFileError(null), 3000);
+        continue;
+      }
+      if (files.length >= MAX_FILES) {
+        setFileError("Máximo 5 archivos");
+        setTimeout(() => setFileError(null), 3000);
+        break;
+      }
+      if (files.some(ef => ef.name === f.name && ef.size === f.size)) continue;
+      setFiles([...files, f]);
+    }
+  };
+
+  const removeFile = (idx: number) => setFiles(files.filter((_, i) => i !== idx));
+
+  const handleDragEnter = (e: React.DragEvent) => {
+    e.preventDefault();
+    dragCounterRef.current++;
+    setDragActive(true);
+  };
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    dragCounterRef.current--;
+    if (dragCounterRef.current <= 0) { dragCounterRef.current = 0; setDragActive(false); }
+  };
+  const handleDragOver = (e: React.DragEvent) => e.preventDefault();
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    dragCounterRef.current = 0;
+    setDragActive(false);
+    if (e.dataTransfer.files.length > 0) addFiles(e.dataTransfer.files);
+  };
+
+  const fmtSize = (b: number) => b < 1024 ? `${b} B` : b < 1048576 ? `${(b/1024).toFixed(1)} KB` : `${(b/1048576).toFixed(1)} MB`;
+  const fmtType = (t: string) => t.includes("pdf") ? "PDF" : t.includes("jpeg") || t.includes("jpg") ? "JPG" : t.includes("png") ? "PNG" : "WEBP";
+  const fileIcon = (t: string) => t.includes("pdf") ? "📄" : "🖼️";
+
+  return (
+    <div
+      onDragEnter={handleDragEnter} onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver} onDrop={handleDrop}
+      style={{ position: "relative" }}
+    >
+      {/* Drag overlay */}
+      {dragActive && (
+        <div style={{
+          position: "absolute", inset: 0, zIndex: 10,
+          background: "rgba(79,143,255,0.08)", border: "2px dashed var(--acc)",
+          borderRadius: 12, display: "flex", flexDirection: "column",
+          alignItems: "center", justifyContent: "center", gap: 6,
+          pointerEvents: "none",
+        }}>
+          <span style={{ fontSize: 28 }}>📁</span>
+          <span style={{ fontSize: 14, fontWeight: 500, color: "var(--acc)" }}>Soltá tu plano PDF o imagen acá</span>
+          <span style={{ fontSize: 11, color: "var(--t3)" }}>PDF, JPG, PNG · Máximo 10MB</span>
+        </div>
+      )}
+
+      {/* File chips */}
+      {(files.length > 0 || fileError) && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 8 }}>
+          {files.map((f, i) => (
+            <div key={`${f.name}-${i}`} style={{
+              display: "flex", alignItems: "center", gap: 6,
+              padding: "5px 10px", borderRadius: 6,
+              background: "var(--s3)", border: "1px solid var(--b1)",
+              fontSize: 11, color: "var(--t2)", maxWidth: 280,
+            }}>
+              <span style={{ fontSize: 14 }}>{fileIcon(f.type)}</span>
+              <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1 }}>{f.name}</span>
+              <span style={{ color: "var(--t3)", flexShrink: 0 }}>{fmtType(f.type)} · {fmtSize(f.size)}</span>
+              <button onClick={() => removeFile(i)} style={{ background: "none", border: "none", color: "var(--t3)", cursor: "pointer", fontSize: 13, padding: "0 2px" }}>✕</button>
+            </div>
+          ))}
+          {fileError && (
+            <div style={{
+              display: "flex", alignItems: "center", gap: 6,
+              padding: "5px 10px", borderRadius: 6,
+              background: "rgba(255,69,58,0.08)", border: "1px solid rgba(255,69,58,0.3)",
+              fontSize: 11, color: "var(--red)",
+            }}>
+              ⚠️ {fileError}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Input row */}
+      <div style={{
+        display: "flex", alignItems: "flex-end", gap: 8,
+        background: "var(--s3)",
+        border: dragActive ? "1px solid var(--acc)" : "1px solid var(--b2)",
+        boxShadow: dragActive ? "0 0 20px rgba(79,143,255,0.15)" : "none",
+        borderRadius: 12, padding: "10px 10px 10px 16px",
+        transition: "border-color 0.15s, box-shadow 0.15s",
+      }}>
+        <textarea value={input} onChange={e => setInput(e.target.value)}
+          onKeyDown={onKey} rows={1} disabled={sending}
+          placeholder="Escribí el enunciado o arrastrá el plano acá..."
+          style={{
+            flex: 1, background: "transparent", border: "none", outline: "none",
+            fontFamily: "inherit", fontSize: 13, color: "var(--t1)",
+            resize: "none", lineHeight: 1.5, maxHeight: 110,
+          }}
+        />
+        <div style={{ display: "flex", alignItems: "center", gap: 5, flexShrink: 0 }}>
+          <input ref={fileRef} type="file" accept=".pdf,.jpg,.jpeg,.png,.webp" multiple style={{ display: "none" }}
+            onChange={e => { if (e.target.files) addFiles(e.target.files); e.target.value = ""; }}
+          />
+          <IconBtn onClick={() => fileRef.current?.click()} title="Adjuntar plano">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+              <path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48" />
+            </svg>
+          </IconBtn>
+          <IconBtn onClick={send} primary disabled={sending || (!input.trim() && files.length === 0)}>
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2">
+              <line x1="22" y1="2" x2="11" y2="13" /><polygon points="22 2 15 22 11 13 2 9 22 2" />
+            </svg>
+          </IconBtn>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/chat/MessageBubble.tsx
+++ b/web/src/components/chat/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import type { UIMessage } from "@/app/quote/[id]/page";
+import type { UIMessage } from "@/lib/types";
 
 interface Props { message: UIMessage; actionText?: string; }
 

--- a/web/src/components/quote/ChatView.tsx
+++ b/web/src/components/quote/ChatView.tsx
@@ -1,0 +1,33 @@
+import type { UIMessage } from "@/lib/types";
+import type { ChatInputProps } from "@/components/chat/ChatInput";
+import MessageBubble from "@/components/chat/MessageBubble";
+import ChatInput from "@/components/chat/ChatInput";
+
+interface Props {
+  messages: UIMessage[];
+  actionText: string;
+  endRef: React.RefObject<HTMLDivElement>;
+  chatInputProps: ChatInputProps;
+}
+
+export default function ChatView({ messages, actionText, endRef, chatInputProps }: Props) {
+  return (
+    <>
+      <div style={{ flex: 1, overflowY: "auto", padding: "28px 28px 16px", display: "flex", flexDirection: "column", gap: 20 }}>
+        {messages.length === 0 && (
+          <div style={{ padding: "14px 18px", background: "var(--s2)", borderRadius: 12, fontSize: 13, color: "var(--t2)" }}>
+            Hola 👋 Soy Valentina. Pasame el enunciado del trabajo y/o el plano.
+          </div>
+        )}
+        {messages.map(msg => <MessageBubble key={msg.id} message={msg} actionText={msg.isStreaming ? actionText : undefined} />)}
+        <div ref={endRef} />
+      </div>
+      <div style={{ flexShrink: 0, padding: "14px 28px 18px", borderTop: "1px solid var(--b1)", background: "var(--s1)" }}>
+        <ChatInput {...chatInputProps} />
+        <div style={{ fontSize: 10, color: "var(--t4)", textAlign: "center", marginTop: 7 }}>
+          Enter para enviar · Shift+Enter para nueva línea
+        </div>
+      </div>
+    </>
+  );
+}

--- a/web/src/components/quote/DetailView.tsx
+++ b/web/src/components/quote/DetailView.tsx
@@ -1,0 +1,179 @@
+import { useMemo } from "react";
+import type { QuoteDetail } from "@/lib/api";
+import { fmtARS, fmtUSD, fmtQty } from "@/lib/format";
+import { tableStyle, thStyle, tdStyle } from "@/lib/constants";
+import { useBreakpoints } from "@/lib/useMediaQuery";
+import Section from "./Section";
+import MetaItem from "./MetaItem";
+import ReqField from "./ReqField";
+import InfoBar from "./InfoBar";
+import PricingSummary from "./PricingSummary";
+import SourceFilesSection from "./SourceFilesSection";
+
+interface Props {
+  quote: QuoteDetail | null;
+  breakdown: Record<string, any> | null;
+  onSwitchToChat: () => void;
+}
+
+export default function DetailView({ quote, breakdown, onSwitchToChat }: Props) {
+  const { isMobile, isTablet } = useBreakpoints();
+  if (!quote) return null;
+
+  const pieces = useMemo(
+    () => breakdown?.sectors?.flatMap((s: any) => s.pieces || []) || [],
+    [breakdown]
+  );
+  const moItems = useMemo(
+    () => (breakdown?.mo_items || []).map((m: any) => ({
+      ...m,
+      total: m.total ?? (m.quantity ?? 0) * (m.unit_price ?? 0),
+    })),
+    [breakdown]
+  );
+  const totalMO = useMemo(
+    () => moItems.reduce((s: number, m: any) => s + (m.total || 0), 0),
+    [moItems]
+  );
+  const merma = breakdown?.merma;
+  const totalM2 = breakdown?.material_m2 || 0;
+  const discountPct = breakdown?.discount_pct || 0;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+
+      {/* A. RESUMEN */}
+      <Section title="Resumen">
+        <div style={{ display: "grid", gridTemplateColumns: isMobile ? "1fr" : isTablet ? "1fr 1fr" : "1fr 1fr 1fr 1fr", gap: isMobile ? 12 : 16 }}>
+          <MetaItem label="Cliente" value={quote.client_name || "—"} />
+          <MetaItem label="Proyecto" value={quote.project || "—"} />
+          <MetaItem label="Material" value={quote.material || "—"} />
+          <MetaItem label="Fecha" value={new Date(quote.created_at).toLocaleDateString("es-AR")} />
+          <MetaItem label="Demora" value={breakdown?.delivery_days || "—"} />
+          <MetaItem label="Origen" value={quote.source === "web" ? "Web (chatbot)" : "Operador"} />
+          <MetaItem label="Total ARS" value={quote.total_ars ? fmtARS(quote.total_ars) : "—"} highlight />
+          <MetaItem label="Total USD" value={quote.total_usd ? fmtUSD(quote.total_usd) : "—"} highlight />
+        </div>
+      </Section>
+
+      {/* A2. SOURCE FILES */}
+      {quote.source_files && quote.source_files.length > 0 && (
+        <SourceFilesSection files={quote.source_files} />
+      )}
+
+      {/* B. SOLICITUD */}
+      {breakdown && (
+        <Section title="Solicitud">
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+            <ReqField label="Material" value={breakdown.material_name || "—"} />
+            <ReqField label="Superficie" value={totalM2 ? `${fmtQty(totalM2)} m²` : "—"} />
+            <ReqField label="Moneda" value={breakdown.material_currency || "—"} />
+            <ReqField label="Precio/m²" value={breakdown.material_price_unit ? (breakdown.material_currency === "USD" ? fmtUSD(breakdown.material_price_unit) : fmtARS(breakdown.material_price_unit)) : "—"} />
+            <ReqField label="Plazo" value={breakdown.delivery_days || "—"} />
+            <ReqField label="Proyecto" value={breakdown.project || "—"} />
+          </div>
+        </Section>
+      )}
+
+      {/* C. DESGLOSE */}
+      {breakdown && (pieces.length > 0 || moItems.length > 0) ? (
+        <Section title="Desglose del Presupuesto">
+          {/* Pieces */}
+          {pieces.length > 0 && (
+            <div style={{ marginBottom: 16 }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: "var(--t1)", marginBottom: 8 }}>
+                Material — {fmtQty(totalM2)} m²
+              </div>
+              <div style={{ overflowX: "auto" }}>
+                <table style={tableStyle}>
+                  <thead>
+                    <tr>
+                      <th style={thStyle}>Pieza</th>
+                      <th style={{ ...thStyle, textAlign: "right" }}>Detalle</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {pieces.map((p: string, i: number) => (
+                      <tr key={i} style={{ background: i % 2 === 1 ? "rgba(255,255,255,.03)" : "transparent" }}>
+                        <td style={tdStyle}>{p}</td>
+                        <td style={{ ...tdStyle, textAlign: "right", color: "var(--t3)" }}></td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* Merma */}
+          {merma && (
+            <InfoBar
+              icon="📐"
+              label="Merma"
+              status={merma.aplica ? "APLICA" : "NO APLICA"}
+              detail={merma.motivo || ""}
+            />
+          )}
+
+          {/* MO */}
+          {moItems.length > 0 && (
+            <div style={{ marginTop: 16, marginBottom: 16 }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: "var(--t1)", marginBottom: 8 }}>Mano de Obra</div>
+              <div style={{ overflowX: "auto" }}>
+                <table style={tableStyle}>
+                  <thead>
+                    <tr>
+                      <th style={thStyle}>Ítem</th>
+                      <th style={{ ...thStyle, textAlign: "right" }}>Cant</th>
+                      <th style={{ ...thStyle, textAlign: "right" }}>Precio</th>
+                      <th style={{ ...thStyle, textAlign: "right" }}>Total</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {moItems.map((m: any, i: number) => (
+                      <tr key={i} style={{ background: i % 2 === 1 ? "rgba(255,255,255,.03)" : "transparent" }}>
+                        <td style={tdStyle}>{m.description}</td>
+                        <td style={{ ...tdStyle, textAlign: "right" }}>{fmtQty(m.quantity)}</td>
+                        <td style={{ ...tdStyle, textAlign: "right" }}>{fmtARS(m.unit_price)}</td>
+                        <td style={{ ...tdStyle, textAlign: "right" }}>{fmtARS(m.total)}</td>
+                      </tr>
+                    ))}
+                    <tr style={{ background: "rgba(255,255,255,.05)" }}>
+                      <td style={{ ...tdStyle, fontWeight: 600 }}>TOTAL MO</td>
+                      <td style={tdStyle}></td>
+                      <td style={tdStyle}></td>
+                      <td style={{ ...tdStyle, textAlign: "right", fontWeight: 600 }}>{fmtARS(totalMO)}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* Discount */}
+          <InfoBar
+            icon="🏷️"
+            label="Descuentos"
+            status={discountPct > 0 ? `APLICA ${discountPct}%` : "NO APLICA"}
+            detail={discountPct > 0 ? `${discountPct}% sobre material` : "Particular sin umbral de m²"}
+          />
+
+          {/* Grand total */}
+          <PricingSummary totalArs={quote.total_ars} totalUsd={quote.total_usd} />
+        </Section>
+      ) : (
+        <Section title="Desglose">
+          <div style={{ fontSize: 13, color: "var(--t3)" }}>
+            Este presupuesto no tiene datos de desglose estructurados. Consultá el historial de chat para ver los detalles.
+          </div>
+          <button onClick={onSwitchToChat} style={{
+            marginTop: 10, background: "none", border: "none", color: "var(--acc)",
+            fontSize: 12, cursor: "pointer", fontFamily: "inherit", padding: 0,
+          }}>
+            Ver chat →
+          </button>
+        </Section>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/quote/InfoBar.tsx
+++ b/web/src/components/quote/InfoBar.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+interface Props {
+  icon: string;
+  label: string;
+  status: string;
+  detail: string;
+}
+
+function InfoBar({ icon, label, status, detail }: Props) {
+  const isNo = status.includes("NO");
+  return (
+    <div style={{
+      display: "flex", alignItems: "center", gap: 10,
+      padding: "10px 14px", borderRadius: 8,
+      background: isNo ? "rgba(255,255,255,.02)" : "rgba(245,166,35,.06)",
+      border: `1px solid ${isNo ? "var(--b1)" : "rgba(245,166,35,.16)"}`,
+      fontSize: 12,
+    }}>
+      <span>{icon}</span>
+      <span style={{ fontWeight: 600, color: "var(--t1)" }}>{label} — {status}</span>
+      <span style={{ color: "var(--t3)" }}>{detail}</span>
+    </div>
+  );
+}
+
+export default React.memo(InfoBar);

--- a/web/src/components/quote/MetaItem.tsx
+++ b/web/src/components/quote/MetaItem.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+interface Props {
+  label: string;
+  value: string;
+  highlight?: boolean;
+}
+
+function MetaItem({ label, value, highlight }: Props) {
+  return (
+    <div>
+      <div style={{ fontSize: 10, color: "var(--t3)", textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 3 }}>{label}</div>
+      <div style={{ fontSize: 14, fontWeight: highlight ? 600 : 400, color: highlight ? "var(--t1)" : "var(--t2)" }}>{value}</div>
+    </div>
+  );
+}
+
+export default React.memo(MetaItem);

--- a/web/src/components/quote/PricingSummary.tsx
+++ b/web/src/components/quote/PricingSummary.tsx
@@ -1,0 +1,31 @@
+import { fmtARS, fmtUSD } from "@/lib/format";
+
+interface Props {
+  totalArs: number | null;
+  totalUsd: number | null;
+}
+
+export default function PricingSummary({ totalArs, totalUsd }: Props) {
+  if (!totalArs && !totalUsd) return null;
+  return (
+    <div style={{
+      marginTop: 20, padding: "16px 20px", borderRadius: 10,
+      background: "var(--s3)", border: "1px solid var(--b2)",
+      display: "flex", justifyContent: "space-between", alignItems: "center",
+    }}>
+      <span style={{ fontSize: 14, fontWeight: 600, color: "var(--t1)" }}>PRESUPUESTO TOTAL</span>
+      <div style={{ textAlign: "right" }}>
+        {totalArs && (
+          <div style={{ fontSize: 18, fontWeight: 700, color: "var(--t1)" }}>
+            {fmtARS(totalArs)} <span style={{ color: "var(--t3)", fontWeight: 400, fontSize: 13 }}>mano de obra</span>
+          </div>
+        )}
+        {totalUsd && (
+          <div style={{ fontSize: 15, fontWeight: 600, color: "var(--acc)", marginTop: 2 }}>
+            + {fmtUSD(totalUsd)} <span style={{ color: "var(--t3)", fontWeight: 400, fontSize: 13 }}>material</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/quote/QuoteHeader.tsx
+++ b/web/src/components/quote/QuoteHeader.tsx
@@ -1,0 +1,46 @@
+import FileLink from "@/components/ui/FileLink";
+import { STATUS, backBtnStyle, badgeStyle } from "@/lib/constants";
+import { useBreakpoints } from "@/lib/useMediaQuery";
+import type { QuoteDetail } from "@/lib/api";
+
+interface Props {
+  quote: QuoteDetail | null;
+  onBack: () => void;
+}
+
+export default function QuoteHeader({ quote, onBack }: Props) {
+  const { isMobile } = useBreakpoints();
+  const st = STATUS[quote?.status || "draft"];
+  return (
+    <div style={{
+      display: "flex", alignItems: isMobile ? "flex-start" : "center",
+      flexDirection: isMobile ? "column" : "row",
+      justifyContent: "space-between",
+      padding: isMobile ? "10px 14px" : "14px 28px",
+      borderBottom: "1px solid var(--b1)",
+      flexShrink: 0, background: "var(--s1)",
+      gap: isMobile ? 10 : 0,
+    }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+        <button onClick={onBack} style={backBtnStyle}>
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="15 18 9 12 15 6" /></svg>
+        </button>
+        <div>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <span style={{ fontSize: 16, fontWeight: 600, color: "var(--t1)" }}>{quote?.client_name || "Nuevo presupuesto"}</span>
+            <span style={{ ...badgeStyle, background: st.bg, color: st.color }}>● {st.label}</span>
+            {quote?.source === "web" && <span style={{ ...badgeStyle, background: "rgba(138,43,226,.15)", color: "#a855f7" }}>WEB</span>}
+          </div>
+          <div style={{ fontSize: 12, color: "var(--t3)", marginTop: 2 }}>
+            {quote?.project}{quote?.material ? ` · ${quote.material}` : ""}
+          </div>
+        </div>
+      </div>
+      <div style={{ display: "flex", gap: 8 }}>
+        {quote?.pdf_url && <FileLink href={quote.pdf_url} label="PDF" color="#ff6b63" />}
+        {quote?.excel_url && <FileLink href={quote.excel_url} label="Excel" color="var(--grn)" />}
+        {quote?.drive_url && <FileLink href={quote.drive_url} label="Drive" color="var(--acc)" />}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/quote/QuoteTabBar.tsx
+++ b/web/src/components/quote/QuoteTabBar.tsx
@@ -1,0 +1,19 @@
+import TabBtn from "@/components/ui/TabBtn";
+
+interface Props {
+  tab: "detail" | "chat";
+  setTab: (t: "detail" | "chat") => void;
+  canShowDetail: boolean;
+}
+
+export default function QuoteTabBar({ tab, setTab, canShowDetail }: Props) {
+  return (
+    <div style={{
+      display: "flex", gap: 0, borderBottom: "1px solid var(--b1)",
+      background: "var(--s1)", paddingLeft: 28,
+    }}>
+      <TabBtn active={tab === "detail"} onClick={() => setTab("detail")} disabled={!canShowDetail}>Detalle</TabBtn>
+      <TabBtn active={tab === "chat"} onClick={() => setTab("chat")}>Chat</TabBtn>
+    </div>
+  );
+}

--- a/web/src/components/quote/ReqField.tsx
+++ b/web/src/components/quote/ReqField.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+interface Props {
+  label: string;
+  value: string;
+}
+
+function ReqField({ label, value }: Props) {
+  return (
+    <div style={{ display: "flex", gap: 8, fontSize: 13 }}>
+      <span style={{ color: "var(--t3)", minWidth: 110, flexShrink: 0 }}>{label}</span>
+      <span style={{ color: "var(--t1)" }}>{value}</span>
+    </div>
+  );
+}
+
+export default React.memo(ReqField);

--- a/web/src/components/quote/Section.tsx
+++ b/web/src/components/quote/Section.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+interface Props {
+  title: string;
+  children: React.ReactNode;
+  style?: React.CSSProperties;
+}
+
+export default function Section({ title, children, style: extraStyle }: Props) {
+  return (
+    <div style={{
+      background: "var(--s1)", border: "1px solid var(--b1)",
+      borderRadius: 12, padding: "18px 22px", ...extraStyle,
+    }}>
+      <div style={{
+        fontSize: 13, fontWeight: 600, color: "var(--t1)",
+        textTransform: "uppercase", letterSpacing: "0.06em",
+        marginBottom: 14, paddingBottom: 8, borderBottom: "1px solid var(--b1)",
+      }}>
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/web/src/components/quote/SourceFilesSection.tsx
+++ b/web/src/components/quote/SourceFilesSection.tsx
@@ -1,0 +1,69 @@
+import Section from "./Section";
+
+interface SourceFile {
+  filename: string;
+  type?: string;
+  size?: number;
+  url: string;
+}
+
+interface Props {
+  files: SourceFile[];
+}
+
+export default function SourceFilesSection({ files }: Props) {
+  if (files.length === 0) return null;
+
+  const fmtSize = (b: number) =>
+    b < 1024 ? `${b} B` : b < 1048576 ? `${(b / 1024).toFixed(1)} KB` : `${(b / 1048576).toFixed(1)} MB`;
+
+  const fmtType = (t?: string) => {
+    if (!t) return "Archivo";
+    if (t.includes("pdf")) return "PDF";
+    if (t.includes("jpeg") || t.includes("jpg")) return "JPG";
+    if (t.includes("png")) return "PNG";
+    return "Archivo";
+  };
+
+  return (
+    <Section title="Archivos Fuente">
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {files.map((f, i) => (
+          <div key={i} style={{
+            display: "flex", alignItems: "center", gap: 12,
+            padding: "12px 16px", borderRadius: 8,
+            background: i % 2 === 0 ? "rgba(255,255,255,.02)" : "transparent",
+            border: "1px solid var(--b1)",
+          }}>
+            <span style={{ fontSize: 20, flexShrink: 0 }}>
+              {f.type?.includes("pdf") ? "📄" : f.type?.includes("image") ? "🖼️" : "📎"}
+            </span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, fontWeight: 500, color: "var(--t1)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {f.filename}
+              </div>
+              <div style={{ fontSize: 11, color: "var(--t3)", marginTop: 2 }}>
+                {fmtType(f.type)}
+                {f.size ? ` · ${fmtSize(f.size)}` : ""}
+              </div>
+            </div>
+            <a href={f.url} download style={{
+              display: "flex", alignItems: "center", gap: 5,
+              padding: "6px 14px", borderRadius: 6,
+              fontSize: 11, fontWeight: 500, textDecoration: "none",
+              border: "1px solid var(--acc3)", background: "transparent",
+              color: "var(--acc)", cursor: "pointer", flexShrink: 0,
+            }}>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+                <polyline points="7 10 12 15 17 10" />
+                <line x1="12" y1="15" x2="12" y2="3" />
+              </svg>
+              Descargar
+            </a>
+          </div>
+        ))}
+      </div>
+    </Section>
+  );
+}

--- a/web/src/components/ui/FileLink.tsx
+++ b/web/src/components/ui/FileLink.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+interface Props {
+  href: string;
+  label: string;
+  color: string;
+}
+
+function FileLink({ href, label, color }: Props) {
+  const emoji = label === "PDF" ? "📄" : label === "Excel" ? "📊" : "☁";
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer" style={{
+      display: "flex", alignItems: "center", gap: 5,
+      padding: "6px 12px", borderRadius: 6,
+      fontSize: 11, fontWeight: 500, textDecoration: "none",
+      border: `1px solid ${color}33`, background: "transparent", color,
+    }}>
+      {emoji} {label}
+    </a>
+  );
+}
+
+export default React.memo(FileLink);

--- a/web/src/components/ui/IconBtn.tsx
+++ b/web/src/components/ui/IconBtn.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+interface Props {
+  onClick: () => void;
+  children: React.ReactNode;
+  primary?: boolean;
+  disabled?: boolean;
+  title?: string;
+}
+
+function IconBtn({ onClick, children, primary, disabled, title }: Props) {
+  return (
+    <button onClick={onClick} disabled={disabled} title={title} style={{
+      width: 32, height: 32, borderRadius: "50%",
+      border: primary ? "none" : "1px solid var(--b1)",
+      background: primary ? "var(--acc)" : "transparent",
+      color: primary ? "#fff" : "var(--t2)",
+      cursor: disabled ? "not-allowed" : "pointer",
+      display: "flex", alignItems: "center", justifyContent: "center",
+      transition: "all .1s", opacity: disabled ? 0.4 : 1,
+    }}>
+      {children}
+    </button>
+  );
+}
+
+export default React.memo(IconBtn);

--- a/web/src/components/ui/TabBtn.tsx
+++ b/web/src/components/ui/TabBtn.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+interface Props {
+  active: boolean;
+  children: React.ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+function TabBtn({ active, children, onClick, disabled }: Props) {
+  return (
+    <button onClick={disabled ? undefined : onClick} style={{
+      padding: "10px 20px", fontSize: 13, fontWeight: 500,
+      border: "none", borderBottom: active ? "2px solid var(--acc)" : "2px solid transparent",
+      background: "transparent",
+      color: disabled ? "var(--t4)" : active ? "var(--acc)" : "var(--t3)",
+      cursor: disabled ? "default" : "pointer",
+      fontFamily: "inherit",
+      opacity: disabled ? 0.5 : 1,
+    }}>
+      {children}
+    </button>
+  );
+}
+
+export default React.memo(TabBtn);

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -1,0 +1,36 @@
+import type React from "react";
+
+export const STATUS: Record<string, { label: string; bg: string; color: string }> = {
+  draft: { label: "Borrador", bg: "var(--amb2)", color: "var(--amb)" },
+  validated: { label: "Validado", bg: "var(--grn2)", color: "var(--grn)" },
+  sent: { label: "Enviado", bg: "var(--acc2)", color: "var(--acc)" },
+};
+
+export const backBtnStyle: React.CSSProperties = {
+  width: 30, height: 30, borderRadius: 6,
+  border: "1px solid var(--b1)", background: "transparent",
+  color: "var(--t2)", cursor: "pointer",
+  display: "flex", alignItems: "center", justifyContent: "center",
+};
+
+export const badgeStyle: React.CSSProperties = {
+  display: "inline-flex", alignItems: "center", gap: 4,
+  padding: "2px 8px", borderRadius: 999, fontSize: 10, fontWeight: 600,
+};
+
+export const tableStyle: React.CSSProperties = {
+  width: "100%", borderCollapse: "collapse",
+  border: "1px solid var(--b1)", borderRadius: 8, overflow: "hidden",
+};
+
+export const thStyle: React.CSSProperties = {
+  padding: "8px 12px", fontSize: 11, fontWeight: 600,
+  color: "var(--t3)", textTransform: "uppercase", letterSpacing: "0.05em",
+  background: "rgba(255,255,255,.03)", borderBottom: "1px solid var(--b1)",
+  textAlign: "left",
+};
+
+export const tdStyle: React.CSSProperties = {
+  padding: "9px 12px", fontSize: 13, color: "var(--t2)",
+  borderBottom: "1px solid rgba(255,255,255,.04)",
+};

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,0 +1,15 @@
+export const fmtARS = (n: number | null | undefined) => {
+  if (n == null || isNaN(n)) return "—";
+  return `$${Math.round(n).toLocaleString("es-AR")}`;
+};
+
+export const fmtUSD = (n: number | null | undefined) => {
+  if (n == null || isNaN(n)) return "—";
+  return `USD ${Math.round(n).toLocaleString("es-AR")}`;
+};
+
+export const fmtQty = (n: number | null | undefined) => {
+  if (n == null || isNaN(n)) return "—";
+  if (Math.abs(n - Math.round(n)) < 0.05) return String(Math.round(n));
+  return n.toFixed(2).replace(".", ",");
+};

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,0 +1,7 @@
+export interface UIMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  isStreaming?: boolean;
+  attachmentName?: string;
+}

--- a/web/src/lib/useMediaQuery.ts
+++ b/web/src/lib/useMediaQuery.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from "react";
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    setMatches(mql.matches);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [query]);
+
+  return matches;
+}
+
+export function useBreakpoints() {
+  const isMobile = useMediaQuery("(max-width: 640px)");
+  const isTablet = useMediaQuery("(min-width: 641px) and (max-width: 1024px)");
+  return { isMobile, isTablet };
+}


### PR DESCRIPTION
## Summary
- **Descompone `quote/[id]/page.tsx`** de 749 líneas → 163 líneas (orquestador)
- **15 componentes extraídos** en archivos separados con responsabilidades claras
- **Responsividad** con hook `useMediaQuery` (mobile ≤640px, tablet ≤1024px, desktop)
- **Performance**: `React.memo` en 6 componentes hoja, `useMemo` en 3 cálculos de breakdown
- **Resuelve import circular** de `UIMessage` (page.tsx ↔ MessageBubble.tsx) via `lib/types.ts`

### Estructura nueva
```
lib/          types.ts, format.ts, constants.ts, useMediaQuery.ts
ui/           IconBtn, TabBtn, FileLink
quote/        Section, MetaItem, ReqField, InfoBar, PricingSummary,
              SourceFilesSection, QuoteHeader, QuoteTabBar, DetailView, ChatView
chat/         ChatInput (extraído con drag-drop)
```

### Responsive breakpoints
| Breakpoint | Cambios |
|------------|---------|
| Mobile ≤640px | Grids 1 col, padding reducido, header vertical |
| Tablet ≤1024px | Grids 2 col |
| Desktop | Sin cambios (layout actual) |

## Test plan
- [ ] Quote draft → tab chat por defecto
- [ ] Quote validated/sent → tab detail por defecto
- [ ] Tab switching funciona
- [ ] Chat streaming end-to-end
- [ ] File upload (click + drag-drop)
- [ ] Links PDF/Excel/Drive en header
- [ ] Responsive: probar 375px, 768px, 1280px
- [ ] `tsc --noEmit` pasa limpio ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)