### PR TITLE
feat: quote comparator + catalog UX overhaul with smart import

### DIFF
--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -18,6 +18,8 @@ from app.modules.agent.agent import AgentService
 from app.modules.agent.schemas import (
     QuoteListResponse,
     QuoteDetailResponse,
+    QuoteCompareItem,
+    QuoteCompareResponse,
     QuoteStatusUpdate,
 )
 
@@ -47,6 +49,103 @@ async def get_quote(quote_id: str, db: AsyncSession = Depends(get_db)):
     if not quote:
         raise HTTPException(status_code=404, detail="Presupuesto no encontrado")
     return quote
+
+
+# ── COMPARE QUOTES ───────────────────────────────────────────────────────────
+
+@router.get("/quotes/{quote_id}/compare", response_model=QuoteCompareResponse)
+async def compare_quotes(quote_id: str, db: AsyncSession = Depends(get_db)):
+    """Return all related quotes (parent + children) for side-by-side comparison."""
+    result = await db.execute(select(Quote).where(Quote.id == quote_id))
+    quote = result.scalar_one_or_none()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Presupuesto no encontrado")
+
+    root_id = quote.parent_quote_id or quote.id
+
+    # Load root quote
+    if root_id != quote.id:
+        root_result = await db.execute(select(Quote).where(Quote.id == root_id))
+        root = root_result.scalar_one_or_none()
+        if not root:
+            raise HTTPException(status_code=404, detail="Presupuesto padre no encontrado")
+    else:
+        root = quote
+
+    # Load all children
+    children_result = await db.execute(
+        select(Quote)
+        .where(Quote.parent_quote_id == root_id)
+        .order_by(Quote.created_at)
+    )
+    children = children_result.scalars().all()
+
+    all_quotes = [root] + list(children)
+    if len(all_quotes) < 2:
+        raise HTTPException(status_code=404, detail="No hay variantes para comparar")
+
+    return QuoteCompareResponse(
+        parent_id=root_id,
+        client_name=root.client_name,
+        project=root.project,
+        quotes=[QuoteCompareItem.model_validate(q) for q in all_quotes],
+    )
+
+
+@router.get("/quotes/{quote_id}/compare/pdf")
+async def compare_pdf(quote_id: str, db: AsyncSession = Depends(get_db)):
+    """Generate and return a comparison PDF for all related quotes."""
+    from fastapi.responses import FileResponse
+    from app.modules.agent.tools.document_tool import generate_comparison_pdf, OUTPUT_DIR
+
+    result = await db.execute(select(Quote).where(Quote.id == quote_id))
+    quote = result.scalar_one_or_none()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Presupuesto no encontrado")
+
+    root_id = quote.parent_quote_id or quote.id
+
+    if root_id != quote.id:
+        root_result = await db.execute(select(Quote).where(Quote.id == root_id))
+        root = root_result.scalar_one_or_none()
+        if not root:
+            raise HTTPException(status_code=404, detail="Presupuesto padre no encontrado")
+    else:
+        root = quote
+
+    children_result = await db.execute(
+        select(Quote)
+        .where(Quote.parent_quote_id == root_id)
+        .order_by(Quote.created_at)
+    )
+    children = children_result.scalars().all()
+    all_quotes = [root] + list(children)
+
+    if len(all_quotes) < 2:
+        raise HTTPException(status_code=404, detail="No hay variantes para comparar")
+
+    quotes_data = []
+    for q in all_quotes:
+        bd = q.quote_breakdown or {}
+        bd["_total_ars"] = q.total_ars or bd.get("total_ars", 0)
+        bd["_total_usd"] = q.total_usd or bd.get("total_usd", 0)
+        bd["_material"] = q.material or bd.get("material_name", "")
+        quotes_data.append(bd)
+
+    pdf_dir = OUTPUT_DIR / root_id
+    pdf_dir.mkdir(exist_ok=True)
+    pdf_path = pdf_dir / "comparativo.pdf"
+
+    import asyncio
+    await asyncio.to_thread(
+        generate_comparison_pdf, pdf_path, root.client_name, root.project, quotes_data
+    )
+
+    return FileResponse(
+        path=str(pdf_path),
+        media_type="application/pdf",
+        filename=f"Comparativo - {root.client_name}.pdf",
+    )
 
 
 # ── UPDATE QUOTE STATUS ───────────────────────────────────────────────────────

--- a/api/app/modules/agent/schemas.py
+++ b/api/app/modules/agent/schemas.py
@@ -29,5 +29,24 @@ class QuoteDetailResponse(QuoteListResponse):
     source_files: Optional[list] = None
 
 
+class QuoteCompareItem(BaseModel):
+    id: str
+    material: Optional[str]
+    total_ars: Optional[float]
+    total_usd: Optional[float]
+    status: QuoteStatus
+    pdf_url: Optional[str]
+    quote_breakdown: Optional[dict] = None
+
+    model_config = {"from_attributes": True}
+
+
+class QuoteCompareResponse(BaseModel):
+    parent_id: str
+    client_name: str
+    project: str
+    quotes: list[QuoteCompareItem]
+
+
 class QuoteStatusUpdate(BaseModel):
     status: QuoteStatus

--- a/api/app/modules/agent/tools/document_tool.py
+++ b/api/app/modules/agent/tools/document_tool.py
@@ -513,4 +513,161 @@ def _format_grand_total(total_ars: float, total_usd: float, currency: str) -> st
     if currency == "USD" and total_usd:
         return f"PRESUPUESTO TOTAL: {_fmt_ars(total_ars)} mano de obra + {_fmt_usd(total_usd)} material"
     return f"PRESUPUESTO TOTAL: {_fmt_ars(total_ars)} mano de obra + material"
-    client_name = data["client_name"]
+
+
+def generate_comparison_pdf(pdf_path: Path, client_name: str, project: str, quotes_data: list[dict]) -> None:
+    """Generate a landscape comparison PDF for multiple material variants."""
+    from fpdf import FPDF
+
+    date_str = datetime.now().strftime("%d/%m/%Y")
+    n = len(quotes_data)
+
+    pdf = FPDF(orientation="L", unit="mm", format="A4")
+    pdf.set_auto_page_break(auto=True, margin=15)
+    pdf.add_page()
+
+    # Top bar
+    pdf.set_fill_color(26, 47, 94)
+    pdf.rect(0, 0, 297, 4, "F")
+
+    # Logo
+    logo_path = TEMPLATES_DIR / "logo-dangelo.png"
+    if logo_path.exists():
+        pdf.image(str(logo_path), x=10, y=10, w=55)
+        pdf.set_y(35)
+    else:
+        pdf.set_y(12)
+        pdf.set_font("Helvetica", "B", 28)
+        pdf.cell(0, 12, "D'ANGELO", new_x="LMARGIN", new_y="NEXT")
+
+    # Contact
+    pdf.set_font("Helvetica", "", 8)
+    pdf.cell(0, 4, "SAN NICOLAS 1160  |  341-3082996  |  marmoleriadangelo@gmail.com", new_x="LMARGIN", new_y="NEXT")
+
+    # Title
+    pdf.ln(3)
+    pdf.set_font("Helvetica", "B", 16)
+    pdf.cell(0, 10, "Comparativo de Presupuestos", new_x="LMARGIN", new_y="NEXT")
+    pdf.set_font("Helvetica", "", 9)
+    pdf.cell(0, 5, f"Fecha: {date_str}  |  Cliente: {client_name}  |  Proyecto: {project}", new_x="LMARGIN", new_y="NEXT")
+
+    # Separator
+    pdf.ln(3)
+    pdf.set_draw_color(26, 26, 26)
+    pdf.line(10, pdf.get_y(), 287, pdf.get_y())
+    pdf.ln(4)
+
+    # Table layout
+    label_w = 55
+    usable = 277 - label_w  # 297 - 2*10 margins - label
+    col_w = usable / n
+
+    # Extract data per variant
+    def _mo_total(bd: dict) -> float:
+        return sum(m.get("quantity", 0) * m.get("unit_price", 0) for m in bd.get("mo_items", []))
+
+    variants = []
+    for bd in quotes_data:
+        merma = bd.get("merma", {})
+        currency = bd.get("material_currency", "USD")
+        fmt_price = _fmt_usd if currency == "USD" else _fmt_ars
+        variants.append({
+            "material": bd.get("_material") or bd.get("material_name", "—"),
+            "currency": currency,
+            "price_m2": fmt_price(bd.get("material_price_unit", 0)),
+            "m2": _fmt_qty(bd.get("material_m2", 0)) + " m\u00b2",
+            "total_mat": fmt_price(bd.get("material_total", 0)),
+            "discount": f"{bd.get('discount_pct', 0)}%" if bd.get("discount_pct") else "No aplica",
+            "mo_total": _fmt_ars(_mo_total(bd)),
+            "merma": merma.get("motivo", "No aplica") if merma else "No aplica",
+            "delivery": _normalize_delivery(bd.get("delivery_days", "")),
+            "total_ars": bd.get("_total_ars") or bd.get("total_ars", 0),
+            "total_usd": bd.get("_total_usd") or bd.get("total_usd", 0),
+        })
+
+    # Find cheapest by total_usd (or total_ars if no USD)
+    best_idx = 0
+    best_val = float("inf")
+    for i, v in enumerate(variants):
+        val = v["total_usd"] if v["total_usd"] else v["total_ars"]
+        if val and val < best_val:
+            best_val = val
+            best_idx = i
+
+    # Header row — material names
+    pdf.set_font("Helvetica", "B", 9)
+    pdf.set_fill_color(26, 47, 94)
+    pdf.set_text_color(255, 255, 255)
+    pdf.cell(label_w, 8, "", fill=True)
+    for i, v in enumerate(variants):
+        pdf.cell(col_w, 8, v["material"][:30], align="C", fill=True)
+    pdf.ln()
+    pdf.set_text_color(0, 0, 0)
+
+    # Rows definition
+    rows = [
+        ("Precio / m\u00b2", "price_m2"),
+        ("Superficie", "m2"),
+        ("Total Material", "total_mat"),
+        ("Descuento", "discount"),
+        ("Mano de Obra", "mo_total"),
+        ("Merma", "merma"),
+        ("Plazo de entrega", "delivery"),
+    ]
+
+    row_counter = 0
+    for label, key in rows:
+        is_odd = row_counter % 2 == 0
+        if is_odd:
+            pdf.set_fill_color(242, 242, 242)
+        else:
+            pdf.set_fill_color(255, 255, 255)
+
+        pdf.set_font("Helvetica", "B", 9)
+        pdf.cell(label_w, 7, label, fill=True)
+        pdf.set_font("Helvetica", "", 9)
+        for v in variants:
+            pdf.cell(col_w, 7, str(v[key])[:35], align="C", fill=True)
+        pdf.ln()
+        row_counter += 1
+
+    # Total rows — highlighted
+    pdf.ln(2)
+    pdf.set_draw_color(26, 47, 94)
+    pdf.line(10, pdf.get_y(), 287, pdf.get_y())
+    pdf.ln(2)
+
+    for total_label, total_key, fmt_fn in [
+        ("TOTAL ARS", "total_ars", _fmt_ars),
+        ("TOTAL USD", "total_usd", _fmt_usd),
+    ]:
+        pdf.set_font("Helvetica", "B", 10)
+        pdf.cell(label_w, 9, total_label)
+        for i, v in enumerate(variants):
+            val = v[total_key]
+            text = fmt_fn(val) if val else "—"
+            if i == best_idx:
+                pdf.set_text_color(0, 128, 0)
+            pdf.cell(col_w, 9, text, align="C")
+            pdf.set_text_color(0, 0, 0)
+        pdf.ln()
+
+    # Best option indicator
+    pdf.ln(4)
+    pdf.set_font("Helvetica", "I", 9)
+    pdf.set_text_color(0, 128, 0)
+    best_name = variants[best_idx]["material"]
+    pdf.cell(0, 5, f"* Opcion mas economica: {best_name}", new_x="LMARGIN", new_y="NEXT")
+    pdf.set_text_color(0, 0, 0)
+
+    # Footer conditions
+    pdf.ln(6)
+    pdf.set_font("Helvetica", "", 7)
+    for line in [
+        "*PRESUPUESTO SUJETO A VARIACION DE PRECIO",
+        "*MATERIALES IMPORTADOS SEGUN COTIZACION DOLAR VENTA BANCO NACION AL MOMENTO DE LA CONFIRMACION",
+        "*LOS PRECIOS INCLUYEN IVA",
+    ]:
+        pdf.cell(0, 3, line, new_x="LMARGIN", new_y="NEXT")
+
+    pdf.output(str(pdf_path))

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,1836 @@
+{
+  "name": "marble-operator-web",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "marble-operator-web",
+      "version": "1.0.0",
+      "dependencies": {
+        "@codemirror/lang-json": "^6.0.2",
+        "@codemirror/theme-one-dark": "^6.1.3",
+        "@types/node": "^20.14.0",
+        "@types/papaparse": "^5.5.2",
+        "@types/react": "^18.3.0",
+        "@types/react-dom": "^18.3.0",
+        "@uiw/react-codemirror": "^4.25.9",
+        "autoprefixer": "^10.4.0",
+        "clsx": "^2.1.1",
+        "date-fns": "^3.6.0",
+        "lucide-react": "^0.383.0",
+        "next": "14.2.29",
+        "papaparse": "^5.5.3",
+        "postcss": "^8.4.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0",
+        "tailwindcss": "^3.4.0",
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
+      "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.0.tgz",
+      "integrity": "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
+      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
+    },
+    "node_modules/@next/env": {
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.29.tgz",
+      "integrity": "sha512-UzgLR2eBfhKIQt0aJ7PWH7XRPYw7SXz0Fpzdl5THjUnvxy4kfBk9OU4RNPNiETewEEtaBcExNFNn1QWH8wQTjg==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.29.tgz",
+      "integrity": "sha512-wWtrAaxCVMejxPHFb1SK/PVV1WDIrXGs9ki0C/kUM8ubKHQm+3hU9MouUywCw8Wbhj3pewfHT2wjunLEr/TaLA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.29.tgz",
+      "integrity": "sha512-7Z/jk+6EVBj4pNLw/JQrvZVrAh9Bv8q81zCFSfvTMZ51WySyEHWVpwCEaJY910LyBftv2F37kuDPQm0w9CEXyg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.29.tgz",
+      "integrity": "sha512-o6hrz5xRBwi+G7JFTHc+RUsXo2lVXEfwh4/qsuWBMQq6aut+0w98WEnoNwAwt7hkEqegzvazf81dNiwo7KjITw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.29.tgz",
+      "integrity": "sha512-9i+JEHBOVgqxQ92HHRFlSW1EQXqa/89IVjtHgOqsShCcB/ZBjTtkWGi+SGCJaYyWkr/lzu51NTMCfKuBf7ULNw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.29.tgz",
+      "integrity": "sha512-B7JtMbkUwHijrGBOhgSQu2ncbCYq9E7PZ7MX58kxheiEOwdkM+jGx0cBb+rN5AeqF96JypEppK6i/bEL9T13lA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.29.tgz",
+      "integrity": "sha512-yCcZo1OrO3aQ38B5zctqKU1Z3klOohIxug6qdiKO3Q3qNye/1n6XIs01YJ+Uf+TdpZQ0fNrOQI2HrTLF3Zprnw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.29.tgz",
+      "integrity": "sha512-WnrfeOEtTVidI9Z6jDLy+gxrpDcEJtZva54LYC0bSKQqmyuHzl0ego+v0F/v2aXq0am67BRqo/ybmmt45Tzo4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.29.tgz",
+      "integrity": "sha512-vkcriFROT4wsTdSeIzbxaZjTNTFKjSYmLd8q/GVH3Dn8JmYjUKOuKXHK8n+lovW/kdcpIvydO5GtN+It2CvKWA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.29.tgz",
+      "integrity": "sha512-iPPwUEKnVs7pwR0EBLJlwxLD7TTHWS/AoVZx1l9ZQzfQciqaFEr5AlYzA2uB6Fyby1IF18t4PL0nTpB+k4Tzlw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/papaparse": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.5.2.tgz",
+      "integrity": "sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@uiw/codemirror-extensions-basic-setup": {
+      "version": "4.25.9",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.9.tgz",
+      "integrity": "sha512-QFAqr+pu6lDmNpAlecODcF49TlsrZ0bj15zPzfhiqSDl+Um3EsDLFLppixC7kFLn+rdDM2LTvVjn5CPvefpRgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": ">=6.0.0",
+        "@codemirror/commands": ">=6.0.0",
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/lint": ">=6.0.0",
+        "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.25.9",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.9.tgz",
+      "integrity": "sha512-HftqCBUYShAOH0pGi1CHP8vfm5L8fQ3+0j0VI6lQD6QpK+UBu3J7nxfEN5O/BXMilMNf9ZyFJRvRcuMMOLHMng==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.25.9",
+        "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/theme-one-dark": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0",
+        "codemirror": ">=6.0.0",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.27",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001774",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
+      "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001784",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
+      "integrity": "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.331",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
+      "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
+      "license": "ISC"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.383.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.383.0.tgz",
+      "integrity": "sha512-13xlG0CQCJtzjSQYwwJ3WRqMHtRj3EXmLlorrARt7y+IHnxUCp3XyFNL1DfaGySWxHObDvnu1u1dV+0VMKHUSg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.29.tgz",
+      "integrity": "sha512-s98mCOMOWLGGpGOfgKSnleXLuegvvH415qtRZXpSp00HeEgdmrxmwL9cgKU+h4XrhB16zEI5d/7BnkS3ATInsA==",
+      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.2.29",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.29",
+        "@next/swc-darwin-x64": "14.2.29",
+        "@next/swc-linux-arm64-gnu": "14.2.29",
+        "@next/swc-linux-arm64-musl": "14.2.29",
+        "@next/swc-linux-x64-gnu": "14.2.29",
+        "@next/swc-linux-x64-musl": "14.2.29",
+        "@next/swc-win32-arm64-msvc": "14.2.29",
+        "@next/swc-win32-ia32-msvc": "14.2.29",
+        "@next/swc-win32-x64-msvc": "14.2.29"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -9,18 +9,23 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "14.2.29",
-    "react": "^18.3.0",
-    "react-dom": "^18.3.0",
-    "typescript": "^5.4.0",
+    "@codemirror/lang-json": "^6.0.2",
+    "@codemirror/theme-one-dark": "^6.1.3",
     "@types/node": "^20.14.0",
+    "@types/papaparse": "^5.5.2",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
-    "tailwindcss": "^3.4.0",
-    "postcss": "^8.4.0",
+    "@uiw/react-codemirror": "^4.25.9",
     "autoprefixer": "^10.4.0",
-    "lucide-react": "^0.383.0",
     "clsx": "^2.1.1",
-    "date-fns": "^3.6.0"
+    "date-fns": "^3.6.0",
+    "lucide-react": "^0.383.0",
+    "next": "14.2.29",
+    "papaparse": "^5.5.3",
+    "postcss": "^8.4.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.4.0"
   }
 }

--- a/web/src/app/config/page.tsx
+++ b/web/src/app/config/page.tsx
@@ -1,63 +1,118 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useEffect, useState, useCallback } from "react";
+import dynamic from "next/dynamic";
 import { fetchCatalogs, fetchCatalog, validateCatalog, updateCatalog } from "@/lib/api";
 import { useToast } from "@/lib/toast-context";
-import clsx from "clsx";
+import CatalogSidebar from "@/components/catalog/CatalogSidebar";
+import CatalogToolbar from "@/components/catalog/CatalogToolbar";
+import CsvImportModal from "@/components/catalog/CsvImportModal";
 
-interface CatalogMeta { name: string; item_count: number; last_updated: string | null; size_kb: number; }
+// Dynamic import to avoid SSR issues with CodeMirror
+const CatalogEditor = dynamic(() => import("@/components/catalog/CatalogEditor"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex-1 flex items-center justify-center">
+      <div className="flex flex-col items-center gap-3">
+        <div className="w-5 h-5 border-2 border-acc/30 border-t-acc rounded-full animate-spin" />
+        <span className="text-xs text-t3">Cargando editor...</span>
+      </div>
+    </div>
+  ),
+});
 
-const GROUPS = [
-  { label: "Mano de obra", items: ["labor", "delivery-zones"] },
-  { label: "Materiales", items: ["materials-silestone", "materials-purastone", "materials-dekton", "materials-neolith", "materials-puraprima", "materials-laminatto", "materials-granito-nacional", "materials-granito-importado", "materials-marmol"] },
-  { label: "Piletas y otros", items: ["sinks", "stock", "architects", "config"] },
-];
+interface CatalogMeta {
+  name: string;
+  item_count: number;
+  last_updated: string | null;
+  size_kb: number;
+}
+
+interface Validation {
+  valid: boolean;
+  warnings: { type: string; sku?: string; message: string }[];
+}
 
 export default function ConfigPage() {
-  const router = useRouter();
   const [catalogs, setCatalogs] = useState<CatalogMeta[]>([]);
   const [selected, setSelected] = useState("labor");
   const [content, setContent] = useState("");
   const [originalContent, setOriginalContent] = useState("");
-  const [validation, setValidation] = useState<{ valid: boolean; warnings: any[] } | null>(null);
+  const [validation, setValidation] = useState<Validation | null>(null);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [validating, setValidating] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [csvImportOpen, setCsvImportOpen] = useState(false);
+  const [warningsExpanded, setWarningsExpanded] = useState(true);
   const toast = useToast();
-
-  useEffect(() => {
-    fetchCatalogs().then(setCatalogs).catch((err: any) => {
-      toast(err.message || "Error al cargar catálogos");
-    });
-  }, [toast]);
-
-  useEffect(() => {
-    setLoading(true); setValidation(null); setLoadError(null);
-    fetchCatalog(selected).then(d => {
-      const s = JSON.stringify(d, null, 2);
-      setContent(s); setOriginalContent(s);
-    }).catch((err: any) => {
-      setLoadError(err.message || "Error al cargar catálogo");
-    }).finally(() => setLoading(false));
-  }, [selected]);
 
   const hasChanges = content !== originalContent;
   const meta = catalogs.find(c => c.name === selected);
 
-  async function handleValidate() {
+  // Load catalog list
+  useEffect(() => {
+    fetchCatalogs().then(setCatalogs).catch((err: any) => {
+      toast(err.message || "Error al cargar catalogos");
+    });
+  }, [toast]);
+
+  // Load selected catalog
+  const loadCatalog = useCallback((name: string) => {
+    setLoading(true);
+    setValidation(null);
+    setLoadError(null);
+    fetchCatalog(name)
+      .then(d => {
+        const s = JSON.stringify(d, null, 2);
+        setContent(s);
+        setOriginalContent(s);
+      })
+      .catch((err: any) => {
+        setLoadError(err.message || "Error al cargar catalogo");
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    loadCatalog(selected);
+  }, [selected, loadCatalog]);
+
+  // Switch catalog with unsaved guard
+  const handleSelectCatalog = useCallback(
+    (name: string) => {
+      if (name === selected) return;
+      if (hasChanges) {
+        const ok = window.confirm(
+          "Tenes cambios sin guardar. Si cambias de catalogo se van a perder.\n\n¿Continuar?"
+        );
+        if (!ok) return;
+      }
+      setSelected(name);
+    },
+    [selected, hasChanges]
+  );
+
+  // Validate
+  const handleValidate = useCallback(async () => {
     setValidating(true);
     try {
       const parsed = JSON.parse(content);
       const result = await validateCatalog(selected, parsed);
       setValidation(result);
+      setWarningsExpanded(true);
     } catch {
-      setValidation({ valid: false, warnings: [{ type: "error", message: "JSON inválido — revisá la sintaxis" }] });
-    } finally { setValidating(false); }
-  }
+      setValidation({
+        valid: false,
+        warnings: [{ type: "error", message: "JSON invalido — revisa la sintaxis" }],
+      });
+    } finally {
+      setValidating(false);
+    }
+  }, [content, selected]);
 
-  async function handleSave() {
+  // Save
+  const handleSave = useCallback(async () => {
     if (!validation?.valid) return;
     setSaving(true);
     try {
@@ -66,129 +121,134 @@ export default function ConfigPage() {
       setValidation(null);
       const updated = await fetchCatalogs();
       setCatalogs(updated);
-      toast("Catálogo guardado correctamente", "success");
+      toast("Catalogo guardado correctamente", "success");
     } catch (err: any) {
-      toast(err.message || "Error al guardar catálogo");
-    } finally { setSaving(false); }
-  }
+      toast(err.message || "Error al guardar catalogo");
+    } finally {
+      setSaving(false);
+    }
+  }, [validation, content, selected, toast]);
 
-  const disableValidate = !hasChanges || validating;
-  const disableSave = !validation?.valid || saving || !hasChanges;
+  // CSV import apply
+  const handleCsvApply = useCallback((jsonString: string) => {
+    setContent(jsonString);
+    setValidation(null);
+    toast("Datos importados. Valida y guarda para confirmar.", "warning");
+  }, [toast]);
+
+  // Keyboard shortcut: Ctrl/Cmd+S to save
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+        e.preventDefault();
+        if (validation?.valid && hasChanges && !saving) {
+          handleSave();
+        }
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [validation, hasChanges, saving, handleSave]);
 
   return (
     <div className="flex flex-col h-full">
-      {/* Header */}
-      <div className="flex items-center justify-between px-7 pt-5 pb-[18px] border-b border-b1 shrink-0">
-        <div className="flex items-center gap-3">
-          <button
-            onClick={() => router.push("/")}
-            className="w-[30px] h-[30px] rounded-md border border-b1 bg-transparent text-t2 cursor-pointer flex items-center justify-center transition hover:border-b2 hover:text-t1"
-          >
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="15 18 9 12 15 6"/></svg>
-          </button>
-          <div>
-            <div className="text-lg font-medium -tracking-[0.03em]">Catálogo</div>
-            <div className="text-[11px] text-t3 mt-0.5">Validación IA antes de guardar</div>
-          </div>
-        </div>
-        <div className="flex gap-[7px]">
-          <button
-            onClick={handleValidate}
-            disabled={disableValidate}
-            className={clsx(
-              "px-3 py-[7px] rounded-md text-xs font-medium font-sans border border-b1 bg-transparent text-t2 -tracking-[0.01em] transition",
-              disableValidate ? "opacity-40 cursor-not-allowed" : "cursor-pointer hover:border-b2 hover:text-t1",
-            )}
-          >
-            {validating ? "Validando..." : "Validar con IA"}
-          </button>
-          <button
-            onClick={handleSave}
-            disabled={disableSave}
-            className={clsx(
-              "px-3 py-[7px] rounded-md text-xs font-medium font-sans border bg-acc-bg border-acc-hover text-acc -tracking-[0.01em] transition",
-              disableSave ? "opacity-40 cursor-not-allowed" : "cursor-pointer hover:bg-acc/20",
-            )}
-          >
-            {saving ? "Guardando..." : "Guardar cambios"}
-          </button>
-        </div>
-      </div>
+      {/* Toolbar */}
+      <CatalogToolbar
+        catalogName={selected}
+        meta={meta}
+        hasChanges={hasChanges}
+        validation={validation}
+        validating={validating}
+        saving={saving}
+        onValidate={handleValidate}
+        onSave={handleSave}
+        onImport={() => setCsvImportOpen(true)}
+        onBack={() => window.history.back()}
+      />
 
       <div className="flex-1 flex flex-col md:flex-row overflow-hidden">
-        {/* Catalog list */}
-        <div className="md:w-[200px] shrink-0 bg-s1 border-b md:border-b-0 md:border-r border-b1 px-2 py-2 md:py-3 overflow-x-auto md:overflow-x-hidden overflow-y-auto flex md:block gap-1 md:gap-0">
-          {GROUPS.map(group => (
-            <div key={group.label}>
-              <div className="hidden md:block text-[10px] font-medium text-t4 uppercase tracking-[0.09em] px-2 pt-2 pb-1 mt-1.5">
-                {group.label}
-              </div>
-              {group.items.map(name => {
-                const m = catalogs.find(c => c.name === name);
-                const isActive = selected === name;
-                return (
-                  <button
-                    key={name}
-                    onClick={() => setSelected(name)}
-                    className={clsx(
-                      "flex flex-col gap-0.5 p-2 rounded-md text-xs cursor-pointer border-none w-full md:w-full shrink-0 md:shrink text-left transition-all duration-100 font-sans whitespace-nowrap md:whitespace-normal",
-                      isActive ? "text-acc bg-acc-bg" : "text-t2 bg-transparent hover:bg-white/[0.04]",
-                    )}
-                  >
-                    {name}.json
-                    <span className={clsx("text-[10px]", isActive ? "text-acc/55" : "text-t3")}>
-                      {m ? `${m.item_count} ítems` : "\u2014"}
-                      {m?.last_updated ? ` · ${m.last_updated}` : ""}
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
-          ))}
-        </div>
+        {/* Sidebar */}
+        <CatalogSidebar
+          catalogs={catalogs}
+          selected={selected}
+          onSelect={handleSelectCatalog}
+          hasUnsavedChanges={hasChanges}
+        />
 
-        {/* Editor */}
+        {/* Editor area */}
         <div className="flex-1 flex flex-col overflow-hidden">
-          <div className="flex items-center justify-between px-[22px] py-3 border-b border-b1 bg-black/[0.12] shrink-0">
-            <div className="text-[13px] font-medium text-t1 flex items-center gap-2.5">
-              {selected}.json
-              {meta && (
-                <span className="text-[10px] px-2 py-[2px] rounded-full font-medium bg-amb-bg text-amb border border-amb/[0.16]">
-                  {meta.item_count} ítems{meta.last_updated ? ` · ${meta.last_updated}` : ""}
-                </span>
-              )}
-              {validation?.valid && !hasChanges && (
-                <span className="text-[10px] px-2 py-[2px] rounded-full font-medium bg-grn-bg text-grn border border-grn/[0.18]">
-                  ✓ Válido
-                </span>
-              )}
-            </div>
-            <span className="text-[11px] text-t3">
-              {hasChanges && !validation && "• Cambios sin guardar"}
-              {validation?.valid && hasChanges && "✓ Validado"}
-              {validation && !validation.valid && "✕ Error"}
-            </span>
-          </div>
-
-          <div className="flex-1 px-[22px] py-4 flex flex-col gap-2.5 overflow-hidden">
-            {validation && validation.warnings.length > 0 && (
-              <div className="bg-amb/[0.06] border border-amb/[0.16] rounded-[7px] px-[13px] py-2.5 text-xs text-amb/85 flex gap-2">
-                <span>⚠</span>
-                <div>{validation.warnings.map((w: any, i: number) => (
-                  <div key={i}>{w.sku && <strong>{w.sku}: </strong>}{w.message}</div>
-                ))}</div>
+          {/* Validation warnings */}
+          {validation && validation.warnings.length > 0 && (
+            <div className="px-5 pt-3 shrink-0">
+              <div className="bg-amb/[0.05] border border-amb/[0.14] rounded-lg overflow-hidden">
+                <button
+                  onClick={() => setWarningsExpanded(!warningsExpanded)}
+                  className="w-full flex items-center gap-2 px-3.5 py-2.5 text-xs text-amb bg-transparent border-none cursor-pointer font-sans text-left hover:bg-amb/[0.03] transition"
+                >
+                  <svg
+                    width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
+                    className={`transition-transform ${warningsExpanded ? "rotate-90" : ""}`}
+                  >
+                    <polyline points="9 18 15 12 9 6" />
+                  </svg>
+                  <span className="font-medium">
+                    {validation.warnings.length} advertencia{validation.warnings.length > 1 ? "s" : ""}
+                  </span>
+                  {!validation.valid && (
+                    <span className="text-err text-[10px] ml-1">— corregir antes de guardar</span>
+                  )}
+                </button>
+                {warningsExpanded && (
+                  <div className="px-3.5 pb-2.5 flex flex-col gap-1">
+                    {validation.warnings.map((w, i) => (
+                      <div key={i} className="flex items-start gap-2 text-[11px] text-amb/85 py-0.5">
+                        <span className="shrink-0 mt-0.5">
+                          {w.type === "error" ? (
+                            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#ff453a" strokeWidth="2"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
+                          ) : (
+                            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+                          )}
+                        </span>
+                        <span>
+                          {w.sku && (
+                            <span className="font-mono text-[10px] px-1 py-px rounded bg-white/[0.05] mr-1.5">
+                              {w.sku}
+                            </span>
+                          )}
+                          {w.message}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
-            )}
-            <textarea
-              value={loading ? "Cargando..." : loadError ? `Error: ${loadError}` : content}
-              onChange={e => setContent(e.target.value)}
-              disabled={loading}
-              spellCheck={false}
-              className="flex-1 bg-black/[0.28] border border-b1 rounded-lg p-3.5 font-mono text-xs text-t2 resize-none outline-none leading-[1.75] transition-[border-color] duration-150 focus:border-acc"
-            />
+            </div>
+          )}
+
+          {/* Editor */}
+          <div className="flex-1 overflow-hidden px-5 py-3">
+            <div className="h-full border border-b1 rounded-lg overflow-hidden">
+              <CatalogEditor
+                value={content}
+                onChange={setContent}
+                loading={loading}
+                loadError={loadError}
+                onRetry={() => loadCatalog(selected)}
+              />
+            </div>
           </div>
         </div>
       </div>
+
+      {/* CSV Import Modal */}
+      {csvImportOpen && (
+        <CsvImportModal
+          catalogName={selected}
+          currentContent={content}
+          onApply={handleCsvApply}
+          onClose={() => setCsvImportOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -2,9 +2,10 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useRouter, useParams } from "next/navigation";
-import { fetchQuote, streamChat, markQuoteAsRead, type QuoteDetail } from "@/lib/api";
+import { fetchQuote, streamChat, markQuoteAsRead, fetchQuoteComparison, type QuoteDetail, type QuoteCompareResponse } from "@/lib/api";
 import { useQuotes } from "@/lib/quotes-context";
 import MessageBubble from "@/components/chat/MessageBubble";
+import CompareView from "@/components/quote/CompareView";
 import clsx from "clsx";
 
 export interface UIMessage {
@@ -45,8 +46,9 @@ export default function QuotePage() {
   const quoteId = params.id as string;
 
   const [quote, setQuote] = useState<QuoteDetail | null>(null);
+  const [comparison, setComparison] = useState<QuoteCompareResponse | null>(null);
   const [messages, setMessages] = useState<UIMessage[]>([]);
-  const [tab, setTab] = useState<"detail" | "chat">("chat");
+  const [tab, setTab] = useState<"detail" | "chat" | "compare">("chat");
   const [input, setInput] = useState("");
   const [attachedFiles, setAttachedFiles] = useState<File[]>([]);
   const [dragActive, setDragActive] = useState(false);
@@ -78,6 +80,8 @@ export default function QuotePage() {
     }).catch((err: any) => {
       setLoadError(err.message || "Error al cargar presupuesto");
     }).finally(() => setLoading(false));
+
+    fetchQuoteComparison(quoteId).then(c => setComparison(c)).catch(() => {});
   }, [quoteId]);
 
   useEffect(() => {
@@ -104,7 +108,7 @@ export default function QuotePage() {
       { id: aid, role: "assistant", content: "", isStreaming: true },
     ]);
     setInput(""); setAttachedFiles([]); setSending(true); setActionText("");
-    if (tab === "detail") setTab("chat");
+    if (tab !== "chat") setTab("chat");
 
     try {
       let acc = "";
@@ -130,6 +134,7 @@ export default function QuotePage() {
           const updated = await fetchQuote(quoteId);
           setQuote(updated);
           refreshQuotes();
+          fetchQuoteComparison(quoteId).then(c => setComparison(c)).catch(() => {});
         }
       }
       if (!gotDone) {
@@ -190,10 +195,15 @@ export default function QuotePage() {
       <div className="flex border-b border-b1 bg-s1 pl-7">
         <TabBtn active={tab === "detail"} onClick={() => setTab("detail")} disabled={!quote || quote.status === "draft"}>Detalle</TabBtn>
         <TabBtn active={tab === "chat"} onClick={() => setTab("chat")}>Chat</TabBtn>
+        {comparison && <TabBtn active={tab === "compare"} onClick={() => setTab("compare")}>Comparar</TabBtn>}
       </div>
 
       {/* Content */}
-      {tab === "detail" ? (
+      {tab === "compare" && comparison ? (
+        <div className="flex-1 overflow-y-auto px-7 py-6">
+          <CompareView data={comparison} />
+        </div>
+      ) : tab === "detail" ? (
         <div className="flex-1 overflow-y-auto px-7 py-6">
           <DetailView quote={quote} breakdown={bd} onSwitchToChat={() => setTab("chat")} />
           <Section title="Modificaciones" className="mt-5">
@@ -202,7 +212,7 @@ export default function QuotePage() {
             <button onClick={() => setTab("chat")} className="mt-2 bg-transparent border-none text-acc text-xs cursor-pointer font-sans p-0">Ver historial completo \u2192</button>
           </Section>
         </div>
-      ) : (
+      ) : tab === "chat" ? (
         <>
           <div className="flex-1 overflow-y-auto px-7 pt-7 pb-4 flex flex-col gap-5">
             {messages.length === 0 && (
@@ -218,7 +228,7 @@ export default function QuotePage() {
             <div className="text-[10px] text-t4 text-center mt-[7px]">Enter para enviar \u00B7 Shift+Enter para nueva l\u00EDnea</div>
           </div>
         </>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/web/src/components/catalog/CatalogEditor.tsx
+++ b/web/src/components/catalog/CatalogEditor.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useCallback, useMemo, useRef } from "react";
+import CodeMirror, { type ReactCodeMirrorRef } from "@uiw/react-codemirror";
+import { json, jsonParseLinter } from "@codemirror/lang-json";
+import { linter } from "@codemirror/lint";
+import { search } from "@codemirror/search";
+import { bracketMatching, foldGutter } from "@codemirror/language";
+import { highlightActiveLine, lineNumbers, EditorView } from "@codemirror/view";
+import { catalogEditorTheme, catalogHighlighting } from "./catalog-theme";
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  loading: boolean;
+  loadError: string | null;
+  onRetry: () => void;
+}
+
+export default function CatalogEditor({ value, onChange, loading, loadError, onRetry }: Props) {
+  const editorRef = useRef<ReactCodeMirrorRef>(null);
+
+  const extensions = useMemo(
+    () => [
+      json(),
+      linter(jsonParseLinter()),
+      foldGutter(),
+      bracketMatching(),
+      highlightActiveLine(),
+      lineNumbers(),
+      search(),
+      catalogHighlighting,
+      EditorView.lineWrapping,
+    ],
+    []
+  );
+
+  const handleChange = useCallback(
+    (val: string) => {
+      onChange(val);
+    },
+    [onChange]
+  );
+
+  if (loading) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="flex flex-col items-center gap-3">
+          <div className="w-5 h-5 border-2 border-acc/30 border-t-acc rounded-full animate-spin" />
+          <span className="text-xs text-t3">Cargando catalogo...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <div className="text-red text-sm font-medium">{loadError}</div>
+          <button
+            onClick={onRetry}
+            className="px-3 py-1.5 rounded-md text-xs font-medium border border-b1 bg-transparent text-t2 cursor-pointer hover:border-b2 hover:text-t1 transition font-sans"
+          >
+            Reintentar
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-hidden">
+      <CodeMirror
+        ref={editorRef}
+        value={value}
+        onChange={handleChange}
+        theme={catalogEditorTheme}
+        extensions={extensions}
+        basicSetup={false}
+        height="100%"
+        style={{ height: "100%", overflow: "auto" }}
+      />
+    </div>
+  );
+}

--- a/web/src/components/catalog/CatalogSidebar.tsx
+++ b/web/src/components/catalog/CatalogSidebar.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import clsx from "clsx";
+
+interface CatalogMeta {
+  name: string;
+  item_count: number;
+  last_updated: string | null;
+  size_kb: number;
+}
+
+interface Props {
+  catalogs: CatalogMeta[];
+  selected: string;
+  onSelect: (name: string) => void;
+  hasUnsavedChanges: boolean;
+}
+
+const GROUPS = [
+  { label: "Mano de obra", items: ["labor", "delivery-zones"] },
+  {
+    label: "Materiales",
+    items: [
+      "materials-silestone", "materials-purastone", "materials-dekton",
+      "materials-neolith", "materials-puraprima", "materials-laminatto",
+      "materials-granito-nacional", "materials-granito-importado", "materials-marmol",
+    ],
+  },
+  { label: "Piletas y otros", items: ["sinks", "stock", "architects", "config"] },
+];
+
+const DISPLAY_NAME: Record<string, string> = {
+  labor: "Mano de obra",
+  "delivery-zones": "Zonas de envio",
+  "materials-silestone": "Silestone",
+  "materials-purastone": "Purastone",
+  "materials-dekton": "Dekton",
+  "materials-neolith": "Neolith",
+  "materials-puraprima": "Puraprima",
+  "materials-laminatto": "Laminatto",
+  "materials-granito-nacional": "Granito Nacional",
+  "materials-granito-importado": "Granito Importado",
+  "materials-marmol": "Marmol",
+  sinks: "Piletas",
+  stock: "Stock retazos",
+  architects: "Arquitectas",
+  config: "Configuracion",
+};
+
+export default function CatalogSidebar({ catalogs, selected, onSelect, hasUnsavedChanges }: Props) {
+  return (
+    <aside className="md:w-[240px] shrink-0 bg-s1 border-b md:border-b-0 md:border-r border-b1 overflow-x-auto md:overflow-x-hidden overflow-y-auto flex md:flex-col gap-1 md:gap-0 px-2 py-2 md:py-0">
+      {GROUPS.map((group, gi) => (
+        <div key={group.label}>
+          {/* Group header */}
+          <div className={clsx(
+            "hidden md:flex items-center gap-2 px-3 pt-4 pb-2",
+            gi > 0 && "mt-1 border-t border-b1",
+          )}>
+            <span className="text-[10px] font-semibold text-t4 uppercase tracking-[0.10em]">
+              {group.label}
+            </span>
+          </div>
+
+          {/* Items */}
+          {group.items.map(name => {
+            const meta = catalogs.find(c => c.name === name);
+            const isActive = selected === name;
+            const displayName = DISPLAY_NAME[name] || name;
+
+            return (
+              <button
+                key={name}
+                onClick={() => onSelect(name)}
+                className={clsx(
+                  "group flex items-center gap-2.5 w-full md:w-full shrink-0 px-3 py-2 md:py-[9px] rounded-lg text-left transition-all duration-100 font-sans border-none cursor-pointer whitespace-nowrap md:whitespace-normal",
+                  isActive
+                    ? "bg-acc/[0.10] text-acc border-l-2 border-l-acc md:ml-0"
+                    : "bg-transparent text-t2 hover:bg-white/[0.04] hover:text-t1",
+                )}
+              >
+                {/* Name + unsaved dot */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-1.5">
+                    <span className={clsx("text-[13px] font-medium truncate", isActive ? "text-acc" : "text-t1")}>
+                      {displayName}
+                    </span>
+                    {isActive && hasUnsavedChanges && (
+                      <span className="w-1.5 h-1.5 rounded-full bg-amb shrink-0" title="Cambios sin guardar" />
+                    )}
+                  </div>
+                  <div className={clsx("text-[10px] mt-0.5 truncate", isActive ? "text-acc/50" : "text-t3")}>
+                    {meta ? `${meta.item_count} items` : "\u2014"}
+                    {meta?.last_updated ? ` \u00B7 ${meta.last_updated}` : ""}
+                  </div>
+                </div>
+
+                {/* Count badge */}
+                {meta && (
+                  <span className={clsx(
+                    "text-[10px] px-[7px] py-px rounded-full font-mono shrink-0 hidden md:inline-flex",
+                    isActive ? "bg-acc/[0.15] text-acc/70" : "bg-white/[0.05] text-t3",
+                  )}>
+                    {meta.item_count}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      ))}
+    </aside>
+  );
+}

--- a/web/src/components/catalog/CatalogToolbar.tsx
+++ b/web/src/components/catalog/CatalogToolbar.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import clsx from "clsx";
+
+interface CatalogMeta {
+  name: string;
+  item_count: number;
+  last_updated: string | null;
+  size_kb: number;
+}
+
+interface Validation {
+  valid: boolean;
+  warnings: { type: string; sku?: string; message: string }[];
+}
+
+interface Props {
+  catalogName: string;
+  meta: CatalogMeta | undefined;
+  hasChanges: boolean;
+  validation: Validation | null;
+  validating: boolean;
+  saving: boolean;
+  onValidate: () => void;
+  onSave: () => void;
+  onImport: () => void;
+  onBack: () => void;
+}
+
+const IMPORTABLE = new Set([
+  "labor", "delivery-zones", "architects", "sinks",
+  "materials-silestone", "materials-purastone", "materials-dekton",
+  "materials-neolith", "materials-puraprima", "materials-laminatto",
+  "materials-granito-nacional", "materials-granito-importado", "materials-marmol",
+]);
+
+export default function CatalogToolbar({
+  catalogName, meta, hasChanges, validation, validating, saving,
+  onValidate, onSave, onImport, onBack,
+}: Props) {
+  const canImport = IMPORTABLE.has(catalogName);
+  const disableValidate = !hasChanges || validating;
+  const disableSave = !validation?.valid || saving || !hasChanges;
+
+  return (
+    <div className="flex items-center justify-between px-5 py-3 border-b border-b1 bg-s1 shrink-0 gap-3">
+      {/* Left: back + title */}
+      <div className="flex items-center gap-3 shrink-0">
+        <button
+          onClick={onBack}
+          className="w-[30px] h-[30px] rounded-md border border-b1 bg-transparent text-t2 cursor-pointer flex items-center justify-center transition hover:border-b2 hover:text-t1"
+          aria-label="Volver"
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="15 18 9 12 15 6"/></svg>
+        </button>
+        <div>
+          <div className="text-[15px] font-medium text-t1 -tracking-[0.02em]">Catalogo</div>
+          <div className="text-[10px] text-t3 mt-0.5">Validacion IA antes de guardar</div>
+        </div>
+      </div>
+
+      {/* Center: filename + badges + status */}
+      <div className="flex items-center gap-2.5 flex-1 justify-center min-w-0">
+        <span className="text-[13px] font-medium text-t1 font-mono">{catalogName}.json</span>
+        {meta && (
+          <span className="text-[10px] px-2 py-[2px] rounded-full font-medium bg-white/[0.05] text-t3 border border-b1 shrink-0">
+            {meta.item_count} items
+          </span>
+        )}
+        {meta?.last_updated && (
+          <span className="text-[10px] text-t4 shrink-0 hidden lg:inline">
+            {meta.last_updated}
+          </span>
+        )}
+
+        {/* Status indicator */}
+        {hasChanges && !validation && (
+          <span className="flex items-center gap-1 text-[10px] text-amb font-medium">
+            <span className="w-1.5 h-1.5 rounded-full bg-amb" />
+            Sin guardar
+          </span>
+        )}
+        {validation?.valid && hasChanges && (
+          <span className="flex items-center gap-1 text-[10px] text-grn font-medium">
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3"><polyline points="20 6 9 17 4 12"/></svg>
+            Validado
+          </span>
+        )}
+        {validation && !validation.valid && (
+          <span className="flex items-center gap-1 text-[10px] text-err font-medium">
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+            Error
+          </span>
+        )}
+      </div>
+
+      {/* Right: action buttons */}
+      <div className="flex items-center gap-2 shrink-0">
+        {canImport && (
+          <button
+            onClick={onImport}
+            className="flex items-center gap-1.5 px-3 py-[7px] rounded-md text-xs font-medium font-sans border border-b1 bg-transparent text-t2 -tracking-[0.01em] transition cursor-pointer hover:border-b2 hover:text-t1"
+            aria-label="Importar datos"
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+            Importar
+          </button>
+        )}
+        <button
+          onClick={onValidate}
+          disabled={disableValidate}
+          className={clsx(
+            "px-3 py-[7px] rounded-md text-xs font-medium font-sans border border-b1 bg-transparent text-t2 -tracking-[0.01em] transition",
+            disableValidate ? "opacity-40 cursor-not-allowed" : "cursor-pointer hover:border-b2 hover:text-t1",
+          )}
+        >
+          {validating ? "Validando..." : "Validar con IA"}
+        </button>
+        <button
+          onClick={onSave}
+          disabled={disableSave}
+          className={clsx(
+            "px-3 py-[7px] rounded-md text-xs font-medium font-sans border bg-acc-bg border-acc-hover text-acc -tracking-[0.01em] transition",
+            disableSave ? "opacity-40 cursor-not-allowed" : "cursor-pointer hover:bg-acc/20",
+          )}
+        >
+          {saving ? "Guardando..." : "Guardar"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/catalog/CsvImportModal.tsx
+++ b/web/src/components/catalog/CsvImportModal.tsx
@@ -1,0 +1,700 @@
+"use client";
+
+import { useState, useRef, useCallback, useEffect, useMemo } from "react";
+import Papa from "papaparse";
+import CsvPreviewTable from "./CsvPreviewTable";
+import clsx from "clsx";
+
+interface Props {
+  catalogName: string;
+  currentContent: string;
+  onApply: (jsonString: string) => void;
+  onClose: () => void;
+}
+
+// Column aliases: CSV/JSON field name → canonical JSON field name
+const ALIASES: Record<string, string> = {
+  precio: "price_ars",
+  precio_ars: "price_ars",
+  precio_usd: "price_usd",
+  nombre: "name",
+  tarea: "task",
+  ubicacion: "location",
+  categoria: "category",
+  tipo: "material_type",
+  espesor: "thickness_mm",
+  unidad: "unit",
+  foto: "photo",
+  descuento: "discount_percentage",
+  notas: "notes",
+  moneda: "currency",
+  ultima_actualizacion: "last_updated",
+};
+
+// Required fields per catalog type
+const REQUIRED_FIELDS: Record<string, string[]> = {
+  labor: ["sku", "name", "price_ars"],
+  "delivery-zones": ["sku", "location", "price_ars"],
+  architects: ["name"],
+  sinks: ["sku", "name", "price_ars"],
+  materials: ["sku", "name", "price_usd"],
+};
+
+// SKU field used for merge matching per catalog type
+const SKU_FIELD: Record<string, string> = {
+  architects: "name",
+};
+
+function getRequiredFields(catalogName: string): string[] {
+  if (catalogName.startsWith("materials-")) return REQUIRED_FIELDS.materials;
+  return REQUIRED_FIELDS[catalogName] || ["sku", "name"];
+}
+
+function getSkuField(catalogName: string): string {
+  return SKU_FIELD[catalogName] || "sku";
+}
+
+function normalizeFieldName(field: string): string {
+  const lower = field.toLowerCase().trim().replace(/\s+/g, "_");
+  return ALIASES[lower] || lower;
+}
+
+type Step = "upload" | "preview" | "confirm";
+type ImportMode = "merge" | "replace";
+
+interface MergeStats {
+  updated: number;
+  added: number;
+  unchanged: number;
+  total: number;
+}
+
+export default function CsvImportModal({ catalogName, currentContent, onApply, onClose }: Props) {
+  const [step, setStep] = useState<Step>("upload");
+  const [mode, setMode] = useState<ImportMode>("merge");
+  const [dragActive, setDragActive] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [headers, setHeaders] = useState<string[]>([]);
+  const [rows, setRows] = useState<Record<string, unknown>[]>([]);
+  const [mappedFields, setMappedFields] = useState<Set<string>>(new Set());
+  const [missingRequired, setMissingRequired] = useState<string[]>([]);
+  const [parseErrors, setParseErrors] = useState<string[]>([]);
+  const [fileName, setFileName] = useState("");
+  const [fileType, setFileType] = useState<"csv" | "json">("csv");
+  const fileRef = useRef<HTMLInputElement>(null);
+  const dragCounter = useRef(0);
+
+  // Parse current catalog items for merge
+  const currentItems = useMemo(() => {
+    try {
+      const parsed = JSON.parse(currentContent);
+      if (Array.isArray(parsed)) return parsed;
+      if (parsed?.items && Array.isArray(parsed.items)) return parsed.items;
+      if (parsed?.stock && Array.isArray(parsed.stock)) return parsed.stock;
+      return [];
+    } catch {
+      return [];
+    }
+  }, [currentContent]);
+
+  // Compute merge stats
+  const mergeStats = useMemo((): MergeStats => {
+    if (mode !== "merge" || rows.length === 0) {
+      return { updated: 0, added: 0, unchanged: 0, total: rows.length };
+    }
+    const skuField = getSkuField(catalogName);
+    const existingMap = new Map<string, Record<string, unknown>>();
+    for (const item of currentItems) {
+      const key = String(item[skuField] || "").toUpperCase();
+      if (key) existingMap.set(key, item);
+    }
+
+    let updated = 0;
+    let added = 0;
+    for (const row of rows) {
+      const key = String(row[skuField] || "").toUpperCase();
+      if (!key) { added++; continue; }
+      const existing = existingMap.get(key);
+      if (!existing) {
+        added++;
+      } else {
+        // Check if any imported field actually changes
+        let changed = false;
+        for (const [field, value] of Object.entries(row)) {
+          if (field === skuField) continue;
+          if (value != null && value !== "" && existing[field] !== value) {
+            changed = true;
+            break;
+          }
+        }
+        if (changed) updated++;
+      }
+    }
+    const matchedKeys = new Set(rows.map(r => String(r[skuField] || "").toUpperCase()).filter(Boolean));
+    const unchanged = currentItems.filter((item: Record<string, unknown>) => {
+      const key = String(item[skuField] || "").toUpperCase();
+      return key && !matchedKeys.has(key);
+    }).length + (rows.length - updated - added);
+
+    return {
+      updated,
+      added,
+      unchanged: currentItems.length - updated + added > 0 ? currentItems.length - updated : 0,
+      total: currentItems.length - updated + rows.length,
+    };
+  }, [mode, rows, currentItems, catalogName]);
+
+  // Escape to close
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  // Normalize rows: apply field aliases to all keys
+  const normalizeRows = useCallback((rawRows: Record<string, unknown>[], rawHeaders: string[]): {
+    normalizedHeaders: string[];
+    normalizedRows: Record<string, unknown>[];
+    mapped: Set<string>;
+  } => {
+    const normalizedHeaders = rawHeaders.map(normalizeFieldName);
+    const mapped = new Set(normalizedHeaders);
+
+    const normalizedRows = rawRows.map(row => {
+      const out: Record<string, unknown> = {};
+      rawHeaders.forEach((origH, i) => {
+        out[normalizedHeaders[i]] = row[origH];
+      });
+      return out;
+    });
+
+    return { normalizedHeaders, normalizedRows, mapped };
+  }, []);
+
+  // Parse CSV file
+  const parseCsvFile = useCallback((file: File) => {
+    Papa.parse(file, {
+      header: true,
+      skipEmptyLines: true,
+      dynamicTyping: true,
+      complete(results) {
+        if (!results.data || results.data.length === 0) {
+          setError("El archivo CSV esta vacio o no se pudo leer.");
+          return;
+        }
+
+        const csvHeaders = results.meta.fields || [];
+        const csvRows = results.data as Record<string, unknown>[];
+        const { normalizedHeaders, normalizedRows, mapped } = normalizeRows(csvRows, csvHeaders);
+
+        const required = getRequiredFields(catalogName);
+        const missing = required.filter(f => !mapped.has(f));
+
+        const errs: string[] = [];
+        if (results.errors.length > 0) {
+          for (const e of results.errors.slice(0, 5)) {
+            errs.push(`Fila ${e.row ?? "?"}: ${e.message}`);
+          }
+          if (results.errors.length > 5) {
+            errs.push(`...y ${results.errors.length - 5} errores mas`);
+          }
+        }
+
+        setHeaders(normalizedHeaders);
+        setRows(normalizedRows);
+        setMappedFields(mapped);
+        setMissingRequired(missing);
+        setParseErrors(errs);
+        setStep("preview");
+      },
+      error(err) {
+        setError(`Error al leer CSV: ${err.message}`);
+      },
+    });
+  }, [catalogName, normalizeRows]);
+
+  // Parse JSON file
+  const parseJsonFile = useCallback((file: File) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const text = reader.result as string;
+        let parsed = JSON.parse(text);
+
+        // Handle different JSON structures
+        let items: Record<string, unknown>[];
+        if (Array.isArray(parsed)) {
+          items = parsed;
+        } else if (parsed?.items && Array.isArray(parsed.items)) {
+          items = parsed.items;
+        } else if (parsed?.stock && Array.isArray(parsed.stock)) {
+          items = parsed.stock;
+        } else if (typeof parsed === "object" && parsed !== null) {
+          // Single object → wrap in array
+          items = [parsed];
+        } else {
+          setError("Formato JSON no reconocido. Se esperaba un array o un objeto con items.");
+          return;
+        }
+
+        if (items.length === 0) {
+          setError("El archivo JSON no contiene items.");
+          return;
+        }
+
+        // Extract headers from all keys across all items
+        const allKeys = new Set<string>();
+        for (const item of items) {
+          for (const key of Object.keys(item)) allKeys.add(key);
+        }
+        const rawHeaders = Array.from(allKeys);
+
+        // Normalize field names (apply aliases)
+        const normalizedHeaders = rawHeaders.map(normalizeFieldName);
+        const mapped = new Set(normalizedHeaders);
+
+        const normalizedRows = items.map(item => {
+          const out: Record<string, unknown> = {};
+          rawHeaders.forEach((origH, i) => {
+            out[normalizedHeaders[i]] = item[origH];
+          });
+          return out;
+        });
+
+        const required = getRequiredFields(catalogName);
+        const missing = required.filter(f => !mapped.has(f));
+
+        setHeaders(normalizedHeaders);
+        setRows(normalizedRows);
+        setMappedFields(mapped);
+        setMissingRequired(missing);
+        setParseErrors([]);
+        setStep("preview");
+      } catch (e: any) {
+        setError(`JSON invalido: ${e.message}`);
+      }
+    };
+    reader.onerror = () => setError("Error al leer el archivo.");
+    reader.readAsText(file);
+  }, [catalogName]);
+
+  const handleFiles = useCallback((files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    const file = files[0];
+    const name = file.name.toLowerCase();
+    setFileName(file.name);
+    setError(null);
+    setParseErrors([]);
+
+    if (name.endsWith(".csv")) {
+      setFileType("csv");
+      parseCsvFile(file);
+    } else if (name.endsWith(".json")) {
+      setFileType("json");
+      parseJsonFile(file);
+    } else {
+      setError("Solo se aceptan archivos .csv o .json");
+    }
+  }, [parseCsvFile, parseJsonFile]);
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounter.current = 0;
+    setDragActive(false);
+    handleFiles(e.dataTransfer.files);
+  }, [handleFiles]);
+
+  // Apply: merge or replace
+  const handleApply = useCallback(() => {
+    try {
+      let resultItems: Record<string, unknown>[];
+
+      if (mode === "merge") {
+        // Build map of existing items by SKU
+        const skuField = getSkuField(catalogName);
+        const existingMap = new Map<string, Record<string, unknown>>();
+        for (const item of currentItems) {
+          const key = String(item[skuField] || "").toUpperCase();
+          if (key) existingMap.set(key, { ...item });
+        }
+
+        // Merge: update existing, add new
+        const touchedKeys = new Set<string>();
+        for (const row of rows) {
+          const key = String(row[skuField] || "").toUpperCase();
+          if (key && existingMap.has(key)) {
+            // Merge: only overwrite fields that have non-null/non-empty values
+            const merged = existingMap.get(key)!;
+            for (const [field, value] of Object.entries(row)) {
+              if (value != null && value !== "") {
+                merged[field] = value;
+              }
+            }
+            existingMap.set(key, merged);
+            touchedKeys.add(key);
+          } else {
+            // New item: add with all fields
+            if (key) {
+              existingMap.set(key, { ...row });
+              touchedKeys.add(key);
+            } else {
+              // No SKU: just append
+              existingMap.set(`__new_${Math.random()}`, { ...row });
+            }
+          }
+        }
+
+        // Reconstruct: existing order preserved, new items at end
+        resultItems = [];
+        const addedKeys = new Set<string>();
+        // First: existing items in original order (updated or not)
+        for (const item of currentItems) {
+          const key = String(item[skuField] || "").toUpperCase();
+          if (key && existingMap.has(key)) {
+            resultItems.push(existingMap.get(key)!);
+            addedKeys.add(key);
+          } else {
+            resultItems.push(item);
+          }
+        }
+        // Then: new items not in original
+        existingMap.forEach((item, key) => {
+          if (!addedKeys.has(key)) {
+            resultItems.push(item);
+          }
+        });
+      } else {
+        // Full replacement
+        resultItems = rows;
+      }
+
+      // Handle catalogs with _metadata wrappers
+      const parsed = (() => { try { return JSON.parse(currentContent); } catch { return null; } })();
+      if (parsed && !Array.isArray(parsed) && parsed?._metadata) {
+        if (parsed.items) {
+          parsed.items = resultItems;
+        } else if (parsed.stock) {
+          parsed.stock = resultItems;
+        }
+        onApply(JSON.stringify(parsed, null, 2));
+      } else {
+        onApply(JSON.stringify(resultItems, null, 2));
+      }
+    } catch {
+      setError("Error al generar JSON. Verifica el contenido.");
+    }
+  }, [mode, catalogName, currentContent, currentItems, rows, onApply]);
+
+  const resetUpload = useCallback(() => {
+    setStep("upload");
+    setRows([]);
+    setHeaders([]);
+    setError(null);
+    setParseErrors([]);
+  }, []);
+
+  return (
+    <div
+      className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Importar datos"
+    >
+      <div
+        className="bg-s2 border border-b1 rounded-xl w-full max-w-[740px] max-h-[85vh] overflow-hidden shadow-[0_24px_80px_rgba(0,0,0,0.5)] flex flex-col animate-[fadeUp_0.2s_ease-out]"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-b1 shrink-0">
+          <div>
+            <div className="text-[15px] font-medium text-t1">Importar datos</div>
+            <div className="text-[11px] text-t3 mt-0.5">
+              {step === "upload" && `Arrastra un CSV o JSON para ${catalogName}.json`}
+              {step === "preview" && `Vista previa de ${fileName} — ${rows.length} filas`}
+              {step === "confirm" && `Confirmar importacion a ${catalogName}.json`}
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-7 h-7 rounded-md flex items-center justify-center text-t3 bg-transparent border-none cursor-pointer hover:text-t1 hover:bg-white/[0.05] transition"
+            aria-label="Cerrar"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-6 py-5">
+
+          {/* ── Step 1: Upload ────────────────────────────────── */}
+          {step === "upload" && (
+            <div>
+              <input
+                ref={fileRef}
+                type="file"
+                accept=".csv,.json"
+                className="hidden"
+                onChange={e => handleFiles(e.target.files)}
+              />
+              <div
+                onDragEnter={e => { e.preventDefault(); dragCounter.current++; setDragActive(true); }}
+                onDragLeave={e => { e.preventDefault(); dragCounter.current--; if (dragCounter.current <= 0) { dragCounter.current = 0; setDragActive(false); } }}
+                onDragOver={e => e.preventDefault()}
+                onDrop={handleDrop}
+                onClick={() => fileRef.current?.click()}
+                className={clsx(
+                  "flex flex-col items-center justify-center gap-3 py-16 px-8 rounded-xl cursor-pointer transition-all duration-200",
+                  dragActive
+                    ? "border-2 border-acc bg-acc/[0.06] shadow-[0_0_30px_rgba(79,143,255,0.10)]"
+                    : "border-2 border-dashed border-b2 bg-white/[0.01] hover:border-b3 hover:bg-white/[0.02]",
+                )}
+              >
+                <div className={clsx(
+                  "w-12 h-12 rounded-xl flex items-center justify-center transition-colors",
+                  dragActive ? "bg-acc/[0.15] text-acc" : "bg-white/[0.04] text-t3",
+                )}>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                    <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+                    <polyline points="17 8 12 3 7 8" />
+                    <line x1="12" y1="3" x2="12" y2="15" />
+                  </svg>
+                </div>
+                <div className="text-center">
+                  <div className={clsx("text-sm font-medium", dragActive ? "text-acc" : "text-t1")}>
+                    {dragActive ? "Solta el archivo aca" : "Arrastra un archivo o hace click para seleccionar"}
+                  </div>
+                  <div className="text-[11px] text-t3 mt-1">
+                    CSV con encabezados o JSON. Se detectan las columnas y se mapean automaticamente.
+                  </div>
+                </div>
+              </div>
+
+              {error && (
+                <div className="mt-4 px-3.5 py-2.5 rounded-lg bg-err/[0.08] border border-err/[0.20] text-xs text-err flex items-start gap-2">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="shrink-0 mt-0.5"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
+                  {error}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* ── Step 2: Preview ───────────────────────────────── */}
+          {step === "preview" && (
+            <div className="flex flex-col gap-4">
+
+              {/* Import mode selector */}
+              <div className="flex items-center gap-2 p-1 bg-white/[0.03] rounded-lg border border-b1 self-start">
+                <button
+                  onClick={() => setMode("merge")}
+                  className={clsx(
+                    "px-3 py-[6px] rounded-md text-xs font-medium font-sans border-none cursor-pointer transition-all",
+                    mode === "merge"
+                      ? "bg-acc/[0.15] text-acc shadow-sm"
+                      : "bg-transparent text-t3 hover:text-t2",
+                  )}
+                >
+                  Actualizar por SKU
+                </button>
+                <button
+                  onClick={() => setMode("replace")}
+                  className={clsx(
+                    "px-3 py-[6px] rounded-md text-xs font-medium font-sans border-none cursor-pointer transition-all",
+                    mode === "replace"
+                      ? "bg-amb/[0.15] text-amb shadow-sm"
+                      : "bg-transparent text-t3 hover:text-t2",
+                  )}
+                >
+                  Reemplazo completo
+                </button>
+              </div>
+
+              {/* Mode explanation */}
+              <div className={clsx(
+                "px-3.5 py-2.5 rounded-lg text-xs flex items-start gap-2",
+                mode === "merge"
+                  ? "bg-acc/[0.04] border border-acc/[0.12] text-acc/80"
+                  : "bg-amb/[0.04] border border-amb/[0.12] text-amb/80",
+              )}>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="shrink-0 mt-0.5"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+                {mode === "merge" ? (
+                  <span>
+                    <strong>Merge inteligente:</strong> Matchea por <code className="text-[10px] font-mono px-1 py-px rounded bg-white/[0.06]">{getSkuField(catalogName)}</code>.
+                    Actualiza solo los campos que trae el archivo. Los items que no estan en el archivo se mantienen sin cambios. Items nuevos se agregan al final.
+                  </span>
+                ) : (
+                  <span>
+                    <strong>Reemplazo completo:</strong> Se elimina todo el contenido actual y se reemplaza por los datos del archivo.
+                    Los items que no esten en el archivo se pierden.
+                  </span>
+                )}
+              </div>
+
+              {/* Merge stats */}
+              {mode === "merge" && rows.length > 0 && (
+                <div className="flex gap-3">
+                  <StatBadge label="Actualizados" count={mergeStats.updated} color="acc" />
+                  <StatBadge label="Nuevos" count={mergeStats.added} color="grn" />
+                  <StatBadge label="Sin cambios" count={mergeStats.unchanged} color="t3" />
+                </div>
+              )}
+
+              {/* Column mapping badges */}
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-[11px] text-t3">Columnas detectadas:</span>
+                {headers.map(h => (
+                  <span
+                    key={h}
+                    className={clsx(
+                      "text-[10px] px-2 py-0.5 rounded-full font-mono",
+                      mappedFields.has(h)
+                        ? "bg-grn/[0.08] text-grn border border-grn/[0.15]"
+                        : "bg-amb/[0.08] text-amb border border-amb/[0.15]",
+                    )}
+                  >
+                    {h}
+                  </span>
+                ))}
+              </div>
+
+              {/* Missing required warning */}
+              {missingRequired.length > 0 && (
+                <div className="px-3.5 py-2.5 rounded-lg bg-amb/[0.06] border border-amb/[0.16] text-xs text-amb flex items-start gap-2">
+                  <span className="shrink-0">&#9888;</span>
+                  <div>
+                    <strong>Campos requeridos faltantes:</strong>{" "}
+                    {missingRequired.join(", ")}
+                    <div className="text-amb/70 mt-0.5">
+                      {mode === "merge"
+                        ? "En modo merge los campos faltantes se mantienen del catalogo actual."
+                        : "Podes continuar, pero el catalogo podria quedar incompleto."
+                      }
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Parse errors */}
+              {parseErrors.length > 0 && (
+                <div className="px-3.5 py-2.5 rounded-lg bg-err/[0.06] border border-err/[0.16] text-xs text-err">
+                  <strong>Errores de parseo:</strong>
+                  {parseErrors.map((e, i) => <div key={i} className="mt-0.5">{e}</div>)}
+                </div>
+              )}
+
+              {/* Preview table */}
+              <CsvPreviewTable headers={headers} rows={rows} mappedFields={mappedFields} />
+
+              {/* Actions */}
+              <div className="flex items-center justify-between pt-2">
+                <button
+                  onClick={resetUpload}
+                  className="px-3 py-[7px] rounded-md text-xs font-medium font-sans border border-b1 bg-transparent text-t2 cursor-pointer hover:border-b2 hover:text-t1 transition"
+                >
+                  Elegir otro archivo
+                </button>
+                <button
+                  onClick={() => setStep("confirm")}
+                  className="px-4 py-[7px] rounded-md text-xs font-medium font-sans border bg-acc-bg border-acc-hover text-acc cursor-pointer hover:bg-acc/20 transition"
+                >
+                  Continuar
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* ── Step 3: Confirm ───────────────────────────────── */}
+          {step === "confirm" && (
+            <div className="flex flex-col items-center gap-5 py-6">
+              <div className={clsx(
+                "w-14 h-14 rounded-2xl flex items-center justify-center",
+                mode === "merge" ? "bg-acc/[0.10]" : "bg-amb/[0.10]",
+              )}>
+                {mode === "merge" ? (
+                  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#4f8fff" strokeWidth="1.5">
+                    <path d="M17 1l4 4-4 4"/><path d="M3 11V9a4 4 0 014-4h14"/>
+                    <path d="M7 23l-4-4 4-4"/><path d="M21 13v2a4 4 0 01-4 4H3"/>
+                  </svg>
+                ) : (
+                  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#f5a623" strokeWidth="1.5">
+                    <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/>
+                    <polyline points="14 2 14 8 20 8"/>
+                    <line x1="12" y1="18" x2="12" y2="12"/>
+                    <line x1="9" y1="15" x2="15" y2="15"/>
+                  </svg>
+                )}
+              </div>
+
+              <div className="text-center">
+                {mode === "merge" ? (
+                  <>
+                    <div className="text-[15px] font-medium text-t1">
+                      Actualizar {catalogName}.json
+                    </div>
+                    <div className="text-xs text-t3 mt-2 max-w-[400px]">
+                      Se actualizan <strong className="text-t1">{mergeStats.updated}</strong> items existentes
+                      {mergeStats.added > 0 && <> y se agregan <strong className="text-t1">{mergeStats.added}</strong> nuevos</>}.
+                      {mergeStats.unchanged > 0 && <> Los restantes <strong className="text-t1">{mergeStats.unchanged}</strong> items quedan sin cambios.</>}
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className="text-[15px] font-medium text-t1">
+                      Reemplazar {catalogName}.json
+                    </div>
+                    <div className="text-xs text-t3 mt-2 max-w-[400px]">
+                      Se reemplaza todo el contenido con <strong className="text-t1">{rows.length}</strong> items del archivo.
+                      {currentItems.length > 0 && (
+                        <> Los <strong className="text-t1">{currentItems.length}</strong> items actuales se eliminan.</>
+                      )}
+                    </div>
+                  </>
+                )}
+                <div className="text-[11px] text-amb mt-3">
+                  Los cambios se cargan en el editor. Debes validar y guardar para que sean definitivos.
+                </div>
+              </div>
+
+              <div className="flex gap-3 mt-2">
+                <button
+                  onClick={() => setStep("preview")}
+                  className="px-4 py-2 rounded-md text-xs font-medium font-sans border border-b1 bg-transparent text-t2 cursor-pointer hover:border-b2 hover:text-t1 transition"
+                >
+                  Volver
+                </button>
+                <button
+                  onClick={() => { handleApply(); onClose(); }}
+                  className={clsx(
+                    "px-5 py-2 rounded-md text-xs font-medium font-sans border-none cursor-pointer transition",
+                    mode === "merge"
+                      ? "bg-acc text-white hover:bg-acc/90 shadow-[0_2px_12px_rgba(79,143,255,0.25)]"
+                      : "bg-amb text-white hover:bg-amb/90 shadow-[0_2px_12px_rgba(245,166,35,0.25)]",
+                  )}
+                >
+                  {mode === "merge" ? "Aplicar actualizacion" : "Aplicar reemplazo"}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Stat badge sub-component ────────────────────────────────────────────────
+
+function StatBadge({ label, count, color }: { label: string; count: number; color: string }) {
+  const colorMap: Record<string, string> = {
+    acc: "bg-acc/[0.08] text-acc border-acc/[0.15]",
+    grn: "bg-grn/[0.08] text-grn border-grn/[0.15]",
+    t3: "bg-white/[0.03] text-t3 border-b1",
+  };
+  return (
+    <div className={clsx("flex items-center gap-2 px-3 py-1.5 rounded-lg border text-xs font-medium", colorMap[color] || colorMap.t3)}>
+      <span className="text-[17px] font-semibold font-mono">{count}</span>
+      <span className="text-[11px] opacity-80">{label}</span>
+    </div>
+  );
+}

--- a/web/src/components/catalog/CsvPreviewTable.tsx
+++ b/web/src/components/catalog/CsvPreviewTable.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import clsx from "clsx";
+
+interface Props {
+  headers: string[];
+  rows: Record<string, unknown>[];
+  mappedFields: Set<string>;
+  maxRows?: number;
+}
+
+export default function CsvPreviewTable({ headers, rows, mappedFields, maxRows = 20 }: Props) {
+  const displayRows = rows.slice(0, maxRows);
+  const remaining = rows.length - displayRows.length;
+
+  return (
+    <div className="border border-b1 rounded-lg overflow-hidden">
+      <div className="overflow-x-auto max-h-[320px] overflow-y-auto">
+        <table className="w-full border-collapse min-w-max">
+          <thead className="sticky top-0 z-10">
+            <tr className="bg-s3">
+              {headers.map(h => (
+                <th
+                  key={h}
+                  className={clsx(
+                    "px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-[0.06em] border-b border-b1 whitespace-nowrap",
+                    mappedFields.has(h) ? "text-t2" : "text-t4",
+                  )}
+                >
+                  <div className="flex items-center gap-1.5">
+                    {h}
+                    {mappedFields.has(h) ? (
+                      <span className="w-1 h-1 rounded-full bg-grn shrink-0" title="Campo mapeado" />
+                    ) : (
+                      <span className="w-1 h-1 rounded-full bg-amb shrink-0" title="Sin mapear" />
+                    )}
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {displayRows.map((row, i) => (
+              <tr key={i} className={clsx(i % 2 === 1 && "bg-white/[0.02]")}>
+                {headers.map(h => (
+                  <td
+                    key={h}
+                    className={clsx(
+                      "px-3 py-[7px] text-xs font-mono border-b border-white/[0.03] whitespace-nowrap max-w-[200px] truncate",
+                      mappedFields.has(h) ? "text-t2" : "text-t4",
+                    )}
+                  >
+                    {row[h] != null ? String(row[h]) : ""}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {remaining > 0 && (
+        <div className="px-3 py-2 text-[11px] text-t3 bg-s2 border-t border-b1 text-center">
+          ...y {remaining} fila{remaining > 1 ? "s" : ""} mas
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/catalog/catalog-theme.ts
+++ b/web/src/components/catalog/catalog-theme.ts
@@ -1,0 +1,159 @@
+import { EditorView } from "@codemirror/view";
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { tags } from "@lezer/highlight";
+
+export const catalogEditorTheme = EditorView.theme(
+  {
+    "&": {
+      backgroundColor: "#0a0a14",
+      color: "rgba(255,255,255,0.58)",
+      fontFamily: "'Geist Mono', monospace",
+      fontSize: "13px",
+      lineHeight: "1.7",
+    },
+    ".cm-content": {
+      caretColor: "#4f8fff",
+      padding: "16px 0",
+    },
+    ".cm-cursor, .cm-dropCursor": {
+      borderLeftColor: "#4f8fff",
+      borderLeftWidth: "2px",
+    },
+    "&.cm-focused .cm-selectionBackground, .cm-selectionBackground": {
+      backgroundColor: "rgba(79,143,255,0.15) !important",
+    },
+    ".cm-activeLine": {
+      backgroundColor: "rgba(255,255,255,0.025)",
+    },
+    ".cm-gutters": {
+      backgroundColor: "#07070e",
+      color: "rgba(255,255,255,0.14)",
+      border: "none",
+      borderRight: "1px solid rgba(255,255,255,0.05)",
+      paddingRight: "4px",
+    },
+    ".cm-activeLineGutter": {
+      backgroundColor: "rgba(255,255,255,0.03)",
+      color: "rgba(255,255,255,0.40)",
+    },
+    ".cm-lineNumbers .cm-gutterElement": {
+      padding: "0 8px 0 16px",
+      minWidth: "40px",
+      fontSize: "11px",
+    },
+    ".cm-foldGutter .cm-gutterElement": {
+      padding: "0 4px",
+      color: "rgba(255,255,255,0.14)",
+      cursor: "pointer",
+      transition: "color 0.1s",
+    },
+    ".cm-foldGutter .cm-gutterElement:hover": {
+      color: "rgba(255,255,255,0.5)",
+    },
+    "&.cm-focused .cm-matchingBracket": {
+      backgroundColor: "rgba(79,143,255,0.25)",
+      outline: "1px solid rgba(79,143,255,0.35)",
+    },
+    ".cm-searchMatch": {
+      backgroundColor: "rgba(245,166,35,0.25)",
+      outline: "1px solid rgba(245,166,35,0.4)",
+    },
+    ".cm-searchMatch.cm-searchMatch-selected": {
+      backgroundColor: "rgba(79,143,255,0.30)",
+      outline: "1px solid rgba(79,143,255,0.5)",
+    },
+    ".cm-panels": {
+      backgroundColor: "#0c0c16",
+      color: "rgba(255,255,255,0.58)",
+      borderBottom: "1px solid rgba(255,255,255,0.07)",
+    },
+    ".cm-panels.cm-panels-top": {
+      borderBottom: "1px solid rgba(255,255,255,0.07)",
+    },
+    ".cm-panel.cm-search": {
+      padding: "8px 12px",
+      backgroundColor: "#0c0c16",
+    },
+    ".cm-panel.cm-search input, .cm-panel.cm-search button": {
+      fontFamily: "'Geist', sans-serif",
+      fontSize: "12px",
+    },
+    ".cm-panel.cm-search input": {
+      backgroundColor: "rgba(0,0,0,0.3)",
+      border: "1px solid rgba(255,255,255,0.10)",
+      borderRadius: "6px",
+      color: "rgba(255,255,255,0.90)",
+      padding: "4px 8px",
+      outline: "none",
+    },
+    ".cm-panel.cm-search input:focus": {
+      borderColor: "#4f8fff",
+    },
+    ".cm-panel.cm-search button": {
+      backgroundColor: "transparent",
+      border: "1px solid rgba(255,255,255,0.10)",
+      borderRadius: "6px",
+      color: "rgba(255,255,255,0.58)",
+      padding: "4px 10px",
+      cursor: "pointer",
+    },
+    ".cm-panel.cm-search button:hover": {
+      backgroundColor: "rgba(255,255,255,0.05)",
+      color: "rgba(255,255,255,0.80)",
+    },
+    ".cm-panel.cm-search label": {
+      color: "rgba(255,255,255,0.40)",
+      fontSize: "11px",
+    },
+    ".cm-tooltip": {
+      backgroundColor: "#15151f",
+      border: "1px solid rgba(255,255,255,0.10)",
+      borderRadius: "6px",
+      boxShadow: "0 8px 32px rgba(0,0,0,0.5)",
+    },
+    ".cm-tooltip .cm-tooltip-arrow::before": {
+      borderTopColor: "transparent",
+      borderBottomColor: "transparent",
+    },
+    ".cm-lintRange-error": {
+      backgroundImage: "none",
+      textDecoration: "wavy underline #ff453a",
+      textDecorationSkipInk: "none",
+    },
+    ".cm-lintRange-warning": {
+      backgroundImage: "none",
+      textDecoration: "wavy underline #f5a623",
+      textDecorationSkipInk: "none",
+    },
+    ".cm-diagnostic-error": {
+      borderLeftColor: "#ff453a",
+    },
+    ".cm-diagnostic-warning": {
+      borderLeftColor: "#f5a623",
+    },
+    ".cm-foldPlaceholder": {
+      backgroundColor: "rgba(79,143,255,0.10)",
+      border: "1px solid rgba(79,143,255,0.20)",
+      borderRadius: "3px",
+      color: "rgba(79,143,255,0.60)",
+      padding: "0 6px",
+      margin: "0 4px",
+    },
+  },
+  { dark: true }
+);
+
+const catalogHighlightStyle = HighlightStyle.define([
+  { tag: tags.propertyName, color: "rgba(255,255,255,0.90)" },
+  { tag: tags.string, color: "#30d158" },
+  { tag: tags.number, color: "#f5a623" },
+  { tag: tags.bool, color: "#f5a623" },
+  { tag: tags.null, color: "rgba(255,255,255,0.28)" },
+  { tag: tags.keyword, color: "#f5a623" },
+  { tag: tags.punctuation, color: "rgba(255,255,255,0.30)" },
+  { tag: tags.brace, color: "rgba(255,255,255,0.35)" },
+  { tag: tags.squareBracket, color: "rgba(255,255,255,0.35)" },
+  { tag: tags.separator, color: "rgba(255,255,255,0.25)" },
+]);
+
+export const catalogHighlighting = syntaxHighlighting(catalogHighlightStyle);

--- a/web/src/components/quote/CompareView.tsx
+++ b/web/src/components/quote/CompareView.tsx
@@ -1,0 +1,232 @@
+import { useMemo } from "react";
+import type { QuoteCompareResponse } from "@/lib/api";
+import { fmtARS, fmtUSD, fmtQty } from "@/lib/format";
+import Section from "./Section";
+
+interface Props {
+  data: QuoteCompareResponse;
+}
+
+// Use relative URLs — Next.js rewrites proxy /api/ and /files/ to the backend
+
+export default function CompareView({ data }: Props) {
+  const variants = useMemo(() => {
+    return data.quotes.map((q) => {
+      const bd = q.quote_breakdown || {};
+      const moItems = (bd.mo_items || []) as { quantity?: number; unit_price?: number }[];
+      const moTotal = moItems.reduce(
+        (s, m) => s + (m.quantity || 0) * (m.unit_price || 0),
+        0
+      );
+      const merma = bd.merma as { aplica?: boolean; motivo?: string } | undefined;
+      const currency = (bd.material_currency || "USD") as "USD" | "ARS";
+
+      return {
+        id: q.id,
+        material: q.material || bd.material_name || "—",
+        currency,
+        priceM2: bd.material_price_unit || 0,
+        m2: bd.material_m2 || 0,
+        totalMat: bd.material_total || 0,
+        discountPct: bd.discount_pct || 0,
+        moTotal,
+        merma: merma?.aplica ? (merma.motivo || "Aplica") : "No aplica",
+        delivery: bd.delivery_days || "—",
+        totalArs: q.total_ars || bd.total_ars || 0,
+        totalUsd: q.total_usd || bd.total_usd || 0,
+        pdfUrl: q.pdf_url,
+      };
+    });
+  }, [data]);
+
+  // Find cheapest by total_usd (or total_ars if no USD)
+  const bestIdx = useMemo(() => {
+    let idx = 0;
+    let best = Infinity;
+    variants.forEach((v, i) => {
+      const val = v.totalUsd || v.totalArs;
+      if (val && val < best) {
+        best = val;
+        idx = i;
+      }
+    });
+    return idx;
+  }, [variants]);
+
+  const n = variants.length;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+      {/* Header */}
+      <Section title="Comparativo de materiales">
+        <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
+          <span style={{ fontSize: 13, color: "var(--t2)" }}>
+            Cliente: <strong style={{ color: "var(--t1)" }}>{data.client_name}</strong>
+          </span>
+          <span style={{ fontSize: 13, color: "var(--t2)" }}>
+            Proyecto: <strong style={{ color: "var(--t1)" }}>{data.project}</strong>
+          </span>
+          <span style={{ fontSize: 13, color: "var(--t2)" }}>
+            {n} variante{n > 1 ? "s" : ""}
+          </span>
+        </div>
+      </Section>
+
+      {/* Comparison table */}
+      <Section title="Comparativa de precios">
+        <div style={{ overflowX: "auto" }}>
+          <table style={{
+            width: "100%", borderCollapse: "collapse",
+            border: "1px solid var(--b1)", borderRadius: 8, overflow: "hidden",
+            minWidth: 400 + n * 150,
+          }}>
+            <thead>
+              <tr>
+                <th style={headerCell}></th>
+                {variants.map((v, i) => (
+                  <th key={v.id} style={{
+                    ...headerCell, textAlign: "center",
+                    background: i === bestIdx ? "rgba(48,209,88,0.12)" : "rgba(255,255,255,.05)",
+                    borderLeft: "1px solid var(--b1)",
+                  }}>
+                    <div style={{ fontSize: 13, fontWeight: 700, color: "var(--t1)" }}>
+                      {v.material}
+                    </div>
+                    {i === bestIdx && (
+                      <div style={{ fontSize: 9, color: "var(--grn)", fontWeight: 600, marginTop: 2 }}>
+                        MAS ECONOMICO
+                      </div>
+                    )}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              <Row label="Precio / m²" values={variants.map(v =>
+                v.currency === "USD" ? fmtUSD(v.priceM2) : fmtARS(v.priceM2)
+              )} bestIdx={bestIdx} odd />
+              <Row label="Superficie" values={variants.map(v =>
+                `${fmtQty(v.m2)} m²`
+              )} bestIdx={bestIdx} />
+              <Row label="Total Material" values={variants.map(v =>
+                v.currency === "USD" ? fmtUSD(v.totalMat) : fmtARS(v.totalMat)
+              )} bestIdx={bestIdx} odd />
+              <Row label="Descuento" values={variants.map(v =>
+                v.discountPct ? `${v.discountPct}%` : "No aplica"
+              )} bestIdx={bestIdx} />
+              <Row label="Mano de Obra" values={variants.map(v =>
+                fmtARS(v.moTotal)
+              )} bestIdx={bestIdx} odd />
+              <Row label="Merma" values={variants.map(v => v.merma)} bestIdx={bestIdx} />
+              <Row label="Plazo" values={variants.map(v => v.delivery)} bestIdx={bestIdx} odd />
+
+              {/* Total rows */}
+              <tr style={{ borderTop: "2px solid var(--b2)" }}>
+                <td style={{ ...cellBase, fontWeight: 700, fontSize: 14, color: "var(--t1)" }}>
+                  Total ARS
+                </td>
+                {variants.map((v, i) => (
+                  <td key={v.id} style={{
+                    ...cellBase, textAlign: "center", fontWeight: 700, fontSize: 14,
+                    color: "var(--t1)",
+                    background: i === bestIdx ? "rgba(48,209,88,0.08)" : "transparent",
+                    borderLeft: "1px solid var(--b1)",
+                  }}>
+                    {v.totalArs ? fmtARS(v.totalArs) : "—"}
+                  </td>
+                ))}
+              </tr>
+              <tr>
+                <td style={{ ...cellBase, fontWeight: 700, fontSize: 14, color: "var(--acc)" }}>
+                  Total USD
+                </td>
+                {variants.map((v, i) => (
+                  <td key={v.id} style={{
+                    ...cellBase, textAlign: "center", fontWeight: 700, fontSize: 14,
+                    color: i === bestIdx ? "var(--grn)" : "var(--acc)",
+                    background: i === bestIdx ? "rgba(48,209,88,0.08)" : "transparent",
+                    borderLeft: "1px solid var(--b1)",
+                  }}>
+                    {v.totalUsd ? fmtUSD(v.totalUsd) : "—"}
+                  </td>
+                ))}
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </Section>
+
+      {/* Actions */}
+      <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+        <a
+          href={`/api/quotes/${data.parent_id}/compare/pdf`}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={btnStyle}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3" />
+          </svg>
+          Descargar comparativo PDF
+        </a>
+        {variants.map((v) => v.pdfUrl && (
+          <a
+            key={v.id}
+            href={`${v.pdfUrl}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ ...btnStyle, background: "transparent", border: "1px solid var(--b2)" }}
+          >
+            PDF {v.material}
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Sub-components ──────────────────────────────────────────────────────────
+
+const headerCell: React.CSSProperties = {
+  padding: "12px 14px", fontSize: 11, fontWeight: 600,
+  color: "var(--t3)", textTransform: "uppercase", letterSpacing: "0.05em",
+  background: "rgba(255,255,255,.03)", borderBottom: "1px solid var(--b1)",
+  textAlign: "left",
+};
+
+const cellBase: React.CSSProperties = {
+  padding: "10px 14px", fontSize: 13, color: "var(--t2)",
+  borderBottom: "1px solid rgba(255,255,255,.04)",
+};
+
+const btnStyle: React.CSSProperties = {
+  display: "inline-flex", alignItems: "center", gap: 8,
+  padding: "8px 16px", borderRadius: 8,
+  background: "var(--acc)", color: "#fff",
+  fontSize: 13, fontWeight: 600, textDecoration: "none",
+  border: "none", cursor: "pointer",
+};
+
+function Row({ label, values, bestIdx, odd }: {
+  label: string;
+  values: string[];
+  bestIdx: number;
+  odd?: boolean;
+}) {
+  return (
+    <tr style={{ background: odd ? "rgba(255,255,255,.03)" : "transparent" }}>
+      <td style={{ ...cellBase, fontWeight: 600, color: "var(--t1)", whiteSpace: "nowrap" }}>
+        {label}
+      </td>
+      {values.map((val, i) => (
+        <td key={i} style={{
+          ...cellBase, textAlign: "center",
+          background: i === bestIdx && odd ? "rgba(48,209,88,0.05)" : undefined,
+          borderLeft: "1px solid var(--b1)",
+        }}>
+          {val}
+        </td>
+      ))}
+    </tr>
+  );
+}

--- a/web/src/components/quote/QuoteTabBar.tsx
+++ b/web/src/components/quote/QuoteTabBar.tsx
@@ -1,12 +1,15 @@
 import TabBtn from "@/components/ui/TabBtn";
 
+export type QuoteTab = "detail" | "chat" | "compare";
+
 interface Props {
-  tab: "detail" | "chat";
-  setTab: (t: "detail" | "chat") => void;
+  tab: QuoteTab;
+  setTab: (t: QuoteTab) => void;
   canShowDetail: boolean;
+  canShowCompare: boolean;
 }
 
-export default function QuoteTabBar({ tab, setTab, canShowDetail }: Props) {
+export default function QuoteTabBar({ tab, setTab, canShowDetail, canShowCompare }: Props) {
   return (
     <div style={{
       display: "flex", gap: 0, borderBottom: "1px solid var(--b1)",
@@ -14,6 +17,9 @@ export default function QuoteTabBar({ tab, setTab, canShowDetail }: Props) {
     }}>
       <TabBtn active={tab === "detail"} onClick={() => setTab("detail")} disabled={!canShowDetail}>Detalle</TabBtn>
       <TabBtn active={tab === "chat"} onClick={() => setTab("chat")}>Chat</TabBtn>
+      {canShowCompare && (
+        <TabBtn active={tab === "compare"} onClick={() => setTab("compare")}>Comparar</TabBtn>
+      )}
     </div>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -127,6 +127,33 @@ export async function markQuoteAsRead(id: string): Promise<void> {
   if (!res.ok) throw new Error("Error al marcar como leído");
 }
 
+// ── Quote Comparison ─────────────────────────────────────────────────────────
+
+export interface QuoteCompareItem {
+  id: string;
+  material: string | null;
+  total_ars: number | null;
+  total_usd: number | null;
+  status: string;
+  pdf_url: string | null;
+  quote_breakdown: QuoteBreakdown | null;
+}
+
+export interface QuoteCompareResponse {
+  parent_id: string;
+  client_name: string;
+  project: string;
+  quotes: QuoteCompareItem[];
+}
+
+export async function fetchQuoteComparison(id: string): Promise<QuoteCompareResponse | null> {
+  const res = await fetch(`${API_BASE}/api/quotes/${id}/compare`, { credentials: "include" });
+  if (res.status === 404) return null;
+  handleAuthError(res);
+  if (!res.ok) throw new Error("Error al cargar comparación");
+  return res.json();
+}
+
 // ── Chat SSE ──────────────────────────────────────────────────────────────────
 
 export interface ChatChunk {


### PR DESCRIPTION
## Summary
- **Quote comparator**: side-by-side comparison view for multi-material quotes with landscape PDF export
- **Catalog UX overhaul**: CodeMirror 6 editor with syntax highlighting, folding, search, linting
- **Smart import**: CSV/JSON import with merge-by-SKU mode (updates only changed fields) or full replacement, column auto-detection, preview with stats

## Test plan
- [ ] Open quote with multiple material variants → "Comparar" tab visible
- [ ] Comparison table shows materials side-by-side, cheapest highlighted
- [ ] /quotes/{id}/compare/pdf downloads landscape PDF
- [ ] /config page loads with CodeMirror editor, syntax highlighting, folding
- [ ] Import CSV → merge mode updates existing items by SKU
- [ ] Import JSON → same flow, auto-detects format
- [ ] Full replacement mode replaces all content
- [ ] Unsaved changes guard when switching catalogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)