### PR TITLE
fix: zocalo default 5cm + patch mode must persist breakdown

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -106,7 +106,7 @@ Cuando el operador pide un cambio sobre un presupuesto que YA TIENE BREAKDOWN (r
 - Tomá el presupuesto actual como fuente de verdad
 - Aplicá SOLO el cambio solicitado
 - Todo campo no mencionado por el operador → INTACTO
-- No recalcular todo — solo lo directamente afectado por el cambio
+- **⛔ SIEMPRE llamar `calculate_quote` después de aplicar el cambio** para que el breakdown se actualice en la DB. NUNCA hacer cuentas mentales sin llamar la tool — los totales solo se persisten si `calculate_quote` corre.
 
 **2. NUNCA hacer por iniciativa propia:**
 - Agregar piezas que no pidió

--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -403,7 +403,7 @@ Todos los catálogos tienen precios SIN IVA. Aplicar ×1.21 al presupuestar sin 
 ### Zócalos
 - Leer cada mesada individualmente — NO asumir simetría ni generalizar
 - **ml de zócalo = dimensión REAL de cada lado** (no el máximo de la pieza)
-- Alto default = **5cm** SOLO si el operador pide zócalo sin especificar alto y NO hay plano. Si el plano tiene cota (ej: 0,06) → usar la cota del plano, NO el default.
+- Alto default = **5cm** cuando no hay cota de alto explícita. Si el plano tiene cota de alto (ej: 0,06) → usar la cota del plano. Si el plano NO tiene cota de alto → usar 5cm sin preguntar. NUNCA preguntar al operador por el alto del zócalo.
 - En PDF/Excel: una sola línea `ZÓCALO X.XX ml x 0.05 m` con total de ml
 - SIEMPRE aclarar que el zócalo está incluido en el presupuesto
 - **Si el zócalo tiene más de 10cm de alto → agregar 1 agujero de toma corriente (TOMAS) en la MO automáticamente.** No preguntar — si el alto > 0.10m, va 1 TOMAS.

--- a/api/rules/plan-reading.md
+++ b/api/rules/plan-reading.md
@@ -229,6 +229,7 @@ Siempre que haya una cota vertical en el frente → calcular frentin frente.
 > Si la F aparece solo en el frente → frentin únicamente en el frente. No asumir laterales.
 > **Regla absoluta: donde dice Z → lleva zócalo.** Sin excepciones, aunque parezca que va contra pared.
 > Si la Z aparece en varios lados → sumar todos los ml de zócalo de cada lado.
+> **Alto del zócalo:** si el plano no tiene cota de alto → usar **5cm (0,05m)** por defecto. NUNCA preguntar al operador.
 
 ### Profundidad de mesada
 - Si no hay cota de profundidad en el plano → usar **0.60m** como estándar.


### PR DESCRIPTION
## Summary
- **Zocalo height:** if plan doesn't show height cota, use 5cm default silently. Never ask operator.
- **Patch mode breakdown:** Valentina must call `calculate_quote` after applying changes so the breakdown persists in DB. Was only showing diff text without updating.

## Test plan
- [ ] Quote with plan + zocalo without height cota → uses 5cm without asking
- [ ] Modify a quote (e.g. remove flete) → verify breakdown updates in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)