### PR TITLE
feat: cascade delete de quotes padre/hijo

### DIFF
--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -453,29 +453,44 @@ async def delete_quote(quote_id: str, db: AsyncSession = Depends(get_db)):
     if not quote:
         raise HTTPException(status_code=404, detail="Presupuesto no encontrado")
 
-    logging.info(f"Deleting quote {quote_id}: client={quote.client_name}, status={quote.status}")
+    # Resolve the family root and collect all related quotes
+    root_id = quote.parent_quote_id or quote.id
+    family_result = await db.execute(
+        select(Quote).where(
+            (Quote.id == root_id) | (Quote.parent_quote_id == root_id)
+        )
+    )
+    family = list(family_result.scalars().all())
 
-    # Delete Drive file if exists (best-effort)
-    if quote.drive_file_id:
-        try:
-            from app.modules.agent.tools.drive_tool import delete_drive_file
-            await delete_drive_file(quote.drive_file_id)
-        except Exception as e:
-            logging.warning(f"Failed to delete Drive file {quote.drive_file_id}: {e}")
+    logging.info(
+        f"Cascade-deleting quote family root={root_id}: "
+        f"{[q.id for q in family]} (triggered by {quote_id})"
+    )
 
-    # Delete local files
     import shutil
     from app.core.static import OUTPUT_DIR
-    output_dir = OUTPUT_DIR / quote_id
-    if output_dir.exists():
-        try:
-            shutil.rmtree(output_dir)
-        except Exception as e:
-            logging.warning(f"Failed to delete local files for {quote_id}: {e}")
 
-    await db.delete(quote)
+    for q in family:
+        # Delete Drive file if exists (best-effort)
+        if q.drive_file_id:
+            try:
+                from app.modules.agent.tools.drive_tool import delete_drive_file
+                await delete_drive_file(q.drive_file_id)
+            except Exception as e:
+                logging.warning(f"Failed to delete Drive file {q.drive_file_id}: {e}")
+
+        # Delete local files
+        output_dir = OUTPUT_DIR / q.id
+        if output_dir.exists():
+            try:
+                shutil.rmtree(output_dir)
+            except Exception as e:
+                logging.warning(f"Failed to delete local files for {q.id}: {e}")
+
+        await db.delete(q)
+
     await db.commit()
-    return {"ok": True}
+    return {"ok": True, "deleted": [q.id for q in family]}
 
 
 # ── CREATE QUOTE (new chat) ───────────────────────────────────────────────────

--- a/api/tests/test_router.py
+++ b/api/tests/test_router.py
@@ -102,11 +102,46 @@ class TestDeleteQuote:
 
         del_resp = await client.delete(f"/api/quotes/{quote_id}")
         assert del_resp.status_code == 200
-        assert del_resp.json()["ok"] is True
+        body = del_resp.json()
+        assert body["ok"] is True
+        assert quote_id in body["deleted"]
 
         # Should be gone
         get_resp = await client.get(f"/api/quotes/{quote_id}")
         assert get_resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_parent_cascades_to_children(self, client):
+        """Deleting a parent quote must also delete all its children."""
+        parent = (await client.post("/api/quotes")).json()["id"]
+        child = (await client.post("/api/quotes")).json()["id"]
+        await client.patch(f"/api/quotes/{child}", json={"parent_quote_id": parent})
+
+        del_resp = await client.delete(f"/api/quotes/{parent}")
+        assert del_resp.status_code == 200
+        body = del_resp.json()
+        assert set(body["deleted"]) == {parent, child}
+
+        assert (await client.get(f"/api/quotes/{parent}")).status_code == 404
+        assert (await client.get(f"/api/quotes/{child}")).status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_child_cascades_to_family(self, client):
+        """Deleting a child quote must also delete the parent and siblings."""
+        parent = (await client.post("/api/quotes")).json()["id"]
+        child1 = (await client.post("/api/quotes")).json()["id"]
+        child2 = (await client.post("/api/quotes")).json()["id"]
+        await client.patch(f"/api/quotes/{child1}", json={"parent_quote_id": parent})
+        await client.patch(f"/api/quotes/{child2}", json={"parent_quote_id": parent})
+
+        del_resp = await client.delete(f"/api/quotes/{child1}")
+        assert del_resp.status_code == 200
+        body = del_resp.json()
+        assert set(body["deleted"]) == {parent, child1, child2}
+
+        assert (await client.get(f"/api/quotes/{parent}")).status_code == 404
+        assert (await client.get(f"/api/quotes/{child1}")).status_code == 404
+        assert (await client.get(f"/api/quotes/{child2}")).status_code == 404
 
     @pytest.mark.asyncio
     async def test_delete_nonexistent_404(self, client):

--- a/web/src/app/config/page.tsx
+++ b/web/src/app/config/page.tsx
@@ -227,7 +227,7 @@ export default function ConfigPage() {
 
           {/* Editor */}
           <div className="flex-1 overflow-hidden px-5 py-3">
-            <div className="h-full border border-b1 rounded-lg overflow-hidden">
+            <div className="h-full border border-b1 rounded-lg overflow-auto">
               <CatalogEditor
                 value={content}
                 onChange={setContent}

--- a/web/src/lib/quotes-context.tsx
+++ b/web/src/lib/quotes-context.tsx
@@ -119,7 +119,10 @@ export function QuotesProvider({ children }: { children: ReactNode }) {
     if (deletingRef.current) return;
     deletingRef.current = true;
     const backup = quotes;
-    setQuotes(prev => prev.filter(q => q.id !== id));
+    // Find the family root and remove the entire family optimistically
+    const target = quotes.find(q => q.id === id);
+    const rootId = target?.parent_quote_id || id;
+    setQuotes(prev => prev.filter(q => q.id !== rootId && q.parent_quote_id !== rootId));
     try {
       await apiDeleteQuote(id);
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- Al eliminar cualquier quote (padre o hijo), se elimina toda la familia completa (padre + todos los hijos)
- El backend resuelve el root de la familia y borra todos los quotes relacionados en una sola transacción
- El frontend elimina optimisticamente toda la familia de la UI

## Test plan
- [x] `test_delete_existing` — borrar quote sin hijos sigue funcionando
- [x] `test_delete_parent_cascades_to_children` — borrar padre elimina hijos
- [x] `test_delete_child_cascades_to_family` — borrar hijo elimina padre y hermanos
- [x] `test_delete_nonexistent_404` — 404 para quote inexistente
- [ ] Test manual: crear quote con variantes, eliminar uno, verificar que todos desaparecen

🤖 Generated with [Claude Code](https://claude.com/claude-code)