### PR TITLE
feat: validación determinista post-despiece + review IA

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -16,6 +16,7 @@ from app.modules.agent.tools.plan_tool import read_plan
 from app.modules.agent.tools.document_tool import generate_documents
 from app.modules.agent.tools.drive_tool import upload_to_drive
 from app.modules.quote_engine.calculator import calculate_quote
+from app.modules.agent.tools.validation_tool import validate_despiece
 
 BASE_DIR = Path(__file__).parent.parent.parent.parent
 
@@ -1264,6 +1265,16 @@ class AgentService:
                     }
                 all_warnings.extend(warnings)
 
+                # Deep deterministic validation (safety net)
+                deep = validate_despiece(qdata)
+                if deep.errors:
+                    error_list = "\n".join(f"❌ {e}" for e in deep.errors)
+                    return {
+                        "ok": False,
+                        "error": f"Validación profunda fallida para {qdata.get('material_name', '?')}:\n{error_list}\n\nRecalcular antes de generar.",
+                    }
+                all_warnings.extend(deep.warnings)
+
             all_results = []
 
             # Load current quote for context
@@ -1553,6 +1564,31 @@ class AgentService:
                     inputs["pileta"] = "empotrada_johnson"
                     logging.warning(f"Auto-injected pileta=empotrada_johnson from conversation keywords")
             calc_result = calculate_quote(inputs)
+
+            # ── Post-calculate deterministic validation ──
+            if calc_result.get("ok"):
+                validation = validate_despiece(calc_result)
+                if not validation.ok:
+                    calc_result["_validation_errors"] = validation.errors
+                    calc_result["_validation_warnings"] = validation.warnings
+                    calc_result["_validation_note"] = (
+                        "⚠️ ERRORES DE VALIDACIÓN DETECTADOS. "
+                        "Corregir los datos y volver a calcular con calculate_quote. "
+                        "NO llamar a generate_documents hasta resolver estos errores."
+                    )
+                    logging.warning(f"Validation FAILED for {save_to_qid}: {validation.errors}")
+                else:
+                    if validation.warnings:
+                        calc_result["_validation_warnings"] = validation.warnings
+                    calc_result["_review_checklist"] = (
+                        "ANTES de llamar a generate_documents, revisá:\n"
+                        "1. ¿Las piezas coinciden con lo que pidió el operador?\n"
+                        "2. ¿El material es correcto?\n"
+                        "3. ¿Pileta/anafe/colocación coinciden con el pedido?\n"
+                        "4. ¿Los m² tienen sentido para las medidas dadas?\n"
+                        "5. ¿El flete es para la zona correcta?"
+                    )
+
             # Persist breakdown + change history to DB
             if calc_result.get("ok"):
                 try:

--- a/api/app/modules/agent/tools/validation_tool.py
+++ b/api/app/modules/agent/tools/validation_tool.py
@@ -1,0 +1,261 @@
+"""Post-despiece deterministic validation.
+
+Pure functions that verify business rules on the qdata dict
+returned by calculate_quote(). No I/O, no async.
+"""
+
+import math
+import logging
+from dataclasses import dataclass, field
+
+from app.core.company_config import get as _cfg
+
+_IVA = _cfg("iva.multiplier", 1.21)
+_SINTETICOS = set(
+    _cfg("materials.sinteticos", ["silestone", "dekton", "neolith", "puraprima", "purastone", "laminatto"])
+)
+
+
+@dataclass
+class ValidationResult:
+    ok: bool
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+# ── Public entry point ──────────────────────────────────────────────────────
+
+
+def validate_despiece(qdata: dict) -> ValidationResult:
+    """Run all sub-validators on a calculate_quote result dict."""
+    all_errors: list[str] = []
+    all_warnings: list[str] = []
+
+    for check in (
+        _check_iva_material,
+        _check_iva_mo,
+        _check_material_total,
+        _check_merma_rules,
+        _check_pegadopileta,
+        _check_piece_m2,
+        _check_mo_item_totals,
+        _check_colocacion_qty,
+    ):
+        try:
+            errors, warnings = check(qdata)
+            all_errors.extend(errors)
+            all_warnings.extend(warnings)
+        except Exception as exc:
+            logging.warning(f"Validation check {check.__name__} crashed: {exc}")
+            all_warnings.append(f"Check {check.__name__} no pudo ejecutarse: {exc}")
+
+    return ValidationResult(
+        ok=len(all_errors) == 0,
+        errors=all_errors,
+        warnings=all_warnings,
+    )
+
+
+# ── Sub-validators ──────────────────────────────────────────────────────────
+
+
+def _check_iva_material(qdata: dict) -> tuple[list[str], list[str]]:
+    """Verify material_price_unit = f(material_price_base * IVA)."""
+    errors, warnings = [], []
+    base = qdata.get("material_price_base")
+    unit = qdata.get("material_price_unit")
+    currency = qdata.get("material_currency", "").upper()
+
+    if base is None or unit is None:
+        if base is None and unit is not None:
+            warnings.append("Falta material_price_base — no se puede verificar IVA del material")
+        return errors, warnings
+
+    if currency == "USD":
+        expected = math.floor(base * _IVA)
+    else:
+        expected = round(base * _IVA)
+
+    if unit != expected:
+        errors.append(
+            f"IVA material inconsistente: price_base={base} × {_IVA} → "
+            f"esperado={expected}, actual={unit} ({currency})"
+        )
+    return errors, warnings
+
+
+def _check_iva_mo(qdata: dict) -> tuple[list[str], list[str]]:
+    """Verify each MO item: unit_price = round(base_price * IVA). MO is always ARS."""
+    errors, warnings = [], []
+    for mo in qdata.get("mo_items", []):
+        bp = mo.get("base_price")
+        up = mo.get("unit_price")
+        desc = mo.get("description", "?")
+
+        if bp is None:
+            continue  # Old data without base_price — skip silently
+        if up is None:
+            warnings.append(f"MO '{desc}' sin unit_price")
+            continue
+
+        expected = round(bp * _IVA)
+        if abs(up - expected) > 1:
+            errors.append(
+                f"IVA MO inconsistente en '{desc}': base={bp} × {_IVA} → "
+                f"esperado={expected}, actual={up}"
+            )
+    return errors, warnings
+
+
+def _check_material_total(qdata: dict) -> tuple[list[str], list[str]]:
+    """Verify material_total = round(m2 * price_unit) - discount_amount."""
+    errors, warnings = [], []
+    m2 = qdata.get("material_m2")
+    price_unit = qdata.get("material_price_unit")
+    total = qdata.get("material_total")
+    discount = qdata.get("discount_amount", 0) or 0
+
+    if m2 is None or price_unit is None or total is None:
+        return errors, warnings
+
+    gross = round(m2 * price_unit)
+    expected_net = gross - discount
+
+    if abs(total - expected_net) > 1:
+        errors.append(
+            f"Total material inconsistente: {m2} m² × {price_unit} = {gross}, "
+            f"descuento={discount} → esperado={expected_net}, actual={total}"
+        )
+    return errors, warnings
+
+
+def _check_merma_rules(qdata: dict) -> tuple[list[str], list[str]]:
+    """Negro Brasil NEVER merma. Synthetics SHOULD have merma."""
+    errors, warnings = [], []
+    mat = (qdata.get("material_name") or "").lower()
+    merma = qdata.get("merma") or {}
+
+    # Negro Brasil + merma = ERROR (upgraded from warning)
+    if "negro brasil" in mat and merma.get("aplica"):
+        errors.append("Negro Brasil NUNCA lleva merma — merma.aplica debe ser False")
+
+    # Synthetic without merma = warning (might be valid if desperdicio < 1.0 m²)
+    mat_type = (qdata.get("material_type") or "").lower()
+    is_synthetic = mat_type in _SINTETICOS or any(s in mat for s in _SINTETICOS)
+    if is_synthetic and not merma.get("aplica"):
+        desperdicio = merma.get("desperdicio", 0)
+        if desperdicio >= 1.0:
+            warnings.append(
+                f"Material sintético ({qdata.get('material_name')}) con desperdicio={desperdicio} m² "
+                f"debería llevar merma (umbral: 1.0 m²)"
+            )
+
+    # Natural stone with merma = warning
+    if not is_synthetic and "negro brasil" not in mat and merma.get("aplica"):
+        warnings.append(f"Piedra natural ({qdata.get('material_name')}) con merma — verificar")
+
+    return errors, warnings
+
+
+def _check_pegadopileta(qdata: dict) -> tuple[list[str], list[str]]:
+    """If pileta is empotrada, exactly 1 pileta MO item should exist."""
+    errors, warnings = [], []
+    pileta = qdata.get("pileta") or ""
+
+    if pileta not in ("empotrada_johnson", "empotrada_cliente"):
+        return errors, warnings
+
+    pileta_mo_count = 0
+    for mo in qdata.get("mo_items", []):
+        desc = (mo.get("description") or "").lower()
+        if "pileta" in desc or "pegado" in desc:
+            pileta_mo_count += 1
+
+    if pileta_mo_count == 0:
+        errors.append(
+            f"Pileta '{pileta}' solicitada pero no hay ítem MO de pileta/pegado"
+        )
+    elif pileta_mo_count > 1:
+        warnings.append(
+            f"Hay {pileta_mo_count} ítems MO de pileta — debería ser 1 por presupuesto"
+        )
+
+    return errors, warnings
+
+
+def _check_piece_m2(qdata: dict) -> tuple[list[str], list[str]]:
+    """Verify piece m2 calculations and total material_m2."""
+    errors, warnings = [], []
+    pieces = qdata.get("piece_details")
+    if not pieces:
+        return errors, warnings
+
+    total_m2 = 0.0
+    for p in pieces:
+        largo = p.get("largo", 0)
+        dim2 = p.get("dim2", 0)
+        m2 = p.get("m2", 0)
+        qty = p.get("quantity", 1)
+        expected_m2 = largo * dim2
+
+        if abs(m2 - expected_m2) > 0.01:
+            errors.append(
+                f"Pieza '{p.get('description', '?')}': m2={m2} pero "
+                f"largo={largo} × dim2={dim2} = {expected_m2:.4f}"
+            )
+        total_m2 += m2 * qty
+
+    declared_m2 = qdata.get("material_m2")
+    if declared_m2 is not None:
+        expected_total = round(total_m2, 2)
+        if abs(declared_m2 - expected_total) > 0.01:
+            errors.append(
+                f"material_m2={declared_m2} no coincide con suma de piezas={expected_total}"
+            )
+
+    return errors, warnings
+
+
+def _check_mo_item_totals(qdata: dict) -> tuple[list[str], list[str]]:
+    """Verify each MO item: total ≈ quantity × unit_price."""
+    errors, warnings = [], []
+    for mo in qdata.get("mo_items", []):
+        qty = mo.get("quantity", 0)
+        up = mo.get("unit_price", 0)
+        total = mo.get("total")
+        desc = mo.get("description", "?")
+
+        if total is None:
+            continue
+
+        expected = round(qty * up)
+        if abs(total - expected) > 2:
+            warnings.append(
+                f"MO '{desc}': total={total} pero qty={qty} × price={up} = {expected}"
+            )
+
+    return errors, warnings
+
+
+def _check_colocacion_qty(qdata: dict) -> tuple[list[str], list[str]]:
+    """If colocacion=True, colocacion MO qty should be max(material_m2, 1.0)."""
+    errors, warnings = [], []
+    if not qdata.get("colocacion"):
+        return errors, warnings
+
+    m2 = qdata.get("material_m2", 0)
+    expected_qty = max(m2, 1.0)
+
+    for mo in qdata.get("mo_items", []):
+        desc = (mo.get("description") or "").lower()
+        if "colocaci" in desc:
+            actual_qty = mo.get("quantity", 0)
+            if abs(actual_qty - expected_qty) > 0.01:
+                warnings.append(
+                    f"Colocación qty={actual_qty} pero material_m2={m2} → "
+                    f"esperado max({m2}, 1.0) = {expected_qty}"
+                )
+            return errors, warnings
+
+    warnings.append("Colocación=True pero no se encontró ítem MO de colocación")
+    return errors, warnings

--- a/api/tests/test_validation.py
+++ b/api/tests/test_validation.py
@@ -1,0 +1,383 @@
+"""Tests for post-despiece deterministic validation."""
+
+import math
+import copy
+import pytest
+
+from app.modules.agent.tools.validation_tool import (
+    validate_despiece,
+    ValidationResult,
+    _check_iva_material,
+    _check_iva_mo,
+    _check_material_total,
+    _check_merma_rules,
+    _check_pegadopileta,
+    _check_piece_m2,
+    _check_mo_item_totals,
+    _check_colocacion_qty,
+)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+IVA = 1.21
+
+
+def _valid_qdata() -> dict:
+    """A fully valid qdata for Silestone Blanco Norte."""
+    base_price = 519
+    unit_price = math.floor(base_price * IVA)  # floor(627.99) = 627
+
+    mo_base_coloc = 49699
+    mo_unit_coloc = round(mo_base_coloc * IVA)  # 60136
+    mo_base_pileta = 53840
+    mo_unit_pileta = round(mo_base_pileta * IVA)  # 65146
+    mo_base_flete = 42975
+    mo_unit_flete = round(mo_base_flete * IVA)  # 51999
+
+    m2 = 1.30
+    material_total = round(m2 * unit_price)  # round(815.1) = 815
+
+    return {
+        "ok": True,
+        "client_name": "Juan Carlos",
+        "project": "Cocina",
+        "date": "31.03.2026",
+        "delivery_days": "30 dias",
+        "material_name": "SILESTONE BLANCO NORTE",
+        "material_type": "silestone",
+        "material_m2": m2,
+        "material_price_base": base_price,
+        "material_price_unit": unit_price,
+        "material_currency": "USD",
+        "material_total": material_total,
+        "discount_pct": 0,
+        "discount_amount": 0,
+        "merma": {
+            "aplica": False,
+            "desperdicio": 0.80,
+            "sobrante_m2": 0,
+            "motivo": "Desperdicio < 1.0 m²",
+        },
+        "piece_details": [
+            {"description": "Mesada", "largo": 2.0, "dim2": 0.60, "m2": 1.2, "quantity": 1},
+            {"description": "Zocalo", "largo": 2.0, "dim2": 0.05, "m2": 0.1, "quantity": 1},
+        ],
+        "mo_items": [
+            {
+                "description": "Agujero y pegado pileta",
+                "quantity": 1,
+                "unit_price": mo_unit_pileta,
+                "base_price": mo_base_pileta,
+                "total": round(1 * mo_unit_pileta),
+            },
+            {
+                "description": "Colocacion",
+                "quantity": 1.30,
+                "unit_price": mo_unit_coloc,
+                "base_price": mo_base_coloc,
+                "total": round(1.30 * mo_unit_coloc),
+            },
+            {
+                "description": "Flete + toma medidas Rosario",
+                "quantity": 1,
+                "unit_price": mo_unit_flete,
+                "base_price": mo_base_flete,
+                "total": round(1 * mo_unit_flete),
+            },
+        ],
+        "sinks": [{"name": "Johnson Quadra Q71A", "quantity": 1, "unit_price": 350000}],
+        "sectors": [{"label": "COCINA", "pieces": ["2.00 X 0.60", "ZOCALO 2.00 X 0.05"]}],
+        "colocacion": True,
+        "pileta": "empotrada_johnson",
+        "anafe": False,
+        "frentin": False,
+        "inglete": False,
+        "pulido": False,
+        "localidad": "Rosario",
+        "total_ars": 245458,
+        "total_usd": material_total,
+    }
+
+
+# ── TestIVAConsistency ──────────────────────────────────────────────────────
+
+
+class TestIVAMaterial:
+    def test_valid_usd_iva(self):
+        qdata = _valid_qdata()
+        errors, warnings = _check_iva_material(qdata)
+        assert errors == []
+
+    def test_invalid_usd_iva(self):
+        qdata = _valid_qdata()
+        qdata["material_price_unit"] = 999  # Wrong
+        errors, warnings = _check_iva_material(qdata)
+        assert len(errors) == 1
+        assert "IVA material inconsistente" in errors[0]
+
+    def test_valid_ars_iva(self):
+        qdata = _valid_qdata()
+        qdata["material_currency"] = "ARS"
+        base = 275958
+        qdata["material_price_base"] = base
+        qdata["material_price_unit"] = round(base * IVA)
+        errors, warnings = _check_iva_material(qdata)
+        assert errors == []
+
+    def test_missing_base_price_warns(self):
+        qdata = _valid_qdata()
+        del qdata["material_price_base"]
+        errors, warnings = _check_iva_material(qdata)
+        assert errors == []
+        assert len(warnings) == 1
+        assert "material_price_base" in warnings[0]
+
+
+class TestIVAMO:
+    def test_valid_mo_iva(self):
+        qdata = _valid_qdata()
+        errors, warnings = _check_iva_mo(qdata)
+        assert errors == []
+
+    def test_mo_iva_mismatch(self):
+        qdata = _valid_qdata()
+        qdata["mo_items"][0]["unit_price"] = 99999  # Wrong
+        errors, warnings = _check_iva_mo(qdata)
+        assert len(errors) == 1
+        assert "IVA MO inconsistente" in errors[0]
+
+    def test_mo_without_base_skips(self):
+        qdata = _valid_qdata()
+        for mo in qdata["mo_items"]:
+            del mo["base_price"]
+        errors, warnings = _check_iva_mo(qdata)
+        assert errors == []
+        assert warnings == []
+
+
+# ── TestMaterialTotal ───────────────────────────────────────────────────────
+
+
+class TestMaterialTotal:
+    def test_valid_total(self):
+        qdata = _valid_qdata()
+        errors, warnings = _check_material_total(qdata)
+        assert errors == []
+
+    def test_total_mismatch(self):
+        qdata = _valid_qdata()
+        qdata["material_total"] = 999
+        errors, warnings = _check_material_total(qdata)
+        assert len(errors) == 1
+        assert "Total material inconsistente" in errors[0]
+
+    def test_total_with_discount(self):
+        qdata = _valid_qdata()
+        gross = round(qdata["material_m2"] * qdata["material_price_unit"])
+        qdata["discount_pct"] = 5
+        qdata["discount_amount"] = round(gross * 5 / 100)
+        qdata["material_total"] = gross - qdata["discount_amount"]
+        errors, warnings = _check_material_total(qdata)
+        assert errors == []
+
+
+# ── TestMermaRules ──────────────────────────────────────────────────────────
+
+
+class TestMermaRules:
+    def test_negro_brasil_no_merma_passes(self):
+        qdata = _valid_qdata()
+        qdata["material_name"] = "GRANITO NEGRO BRASIL"
+        qdata["material_type"] = "granito"
+        qdata["merma"] = {"aplica": False, "desperdicio": 0, "sobrante_m2": 0, "motivo": ""}
+        errors, warnings = _check_merma_rules(qdata)
+        assert errors == []
+
+    def test_negro_brasil_with_merma_errors(self):
+        qdata = _valid_qdata()
+        qdata["material_name"] = "GRANITO NEGRO BRASIL"
+        qdata["material_type"] = "granito"
+        qdata["merma"] = {"aplica": True, "desperdicio": 1.5, "sobrante_m2": 0.75, "motivo": ""}
+        errors, warnings = _check_merma_rules(qdata)
+        assert len(errors) == 1
+        assert "Negro Brasil" in errors[0]
+
+    def test_synthetic_without_merma_warns_if_high_waste(self):
+        qdata = _valid_qdata()
+        qdata["merma"] = {"aplica": False, "desperdicio": 1.5, "sobrante_m2": 0, "motivo": ""}
+        errors, warnings = _check_merma_rules(qdata)
+        assert len(warnings) == 1
+        assert "sintético" in warnings[0].lower() or "merma" in warnings[0].lower()
+
+    def test_synthetic_without_merma_ok_if_low_waste(self):
+        qdata = _valid_qdata()
+        # desperdicio < 1.0 → no merma is correct
+        qdata["merma"] = {"aplica": False, "desperdicio": 0.5, "sobrante_m2": 0, "motivo": ""}
+        errors, warnings = _check_merma_rules(qdata)
+        assert errors == []
+        assert warnings == []
+
+    def test_natural_stone_no_merma_passes(self):
+        qdata = _valid_qdata()
+        qdata["material_name"] = "GRANITO AMADEUS"
+        qdata["material_type"] = "granito"
+        qdata["merma"] = {"aplica": False}
+        errors, warnings = _check_merma_rules(qdata)
+        assert errors == []
+        assert warnings == []
+
+    def test_natural_stone_with_merma_warns(self):
+        qdata = _valid_qdata()
+        qdata["material_name"] = "GRANITO AMADEUS"
+        qdata["material_type"] = "granito"
+        qdata["merma"] = {"aplica": True, "desperdicio": 1.0, "sobrante_m2": 0.5, "motivo": ""}
+        errors, warnings = _check_merma_rules(qdata)
+        assert len(warnings) == 1
+        assert "natural" in warnings[0].lower()
+
+
+# ── TestPegadoPileta ────────────────────────────────────────────────────────
+
+
+class TestPegadoPileta:
+    def test_one_sink_one_mo_passes(self):
+        qdata = _valid_qdata()
+        errors, warnings = _check_pegadopileta(qdata)
+        assert errors == []
+
+    def test_empotrada_missing_mo_errors(self):
+        qdata = _valid_qdata()
+        # Remove pileta MO item
+        qdata["mo_items"] = [m for m in qdata["mo_items"] if "pileta" not in m["description"].lower()]
+        errors, warnings = _check_pegadopileta(qdata)
+        assert len(errors) == 1
+        assert "pileta" in errors[0].lower()
+
+    def test_no_pileta_skips(self):
+        qdata = _valid_qdata()
+        qdata["pileta"] = None
+        errors, warnings = _check_pegadopileta(qdata)
+        assert errors == []
+        assert warnings == []
+
+    def test_multiple_pileta_mo_warns(self):
+        qdata = _valid_qdata()
+        # Duplicate the pileta MO item
+        pileta_mo = next(m for m in qdata["mo_items"] if "pileta" in m["description"].lower())
+        qdata["mo_items"].append(copy.deepcopy(pileta_mo))
+        errors, warnings = _check_pegadopileta(qdata)
+        assert len(warnings) == 1
+        assert "2" in warnings[0]
+
+
+# ── TestPieceM2 ─────────────────────────────────────────────────────────────
+
+
+class TestPieceM2:
+    def test_valid_pieces(self):
+        qdata = _valid_qdata()
+        errors, warnings = _check_piece_m2(qdata)
+        assert errors == []
+
+    def test_m2_sum_mismatch(self):
+        qdata = _valid_qdata()
+        qdata["material_m2"] = 5.0  # Wrong sum
+        errors, warnings = _check_piece_m2(qdata)
+        assert len(errors) == 1
+        assert "material_m2" in errors[0]
+
+    def test_piece_m2_calc_wrong(self):
+        qdata = _valid_qdata()
+        qdata["piece_details"][0]["m2"] = 9.99  # Should be 1.2
+        errors, warnings = _check_piece_m2(qdata)
+        assert any("m2=" in e for e in errors)
+
+    def test_no_piece_details_skips(self):
+        qdata = _valid_qdata()
+        del qdata["piece_details"]
+        errors, warnings = _check_piece_m2(qdata)
+        assert errors == []
+
+
+# ── TestMOTotals ────────────────────────────────────────────────────────────
+
+
+class TestMOTotals:
+    def test_valid_totals(self):
+        qdata = _valid_qdata()
+        errors, warnings = _check_mo_item_totals(qdata)
+        assert warnings == []
+
+    def test_total_mismatch_warns(self):
+        qdata = _valid_qdata()
+        qdata["mo_items"][0]["total"] = 1  # Wrong
+        errors, warnings = _check_mo_item_totals(qdata)
+        assert len(warnings) == 1
+
+
+# ── TestColocacion ──────────────────────────────────────────────────────────
+
+
+class TestColocacion:
+    def test_valid_colocacion_qty(self):
+        qdata = _valid_qdata()
+        errors, warnings = _check_colocacion_qty(qdata)
+        assert warnings == []
+
+    def test_wrong_colocacion_qty_warns(self):
+        qdata = _valid_qdata()
+        # Set wrong qty
+        for mo in qdata["mo_items"]:
+            if "colocaci" in mo["description"].lower():
+                mo["quantity"] = 99.0
+        errors, warnings = _check_colocacion_qty(qdata)
+        assert len(warnings) == 1
+        assert "Colocación" in warnings[0] or "colocaci" in warnings[0].lower()
+
+    def test_colocacion_min_1(self):
+        qdata = _valid_qdata()
+        qdata["material_m2"] = 0.5
+        for mo in qdata["mo_items"]:
+            if "colocaci" in mo["description"].lower():
+                mo["quantity"] = 1.0  # max(0.5, 1.0) = 1.0
+        errors, warnings = _check_colocacion_qty(qdata)
+        assert warnings == []
+
+    def test_no_colocacion_skips(self):
+        qdata = _valid_qdata()
+        qdata["colocacion"] = False
+        errors, warnings = _check_colocacion_qty(qdata)
+        assert errors == []
+        assert warnings == []
+
+
+# ── TestFullValidation ──────────────────────────────────────────────────────
+
+
+class TestFullValidation:
+    def test_fully_valid_passes(self):
+        result = validate_despiece(_valid_qdata())
+        assert result.ok is True
+        assert result.errors == []
+
+    def test_multiple_errors_all_reported(self):
+        qdata = _valid_qdata()
+        qdata["material_price_unit"] = 999  # IVA error
+        qdata["material_total"] = 1  # Total error
+        qdata["material_name"] = "GRANITO NEGRO BRASIL"  # Keep merma.aplica=False so no error there
+        qdata["merma"]["aplica"] = True  # Negro Brasil + merma = error
+        result = validate_despiece(qdata)
+        assert result.ok is False
+        assert len(result.errors) >= 3
+
+    def test_only_warnings_still_ok(self):
+        qdata = _valid_qdata()
+        # Trigger only a warning: synthetic without merma but low desperdicio is fine
+        # Trigger colocacion qty warning instead
+        for mo in qdata["mo_items"]:
+            if "colocaci" in mo["description"].lower():
+                mo["quantity"] = 99.0
+        result = validate_despiece(qdata)
+        assert result.ok is True
+        assert len(result.warnings) >= 1


### PR DESCRIPTION
## Summary

- Adds `validation_tool.py` with 8 deterministic checks that run after `calculate_quote` and before `generate_documents`
- Validates: IVA consistency (USD floor / ARS round), material totals, merma rules (Negro Brasil NEVER), pegadopileta count, piece m² calculations, MO item totals, and colocación quantity
- Errors block PDF generation; warnings are flagged but allowed
- Injects a review checklist into tool results so Claude self-verifies before generating documents
- Includes 33 unit tests covering all validation rules

## Checks implemented

| Check | Type | Rule |
|-------|------|------|
| IVA material | Error | `price_unit == floor/round(base × 1.21)` |
| IVA MO | Error | `unit_price == round(base × 1.21)` |
| Material total | Error | `total == round(m2 × price) - discount` |
| Merma Negro Brasil | Error | NEVER merma |
| Merma sintéticos | Warning | Should have merma if desperdicio ≥ 1.0 m² |
| Pegadopileta count | Error | Exactly 1 per presupuesto if empotrada |
| Piece m² | Error | `m2 == largo × dim2`, sum matches `material_m2` |
| MO totals | Warning | `total == qty × unit_price` |
| Colocación qty | Warning | `qty == max(m2, 1.0)` |

## Test plan

- [x] 33 new tests pass (`tests/test_validation.py`)
- [x] Full test suite: 533 passed, 5 pre-existing failures (unrelated catalog/price range issues), 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)