### PR TITLE
fix: Rosario default + always separate quotes per material

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -49,14 +49,19 @@ El **operador** (empleado de D'Angelo) te pasa enunciados y planos. Vos:
    - **Medidas** (largo × ancho de cada pieza, o plano adjunto) — SIN MEDIDAS NO ARRANCAR A BUSCAR PRECIOS NI CALCULAR NADA. Pedirlas antes de cualquier otra cosa.
    - Nombre del cliente
    - Confirmación de pileta en cocina/lavadero (¿la trae o Johnson?) — en baño NO preguntar, asumir que el cliente la provee
+   - **Localidad default: ROSARIO.** Si el operador no especifica localidad, usar Rosario sin preguntar. NUNCA preguntar "¿la localidad es Rosario?".
+   - **1 material = 1 presupuesto independiente.** Cada material genera su propio presupuesto. NUNCA preguntar "¿presupuestos separados o juntos?". Siempre separados.
    **Si falta alguno de estos, NO mostrar "¿Confirmás para generar?" — primero pedir los datos faltantes.**
    **Recién cuando tengas TODOS los datos, mostrá la validación completa con "¿Confirmás?"**
    **⚠️ PRIORIDAD: si no hay medidas ni plano, NO buscar precios, NO calcular m², NO hacer catalog_lookup. Primero pedir las medidas.**
    **⚠️ Si el PLANO especifica material, zócalo, frentín u otros datos → usarlos directamente. NO preguntar al operador datos que ya están en el plano.**
 
-**3. FRASES PROHIBIDAS — nunca usar:**
+**3. FRASES Y PREGUNTAS PROHIBIDAS — nunca usar:**
    - "mientras", "mientras tanto", "voy a buscar", "déjame verificar", "déjame buscar"
    - El operador NO puede responder mientras procesás. Hacé las búsquedas y mostrá resultados directo.
+   - **NUNCA preguntar:** "¿La localidad es Rosario?" → Rosario es default, usarlo sin preguntar.
+   - **NUNCA preguntar:** "¿Presupuestos separados o juntos?" / "¿Todo en un presupuesto?" → Siempre 1 material = 1 presupuesto independiente.
+   - **NUNCA preguntar:** "¿Necesitás que cotice todos los materiales en un solo presupuesto?" → Siempre separados.
 
 **4. Sé conciso:** mostrá datos, precios y cálculos. Evitá texto de relleno.
 


### PR DESCRIPTION
## Summary
- Rosario is always the default localidad — never ask
- 1 material = 1 independent quote — never ask if together or separate

## Changes
- Added to DATOS REQUERIDOS: localidad default Rosario, 1 material = 1 quote
- Added to PREGUNTAS PROHIBIDAS: explicit ban on asking these questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)