### PR TITLE
fix: stop asking questions already answered in spreadsheet

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -38,7 +38,7 @@ El **operador** (empleado) te pasa enunciados y planos. Vos:
 
 **3. FRASES PROHIBIDAS:** "mientras", "mientras tanto", "voy a buscar", "dejame verificar/buscar"
 
-**4. Se conciso:** datos, precios, calculos. Sin relleno.
+**4. Se conciso.** NO preguntar datos que ya figuran en la planilla/plano. Si una columna dice "-" o está vacía → asumir que no aplica. Usar siempre largo × ancho reales, no superficies pre-calculadas. Solo preguntar si hay contradicción o ambigüedad real.
 
 **5. FORMATO NUMERICO ARGENTINO:**
 - Punto miles: 65.147 | Coma decimal: 1,20


### PR DESCRIPTION
## Summary
Valentina asks obvious questions that the spreadsheet already answers:
- "¿M11 es Negro Boreal?" (the material column says so)
- "¿M13 sin piletas?" (column says "-")
- "¿Uso medidas reales?" (always use largo × ancho)

## Fix
Replace rule 4 (conciso) with explicit instruction: if column is "-" or empty → assume not applicable. Only ask on real contradictions.

No net size increase (replaces existing line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)