### PR TITLE
fix: edificio Excel grand total border, USD format, footer

### DIFF
--- a/api/app/modules/agent/tools/document_tool.py
+++ b/api/app/modules/agent/tools/document_tool.py
@@ -440,10 +440,10 @@ def _generate_resumen_obra_excel(excel_path: Path, data: dict) -> None:
         ws.cell(r, 2).number_format = '#,##0.00'
         ws.cell(r, 3, cur).font = normal
         if cur == "USD":
-            ws.cell(r, 4, f"USD{m['price_unit']}").font = normal
-            ws.cell(r, 5, f"USD{m['subtotal']}").font = normal
-            ws.cell(r, 6, f"-USD{m['discount_amount']}" if m['discount_amount'] else "-").font = normal
-            ws.cell(r, 7, f"USD{m['net']}").font = bold
+            ws.cell(r, 4, _fmt_usd(m['price_unit'])).font = normal
+            ws.cell(r, 5, _fmt_usd(m['subtotal'])).font = normal
+            ws.cell(r, 6, f"-{_fmt_usd(m['discount_amount'])}" if m['discount_amount'] else "-").font = normal
+            ws.cell(r, 7, _fmt_usd(m['net'])).font = bold
         else:
             ws.cell(r, 4, m["price_unit"]).font = normal
             ws.cell(r, 4).number_format = ars_fmt
@@ -463,7 +463,7 @@ def _generate_resumen_obra_excel(excel_path: Path, data: dict) -> None:
         r += 1
     if data["total_mat_usd"]:
         ws.cell(r, 1, "Total materiales USD").font = bold
-        ws.cell(r, 7, f"USD{data['total_mat_usd']}").font = bold
+        ws.cell(r, 7, _fmt_usd(data['total_mat_usd'])).font = bold
         r += 1
 
     # MO table
@@ -499,7 +499,7 @@ def _generate_resumen_obra_excel(excel_path: Path, data: dict) -> None:
         r += 1
     if data["total_mat_usd"]:
         ws.cell(r, 1, "Total materiales USD").font = normal
-        ws.cell(r, 5, f"USD{data['total_mat_usd']}").font = normal
+        ws.cell(r, 5, _fmt_usd(data['total_mat_usd'])).font = normal
         r += 1
     ws.cell(r, 1, "Total mano de obra ARS").font = normal
     ws.cell(r, 5, data["mo_total"]).font = normal
@@ -511,7 +511,7 @@ def _generate_resumen_obra_excel(excel_path: Path, data: dict) -> None:
     r += 1
     if data["grand_total_usd"]:
         ws.cell(r, 1, "TOTAL FINAL USD").font = bold
-        ws.cell(r, 5, f"USD{data['grand_total_usd']}").font = bold
+        ws.cell(r, 5, _fmt_usd(data['grand_total_usd'])).font = bold
 
     # Clarification
     r += 2
@@ -523,9 +523,26 @@ def _generate_resumen_obra_excel(excel_path: Path, data: dict) -> None:
         ws.cell(r, 1, f"  - {name}").font = italic
         r += 1
 
-    # Conditions
+    # Conditions — match PDF
     r += 1
-    ws.cell(r, 1, "Forma de pago: Contado").font = Font(name="Calibri", size=8)
+    co = _load_company_config()
+    cond_font = Font(name="Calibri", size=7)
+    ws.cell(r, 1, "Forma de pago: Contado").font = cond_font
+    r += 1
+    if co.get("conditions_general"):
+        for line in co["conditions_general"].split("\n"):
+            if line.strip():
+                ws.cell(r, 1, line.strip()).font = cond_font
+                r += 1
+    if co.get("conditions_payment"):
+        r += 1
+        for line in co["conditions_payment"].split("\n"):
+            if line.strip():
+                ws.cell(r, 1, line.strip()).font = cond_font
+                r += 1
+    # Footer
+    r += 1
+    ws.cell(r, 1, "No se suben mesadas que no entren en ascensor").font = Font(name="Calibri", italic=True, size=7)
 
     wb.save(str(excel_path))
 
@@ -757,11 +774,18 @@ def _generate_edificio_excel(excel_path: Path, data: dict) -> None:
     for mc in list(ws.merged_cells.ranges):
         ws.unmerge_cells(str(mc))
 
-    from openpyxl.styles import Font
+    from openpyxl.styles import Font, Alignment, Border, Side
     bold = Font(name="Calibri", bold=True, size=10)
     normal = Font(name="Calibri", bold=False, size=10)
     ars_fmt = '"$"#,##0'
     qty_fmt = '#,##0.00'
+    thin_border = Border(
+        left=Side(style="thin"),
+        right=Side(style="thin"),
+        top=Side(style="thin"),
+        bottom=Side(style="thin"),
+    )
+    center_align = Alignment(horizontal="center")
 
     client_name = data.get("client_name", "")
     project = data.get("project", "")
@@ -817,8 +841,8 @@ def _generate_edificio_excel(excel_path: Path, data: dict) -> None:
     ws["D23"].value = mat_m2
     ws["D23"].number_format = qty_fmt
     if currency == "USD":
-        ws["E23"].value = f"USD{mat_price}"
-        ws["F23"].value = f"USD{mat_total_bruto}"
+        ws["E23"].value = _fmt_usd(mat_price)
+        ws["F23"].value = _fmt_usd(mat_total_bruto)
     else:
         ws["E23"].value = mat_price
         ws["E23"].number_format = ars_fmt
@@ -854,7 +878,7 @@ def _generate_edificio_excel(excel_path: Path, data: dict) -> None:
                     ws.cell(r, 5).font = Font(name="Calibri", italic=True, size=10)
                     disc = round(mat_total_bruto * discount_pct / 100)
                     if currency == "USD":
-                        ws.cell(r, 6).value = f"USD{disc}"
+                        ws.cell(r, 6).value = _fmt_usd(disc)
                     else:
                         ws.cell(r, 6).value = disc
                         ws.cell(r, 6).number_format = ars_fmt
@@ -863,7 +887,7 @@ def _generate_edificio_excel(excel_path: Path, data: dict) -> None:
                     ws.cell(r, 5).font = bold
                     mat_net = mat_total_bruto - disc
                     if currency == "USD":
-                        ws.cell(r, 6).value = f"USD{mat_net}"
+                        ws.cell(r, 6).value = _fmt_usd(mat_net)
                     else:
                         ws.cell(r, 6).value = mat_net
                         ws.cell(r, 6).number_format = ars_fmt
@@ -872,7 +896,7 @@ def _generate_edificio_excel(excel_path: Path, data: dict) -> None:
                     ws.cell(r, 5).value = f"Total {currency}"
                     ws.cell(r, 5).font = bold
                     if currency == "USD":
-                        ws.cell(r, 6).value = f"USD{mat_total_bruto}"
+                        ws.cell(r, 6).value = _fmt_usd(mat_total_bruto)
                     else:
                         ws.cell(r, 6).value = mat_total_bruto
                         ws.cell(r, 6).number_format = ars_fmt
@@ -910,16 +934,22 @@ def _generate_edificio_excel(excel_path: Path, data: dict) -> None:
 
     r += 2  # spacer
 
-    # Grand total
+    # Grand total — bordered box, centered (matching PDF exactly)
     if grand_text:
-        ws.cell(r, 1).value = grand_text
-        ws.cell(r, 1).font = bold
         ws.merge_cells(f"A{r}:F{r}")
+        cell_gt = ws.cell(r, 1)
+        cell_gt.value = grand_text
+        cell_gt.font = Font(name="Calibri", bold=True, size=9)
+        cell_gt.alignment = center_align
+        cell_gt.border = thin_border
+        # Apply border to all merged cells in the row
+        for col in range(2, 7):
+            ws.cell(r, col).border = thin_border
 
     # Conditions — same as PDF
     r += 2
     co = _load_company_config()
-    cond_font = Font(name="Calibri", size=8)
+    cond_font = Font(name="Calibri", size=7)  # Match PDF 7pt
     ws.cell(r, 1).value = "Forma de pago: Contado"
     ws.cell(r, 1).font = cond_font
     r += 1
@@ -936,6 +966,11 @@ def _generate_edificio_excel(excel_path: Path, data: dict) -> None:
                 ws.cell(r, 1).value = line.strip()
                 ws.cell(r, 1).font = cond_font
                 r += 1
+
+    # Footer — match PDF exactly
+    r += 1
+    ws.cell(r, 1).value = "No se suben mesadas que no entren en ascensor"
+    ws.cell(r, 1).font = Font(name="Calibri", italic=True, size=7)
 
     wb.save(str(excel_path))
     _inject_locale(str(excel_path))
@@ -1250,8 +1285,8 @@ def _generate_excel(output_path: Path, data: dict) -> None:
     ws["D22"].value = mat_m2
     ws["D22"].number_format = qty_fmt
     if currency == "USD":
-        ws["E22"].value = f"USD{mat_price}"
-        ws["F22"].value = f"USD{total_mat}"  # Bruto (before discount)
+        ws["E22"].value = _fmt_usd(mat_price)
+        ws["F22"].value = _fmt_usd(total_mat)  # Bruto (before discount)
     else:
         ws["E22"].value = mat_price
         ws["E22"].number_format = ars_fmt
@@ -1290,7 +1325,7 @@ def _generate_excel(output_path: Path, data: dict) -> None:
         ws.cell(24, 1).value = all_pieces[1]
     if currency == "USD":
         ws.cell(24, 5).value = f"TOTAL {currency}"
-        ws.cell(24, 6).value = f"USD{total_mat_net}"
+        ws.cell(24, 6).value = _fmt_usd(total_mat_net)
     else:
         # ARS-only: clear template's hardcoded "TOTAL USD" from E24/F24
         ws.cell(24, 5).value = None

--- a/api/tests/test_excel_regression.py
+++ b/api/tests/test_excel_regression.py
@@ -397,3 +397,68 @@ class TestExcelPdfParity:
             heights = re.findall(r'ht="([\d.]+)"', sheet_xml)
             for h in heights:
                 assert float(h) <= 50, f"Row height {h}px too large in {xlsx.name} — template height leak"
+
+    @pytest.mark.skipif(not ESH_PDF.exists(), reason="ESH PDF not available")
+    @pytest.mark.asyncio
+    async def test_edificio_excel_grand_total_has_border(self):
+        """Grand total row in edificio Excel must have a border (matching PDF box)."""
+        import re as _re
+        paso2, summary = _build_esh_paso2()
+        qid = "test-excel-parity-007"
+        await generate_edificio_documents(qid, paso2, summary, "ESH", "Test")
+
+        for xlsx in (OUTPUT_DIR / qid).glob("*.xlsx"):
+            if "Resumen" in xlsx.name:
+                continue
+            # Read raw XML — openpyxl can't load due to locale injection
+            with zipfile.ZipFile(str(xlsx)) as z:
+                styles_xml = z.read("xl/styles.xml").decode("utf-8")
+            # Check that styles.xml has a border with "thin" style (our injected border)
+            assert "thin" in styles_xml, f"No thin border style found in {xlsx.name}"
+            # Check styles.xml has horizontal="center" alignment (grand total cell)
+            assert 'horizontal="center"' in styles_xml, f"No centered alignment style in {xlsx.name}"
+
+    @pytest.mark.skipif(not ESH_PDF.exists(), reason="ESH PDF not available")
+    @pytest.mark.asyncio
+    async def test_edificio_excel_usd_format(self):
+        """USD values in edificio Excel must use 'USD 1.937' format (space + dots), not 'USD1937'."""
+        paso2, summary = _build_esh_paso2()
+        qid = "test-excel-parity-008"
+        await generate_edificio_documents(qid, paso2, summary, "ESH", "Test")
+
+        for xlsx in (OUTPUT_DIR / qid).glob("*.xlsx"):
+            if "Resumen" in xlsx.name:
+                continue
+            xml = _read_excel_xml(xlsx)
+            shared = ""
+            try:
+                with zipfile.ZipFile(str(xlsx)) as z:
+                    shared = z.read("xl/sharedStrings.xml").decode("utf-8")
+            except Exception:
+                pass
+            all_text = xml + shared
+            # Should NOT have "USD" immediately followed by a digit (no space)
+            import re
+            bad_usd = re.findall(r'USD\d', all_text)
+            assert len(bad_usd) == 0, f"USD values without space found in {xlsx.name}: {bad_usd}"
+
+    @pytest.mark.skipif(not ESH_PDF.exists(), reason="ESH PDF not available")
+    @pytest.mark.asyncio
+    async def test_edificio_excel_has_footer(self):
+        """Edificio Excel must have 'No se suben mesadas' footer like PDF."""
+        paso2, summary = _build_esh_paso2()
+        qid = "test-excel-parity-009"
+        await generate_edificio_documents(qid, paso2, summary, "ESH", "Test")
+
+        for xlsx in (OUTPUT_DIR / qid).glob("*.xlsx"):
+            if "Resumen" in xlsx.name:
+                continue
+            xml = _read_excel_xml(xlsx)
+            shared = ""
+            try:
+                with zipfile.ZipFile(str(xlsx)) as z:
+                    shared = z.read("xl/sharedStrings.xml").decode("utf-8")
+            except Exception:
+                pass
+            all_text = (xml + shared).lower()
+            assert "no se suben mesadas" in all_text, f"Footer missing from {xlsx.name}"


### PR DESCRIPTION
## Root Cause Analysis

La función `_generate_edificio_excel()` tenía **5 diferencias de formato** vs `_generate_edificio_pdf()`:

### 1. ❌ Grand Total sin borde ni centrado
- **PDF**: rectángulo con borde (`pdf.rect()`) + texto centrado (`align="C"`)
- **Excel**: solo texto en celda sin borde, alineado a la izquierda
- **Fix**: agregado `thin_border` + `center_align` al grand total row

### 2. ❌ Formato USD roto — `"USD1937"` en vez de `"USD 1.937"`
- **PDF**: usa `_fmt_usd(value)` → `"USD 1.937"` (espacio + puntos miles)
- **Excel**: usaba `f"USD{value}"` → `"USD1937"` (sin espacio, sin puntos)
- **Fix**: reemplazado `f"USD{value}"` por `_fmt_usd(value)` en TODAS las funciones Excel (edificio + resumen + normal)

### 3. ❌ Footer faltante
- **PDF**: tiene `"No se suben mesadas que no entren en ascensor"` (italic 7pt)
- **Excel**: no lo tenía
- **Fix**: agregado footer en edificio Excel y resumen Excel

### 4. ❌ Font conditions 8pt → 7pt
- **PDF**: conditions a 7pt
- **Excel**: conditions estaba a 8pt
- **Fix**: cambiado a 7pt para match

### 5. ❌ Resumen Obra Excel — mismos bugs USD + conditions incompletas
- Misma corrección de USD format + conditions completas + footer

## Archivos modificados
- `api/app/modules/agent/tools/document_tool.py` — fixes en 3 funciones Excel
- `api/tests/test_excel_regression.py` — 3 tests nuevos (border, USD format, footer)

## Tests
32/32 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)