### PR TITLE
fix: auto row height for long piece text in edificio Excel

### DIFF
--- a/api/app/modules/agent/tools/document_tool.py
+++ b/api/app/modules/agent/tools/document_tool.py
@@ -913,6 +913,9 @@ def _generate_edificio_excel(excel_path: Path, data: dict) -> None:
             apply_zebra(r)
             ws.cell(r, 1).value = display
             ws.cell(r, 1).font = normal_8
+            # Auto-adjust row height for long piece text that wraps in Google Sheets
+            if len(display) > 25:
+                ws.row_dimensions[r].height = 30  # 2 lines
             if first_piece:
                 # Total on same row as first piece (matching PDF)
                 if discount_pct:


### PR DESCRIPTION
Pieces longer than 25 chars wrap in Google Sheets (col A = 7.75 width).
Row height 15px only shows 1 line → text gets cut off.
Fix: set row height to 30px for long pieces so both lines are visible.

32/32 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)