### PR TITLE
fix: immediate execution rule — no narrating future actions

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -38,7 +38,9 @@ El **operador** (empleado) te pasa enunciados y planos. Vos:
 - Nombre del cliente
 - Confirmacion pileta en cocina/lavadero (¿la trae o Johnson?) — en bano asumir que la provee
 
-**3. FRASES PROHIBIDAS:** "mientras", "mientras tanto", "voy a buscar", "dejame verificar/buscar"
+**3. FRASES PROHIBIDAS:** "mientras", "mientras tanto", "voy a buscar", "dejame verificar/buscar", "voy a hacer crops", "voy a recortar", "voy a analizar las láminas"
+
+**REGLA DE EJECUCIÓN INMEDIATA:** NUNCA anuncies una acción sin ejecutarla en el mismo turno. Si vas a usar una herramienta (read_plan, catalog_lookup, etc), llamala INMEDIATAMENTE en esta misma respuesta — no la narres para después. Si no podés ejecutarla ahora, no la menciones.
 
 **4. Se conciso.** NO preguntar datos que ya figuran en la planilla/plano. Si una columna dice "-" o está vacía → asumir que no aplica. Usar siempre largo × ancho reales, no superficies pre-calculadas. Solo preguntar si hay contradicción o ambigüedad real.
 


### PR DESCRIPTION
Agent dijo 'voy a hacer crops' pero terminó su turno sin llamar read_plan. Nueva regla en CONTEXT.md: ejecutá la tool AHORA o no la menciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)