### PR TITLE
fix: prevent token overflow in read_plan — native blocks + compression + limits

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -417,7 +417,7 @@ TOOLS = [
     {"name": "catalog_batch_lookup", "description": "Busca múltiples SKUs. Preferir sobre catalog_lookup para 2+.", "input_schema": {"type": "object", "properties": {"queries": {"type": "array", "items": {"type": "object", "properties": {"catalog": {"type": "string"}, "sku": {"type": "string"}}, "required": ["catalog", "sku"]}}}, "required": ["queries"]}},
     {"name": "check_stock", "description": "Verifica retazos en stock.", "input_schema": {"type": "object", "properties": {"material_sku": {"type": "string"}}, "required": ["material_sku"]}},
     {"name": "check_architect", "description": "Verifica si cliente es arquitecta con descuento.", "input_schema": {"type": "object", "properties": {"client_name": {"type": "string"}}, "required": ["client_name"]}},
-    {"name": "read_plan", "description": "Herramienta AUXILIAR para rasterizar y recortar regiones específicas de un plano PDF a 200 DPI. REGLAS ESTRICTAS: 1) Si el PDF ya fue adjuntado como document base64 en este mensaje, NO uses read_plan para el análisis inicial — analizá las páginas directamente con tu visión nativa y extraé por lámina: tipología, cantidad, material, medidas de mesadas, zócalos, piletas/perforaciones, notas. 2) Si el archivo es una imagen simple (JPEG/PNG/WebP), NO uses read_plan — usá visión nativa directa. 3) Usá read_plan SOLO para: crops de subregiones específicas después del análisis inicial, reintentos en páginas puntuales, o fallback si necesitás mayor resolución en un detalle.", "input_schema": {"type": "object", "properties": {"filename": {"type": "string"}, "crop_instructions": {"type": "array", "items": {"type": "object", "properties": {"label": {"type": "string"}, "x1": {"type": "integer"}, "y1": {"type": "integer"}, "x2": {"type": "integer"}, "y2": {"type": "integer"}}}}}, "required": ["filename"]}},
+    {"name": "read_plan", "description": "AUXILIAR — zoom táctico en zonas de un plano. NO usar para análisis inicial (usá visión nativa sobre el PDF/imagen adjunto). Solo para: cotas chicas, detalles ilegibles, subregiones específicas. LÍMITE: máximo 2 crops por llamada. Si necesitás más, analizá los primeros 2 y después llamá de nuevo.", "input_schema": {"type": "object", "properties": {"filename": {"type": "string"}, "crop_instructions": {"type": "array", "maxItems": 2, "items": {"type": "object", "properties": {"label": {"type": "string"}, "x1": {"type": "integer"}, "y1": {"type": "integer"}, "x2": {"type": "integer"}, "y2": {"type": "integer"}}}}}, "required": ["filename"]}},
     {"name": "generate_documents", "description": "Genera PDF+Excel. 1 quote por material.", "input_schema": {"type": "object", "properties": {"quotes": {"type": "array", "items": {"type": "object", "properties": {"client_name": {"type": "string"}, "project": {"type": "string"}, "date": {"type": "string"}, "delivery_days": {"type": "string"}, "material_name": {"type": "string"}, "material_m2": {"type": "number"}, "material_price_unit": {"type": "number"}, "material_currency": {"type": "string", "enum": ["USD", "ARS"]}, "discount_pct": {"type": "number"}, "sectors": {"type": "array", "items": {"type": "object", "properties": {"label": {"type": "string"}, "pieces": {"type": "array", "items": {"type": "string"}}}}}, "sinks": {"type": "array", "items": {"type": "object", "properties": {"name": {"type": "string"}, "quantity": {"type": "integer"}, "unit_price": {"type": "number"}}}}, "mo_items": {"type": "array", "items": {"type": "object", "properties": {"description": {"type": "string"}, "quantity": {"type": "number"}, "unit_price": {"type": "number"}, "total": {"type": "number"}}}}, "total_ars": {"type": "number"}, "total_usd": {"type": "number"}}, "required": ["client_name", "material_name"]}}}, "required": ["quotes"]}},
     {"name": "update_quote", "description": "Actualiza client_name/project/status en DB.", "input_schema": {"type": "object", "properties": {"quote_id": {"type": "string"}, "updates": {"type": "object", "properties": {"client_name": {"type": "string"}, "project": {"type": "string"}, "material": {"type": "string"}, "total_ars": {"type": "number"}, "total_usd": {"type": "number"}, "status": {"type": "string", "enum": ["draft", "validated", "sent"]}}}}, "required": ["quote_id", "updates"]}},
     {"name": "calculate_quote", "description": "Calcula m², MO, totales. SIEMPRE usar para cálculos.", "input_schema": {"type": "object", "properties": {"client_name": {"type": "string"}, "project": {"type": "string"}, "material": {"type": "string"}, "pieces": {"type": "array", "items": {"type": "object", "properties": {"description": {"type": "string"}, "largo": {"type": "number"}, "prof": {"type": "number"}, "alto": {"type": "number"}}, "required": ["description", "largo"]}}, "localidad": {"type": "string"}, "colocacion": {"type": "boolean"}, "is_edificio": {"type": "boolean"}, "pileta": {"type": "string", "enum": ["empotrada_cliente", "empotrada_johnson", "apoyo"]}, "pileta_qty": {"type": "integer"}, "pileta_sku": {"type": "string"}, "anafe": {"type": "boolean"}, "frentin": {"type": "boolean"}, "frentin_ml": {"type": "number"}, "inglete": {"type": "boolean"}, "pulido": {"type": "boolean"}, "skip_flete": {"type": "boolean", "description": "true SOLO si el cliente retira en fábrica. Default false — siempre cobrar flete."}, "plazo": {"type": "string"}, "discount_pct": {"type": "number"}}, "required": ["client_name", "material", "pieces", "localidad", "plazo"]}},
@@ -1784,20 +1784,33 @@ class AgentService:
                     if isinstance(result, dict):
                         log_keys = {k: v for k, v in result.items() if k in ("ok", "total_ars", "total_usd", "material", "material_name", "removed", "added", "error", "quote_id")}
                         logging.info(f"🔧 TOOL RESULT [{quote_id}] {tool_use.name}: {log_keys}")
+                    elif isinstance(result, list):
+                        logging.info(f"🔧 TOOL RESULT [{quote_id}] {tool_use.name}: {len(result)} content blocks")
                 except Exception:
                     pass
 
-                try:
-                    result_json = json.dumps(result)
-                except (TypeError, ValueError) as e:
-                    logging.error(f"JSON serialization error for tool {tool_use.name}: {e}")
-                    result_json = json.dumps({"ok": False, "error": f"Error serializando resultado de {tool_use.name}"})
+                # read_plan returns native content blocks (list of image/text dicts)
+                # to avoid inflating context with base64 inside JSON strings.
+                # All other tools return dicts that get JSON-serialized.
+                if isinstance(result, list):
+                    # Native content blocks (image + text) — pass directly
+                    tool_results.append({
+                        "type": "tool_result",
+                        "tool_use_id": tool_use.id,
+                        "content": result,
+                    })
+                else:
+                    try:
+                        result_json = json.dumps(result)
+                    except (TypeError, ValueError) as e:
+                        logging.error(f"JSON serialization error for tool {tool_use.name}: {e}")
+                        result_json = json.dumps({"ok": False, "error": f"Error serializando resultado de {tool_use.name}"})
 
-                tool_results.append({
-                    "type": "tool_result",
-                    "tool_use_id": tool_use.id,
-                    "content": result_json,
-                })
+                    tool_results.append({
+                        "type": "tool_result",
+                        "tool_use_id": tool_use.id,
+                        "content": result_json,
+                    })
 
             assistant_messages.append({"role": "assistant", "content": _serialize_content(final_message.content)})
             assistant_messages.append({"role": "user", "content": tool_results})

--- a/api/app/modules/agent/tools/plan_tool.py
+++ b/api/app/modules/agent/tools/plan_tool.py
@@ -1,4 +1,5 @@
 import base64
+import logging
 import tempfile
 from pathlib import Path
 from typing import Optional
@@ -13,6 +14,12 @@ except ImportError:
 TEMP_DIR = Path(tempfile.gettempdir()) / "marble_plans"
 TEMP_DIR.mkdir(exist_ok=True)
 
+# ── Limits to prevent token overflow ──
+MAX_CROPS_PER_CALL = 2       # Hard limit: max 2 crops per tool call
+CROP_MAX_WIDTH = 1024         # Max pixel width for crop output
+CROP_JPEG_QUALITY = 75        # Aggressive compression
+FULL_PLAN_MAX_WIDTH = 1200    # Full plan thumbnail (smaller than before)
+
 
 def _fuzzy_find_file(filename: str) -> Optional[Path]:
     """Find file in TEMP_DIR with fuzzy matching for LLM-hallucinated filenames.
@@ -24,7 +31,6 @@ def _fuzzy_find_file(filename: str) -> Optional[Path]:
     if exact.exists():
         return exact
 
-    # Normalize: lowercase, remove spaces/dashes/underscores
     import re
     def _normalize(s: str) -> str:
         return re.sub(r'[\s\-_]+', '', s.lower())
@@ -36,100 +42,122 @@ def _fuzzy_find_file(filename: str) -> Optional[Path]:
             candidates.append(f)
 
     if len(candidates) == 1:
-        import logging
         logging.info(f"[read_plan] fuzzy match: '{filename}' → '{candidates[0].name}'")
         return candidates[0]
 
     return None
 
 
-async def read_plan(filename: str, crop_instructions: list) -> dict:
-    """
-    Rasterize a plan file at 200 DPI and optionally crop individual mesadas.
-    Returns base64-encoded images for Claude to analyze.
-    """
-    plan_path = _fuzzy_find_file(filename)
-    if plan_path is None:
-        available = [f.name for f in TEMP_DIR.iterdir() if f.is_file()] if TEMP_DIR.exists() else []
-        return {"error": f"Archivo no encontrado: {filename}", "available_files": available}
-
-    ext = plan_path.suffix.lower()
-    images = []
-
-    try:
-        if ext == ".pdf" and PDF2IMAGE_AVAILABLE:
-            pages = convert_from_bytes(
-                plan_path.read_bytes(),
-                dpi=200,  # 200 default; 300 only as fallback for ambiguous pages
-                fmt="jpeg",
-            )
-            if pages:
-                images = [pages[0]]
-        else:
-            img = Image.open(plan_path)
-            images = [img]
-    except Exception as e:
-        return {"error": f"Error al procesar el plano: {str(e)}"}
-
-    if not images:
-        return {"error": "No se pudo rasterizar el plano"}
-
-    base_image = images[0]
-    result_images = []
-
-    # Full plan (reduced)
-    full_w = base_image.width
-    full_h = base_image.height
-    result_images.append({
-        "label": "plano_completo",
-        "base64": _image_to_b64(base_image, max_width=2000),
-        "width": full_w,
-        "height": full_h,
-    })
-
-    # Individual crops
-    for crop in crop_instructions:
-        try:
-            cropped = base_image.crop((
-                crop["x1"], crop["y1"],
-                crop["x2"], crop["y2"],
-            ))
-            result_images.append({
-                "label": crop["label"],
-                "base64": _image_to_b64(cropped),
-                "width": cropped.width,
-                "height": cropped.height,
-            })
-        except Exception as e:
-            result_images.append({
-                "label": crop.get("label", "crop"),
-                "error": str(e),
-            })
-
-    return {
-        "ok": True,
-        "filename": filename,
-        "original_size": {"width": full_w, "height": full_h},
-        "images": result_images,
-        "note": "Imágenes rasterizadas a 300 DPI. Analizar cada crop individualmente.",
-    }
-
-
-def _image_to_b64(img: Image.Image, max_width: Optional[int] = None) -> str:
-    if max_width and img.width > max_width:
+def _image_to_b64(img: Image.Image, max_width: int, quality: int = CROP_JPEG_QUALITY) -> str:
+    """Convert PIL Image to compressed base64 JPEG, capped at max_width."""
+    if img.width > max_width:
         ratio = max_width / img.width
         new_h = int(img.height * ratio)
         img = img.resize((max_width, new_h), Image.LANCZOS)
 
     import io
     buf = io.BytesIO()
-    img.save(buf, format="JPEG", quality=90)
+    img.save(buf, format="JPEG", quality=quality)
     return base64.b64encode(buf.getvalue()).decode()
+
+
+async def read_plan(filename: str, crop_instructions: list) -> list:
+    """Rasterize a plan file at 200 DPI and return crops as native image content blocks.
+
+    AUXILIARY tool for tactical zoom/crop only. PDF visual analysis should
+    use native vision on the document already attached inline.
+
+    Returns a LIST of Anthropic-native content blocks (type: "image" + type: "text")
+    instead of a JSON dict, so images don't inflate the text context.
+
+    Hard limits:
+    - Max 2 crops per call (prevents token overflow)
+    - Max 1024px width per crop
+    - JPEG quality 75
+    """
+    plan_path = _fuzzy_find_file(filename)
+    if plan_path is None:
+        available = [f.name for f in TEMP_DIR.iterdir() if f.is_file()] if TEMP_DIR.exists() else []
+        return [{"type": "text", "text": f"Error: archivo no encontrado: {filename}. Disponibles: {available}"}]
+
+    ext = plan_path.suffix.lower()
+    base_image = None
+
+    try:
+        if ext == ".pdf" and PDF2IMAGE_AVAILABLE:
+            pages = convert_from_bytes(
+                plan_path.read_bytes(),
+                dpi=200,
+                fmt="jpeg",
+            )
+            if pages:
+                base_image = pages[0]
+        else:
+            base_image = Image.open(plan_path)
+    except Exception as e:
+        return [{"type": "text", "text": f"Error al procesar el plano: {str(e)}"}]
+
+    if base_image is None:
+        return [{"type": "text", "text": "No se pudo rasterizar el plano"}]
+
+    result_blocks = []
+
+    # If no crop instructions, return a compressed full thumbnail
+    if not crop_instructions:
+        b64 = _image_to_b64(base_image, max_width=FULL_PLAN_MAX_WIDTH)
+        result_blocks.append({
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/jpeg", "data": b64},
+        })
+        result_blocks.append({
+            "type": "text",
+            "text": f"Plano completo ({base_image.width}x{base_image.height}px, reducido a {FULL_PLAN_MAX_WIDTH}px). Analizá directamente.",
+        })
+        return result_blocks
+
+    # Enforce crop limit
+    crops_to_process = crop_instructions[:MAX_CROPS_PER_CALL]
+    truncated = len(crop_instructions) > MAX_CROPS_PER_CALL
+
+    for crop in crops_to_process:
+        try:
+            cropped = base_image.crop((
+                crop["x1"], crop["y1"],
+                crop["x2"], crop["y2"],
+            ))
+            b64 = _image_to_b64(cropped, max_width=CROP_MAX_WIDTH)
+            result_blocks.append({
+                "type": "image",
+                "source": {"type": "base64", "media_type": "image/jpeg", "data": b64},
+            })
+            result_blocks.append({
+                "type": "text",
+                "text": f"Crop: {crop.get('label', '?')} ({cropped.width}x{cropped.height}px → {CROP_MAX_WIDTH}px max)",
+            })
+        except Exception as e:
+            result_blocks.append({
+                "type": "text",
+                "text": f"Error en crop '{crop.get('label', '?')}': {str(e)}",
+            })
+
+    if truncated:
+        remaining = [c.get("label", "?") for c in crop_instructions[MAX_CROPS_PER_CALL:]]
+        result_blocks.append({
+            "type": "text",
+            "text": (
+                f"⚠️ Límite de {MAX_CROPS_PER_CALL} crops por llamada alcanzado. "
+                f"Analizá estos primero. Pendientes: {', '.join(remaining)}. "
+                f"Llamá read_plan de nuevo para los siguientes crops."
+            ),
+        })
+
+    logging.info(f"[read_plan] Returned {len(crops_to_process)} crops ({len(result_blocks)} blocks) for {filename}")
+    return result_blocks
 
 
 def save_plan_to_temp(filename: str, data: bytes) -> Path:
     """Save uploaded plan file to temp directory for tool access."""
-    safe_name = Path(filename).name  # strip directory traversal (../ etc.)
+    safe_name = Path(filename).name
     path = TEMP_DIR / safe_name
     path.write_bytes(data)
     return path
@@ -140,7 +168,7 @@ def cleanup_temp_files():
     import time
     if not TEMP_DIR.exists():
         return
-    cutoff = time.time() - 3600  # 1 hour
+    cutoff = time.time() - 3600
     for f in TEMP_DIR.iterdir():
         if f.is_file() and f.stat().st_mtime < cutoff:
             f.unlink(missing_ok=True)


### PR DESCRIPTION
## Root Cause
`read_plan` devolvía base64 como JSON string → 700K tokens por crop × 2 = 1.2M tokens > 1M limit API.

## Fixes
1. **Native content blocks**: `type: "image"` directo, no JSON-stringified
2. **Compresión**: 1024px max, JPEG q75 (era 2000px, q90)
3. **Límite duro**: max 2 crops por llamada (code + schema)
4. **Tool description**: "AUXILIAR — zoom táctico only"

## Token savings estimados
| Antes | Después |
|-------|---------|
| ~700K tokens/crop (base64 en JSON) | ~50K tokens/crop (native image block compressed) |
| 2 crops = 1.4M tokens overflow | 2 crops = ~100K tokens OK |

32/32 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)