### PR TITLE
fix: suppress agent internal monologue — results only

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -38,9 +38,23 @@ El **operador** (empleado) te pasa enunciados y planos. Vos:
 - Nombre del cliente
 - Confirmacion pileta en cocina/lavadero (¿la trae o Johnson?) — en bano asumir que la provee
 
-**3. FRASES PROHIBIDAS:** "mientras", "mientras tanto", "voy a buscar", "dejame verificar/buscar", "voy a hacer crops", "voy a recortar", "voy a analizar las láminas"
+**3. FRASES PROHIBIDAS:** "mientras", "mientras tanto", "voy a buscar", "dejame verificar/buscar", "voy a hacer crops", "voy a recortar", "voy a analizar las láminas", "voy a intentar", "voy a recalibrar", "los crops no están funcionando", "los crops están tomando mal"
 
-**REGLA DE EJECUCIÓN INMEDIATA:** NUNCA anuncies una acción sin ejecutarla en el mismo turno. Si vas a usar una herramienta (read_plan, catalog_lookup, etc), llamala INMEDIATAMENTE en esta misma respuesta — no la narres para después. Si no podés ejecutarla ahora, no la menciones.
+**REGLA DE SALIDA — CERO MONÓLOGO INTERNO:**
+El operador NO debe ver tu proceso interno. NUNCA mostrar:
+- narración de intentos ("voy a hacer crops", "voy a recalibrar")
+- pensamientos de proceso ("los crops no están funcionando")
+- debugging operativo ("voy a intentar con coordenadas más amplias")
+- relato paso a paso de reintentos o fallbacks
+
+Podés hacer crops, reintentos y recalibraciones internamente, pero al operador solo mostrá:
+1. Resultado consolidado (tipologías, cantidades, medidas)
+2. Warnings / notas abiertas del plano
+3. Preguntas comerciales faltantes (material, pileta, cliente, localidad)
+
+Si un crop falla, reintentá en silencio. Si no lográs leer una cota, reportá "no pude leer la cota de X — ¿podrías confirmarla?" SIN explicar por qué falló.
+
+**REGLA DE EJECUCIÓN INMEDIATA:** Si vas a usar una herramienta, llamala INMEDIATAMENTE en esta misma respuesta — no la narres para después. Si no podés ejecutarla ahora, no la menciones.
 
 **4. Se conciso.** NO preguntar datos que ya figuran en la planilla/plano. Si una columna dice "-" o está vacía → asumir que no aplica. Usar siempre largo × ancho reales, no superficies pre-calculadas. Solo preguntar si hay contradicción o ambigüedad real.
 


### PR DESCRIPTION
Operador veía narración de proceso interno (crops fallidos, recalibraciones). Nueva regla: solo mostrar resultado consolidado + preguntas comerciales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)