### PR TITLE
fix: suppress ALL visual PDF monologue + honest CAD output format

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -247,6 +247,21 @@ El operador responde decisiones COMERCIALES (material, pileta, cliente, localida
 
 Si no ves bien una zona del plano, usá `read_plan` con crop_instructions para recortar vos esa región. Si una lámina tiene múltiples vistas/cortes y no lográs extraer medidas, reportá lo que SÍ pudiste leer y preguntá SOLO por las decisiones de negocio faltantes (material, terminación, etc).
 
+**FORMATO DE SALIDA PARA PLANOS CAD/ARQUITECTÓNICOS:**
+Cuando analices un PDF visual multipágina, tu respuesta debe ser SOLO el resultado consolidado. Formato:
+
+1. **Resumen del plano**: obra, cantidad de láminas/tipologías
+2. **Por tipología**: nombre, cantidad de unidades, notas relevantes
+3. **Material**: si es claro o ambiguo (ej: "Cuarzo Blanco Norte o Granito Blanco Ceara — a definir")
+4. **Notas abiertas**: warnings del plano ("VERIFICAR MEDIDAS EN OBRA", "PRELIMINAR", etc)
+5. **Decisiones comerciales pendientes**: material final, piletas, cliente, localidad
+6. **Despiece**: si las cotas son claras, presentar despiece. Si hay ambigüedad, decir: "Se identifican cotas relevantes pero el despiece exacto requiere confirmación en estos puntos: [lista]"
+
+NO presentar:
+- Volcado de cotas sueltas como si fueran piezas finales
+- Narración de proceso ("estoy analizando...", "voy a hacer crops...")
+- Listado de cada cota leída por lámina sin contexto
+
 **REGLA PARA CROQUIS A MANO ALZADA:** Cuando analices dibujos manuscritos simples de piezas individuales en planta, asumí que las cotas visibles representan las dimensiones totales de la pieza (Largo x Ancho/Profundidad). No asumas que falta una tercera dimensión ni interpretes una de las cotas como "altura", a menos que el dibujo muestre explícitamente un corte, una vista lateral o indique la palabra "faldón/zócalo".
 
 - Cota ARRIBA = zocalo | Cota ABAJO = frentin/faldon

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1540,6 +1540,10 @@ class AgentService:
             full_text = ""
             tool_uses = []
 
+            # Show a brief status for visual PDF processing (operator sees blank otherwise)
+            if needs_vision and pdf_has_images and _loop_iterations == 0:
+                yield {"type": "action", "content": "📐 Analizando plano..."}
+
             # Model selection:
             # - Opus: first iteration with plan, OR iteration after visual tool call
             # - Sonnet: everything else (prices, MO, docs)
@@ -1597,11 +1601,13 @@ class AgentService:
                                 if event.type == "content_block_delta":
                                     if hasattr(event.delta, "text"):
                                         full_text += event.delta.text
-                                        # Buffer text during visual tool iterations to suppress
-                                        # internal monologue ("voy a hacer crops", "ajustando coords")
-                                        # _suppress_text is set when we're in a read_plan loop
-                                        if not _suppress_text:
+                                        # For visual PDFs: buffer ALL text until we know if this
+                                        # iteration has tool calls. If it does, text is monologue
+                                        # and gets suppressed. If not, it's the final response
+                                        # and gets flushed in the no-tool-calls branch below.
+                                        if not (needs_vision and pdf_has_images):
                                             yield {"type": "text", "content": event.delta.text}
+                                        # For non-visual flows, stream text normally
                                 elif event.type == "content_block_start":
                                     if hasattr(event.content_block, "type") and event.content_block.type == "tool_use":
                                         tool_uses.append({
@@ -1725,10 +1731,11 @@ class AgentService:
             tool_use_blocks = [b for b in final_message.content if b.type == "tool_use"]
 
             if not tool_use_blocks:
-                # No tool calls — this is the final response. Flush suppressed text.
-                if _suppress_text and full_text:
+                # No tool calls — this is the final response.
+                # For visual PDFs: flush the buffered final response text now
+                if needs_vision and pdf_has_images and full_text:
                     yield {"type": "text", "content": full_text}
-                    logging.info(f"[suppress] Flushed {len(full_text)} chars of final response")
+                    logging.info(f"[visual-pdf] Flushed {len(full_text)} chars of final consolidated response")
                 _suppress_text = False
 
                 # ── Guardrail: Paso 1 must use list_pieces ──


### PR DESCRIPTION
## Code fix
- `needs_vision && pdf_has_images` → buffer ALL text, flush only on final response
- Shows "📐 Analizando plano..." action so operator isn't staring at blank screen
- Previous fix only suppressed after first read_plan; now suppresses from iteration 0

## Prompt fix (CONTEXT.md)
Nuevo formato de salida para planos CAD:
1. Resumen consolidado (tipologías, cantidades)
2. Material claro o ambiguo
3. Notas abiertas del plano
4. Decisiones comerciales pendientes
5. Despiece honesto: si hay ambigüedad, decirlo

NO mostrar: cotas sueltas, narración de proceso, volcado sin contexto.

32/32 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)