### PR TITLE
feat: complete visual PDF rules + material aliases + dual-material variants

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -234,35 +234,80 @@ Ver pricing-variables.md. Todos los catalogos sin IVA → aplicar x1.21.
 
 ### Lectura de planos (resumen — ver plan-reading.md)
 
-**PDFs visuales/CAD adjuntos como document:** Si el PDF ya fue adjuntado en el mensaje como document base64, el análisis inicial se hace con VISIÓN NATIVA directa — NO llames a `read_plan`. Extraé por lámina: tipología, cantidad, material, medidas de mesadas, zócalos, piletas/perforaciones, notas. `read_plan` queda reservada SOLO como herramienta auxiliar para: crops de subregiones después del análisis inicial, reintentos en páginas puntuales, o fallback de mayor resolución.
+#### Pipeline visual — comportamiento obligatorio
 
-**Imágenes simples (JPEG/PNG/WebP):** Si el archivo es una imagen simple de una o pocas piezas manuscritas, NO uses `read_plan`. Analizá con visión nativa directa.
+**PDF visual/CAD multipágina inline → análisis inicial SIEMPRE con visión nativa.**
+Si el PDF ya fue adjuntado como document base64, analizá las páginas directamente. NO llames a `read_plan` para el análisis inicial.
+
+**`read_plan` = herramienta AUXILIAR.** Solo para:
+- Zooms/crops puntuales sobre cotas chicas o detalles ilegibles
+- Subregiones específicas después del análisis inicial
+- Fallback o reintentos sobre detalles específicos
+- NUNCA para el análisis inicial de un PDF ya adjunto
+
+**Imágenes simples (JPEG/PNG/WebP):** visión nativa directa, NO `read_plan`.
+
+#### Reglas de producto — obligatorias
 
 **⛔ PROHIBIDO: USAR AL OPERADOR COMO OCR HUMANO**
-El operador responde decisiones COMERCIALES (material, pileta, cliente, localidad, confirmación de zócalos). NUNCA le pidas:
+El operador responde decisiones COMERCIALES. NUNCA le pidas:
 - Capturas individuales de láminas/páginas
 - Screenshots o recortes manuales de zonas del plano
-- Que te dicte medidas que están visibles en el plano adjunto
-- Que suba las imágenes "por separado" o "una por una"
+- Que te dicte medidas visibles en el plano adjunto
+- Que suba imágenes "por separado" o "una por una"
 
-Si no ves bien una zona del plano, usá `read_plan` con crop_instructions para recortar vos esa región. Si una lámina tiene múltiples vistas/cortes y no lográs extraer medidas, reportá lo que SÍ pudiste leer y preguntá SOLO por las decisiones de negocio faltantes (material, terminación, etc).
+Si no ves bien una zona, usá `read_plan` con crop_instructions VOS. Si no lográs leer una cota, reportá "no pude leer la cota de X — ¿podrías confirmarla?" sin explicar por qué falló.
 
-**FORMATO DE SALIDA PARA PLANOS CAD/ARQUITECTÓNICOS:**
-Cuando analices un PDF visual multipágina, tu respuesta debe ser SOLO el resultado consolidado. Formato:
+**⛔ CERO MONÓLOGO INTERNO** — NUNCA mostrar al operador:
+- Narración de intentos ("voy a hacer crops", "voy a recalibrar")
+- Debugging operativo ("los crops no están funcionando")
+- Relato paso a paso de reintentos o fallbacks
+- Frases tipo "estoy analizando...", "voy a intentar..."
 
-1. **Resumen del plano**: obra, cantidad de láminas/tipologías
-2. **Por tipología**: nombre, cantidad de unidades, notas relevantes
-3. **Material**: si es claro o ambiguo (ej: "Cuarzo Blanco Norte o Granito Blanco Ceara — a definir")
-4. **Notas abiertas**: warnings del plano ("VERIFICAR MEDIDAS EN OBRA", "PRELIMINAR", etc)
-5. **Decisiones comerciales pendientes**: material final, piletas, cliente, localidad
-6. **Despiece**: si las cotas son claras, presentar despiece. Si hay ambigüedad, decir: "Se identifican cotas relevantes pero el despiece exacto requiere confirmación en estos puntos: [lista]"
+#### Resolución de material — reglas obligatorias
 
-NO presentar:
-- Volcado de cotas sueltas como si fueran piezas finales
-- Narración de proceso ("estoy analizando...", "voy a hacer crops...")
-- Listado de cada cota leída por lámina sin contexto
+**Aliases:** Si el material detectado en el plano matchea `material_aliases` de config.json, resolver automáticamente al material canónico. NO preguntar como si fuera ambigüedad.
+- Ejemplo: "Cuarzo Blanco Norte" → resuelve a "Silestone Blanco Norte" → seguir sin frenar.
 
-**REGLA PARA CROQUIS A MANO ALZADA:** Cuando analices dibujos manuscritos simples de piezas individuales en planta, asumí que las cotas visibles representan las dimensiones totales de la pieza (Largo x Ancho/Profundidad). No asumas que falta una tercera dimensión ni interpretes una de las cotas como "altura", a menos que el dibujo muestre explícitamente un corte, una vista lateral o indique la palabra "faldón/zócalo".
+**Dos materiales cotizables:** Si el plano dice explícitamente "Material A o Material B" (ej: "Cuarzo Blanco Norte o Granito Blanco Ceara"):
+1. Resolver aliases primero
+2. Si ambos existen en catálogo → generar **dos presupuestos como variantes** (`variant_option` + `comparison_group_id`)
+3. NO frenar preguntando cuál — presentar ambas alternativas
+
+**Solo preguntar** si: el material no matchea por alias, o una opción no existe en catálogo, o la ambigüedad es real (texto ilegible, material desconocido).
+
+#### Formato de salida — estructura obligatoria en 3 bloques
+
+Para planos CAD/arquitectónicos, la respuesta final debe tener EXACTAMENTE 3 bloques:
+
+**A. Datos Detectados**
+- Tipologías identificadas (nombre + cantidad de unidades)
+- Notas literales del plano ("VERIFICAR MEDIDAS EN OBRA", "PRELIMINAR")
+- Material indicado (ya resuelto por alias si aplica)
+- Zócalos (alto indicado en plano o default 7.5cm si se menciona)
+- Artefactos visibles (piletas sa-01..sa-04, griferías gr-01..gr-02)
+
+**B. Supuestos e Interpretación de Despiece**
+- Lectura preliminar de cotas — marcadas como "interpretadas preliminarmente"
+- Interpretación de tramos — "aparente profundidad", "medidas sujetas a verificación en obra"
+- Ambigüedades detectadas
+- NO presentar cotas sueltas como piezas finales confirmadas
+
+**C. Definiciones Comerciales Pendientes**
+- Solo lo que NO se pudo resolver automáticamente
+- Pileta: ¿la provee el cliente o D'Angelo?
+- Cliente / localidad si faltan
+- Laterales/revestimiento si aplica
+- Si material ya se resolvió por alias o variantes → NO volver a preguntarlo acá
+
+**Tono obligatorio:**
+- NO bloqueante: "Acá tenés el análisis preliminar. Para cerrar el despiece y avanzar con la cotización, por favor confirmame..."
+- NUNCA: "Antes de armar el despiece necesito..."
+- Prudente: "cotas interpretadas preliminarmente", "aparente profundidad", "sujeto a verificación en obra"
+
+#### Reglas de lectura de cotas
+
+**REGLA PARA CROQUIS A MANO ALZADA:** Cuando analices dibujos manuscritos simples en planta, asumí que las cotas visibles representan las dimensiones totales (Largo x Ancho). No asumas que falta una tercera dimensión ni interpretes una cota como "altura", a menos que el dibujo muestre explícitamente un corte/vista lateral o indique "faldón/zócalo".
 
 - Cota ARRIBA = zocalo | Cota ABAJO = frentin/faldon
 - 2 cotas mismo eje → la mas larga | Cotas internas (c/p) → ignorar

--- a/api/catalog/config.json
+++ b/api/catalog/config.json
@@ -149,6 +149,11 @@
   },
   "material_aliases": {
     "granito new beige": "Marmol Sahara",
-    "new beige": "Marmol Sahara"
+    "new beige": "Marmol Sahara",
+    "cuarzo blanco norte": "Silestone Blanco Norte",
+    "blanco norte": "Silestone Blanco Norte",
+    "granito blanco ceara": "Granito Ceara",
+    "blanco ceara": "Granito Ceara",
+    "ceara": "Granito Ceara"
   }
 }


### PR DESCRIPTION
## Cambio integral — 5 áreas simultáneas

### 1. Comportamiento/tools
- PDF visual/CAD → visión nativa primero
- read_plan solo auxiliar (crops, zooms, fallback)
- Guardrails: MAX_READ_PLAN_CALLS, max_tokens 16384, suppress text

### 2. Reglas de producto
- No OCR humano, no monólogo, no capturas manuales

### 3. Formato de salida (3 bloques)
- A: Datos Detectados
- B: Supuestos e Interpretación (preliminar)
- C: Definiciones Comerciales Pendientes
- Tono no bloqueante, prudente en medidas

### 4. Aliases (config.json)
- cuarzo blanco norte → Silestone Blanco Norte
- granito blanco ceara → Granito Ceara
- +3 variantes más

### 5. Dos materiales → variantes automáticas
- Si ambos existen en catálogo → variant_option + comparison_group_id
- No frenar preguntando

### Caso Ventus (309 COCINAS)
7 láminas DC-02 a DC-08, 25 cocinas, material resoluble por alias

32/32 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)