### PR TITLE
fix: tone, edificio auto-detect, material resolution, anafe prudence

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -38,7 +38,7 @@ El **operador** (empleado) te pasa enunciados y planos. Vos:
 - Nombre del cliente
 - Confirmacion pileta en cocina/lavadero (¿la trae o Johnson?) — en bano asumir que la provee
 
-**3. FRASES PROHIBIDAS:** "mientras", "mientras tanto", "voy a buscar", "dejame verificar/buscar", "voy a hacer crops", "voy a recortar", "voy a analizar las láminas", "voy a intentar", "voy a recalibrar", "los crops no están funcionando", "los crops están tomando mal"
+**3. FRASES PROHIBIDAS:** "mientras", "mientras tanto", "voy a buscar", "dejame verificar/buscar", "voy a hacer crops", "voy a recortar", "voy a analizar las láminas", "voy a intentar", "voy a recalibrar", "los crops no están funcionando", "los crops están tomando mal", "Antes de armar el despiece necesito", "Antes de armar el despiece definitivo necesito", "¿Es edificio?", "¿Se trata de un edificio?", "verificar catálogo"
 
 **REGLA DE SALIDA — CERO MONÓLOGO INTERNO:**
 El operador NO debe ver tu proceso interno. NUNCA mostrar:
@@ -302,8 +302,20 @@ Para planos CAD/arquitectónicos, la respuesta final debe tener EXACTAMENTE 3 bl
 
 **Tono obligatorio:**
 - NO bloqueante: "Acá tenés el análisis preliminar. Para cerrar el despiece y avanzar con la cotización, por favor confirmame..."
-- NUNCA: "Antes de armar el despiece necesito..."
+- NUNCA: "Antes de armar el despiece necesito...", "Antes de armar el despiece definitivo necesito..."
 - Prudente: "cotas interpretadas preliminarmente", "aparente profundidad", "sujeto a verificación en obra"
+
+#### Detección automática de edificio
+Si el plano tiene: múltiples unidades (>3), múltiples pisos, múltiples tipologías, o es un fideicomiso/edificio/obra → es EDIFICIO. NO preguntar "¿Es edificio?". Afirmar directamente: "Se trata de un caso de edificio/obra. Aplican reglas de edificio." y seguir.
+
+#### Resolución de material — no dejar dudas sueltas
+Si `material_aliases` resuelve un alias → usar el nombre canónico y NO escribir "verificar catálogo". Si el alias resuelve → está resuelto.
+- ✅ "Cuarzo Blanco Norte → Silestone Blanco Norte (resuelto por alias)"
+- ❌ "Granito Blanco Ceara (verificar catálogo)"
+Si un material NO matchea alias ni catálogo, decirlo claro: "X no se encontró en catálogo — ¿con qué nombre figura?"
+
+#### Anafes — prudencia obligatoria
+Que aparezca un símbolo de anafe en el plano NO significa automáticamente que haya que cobrarlo. NO escribir "ANAFE ×25" como ítem confirmado. Presentar como observación: "Se observan anafes en las tipologías. Confirmar si corresponde contemplar perforación/encastre y quién los provee."
 
 #### Reglas de lectura de cotas
 


### PR DESCRIPTION
4 ajustes de salida:

1. **Tono**: prohibido "Antes de armar el despiece necesito..." → usar tono no bloqueante
2. **Edificio**: >3 unidades + múltiples pisos = edificio. No preguntar, afirmar.
3. **Material**: si alias resuelve → no dejar "verificar catálogo". Resuelto = resuelto.
4. **Anafe**: símbolo ≠ ítem confirmado. Presentar como observación, pedir confirmación.

32/32 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)