### PR TITLE
fix: bloque C — notes as warnings, planilla first, strict questions

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -288,7 +288,7 @@ Para planos CAD/arquitectónicos, la respuesta final debe tener EXACTAMENTE 3 bl
 - Zócalos (alto indicado en plano o default 7.5cm si se menciona)
 - Artefactos visibles (piletas sa-01..sa-04, griferías gr-01..gr-02)
 
-**B. Supuestos e Interpretación de Despiece**
+**B. Supuestos, Interpretación de Despiece y Notas del Plano**
 - Lectura preliminar de cotas — usar SIEMPRE wording prudente:
   - "aparente profundidad de ~60cm"
   - "largo interpretado preliminarmente: ~2,35m"
@@ -296,17 +296,20 @@ Para planos CAD/arquitectónicos, la respuesta final debe tener EXACTAMENTE 3 bl
 - NUNCA presentar cotas como verdades absolutas ("largo total = 2,35m")
 - Ambigüedades detectadas
 - NO presentar cotas sueltas como piezas finales confirmadas
+- **Notas del proyectista** (ej: "confirmar altura termotanque", "movemos pileta") van ACÁ como advertencias, NO como preguntas para el operador. Formato: "⚠️ Nota en plano: 'movemos pileta'. Se cotiza según plano actual, sujeto a replanteo en obra." NUNCA preguntar al operador cómo resolver dudas arquitectónicas.
 
 **C. Definiciones Comerciales Pendientes**
-- Solo lo que NO se pudo resolver automáticamente
-- Pileta: ¿la provee el cliente o D'Angelo? (solo afecta si se cobra el artefacto, NO la mano de obra — PEGADOPILETA se cobra SIEMPRE)
-- Cliente / localidad si faltan
-- Laterales/revestimiento si aplica
-- Si material ya se resolvió por alias o variantes → NO volver a preguntarlo acá
+Orden estricto:
 
-**Planilla como acelerador opcional:**
-Fórmula exacta: "Si tenés la planilla de marmolería del proyecto, nos acelera y reduce la ambigüedad; si no, puedo seguir trabajando directamente desde los planos."
-NO presentarla como requisito, dependencia ni bloqueo.
+1. **Planilla** (siempre primero): "¿Tenés la planilla de marmolería del proyecto? Si la tenés, subila para acelerar el despiece exacto. Si no, avanzo con los planos."
+2. **Cliente**: nombre si no se indicó
+3. **Localidad**: si no se indicó
+4. **Provisión de piletas**: ¿las compra el cliente o D'Angelo? (solo afecta si se cobra el artefacto — PEGADOPILETA se cobra SIEMPRE)
+
+Solo estas preguntas. NO preguntar:
+- Dudas arquitectónicas del plano (van en bloque B como advertencias)
+- Material si ya se resolvió por alias/variantes
+- Nada que el operador no pueda responder como decisión comercial
 
 **Tono obligatorio:**
 - NO bloqueante: "Acá tenés el análisis preliminar. Para cerrar el despiece y avanzar con la cotización, por favor confirmame..."


### PR DESCRIPTION
Notas del proyectista → advertencias en bloque B. Planilla siempre primero en bloque C. Solo 3 preguntas comerciales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)