### PR TITLE
feat: deterministic visual quote builder for CAD/building PDFs

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -277,6 +277,41 @@ Si no ves bien una zona, usá `read_plan` con crop_instructions VOS. Si no logr�
 
 **Solo preguntar** si: el material no matchea por alias NI por catálogo (fuzzy match incluido), o la ambigüedad es real (texto ilegible, material desconocido). NUNCA escribir "verificar catálogo" o "a verificar" si el alias o el fuzzy match ya lo resolvió.
 
+#### Extracción estructurada para PDFs visuales multipágina de obra
+
+Cuando analices un PDF visual multipágina de obra/edificio (>3 unidades, múltiples tipologías), tu respuesta debe ser un JSON estructurado que el sistema procesará automáticamente. NO hagas cálculos de m² ni totales — el código lo hace.
+
+Formato de extracción obligatorio (JSON en bloque ```json):
+```json
+{
+  "material_text": "Cuarzo Blanco Norte o Granito Blanco Ceara 2 cm de espesor",
+  "tipologias": [
+    {
+      "id": "DC-02",
+      "qty": 2,
+      "shape": "L",
+      "depth_m": 0.62,
+      "segments_m": [2.35, 1.15],
+      "backsplash_ml": 4.12,
+      "embedded_sink_count": 1,
+      "hob_count": 1,
+      "notes": ["movemos pileta"]
+    }
+  ]
+}
+```
+
+Reglas de extracción:
+- `shape`: "L" si la mesada tiene retorno, "linear" si es recta
+- `segments_m`: para L, [tramo largo, tramo corto]. Para linear, [largo total]. Leer de cotas de planta y cortes. Si hay módulos (55+60+60), sumar: 2.35m
+- `depth_m`: profundidad de la mesada (ancho). Leer de planta o corte transversal.
+- `backsplash_ml`: metros lineales de zócalo estimados. Si no podés determinar, omitir (el código usa fallback conservador).
+- `embedded_sink_count`: piletas empotradas por unidad. Leer de simbología (sa-01, etc).
+- `hob_count`: anafes por unidad. Si mesada continua + anafe empotrado → 1.
+- `notes`: notas literales del plano relevantes para esa tipología.
+- NO incluir `confidence` — el código lo calcula.
+- NO calcular m² — el código lo hace con la fórmula correcta (L-shape resta esquina).
+
 #### Formato de salida — estructura obligatoria en 3 bloques
 
 Para planos CAD/arquitectónicos, la respuesta final debe tener EXACTAMENTE 3 bloques:

--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -303,7 +303,7 @@ Formato de extracción obligatorio (JSON en bloque ```json):
 
 Reglas de extracción:
 - `shape`: "L" si la mesada tiene retorno, "linear" si es recta
-- `segments_m`: para L, [tramo largo, tramo corto]. Para linear, [largo total]. Leer de cotas de planta y cortes. Si hay módulos (55+60+60), sumar: 2.35m
+- `segments_m`: para L, [tramo largo, tramo corto]. Para linear, [largo total]. Leer de cotas de planta y cortes. Si hay módulos (55+60+60), sumar: 1.75m. Si son (55+60+60+60), sumar: 2.35m
 - `depth_m`: profundidad de la mesada (ancho). Leer de planta o corte transversal.
 - `backsplash_ml`: metros lineales de zócalo estimados. Si no podés determinar, omitir (el código usa fallback conservador).
 - `embedded_sink_count`: piletas empotradas por unidad. Leer de simbología (sa-01, etc).

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1084,6 +1084,7 @@ class AgentService:
         # Build user message content
         content = []
         pdf_has_images = False  # Track if PDF has drawings (needs vision pass)
+        is_visual_building = False  # Track if this is a multipágina CAD building (Ventus-type)
         if plan_bytes and plan_filename:
             # Persist plan file to temp so read_plan tool can access it later
             save_plan_to_temp(plan_filename, plan_bytes)
@@ -1332,6 +1333,16 @@ class AgentService:
                         },
                     })
                     logging.info(f"PDF has images/drawings — sending as document for vision pass")
+
+                    # Detect visual building: multipágina CAD with building keywords
+                    # Only applies to visual path — tabular ESH is handled separately above
+                    _building_keywords = ["tipolog", "cantidad", "unidad", "piso", "fideicomiso",
+                                          "edificio", "obra", "cocina", "desarrollo", "lamina", "lámina"]
+                    _text_lower = extracted_text.lower()
+                    _keyword_hits = sum(1 for kw in _building_keywords if kw in _text_lower)
+                    if num_pages >= 3 and pdf_has_images and _keyword_hits >= 2:
+                        is_visual_building = True
+                        logging.info(f"Visual building detected: {num_pages} pages, {_keyword_hits} keyword hits")
                 else:
                     logging.info(f"PDF is text-only (no images) — skipping vision pass, using extracted text only")
             else:
@@ -1735,7 +1746,8 @@ class AgentService:
                 # No tool calls — this is the final response.
 
                 # ── Visual building pipeline: intercept JSON and compute deterministically ──
-                if needs_vision and pdf_has_images and full_text and not _visual_builder_done:
+                # Only for multipágina CAD buildings (Ventus-type), NOT simple images or single-page PDFs
+                if is_visual_building and full_text and not _visual_builder_done:
                     from app.modules.quote_engine.visual_quote_builder import (
                         parse_visual_extraction,
                         resolve_visual_materials,
@@ -1822,9 +1834,10 @@ class AgentService:
                         logging.warning(f"[visual-builder] Could not parse JSON from Claude response — showing raw")
                         yield {"type": "text", "content": full_text}
 
-                elif needs_vision and pdf_has_images and full_text:
+                elif needs_vision and pdf_has_images and full_text and not is_visual_building:
+                    # Non-building visual PDF (simple plan, single page) — flush text
                     yield {"type": "text", "content": full_text}
-                    logging.info(f"[visual-pdf] Flushed {len(full_text)} chars (no JSON found or builder already done)")
+                    logging.info(f"[visual-pdf] Flushed {len(full_text)} chars (non-building visual)")
 
                 _suppress_text = False
 

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1530,6 +1530,7 @@ class AgentService:
         _suppress_text = False        # Suppress streaming text during visual tool loops
         _read_plan_calls = 0          # Count read_plan calls to enforce limit
         MAX_READ_PLAN_CALLS = 3       # Hard limit: max 3 read_plan calls per conversation
+        _visual_builder_done = False  # Track if visual builder already processed
 
         while True:
             if _loop_iterations >= MAX_ITERATIONS:
@@ -1732,10 +1733,99 @@ class AgentService:
 
             if not tool_use_blocks:
                 # No tool calls — this is the final response.
-                # For visual PDFs: flush the buffered final response text now
-                if needs_vision and pdf_has_images and full_text:
+
+                # ── Visual building pipeline: intercept JSON and compute deterministically ──
+                if needs_vision and pdf_has_images and full_text and not _visual_builder_done:
+                    from app.modules.quote_engine.visual_quote_builder import (
+                        parse_visual_extraction,
+                        resolve_visual_materials,
+                        validate_visual_extraction,
+                        compute_visual_geometry,
+                        infer_visual_services,
+                        build_visual_pending_questions,
+                        render_visual_extraction_summary,
+                        render_visual_building_step1,
+                    )
+
+                    parsed = parse_visual_extraction(full_text)
+                    if parsed and parsed.get("tipologias"):
+                        logging.info(f"[visual-builder] Parsed {len(parsed['tipologias'])} tipologías from Claude response")
+
+                        # Resolve materials
+                        mat_res = resolve_visual_materials(parsed.get("material_text", ""))
+                        logging.info(f"[visual-builder] Material resolution: {mat_res.mode} → {mat_res.resolved}")
+
+                        # Validate extraction
+                        validation = validate_visual_extraction(parsed["tipologias"])
+
+                        if validation.requires_operator_validation:
+                            # Show validation summary, wait for confirmation
+                            summary = render_visual_extraction_summary(validation, mat_res)
+                            yield {"type": "text", "content": summary}
+                            logging.info(f"[visual-builder] Showing validation summary — awaiting operator confirmation")
+
+                            # Persist to quote_breakdown for next message
+                            try:
+                                await db.execute(
+                                    update(Quote).where(Quote.id == quote_id).values(
+                                        quote_breakdown={
+                                            "visual_extraction": parsed["tipologias"],
+                                            "material_resolution": mat_res.to_dict(),
+                                            "building_step": "awaiting_visual_confirmation",
+                                        }
+                                    )
+                                )
+                                await db.commit()
+                            except Exception as e:
+                                logging.error(f"[visual-builder] Failed to persist: {e}")
+
+                            _visual_builder_done = True
+                            assistant_messages.append({
+                                "role": "assistant",
+                                "content": _serialize_content(final_message.content),
+                            })
+                            break
+                        else:
+                            # All high confidence → compute directly
+                            geometry = compute_visual_geometry(parsed["tipologias"], mat_res)
+                            services = infer_visual_services(parsed["tipologias"], geometry)
+                            pending = build_visual_pending_questions(mat_res, services, parsed["tipologias"])
+                            step1 = render_visual_building_step1(geometry, services, mat_res, pending)
+                            yield {"type": "text", "content": step1}
+                            logging.info(f"[visual-builder] Rendered PASO 1: {geometry.total_m2} m²")
+
+                            # Persist
+                            try:
+                                await db.execute(
+                                    update(Quote).where(Quote.id == quote_id).values(
+                                        quote_breakdown={
+                                            "visual_extraction": parsed["tipologias"],
+                                            "material_resolution": mat_res.to_dict(),
+                                            "geometry": geometry.to_dict(),
+                                            "services": services.to_dict(),
+                                            "building_step": "visual_step1_shown",
+                                        }
+                                    )
+                                )
+                                await db.commit()
+                            except Exception as e:
+                                logging.error(f"[visual-builder] Failed to persist: {e}")
+
+                            _visual_builder_done = True
+                            assistant_messages.append({
+                                "role": "assistant",
+                                "content": _serialize_content(final_message.content),
+                            })
+                            break
+                    else:
+                        # Couldn't parse JSON — fall through to normal display
+                        logging.warning(f"[visual-builder] Could not parse JSON from Claude response — showing raw")
+                        yield {"type": "text", "content": full_text}
+
+                elif needs_vision and pdf_has_images and full_text:
                     yield {"type": "text", "content": full_text}
-                    logging.info(f"[visual-pdf] Flushed {len(full_text)} chars of final consolidated response")
+                    logging.info(f"[visual-pdf] Flushed {len(full_text)} chars (no JSON found or builder already done)")
+
                 _suppress_text = False
 
                 # ── Guardrail: Paso 1 must use list_pieces ──

--- a/api/app/modules/quote_engine/visual_quote_builder.py
+++ b/api/app/modules/quote_engine/visual_quote_builder.py
@@ -1,0 +1,894 @@
+"""Deterministic pipeline for visual/CAD building quotes.
+
+Separates LLM extraction (soft) from computation (hard):
+- Claude extracts JSON per tipología from plan pages
+- This module resolves materials, validates, computes geometry, infers services
+
+Only applies to visual/CAD multipágina path. Does NOT affect:
+- ESH tabular pipeline (edificio_parser.py)
+- Normal text quotes
+- Simple image quotes
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import re
+import unicodedata
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Optional
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+CATALOG_DIR = Path(__file__).parent.parent.parent.parent / "catalog"
+
+# Material max slab length (m) — for physical piece count / flete calculation
+MATERIAL_MAX_LENGTHS = {
+    "silestone": 3.20,
+    "purastone": 3.20,
+    "puraprima": 3.20,
+    "dekton": 3.20,
+    "neolith": 3.20,
+    "laminatto": 3.20,
+    "granito nacional": 2.80,
+    "granito importado": 3.00,
+    "marmol": 2.80,
+    "default": 3.00,
+}
+
+# Confidence thresholds
+CONF_HIGH = 0.80
+CONF_REVIEW = 0.55
+
+# Validation limits
+VALIDATION_ALWAYS_THRESHOLD = 10  # Always show validation if total units > this
+
+
+# ── Data classes ───────────────────────────────────────────────────────────────
+
+@dataclass
+class MaterialResolution:
+    raw_text: str
+    resolved: list[str]
+    mode: str  # "single" | "variants" | "needs_clarification"
+    unresolved: list[str]
+    thickness_mm: int = 20
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class FieldConfidence:
+    shape: float = 0.0
+    depth: float = 0.0
+    segments: float = 0.0
+    backsplash: float = 0.0
+    sink: float = 0.0
+    hob: float = 0.0
+
+    def min_score(self) -> float:
+        return min(self.shape, self.depth, self.segments)
+
+    def has_review_needed(self) -> bool:
+        return any(v < CONF_HIGH for v in [self.shape, self.depth, self.segments,
+                                            self.backsplash, self.sink, self.hob])
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class TipologiaGeometry:
+    id: str
+    qty: int
+    shape: str  # "L" | "linear"
+    segments_m: list[float]
+    depth_m: float
+    m2_unit: float
+    m2_total: float
+    backsplash_ml_unit: float
+    backsplash_m2_unit: float
+    backsplash_m2_total: float
+    physical_pieces_per_unit: int
+    physical_pieces_total: int
+    notes: list[str] = field(default_factory=list)
+    confidence: FieldConfidence = field(default_factory=FieldConfidence)
+
+
+@dataclass
+class GeometrySummary:
+    tipologias: list[TipologiaGeometry]
+    total_mesada_m2: float
+    total_backsplash_m2: float
+    total_m2: float
+    total_physical_pieces: int
+    flete_qty: int
+
+    def to_dict(self) -> dict:
+        return {
+            "tipologias": [asdict(t) for t in self.tipologias],
+            "total_mesada_m2": self.total_mesada_m2,
+            "total_backsplash_m2": self.total_backsplash_m2,
+            "total_m2": self.total_m2,
+            "total_physical_pieces": self.total_physical_pieces,
+            "flete_qty": self.flete_qty,
+        }
+
+
+@dataclass
+class ServiceInference:
+    is_building: bool = True
+    colocacion: bool = False  # edificio → no
+    pegadopileta_qty: int = 0
+    pegadopileta_confidence: float = 0.0
+    anafe_qty: int = 0
+    anafe_confidence: float = 0.0
+    backsplash_height_m: float = 0.075
+    flete_qty: int = 0
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+# ── 1. Material Resolution ─────────────────────────────────────────────────────
+
+def _normalize_text(text: str) -> str:
+    """Lowercase, strip, remove accents, collapse whitespace."""
+    text = text.lower().strip()
+    # Remove accents
+    text = unicodedata.normalize("NFKD", text)
+    text = "".join(c for c in text if not unicodedata.combining(c))
+    # Collapse whitespace
+    text = re.sub(r"\s+", " ", text)
+    return text
+
+
+def _load_material_aliases() -> dict[str, str]:
+    """Load material_aliases from config.json."""
+    try:
+        with open(CATALOG_DIR / "config.json") as f:
+            cfg = json.load(f)
+        return cfg.get("material_aliases", {})
+    except Exception:
+        return {}
+
+
+def _fuzzy_alias_match(text: str, aliases: dict[str, str]) -> Optional[str]:
+    """Try exact match first, then normalized match."""
+    norm = _normalize_text(text)
+
+    # Exact match (case-insensitive)
+    for alias_key, canonical in aliases.items():
+        if _normalize_text(alias_key) == norm:
+            return canonical
+
+    # Substring match: if normalized text contains an alias
+    for alias_key, canonical in sorted(aliases.items(), key=lambda x: -len(x[0])):
+        if _normalize_text(alias_key) in norm:
+            return canonical
+
+    return None
+
+
+def _catalog_exists(material_name: str) -> bool:
+    """Check if a material name exists in any catalog (fuzzy)."""
+    norm = _normalize_text(material_name)
+    for catalog_file in CATALOG_DIR.glob("materials-*.json"):
+        try:
+            with open(catalog_file) as f:
+                items = json.load(f)
+            for item in items:
+                if _normalize_text(item.get("name", "")) == norm:
+                    return True
+                # Also check partial match
+                if norm in _normalize_text(item.get("name", "")):
+                    return True
+        except Exception:
+            continue
+    return False
+
+
+def resolve_visual_materials(raw_text: str) -> MaterialResolution:
+    """Resolve material text from plan into canonical catalog names.
+
+    Rules:
+    - Try alias match first
+    - If 2-3 resolved materials → mode="variants" (auto)
+    - If 1 resolved → mode="single"
+    - If any unresolved → mode="needs_clarification"
+    """
+    aliases = _load_material_aliases()
+
+    # Parse "Material A o Material B" patterns
+    # Also handle "Material A / Material B"
+    # Strip thickness info first
+    clean = re.sub(r"\d+\s*(cm|mm)\s*(de\s+)?espesor", "", raw_text, flags=re.IGNORECASE).strip()
+    thickness_match = re.search(r"(\d+)\s*(cm|mm)", raw_text, re.IGNORECASE)
+    thickness_mm = 20
+    if thickness_match:
+        val = int(thickness_match.group(1))
+        unit = thickness_match.group(2).lower()
+        thickness_mm = val * 10 if unit == "cm" else val
+
+    # Split by "o" / "or" / "/"
+    parts = re.split(r"\s+o\s+|\s*/\s*", clean, flags=re.IGNORECASE)
+    parts = [p.strip() for p in parts if p.strip()]
+
+    resolved = []
+    unresolved = []
+
+    for part in parts:
+        # Try alias first
+        canonical = _fuzzy_alias_match(part, aliases)
+        if canonical:
+            if canonical not in resolved:
+                resolved.append(canonical)
+            continue
+
+        # Try direct catalog match
+        if _catalog_exists(part):
+            if part not in resolved:
+                resolved.append(part)
+            continue
+
+        unresolved.append(part)
+
+    if unresolved:
+        mode = "needs_clarification"
+    elif len(resolved) >= 2:
+        mode = "variants"
+    elif len(resolved) == 1:
+        mode = "single"
+    else:
+        mode = "needs_clarification"
+
+    return MaterialResolution(
+        raw_text=raw_text,
+        resolved=resolved,
+        mode=mode,
+        unresolved=unresolved,
+        thickness_mm=thickness_mm,
+    )
+
+
+# ── 2. Field Confidence (deterministic, not from LLM) ─────────────────────────
+
+def compute_field_confidence(tipologia: dict) -> FieldConfidence:
+    """Compute confidence per field using deterministic range checks."""
+    segs = tipologia.get("segments_m", [])
+    depth = tipologia.get("depth_m", 0)
+    shape = tipologia.get("shape", "unknown")
+    sink = tipologia.get("embedded_sink_count", 0)
+    hob = tipologia.get("hob_count", 0)
+    backsplash = tipologia.get("backsplash_ml")
+
+    conf = FieldConfidence()
+
+    # Shape: must be explicit
+    if shape in ("L", "linear"):
+        conf.shape = 0.9
+    else:
+        conf.shape = 0.4
+
+    # Shape-segment consistency
+    if shape == "L" and len(segs) != 2:
+        conf.segments = 0.3
+    elif shape == "linear" and len(segs) != 1:
+        conf.segments = 0.3
+    elif all(0.3 <= s <= 5.0 for s in segs) and len(segs) > 0:
+        conf.segments = 0.9
+    else:
+        conf.segments = 0.5
+
+    # Depth: typical mesada range
+    if 0.40 <= depth <= 0.80:
+        conf.depth = 0.9
+    elif 0.20 <= depth <= 1.0:
+        conf.depth = 0.6
+    else:
+        conf.depth = 0.3
+
+    # Sink: expected 0 or 1 per unit
+    if 0 <= sink <= 2:
+        conf.sink = 0.9
+    else:
+        conf.sink = 0.5
+
+    # Hob: expected 0 or 1
+    if 0 <= hob <= 1:
+        conf.hob = 0.9
+    else:
+        conf.hob = 0.5
+
+    # Backsplash: always needs review (visually weak)
+    if backsplash is not None:
+        total_seg = sum(segs) if segs else 1
+        if backsplash > total_seg * 2.5:
+            conf.backsplash = 0.3  # incoherent
+        elif backsplash < depth * 0.5:
+            conf.backsplash = 0.4  # suspiciously low
+        else:
+            conf.backsplash = 0.6  # plausible but always review
+    else:
+        conf.backsplash = 0.5  # no data → will use fallback
+
+    return conf
+
+
+# ── 3. Validate Visual Extraction ──────────────────────────────────────────────
+
+@dataclass
+class ValidationResult:
+    all_tipologias: list[dict]  # original + confidence added
+    high_confidence: list[dict]
+    needs_review: list[dict]
+    unusable: list[dict]
+    soft_field_warnings: list[str]
+    requires_operator_validation: bool
+
+
+def validate_visual_extraction(tipologias: list[dict]) -> ValidationResult:
+    """Validate extracted tipologías and classify by confidence."""
+    high = []
+    review = []
+    unusable = []
+    warnings = []
+
+    total_units = sum(t.get("qty", 1) for t in tipologias)
+
+    for t in tipologias:
+        conf = compute_field_confidence(t)
+        t["_confidence"] = conf.to_dict()
+
+        min_core = min(conf.shape, conf.depth, conf.segments)
+        if min_core >= CONF_HIGH:
+            high.append(t)
+        elif min_core >= CONF_REVIEW:
+            review.append(t)
+        else:
+            unusable.append(t)
+
+        # Soft field warnings
+        if conf.backsplash < CONF_HIGH:
+            warnings.append(f"{t.get('id', '?')}: zócalo/backsplash requiere confirmación")
+        if conf.sink < CONF_HIGH:
+            warnings.append(f"{t.get('id', '?')}: cantidad de piletas requiere confirmación")
+        if conf.hob < CONF_HIGH:
+            warnings.append(f"{t.get('id', '?')}: anafe requiere confirmación")
+
+    # Always validate if large project or if there are review/unusable items
+    requires_validation = (
+        len(review) > 0
+        or len(unusable) > 0
+        or total_units > VALIDATION_ALWAYS_THRESHOLD
+    )
+
+    return ValidationResult(
+        all_tipologias=tipologias,
+        high_confidence=high,
+        needs_review=review,
+        unusable=unusable,
+        soft_field_warnings=warnings,
+        requires_operator_validation=requires_validation,
+    )
+
+
+# ── 4. Compute Geometry (deterministic) ────────────────────────────────────────
+
+def _get_material_max_length(material_name: str) -> float:
+    """Get max slab length for a material."""
+    norm = _normalize_text(material_name)
+    for key, length in MATERIAL_MAX_LENGTHS.items():
+        if key in norm:
+            return length
+    return MATERIAL_MAX_LENGTHS["default"]
+
+
+def compute_physical_pieces(segments_m: list[float], material_max_length: float) -> int:
+    """Each segment divided into physical pieces by material max slab length."""
+    total = 0
+    for seg in segments_m:
+        total += math.ceil(seg / material_max_length)
+    return total
+
+
+def compute_visual_geometry(
+    tipologias: list[dict],
+    material_resolution: MaterialResolution,
+    backsplash_height_m: float = 0.075,
+) -> GeometrySummary:
+    """Compute exact m², backsplash, physical pieces from validated tipologías."""
+    # Use first resolved material for max length (both variants share geometry)
+    mat_name = material_resolution.resolved[0] if material_resolution.resolved else ""
+    max_length = _get_material_max_length(mat_name)
+
+    results = []
+    total_mesada = 0
+    total_backsplash = 0
+    total_pieces = 0
+
+    for t in tipologias:
+        tid = t.get("id", "?")
+        qty = t.get("qty", 1)
+        shape = t.get("shape", "linear")
+        segs = t.get("segments_m", [])
+        depth = t.get("depth_m", 0.60)
+        notes = t.get("notes", [])
+
+        # m² per unit — L-shape subtracts corner overlap
+        if shape == "L" and len(segs) == 2:
+            m2_unit = (segs[0] * depth) + (segs[1] * depth) - (depth * depth)
+        else:
+            m2_unit = sum(s * depth for s in segs)
+        m2_unit = round(m2_unit, 2)
+        m2_total = round(m2_unit * qty, 2)
+
+        # Backsplash ml per unit
+        backsplash_ml = t.get("backsplash_ml")
+        if backsplash_ml is None:
+            # Fallback: conservative (all segments + depth for L)
+            # TODO: this overestimates if not all sides have backsplash
+            backsplash_ml = sum(segs)
+            if shape == "L":
+                backsplash_ml += depth  # return side
+        backsplash_m2_unit = round(backsplash_ml * backsplash_height_m, 2)
+        backsplash_m2_total = round(backsplash_m2_unit * qty, 2)
+
+        # Physical pieces per unit
+        pieces_unit = compute_physical_pieces(segs, max_length)
+        pieces_total = pieces_unit * qty
+
+        geo = TipologiaGeometry(
+            id=tid,
+            qty=qty,
+            shape=shape,
+            segments_m=segs,
+            depth_m=depth,
+            m2_unit=m2_unit,
+            m2_total=m2_total,
+            backsplash_ml_unit=round(backsplash_ml, 2),
+            backsplash_m2_unit=backsplash_m2_unit,
+            backsplash_m2_total=backsplash_m2_total,
+            physical_pieces_per_unit=pieces_unit,
+            physical_pieces_total=pieces_total,
+            notes=notes,
+        )
+        results.append(geo)
+        total_mesada += m2_total
+        total_backsplash += backsplash_m2_total
+        total_pieces += pieces_total
+
+    flete_qty = math.ceil(total_pieces / 6)
+
+    return GeometrySummary(
+        tipologias=results,
+        total_mesada_m2=round(total_mesada, 2),
+        total_backsplash_m2=round(total_backsplash, 2),
+        total_m2=round(total_mesada + total_backsplash, 2),
+        total_physical_pieces=total_pieces,
+        flete_qty=flete_qty,
+    )
+
+
+# ── 5. Infer Services ─────────────────────────────────────────────────────────
+
+def infer_visual_services(
+    tipologias: list[dict],
+    geometry: GeometrySummary,
+) -> ServiceInference:
+    """Infer building services from tipologías."""
+    total_sinks = 0
+    total_hobs = 0
+    min_sink_conf = 1.0
+    min_hob_conf = 1.0
+
+    for t in tipologias:
+        qty = t.get("qty", 1)
+        total_sinks += t.get("embedded_sink_count", 0) * qty
+        total_hobs += t.get("hob_count", 0) * qty
+
+        conf = t.get("_confidence", {})
+        min_sink_conf = min(min_sink_conf, conf.get("sink", 0.5))
+        min_hob_conf = min(min_hob_conf, conf.get("hob", 0.5))
+
+    return ServiceInference(
+        is_building=True,
+        colocacion=False,
+        pegadopileta_qty=total_sinks,
+        pegadopileta_confidence=min_sink_conf,
+        anafe_qty=total_hobs,
+        anafe_confidence=min_hob_conf,
+        backsplash_height_m=0.075,
+        flete_qty=geometry.flete_qty,
+    )
+
+
+# ── 6. Pending Questions (deterministic) ───────────────────────────────────────
+
+def build_visual_pending_questions(
+    material_res: MaterialResolution,
+    services: ServiceInference,
+    tipologias: list[dict],
+    quote: Optional[dict] = None,
+) -> list[str]:
+    """Build list of genuinely pending commercial questions."""
+    questions = []
+
+    # Planilla always first
+    questions.append("planilla_marmoleria")
+
+    # Client name
+    q = quote or {}
+    if not q.get("client_name"):
+        questions.append("client_name")
+
+    # Locality — only if not already set (NOT defaulting to Rosario)
+    if not q.get("locality"):
+        questions.append("locality")
+
+    # Material — only if needs clarification
+    if material_res.mode == "needs_clarification":
+        questions.append("material_definition")
+
+    # Pileta provision — only if sinks detected
+    if services.pegadopileta_qty > 0:
+        questions.append("pileta_provision")
+
+    # Low confidence fields
+    for t in tipologias:
+        conf = t.get("_confidence", {})
+        if conf.get("backsplash", 0) < CONF_HIGH:
+            questions.append(f"confirm_backsplash_{t.get('id', '?')}")
+            break  # Only ask once, not per tipología
+
+    return questions
+
+
+# ── 7. Parse Operator Corrections (deterministic regex) ────────────────────────
+
+# Flexible ID pattern: DC-02, BAÑ-01, COC-03, TIPO-A, etc.
+CORRECTION_PATTERN = re.compile(
+    r"(\S+[-]\S+|\S+\d+)\s+"                    # tipología ID (flexible)
+    r"(profundidad|depth|tramo\d?|tramo_?\d?|"
+    r"zocalo_ml|zocalo|backsplash|"
+    r"qty|cantidad|largo|ancho|"
+    r"segments?|segmento?\d?)\s*"
+    r"[=:]\s*"
+    r"([\d]+[.,]?\d*)",
+    re.IGNORECASE,
+)
+
+
+def normalize_field_name(raw: str) -> str:
+    """Normalize correction field name to canonical."""
+    raw = raw.lower().strip()
+    mapping = {
+        "profundidad": "depth_m",
+        "depth": "depth_m",
+        "ancho": "depth_m",
+        "tramo": "segments_m_0",
+        "tramo1": "segments_m_0",
+        "tramo_1": "segments_m_0",
+        "tramo2": "segments_m_1",
+        "tramo_2": "segments_m_1",
+        "segmento1": "segments_m_0",
+        "segmento2": "segments_m_1",
+        "segment1": "segments_m_0",
+        "segment2": "segments_m_1",
+        "largo": "segments_m_0",
+        "zocalo_ml": "backsplash_ml",
+        "zocalo": "backsplash_ml",
+        "backsplash": "backsplash_ml",
+        "qty": "qty",
+        "cantidad": "qty",
+    }
+    return mapping.get(raw, raw)
+
+
+def parse_number(raw: str) -> float:
+    """Parse number with comma or dot decimal."""
+    raw = raw.strip().replace(",", ".")
+    return float(raw)
+
+
+def looks_like_correction(text: str) -> bool:
+    """Detect if text looks like it INTENDS to be a correction but failed regex."""
+    indicators = ["=", ":", "tramo", "profundidad", "zocalo", "zócalo", "largo", "ancho"]
+    text_lower = text.lower()
+    return any(ind in text_lower for ind in indicators)
+
+
+def parse_operator_corrections(text: str, known_ids: list[str] = None) -> Optional[list[dict]]:
+    """Parse operator corrections using deterministic regex.
+
+    Returns list of corrections, or None if text looks like a correction
+    but couldn't be parsed (→ ask for format).
+    Returns empty list if text is not a correction (e.g., "confirmo").
+    """
+    corrections = []
+    for match in CORRECTION_PATTERN.finditer(text):
+        raw_id = match.group(1).upper()
+        raw_field = match.group(2)
+        raw_value = match.group(3)
+
+        # Validate against known IDs if provided
+        if known_ids and raw_id not in [k.upper() for k in known_ids]:
+            logging.warning(f"[correction] Unknown tipología ID: {raw_id}")
+            continue
+
+        corrections.append({
+            "tipologia_id": raw_id,
+            "field": normalize_field_name(raw_field),
+            "value": parse_number(raw_value),
+        })
+
+    if not corrections and looks_like_correction(text):
+        return None  # Tried to correct but format didn't match
+
+    return corrections
+
+
+def apply_corrections(tipologias: list[dict], corrections: list[dict]) -> list[dict]:
+    """Apply parsed corrections to tipologías."""
+    tip_map = {t.get("id", "").upper(): t for t in tipologias}
+
+    for corr in corrections:
+        tid = corr["tipologia_id"]
+        field = corr["field"]
+        value = corr["value"]
+
+        if tid not in tip_map:
+            logging.warning(f"[correction] Tipología {tid} not found")
+            continue
+
+        t = tip_map[tid]
+
+        if field == "depth_m":
+            t["depth_m"] = value
+        elif field == "qty":
+            t["qty"] = int(value)
+        elif field == "backsplash_ml":
+            t["backsplash_ml"] = value
+        elif field.startswith("segments_m_"):
+            idx = int(field.split("_")[-1])
+            segs = t.get("segments_m", [])
+            if idx < len(segs):
+                segs[idx] = value
+            else:
+                segs.append(value)
+            t["segments_m"] = segs
+
+        logging.info(f"[correction] Applied: {tid} {field} = {value}")
+
+    return tipologias
+
+
+# ── 8. Render Functions ────────────────────────────────────────────────────────
+
+def render_visual_extraction_summary(
+    validation: ValidationResult,
+    material_res: MaterialResolution,
+) -> str:
+    """Render validation summary for operator review."""
+    lines = []
+
+    # Material
+    if material_res.mode == "variants":
+        lines.append(f"**Material:** {' / '.join(material_res.resolved)} (se generan ambas variantes)")
+    elif material_res.mode == "single":
+        lines.append(f"**Material:** {material_res.resolved[0]}")
+    else:
+        lines.append(f"**Material:** ⚠️ {material_res.raw_text} — requiere definición")
+
+    lines.append(f"**Espesor:** {material_res.thickness_mm}mm")
+    lines.append("")
+    lines.append("**Tipologías extraídas del plano:**")
+    lines.append("")
+
+    for t in validation.all_tipologias:
+        conf = t.get("_confidence", {})
+        tid = t.get("id", "?")
+        qty = t.get("qty", 1)
+        shape = t.get("shape", "?")
+        segs = t.get("segments_m", [])
+        depth = t.get("depth_m", 0)
+
+        # Format segments
+        if shape == "L" and len(segs) == 2:
+            seg_str = f"{segs[0]}m + {segs[1]}m"
+        else:
+            seg_str = " + ".join(f"{s}m" for s in segs)
+
+        # Confidence indicator
+        min_core = min(conf.get("shape", 0), conf.get("depth", 0), conf.get("segments", 0))
+        if min_core >= CONF_HIGH:
+            icon = "✅"
+        elif min_core >= CONF_REVIEW:
+            icon = "⚠️"
+        else:
+            icon = "❌"
+
+        lines.append(f"- {icon} **{tid}** ×{qty} — {shape} — {seg_str} — prof {depth}m")
+
+        # Soft field notes
+        if conf.get("backsplash", 0) < CONF_HIGH:
+            bl = t.get("backsplash_ml")
+            lines.append(f"  ↳ zócalo: {f'{bl}ml' if bl else 'sin dato'} (requiere confirmación)")
+
+    if validation.soft_field_warnings:
+        lines.append("")
+        lines.append("**Campos que requieren confirmación:**")
+        for w in validation.soft_field_warnings[:5]:  # Max 5 warnings
+            lines.append(f"- {w}")
+
+    lines.append("")
+    if validation.requires_operator_validation:
+        lines.append("¿Confirmás estos datos? Si hay que corregir, usá el formato:")
+        lines.append("`DC-02 profundidad = 0.65` o `DC-07 tramo2 = 1.54`")
+    else:
+        lines.append("Datos validados automáticamente. Calculando despiece...")
+
+    return "\n".join(lines)
+
+
+def render_visual_building_step1(
+    geometry: GeometrySummary,
+    services: ServiceInference,
+    material_res: MaterialResolution,
+    pending: list[str],
+) -> str:
+    """Render PASO 1 with deterministic geometry."""
+    lines = []
+
+    # Material header
+    if material_res.mode == "variants":
+        lines.append(f"**Despiece geométrico** (aplica para ambos materiales: {' y '.join(material_res.resolved)})")
+    else:
+        mat_name = material_res.resolved[0] if material_res.resolved else "?"
+        lines.append(f"**Despiece — {mat_name}**")
+
+    lines.append("")
+    lines.append("| Tipología | Cant | Forma | Medida unit | m² unit | m² total |")
+    lines.append("|-----------|------|-------|-------------|---------|----------|")
+
+    for t in geometry.tipologias:
+        if t.shape == "L":
+            medida = f"{t.segments_m[0]}×{t.depth_m} + {t.segments_m[1]}×{t.depth_m}"
+        else:
+            medida = f"{t.segments_m[0]}×{t.depth_m}" if t.segments_m else "?"
+        lines.append(f"| {t.id} | {t.qty} | {t.shape} | {medida} | {t.m2_unit} | {t.m2_total} |")
+
+    lines.append(f"| **TOTAL MESADA** | | | | | **{geometry.total_mesada_m2}** |")
+    lines.append(f"| **TOTAL ZÓCALO** | | | | | **{geometry.total_backsplash_m2}** |")
+    lines.append(f"| **TOTAL GENERAL** | | | | | **{geometry.total_m2}** |")
+
+    lines.append("")
+    lines.append("**Servicios:**")
+    lines.append(f"- Colocación: NO (edificio)")
+    lines.append(f"- PEGADOPILETA: ×{services.pegadopileta_qty}")
+    lines.append(f"- ANAFE: ×{services.anafe_qty}")
+    lines.append(f"- Flete + toma medidas: {services.flete_qty} viaje(s) (ceil({geometry.total_physical_pieces} piezas / 6))")
+
+    # Pending questions
+    if pending:
+        lines.append("")
+        lines.append("**Para avanzar con la cotización, confirmame:**")
+
+        q_labels = {
+            "planilla_marmoleria": "¿Tenés la planilla de marmolería? Si la tenés, subila para acelerar. Si no, avanzo con los planos.",
+            "client_name": "Nombre del cliente",
+            "locality": "Localidad de la obra",
+            "material_definition": f"Material: {material_res.raw_text} — ¿cuál corresponde?",
+            "pileta_provision": "Piletas: ¿las provee el cliente o D'Angelo?",
+        }
+
+        for i, q in enumerate(pending, 1):
+            if q.startswith("confirm_backsplash_"):
+                lines.append(f"{i}. Zócalo: confirmar ml por tipología")
+            elif q in q_labels:
+                lines.append(f"{i}. {q_labels[q]}")
+
+    return "\n".join(lines)
+
+
+# ── 9. JSON Parser (robust) ───────────────────────────────────────────────────
+
+def parse_visual_extraction(claude_response: str) -> Optional[dict]:
+    """Extract and validate JSON from Claude's response.
+
+    Returns dict with 'material_text' and 'tipologias', or None on failure.
+    """
+    # Try to find JSON block in markdown
+    json_match = re.search(r"```json\s*(.*?)```", claude_response, re.DOTALL)
+    if json_match:
+        raw_json = json_match.group(1).strip()
+    else:
+        # Try to find raw JSON object
+        json_match = re.search(r"\{[\s\S]*\"tipologias\"[\s\S]*\}", claude_response)
+        if json_match:
+            raw_json = json_match.group(0)
+        else:
+            logging.warning("[visual_parse] No JSON found in Claude response")
+            return None
+
+    try:
+        data = json.loads(raw_json)
+    except json.JSONDecodeError as e:
+        logging.error(f"[visual_parse] JSON decode error: {e}")
+        return None
+
+    # Validate required fields
+    tipologias = data.get("tipologias", [])
+    if not tipologias:
+        logging.warning("[visual_parse] No tipologías in JSON")
+        return None
+
+    # Validate and clean each tipología
+    cleaned = []
+    seen_ids = set()
+    for t in tipologias:
+        tid = t.get("id", "")
+        if not tid:
+            continue
+
+        # Dedup
+        if tid in seen_ids:
+            logging.warning(f"[visual_parse] Duplicate tipología: {tid}")
+            continue
+        seen_ids.add(tid)
+
+        # Required fields with defaults
+        qty = t.get("qty", 1)
+        if not isinstance(qty, int) or qty < 1 or qty > 100:
+            qty = 1
+
+        shape = t.get("shape", "linear")
+        if shape not in ("L", "linear"):
+            shape = "linear"
+
+        segs = t.get("segments_m", [])
+        if not isinstance(segs, list) or not segs:
+            continue
+        # Validate segment ranges
+        valid_segs = []
+        for s in segs:
+            try:
+                s = float(s)
+                if 0.1 <= s <= 10.0:
+                    valid_segs.append(round(s, 2))
+            except (TypeError, ValueError):
+                pass
+        if not valid_segs:
+            continue
+
+        depth = t.get("depth_m", 0.60)
+        try:
+            depth = float(depth)
+            if not (0.1 <= depth <= 2.0):
+                depth = 0.60
+        except (TypeError, ValueError):
+            depth = 0.60
+
+        cleaned.append({
+            "id": tid,
+            "qty": qty,
+            "shape": shape,
+            "depth_m": round(depth, 2),
+            "segments_m": valid_segs,
+            "backsplash_ml": t.get("backsplash_ml"),
+            "embedded_sink_count": t.get("embedded_sink_count", 0),
+            "hob_count": t.get("hob_count", 0),
+            "notes": t.get("notes", []),
+        })
+
+    if not cleaned:
+        return None
+
+    return {
+        "material_text": data.get("material_text", ""),
+        "tipologias": cleaned,
+    }

--- a/api/tests/test_visual_quote_builder.py
+++ b/api/tests/test_visual_quote_builder.py
@@ -1,0 +1,315 @@
+"""Tests for visual_quote_builder — deterministic pipeline for CAD/visual building quotes."""
+
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from app.modules.quote_engine.visual_quote_builder import (
+    resolve_visual_materials,
+    compute_field_confidence,
+    validate_visual_extraction,
+    compute_visual_geometry,
+    compute_physical_pieces,
+    infer_visual_services,
+    build_visual_pending_questions,
+    parse_visual_extraction,
+    parse_operator_corrections,
+    apply_corrections,
+    normalize_field_name,
+    render_visual_extraction_summary,
+    render_visual_building_step1,
+    MaterialResolution,
+    CONF_HIGH,
+    CONF_REVIEW,
+)
+
+
+# ── Material Resolution ──────────────────────────────────────────────────────
+
+class TestMaterialResolution:
+    def test_single_alias(self):
+        res = resolve_visual_materials("Cuarzo Blanco Norte 2cm espesor")
+        assert res.mode == "single"
+        assert "Silestone Blanco Norte" in res.resolved
+        assert res.thickness_mm == 20
+
+    def test_two_variants(self):
+        res = resolve_visual_materials("Cuarzo Blanco Norte o Granito Blanco Ceara 2 cm de espesor")
+        assert res.mode == "variants"
+        assert len(res.resolved) == 2
+        assert "Silestone Blanco Norte" in res.resolved
+        assert "Granito Ceara" in res.resolved
+
+    def test_unknown_material(self):
+        res = resolve_visual_materials("Marmol Inexistente xyz")
+        assert res.mode == "needs_clarification"
+        assert len(res.unresolved) > 0
+
+    def test_thickness_cm(self):
+        res = resolve_visual_materials("Blanco Norte 2cm espesor")
+        assert res.thickness_mm == 20
+
+    def test_thickness_mm(self):
+        res = resolve_visual_materials("Blanco Norte 20mm espesor")
+        assert res.thickness_mm == 20
+
+    def test_slash_separator(self):
+        res = resolve_visual_materials("Blanco Norte / Ceara")
+        assert res.mode == "variants"
+
+
+# ── Field Confidence ─────────────────────────────────────────────────────────
+
+class TestFieldConfidence:
+    def test_l_shape_two_segments(self):
+        conf = compute_field_confidence({
+            "shape": "L", "segments_m": [2.35, 1.15], "depth_m": 0.62,
+        })
+        assert conf.shape >= CONF_HIGH
+        assert conf.segments >= CONF_HIGH
+        assert conf.depth >= CONF_HIGH
+
+    def test_l_shape_wrong_segments(self):
+        """L with 1 segment should drop confidence."""
+        conf = compute_field_confidence({
+            "shape": "L", "segments_m": [2.35], "depth_m": 0.62,
+        })
+        assert conf.segments < CONF_REVIEW  # Should be very low
+
+    def test_linear_wrong_segments(self):
+        """Linear with 2 segments should drop confidence."""
+        conf = compute_field_confidence({
+            "shape": "linear", "segments_m": [2.35, 1.15], "depth_m": 0.62,
+        })
+        assert conf.segments < CONF_REVIEW
+
+    def test_extreme_depth(self):
+        conf = compute_field_confidence({
+            "shape": "linear", "segments_m": [2.0], "depth_m": 3.0,
+        })
+        assert conf.depth < CONF_REVIEW
+
+    def test_backsplash_always_review(self):
+        conf = compute_field_confidence({
+            "shape": "linear", "segments_m": [2.0], "depth_m": 0.60,
+            "backsplash_ml": 2.0,
+        })
+        assert conf.backsplash < CONF_HIGH  # Always needs review
+
+
+# ── Geometry Computation ─────────────────────────────────────────────────────
+
+class TestGeometry:
+    def test_linear_m2(self):
+        mat = MaterialResolution("x", ["Silestone Blanco Norte"], "single", [], 20)
+        geo = compute_visual_geometry([{
+            "id": "DC-04", "qty": 8, "shape": "linear",
+            "segments_m": [1.88], "depth_m": 0.62,
+        }], mat)
+        expected_unit = round(1.88 * 0.62, 2)
+        assert geo.tipologias[0].m2_unit == expected_unit
+        # Total = rounded unit × qty (not raw × qty then round)
+        assert geo.tipologias[0].m2_total == round(expected_unit * 8, 2)
+
+    def test_l_shape_subtracts_corner(self):
+        """L-shape must subtract corner overlap (depth × depth)."""
+        mat = MaterialResolution("x", ["Silestone Blanco Norte"], "single", [], 20)
+        geo = compute_visual_geometry([{
+            "id": "DC-02", "qty": 2, "shape": "L",
+            "segments_m": [2.35, 1.15], "depth_m": 0.62,
+        }], mat)
+        expected = round((2.35 * 0.62) + (1.15 * 0.62) - (0.62 * 0.62), 2)
+        assert geo.tipologias[0].m2_unit == expected
+
+    def test_total_closes_with_rows(self):
+        """Total m² must equal sum of all row totals."""
+        mat = MaterialResolution("x", ["Silestone Blanco Norte"], "single", [], 20)
+        geo = compute_visual_geometry([
+            {"id": "A", "qty": 2, "shape": "linear", "segments_m": [2.0], "depth_m": 0.60},
+            {"id": "B", "qty": 3, "shape": "L", "segments_m": [1.5, 0.8], "depth_m": 0.55},
+        ], mat)
+        row_sum = sum(t.m2_total for t in geo.tipologias)
+        assert geo.total_mesada_m2 == round(row_sum, 2)
+
+    def test_physical_pieces_short_slab(self):
+        """Segment shorter than max slab = 1 piece."""
+        assert compute_physical_pieces([2.0], 3.20) == 1
+
+    def test_physical_pieces_long_slab(self):
+        """Segment longer than max slab = 2 pieces."""
+        assert compute_physical_pieces([3.50], 3.20) == 2
+
+    def test_physical_pieces_multiple_segments(self):
+        assert compute_physical_pieces([2.35, 1.15], 3.20) == 2  # 1 + 1
+
+    def test_flete_calculation(self):
+        mat = MaterialResolution("x", ["Silestone Blanco Norte"], "single", [], 20)
+        geo = compute_visual_geometry([
+            {"id": "A", "qty": 10, "shape": "linear", "segments_m": [2.0], "depth_m": 0.60},
+        ], mat)
+        # 10 pieces, each 1 physical piece = 10 total. ceil(10/6) = 2
+        assert geo.flete_qty == 2
+
+
+# ── Services ─────────────────────────────────────────────────────────────────
+
+class TestServices:
+    def test_building_services(self):
+        tipologias = [
+            {"id": "A", "qty": 25, "embedded_sink_count": 1, "hob_count": 1,
+             "_confidence": {"sink": 0.9, "hob": 0.9}},
+        ]
+        mat = MaterialResolution("x", ["Silestone Blanco Norte"], "single", [], 20)
+        geo = compute_visual_geometry([
+            {"id": "A", "qty": 25, "shape": "linear", "segments_m": [2.0], "depth_m": 0.60},
+        ], mat)
+        services = infer_visual_services(tipologias, geo)
+        assert services.pegadopileta_qty == 25
+        assert services.anafe_qty == 25
+        assert services.colocacion is False
+        assert services.is_building is True
+
+
+# ── Pending Questions ────────────────────────────────────────────────────────
+
+class TestPendingQuestions:
+    def test_material_resolved_not_asked(self):
+        mat = MaterialResolution("x", ["Silestone"], "single", [], 20)
+        services = infer_visual_services(
+            [{"qty": 1, "embedded_sink_count": 0, "hob_count": 0, "_confidence": {}}],
+            compute_visual_geometry([{"id": "A", "qty": 1, "shape": "linear", "segments_m": [1.0], "depth_m": 0.6}], mat),
+        )
+        pending = build_visual_pending_questions(mat, services, [], {"client_name": "Test"})
+        assert "material_definition" not in pending
+
+    def test_needs_clarification_asked(self):
+        mat = MaterialResolution("xyz", [], "needs_clarification", ["xyz"], 20)
+        services = infer_visual_services([], compute_visual_geometry([], mat))
+        pending = build_visual_pending_questions(mat, services, [], {})
+        assert "material_definition" in pending
+
+    def test_planilla_always_first(self):
+        mat = MaterialResolution("x", ["Silestone"], "single", [], 20)
+        services = infer_visual_services([], compute_visual_geometry([], mat))
+        pending = build_visual_pending_questions(mat, services, [], {})
+        assert pending[0] == "planilla_marmoleria"
+
+
+# ── Operator Corrections ─────────────────────────────────────────────────────
+
+class TestCorrections:
+    def test_parse_standard_format(self):
+        text = "DC-02 profundidad = 0.65\nDC-07 tramo2 = 1.54"
+        result = parse_operator_corrections(text)
+        assert len(result) == 2
+        assert result[0]["tipologia_id"] == "DC-02"
+        assert result[0]["field"] == "depth_m"
+        assert result[0]["value"] == 0.65
+
+    def test_parse_flexible_ids(self):
+        """IDs like BAÑ-01, COC-03 should work."""
+        text = "COC-03 profundidad = 0.55"
+        result = parse_operator_corrections(text)
+        assert len(result) == 1
+        assert result[0]["tipologia_id"] == "COC-03"
+
+    def test_parse_comma_decimal(self):
+        text = "DC-04 tramo1 = 1,88"
+        result = parse_operator_corrections(text)
+        assert result[0]["value"] == 1.88
+
+    def test_no_correction_returns_empty(self):
+        result = parse_operator_corrections("confirmo")
+        assert result == []
+
+    def test_failed_correction_returns_none(self):
+        result = parse_operator_corrections("DC-04 la profundidad deberia ser mas grande")
+        assert result is None  # Looks like correction but can't parse
+
+    def test_apply_depth_correction(self):
+        tipologias = [{"id": "DC-02", "depth_m": 0.62, "segments_m": [2.35, 1.15]}]
+        corrections = [{"tipologia_id": "DC-02", "field": "depth_m", "value": 0.65}]
+        result = apply_corrections(tipologias, corrections)
+        assert result[0]["depth_m"] == 0.65
+
+    def test_apply_segment_correction(self):
+        tipologias = [{"id": "DC-07", "segments_m": [1.96, 1.54]}]
+        corrections = [{"tipologia_id": "DC-07", "field": "segments_m_1", "value": 1.60}]
+        result = apply_corrections(tipologias, corrections)
+        assert result[0]["segments_m"][1] == 1.60
+
+
+# ── JSON Parser ──────────────────────────────────────────────────────────────
+
+class TestJSONParser:
+    def test_parse_valid_json(self):
+        response = '''Análisis del plano:
+```json
+{
+  "material_text": "Cuarzo Blanco Norte 2cm",
+  "tipologias": [
+    {"id": "DC-02", "qty": 2, "shape": "L", "depth_m": 0.62, "segments_m": [2.35, 1.15]}
+  ]
+}
+```'''
+        result = parse_visual_extraction(response)
+        assert result is not None
+        assert len(result["tipologias"]) == 1
+        assert result["tipologias"][0]["id"] == "DC-02"
+
+    def test_dedup_tipologias(self):
+        response = '''```json
+{"tipologias": [
+  {"id": "DC-02", "qty": 2, "shape": "L", "depth_m": 0.62, "segments_m": [2.35, 1.15]},
+  {"id": "DC-02", "qty": 2, "shape": "L", "depth_m": 0.62, "segments_m": [2.35, 1.15]}
+]}```'''
+        result = parse_visual_extraction(response)
+        assert len(result["tipologias"]) == 1
+
+    def test_reject_absurd_segments(self):
+        response = '''```json
+{"tipologias": [
+  {"id": "X", "qty": 1, "shape": "linear", "depth_m": 0.6, "segments_m": [50.0]}
+]}```'''
+        result = parse_visual_extraction(response)
+        assert result is None  # 50m segment is out of range
+
+    def test_no_json_returns_none(self):
+        result = parse_visual_extraction("Just some text without JSON")
+        assert result is None
+
+    def test_invalid_json_returns_none(self):
+        result = parse_visual_extraction("```json\n{broken json\n```")
+        assert result is None
+
+
+# ── Render Functions ─────────────────────────────────────────────────────────
+
+class TestRender:
+    def test_render_summary_contains_tipologias(self):
+        validation = validate_visual_extraction([
+            {"id": "DC-02", "qty": 2, "shape": "L", "depth_m": 0.62,
+             "segments_m": [2.35, 1.15], "embedded_sink_count": 1, "hob_count": 1},
+        ])
+        mat = MaterialResolution("x", ["Silestone Blanco Norte"], "single", [], 20)
+        text = render_visual_extraction_summary(validation, mat)
+        assert "DC-02" in text
+        assert "Silestone Blanco Norte" in text
+
+    def test_render_step1_total_closes(self):
+        mat = MaterialResolution("x", ["Silestone Blanco Norte", "Granito Ceara"], "variants", [], 20)
+        geo = compute_visual_geometry([
+            {"id": "A", "qty": 5, "shape": "linear", "segments_m": [2.0], "depth_m": 0.60},
+            {"id": "B", "qty": 3, "shape": "L", "segments_m": [1.5, 0.8], "depth_m": 0.55},
+        ], mat)
+        services = infer_visual_services(
+            [{"qty": 5, "embedded_sink_count": 1, "hob_count": 1, "_confidence": {"sink": 0.9, "hob": 0.9}},
+             {"qty": 3, "embedded_sink_count": 1, "hob_count": 0, "_confidence": {"sink": 0.9, "hob": 0.9}}],
+            geo,
+        )
+        text = render_visual_building_step1(geo, services, mat, [])
+        assert "TOTAL GENERAL" in text
+        assert str(geo.total_m2) in text
+        assert "ambos materiales" in text


### PR DESCRIPTION
## Problema
PASO 1 para Ventus (25 cocinas) dependía 100% del LLM → totales inconsistentes, promedios, esquina L sin restar.

## Solución
Nuevo módulo `visual_quote_builder.py`: Claude solo extrae JSON, el código calcula todo.

### Pipeline
```
Claude → JSON tipologías → resolve_materials → validate (field confidence)
→ compute_geometry (L corner deduction) → infer_services → render PASO 1
```

### Funciones (todas con tests)
| Función | Qué hace |
|---------|----------|
| `resolve_visual_materials` | Alias + fuzzy → single/variants/needs_clarification |
| `compute_field_confidence` | Determinístico por campo (no LLM self-eval) |
| `validate_visual_extraction` | Gating 0.80/0.55 + validación para obras >10 units |
| `compute_visual_geometry` | m² exacto, L-shape resta esquina, physical pieces |
| `infer_visual_services` | PEGADOPILETA/ANAFE desde datos parseados |
| `build_visual_pending_questions` | Solo preguntas genuinamente pendientes |
| `parse_operator_corrections` | Regex determinístico, NO LLM |
| `parse_visual_extraction` | JSON robusto: dedup, rangos, schema validation |

### No toca
- ESH tabular pipeline
- Quotes normales
- Imágenes simples

### Tests
79/79 passed (36 nuevos + 43 existentes) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)