### PR TITLE
fix: separate ETAPA 1 JSON from ETAPA 2 A/B/C + remove read_plan for extraction

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -277,11 +277,17 @@ Si no ves bien una zona, usá `read_plan` con crop_instructions VOS. Si no logr�
 
 **Solo preguntar** si: el material no matchea por alias NI por catálogo (fuzzy match incluido), o la ambigüedad es real (texto ilegible, material desconocido). NUNCA escribir "verificar catálogo" o "a verificar" si el alias o el fuzzy match ya lo resolvió.
 
-#### Extracción estructurada para PDFs visuales multipágina de obra
+#### ETAPA 1 — Extracción estructurada (PRIMERA RESPUESTA — SOLO JSON)
 
-Cuando analices un PDF visual multipágina de obra/edificio (>3 unidades, múltiples tipologías), tu respuesta debe ser un JSON estructurado que el sistema procesará automáticamente. NO hagas cálculos de m² ni totales — el código lo hace.
+Cuando analices un PDF visual multipágina de obra/edificio (>3 unidades, múltiples tipologías):
 
-Formato de extracción obligatorio (JSON en bloque ```json):
+⛔ En esta etapa tu respuesta debe ser ÚNICAMENTE un bloque ```json. NADA MÁS.
+⛔ NO usar bloques A/B/C en esta etapa — eso es para la ETAPA 2.
+⛔ NO hacer preguntas al operador.
+⛔ NO llamar read_plan — analizar el PDF completo con visión nativa directa.
+⛔ NO calcular m² — el código lo hace con fórmula exacta (L-shape resta esquina).
+
+Formato obligatorio:
 ```json
 {
   "material_text": "Cuarzo Blanco Norte o Granito Blanco Ceara 2 cm de espesor",
@@ -310,11 +316,13 @@ Reglas de extracción:
 - `hob_count`: anafes por unidad. Si mesada continua + anafe empotrado → 1.
 - `notes`: notas literales del plano relevantes para esa tipología.
 - NO incluir `confidence` — el código lo calcula.
-- NO calcular m² — el código lo hace con la fórmula correcta (L-shape resta esquina).
 
-#### Formato de salida — estructura obligatoria en 3 bloques
+El sistema procesará el JSON automáticamente y te devolverá el resultado calculado.
 
-Para planos CAD/arquitectónicos, la respuesta final debe tener EXACTAMENTE 3 bloques:
+#### ETAPA 2 — Respuesta final al operador (SOLO después de que el sistema procesó el JSON)
+
+Esta etapa la maneja el sistema — el código renderiza el PASO 1 con los datos calculados.
+Si el sistema te devuelve un resultado con tipologías validadas y necesita confirmación del operador, recién ahí responder con los 3 bloques:
 
 **A. Datos Detectados**
 - Tipologías identificadas (nombre + cantidad de unidades)

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1603,6 +1603,12 @@ class AgentService:
                     # data comes from deterministic pipeline, not list_pieces
                     active_tools = [t for t in TOOLS if t["name"] != "list_pieces"] if is_building else TOOLS
 
+                    # Visual building: remove read_plan on first iteration to force JSON extraction
+                    # Claude must use native vision on the PDF document, not call read_plan
+                    # read_plan comes back in later iterations if needed for corrections/zoom
+                    if is_visual_building and not _visual_builder_done:
+                        active_tools = [t for t in active_tools if t["name"] != "read_plan"]
+
                     # Dynamic max_tokens: higher for visual PDFs (7+ láminas need space for analysis + tool_use)
                     _max_tokens = 16384 if (needs_vision and pdf_has_images) else 8096
 


### PR DESCRIPTION
## Root Cause
CONTEXT.md tenía "respondé con JSON" y "respondé con bloques A/B/C" en la misma sección. Claude eligió A/B/C (más peso sintáctico). También llamaba read_plan 3x a pesar de las instrucciones.

## Fix 1 — CONTEXT.md
- **ETAPA 1**: "SOLO JSON. NADA MÁS." con ⛔ explícitos (no A/B/C, no preguntas, no read_plan, no m²)
- **ETAPA 2**: "SOLO después de que el sistema procesó" — bloques A/B/C van acá

## Fix 2 — agent.py
- `read_plan` removido de `active_tools` cuando `is_visual_building and not _visual_builder_done`
- Claude no puede llamar lo que no tiene. Fuerza extracción JSON pura.
- `read_plan` vuelve después del builder (correcciones/zoom)

79/79 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)