### PR TITLE
fix: inferred + high confidence = ✅ not ⚠️

### DIFF
--- a/api/app/modules/quote_engine/visual_quote_builder.py
+++ b/api/app/modules/quote_engine/visual_quote_builder.py
@@ -782,10 +782,17 @@ def apply_corrections(tipologias: list[dict], corrections: list[dict]) -> list[d
 # ── 8. Render Functions ────────────────────────────────────────────────────────
 
 def render_field(value: str, conf: float, method: str) -> str:
-    """Render a field value with confidence marker."""
+    """Render a field value with confidence marker.
+
+    Rules:
+    - ❌: fallback method OR very low confidence (< CONF_REVIEW)
+    - ⚠️: low confidence (< CONF_HIGH) regardless of method
+    - ✅: high confidence (>= CONF_HIGH) — even if method is "inferred"
+           (high conf inferred = Claude read it clearly from the plan)
+    """
     if method == "fallback" or conf < CONF_REVIEW:
         return f"{value} ❌"
-    elif method == "inferred" or conf < CONF_HIGH:
+    elif conf < CONF_HIGH:
         return f"{value} ⚠️"
     return f"{value} ✅"
 

--- a/api/tests/test_visual_quote_builder.py
+++ b/api/tests/test_visual_quote_builder.py
@@ -390,7 +390,8 @@ class TestRender:
         """Fields show correct markers based on confidence and method."""
         assert "✅" in render_field("2.35m", 0.9, "direct_read")
         assert "⚠️" in render_field("0.87m", 0.7, "direct_read")
-        assert "⚠️" in render_field("0.87m", 0.9, "inferred")
+        assert "✅" in render_field("0.87m", 0.9, "inferred")  # high conf inferred = ✅
+        assert "⚠️" in render_field("0.87m", 0.6, "inferred")  # low conf inferred = ⚠️
         assert "❌" in render_field("1.50m", 0.9, "fallback")
         assert "❌" in render_field("1.50m", 0.3, "direct_read")
 


### PR DESCRIPTION
render_field mostraba ⚠️ para todo 'inferred' aunque conf=0.9. Fix: solo conf < CONF_HIGH → ⚠️. 54/54 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)