### PR TITLE
fix: multi-page read_plan + show all warnings

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1804,12 +1804,13 @@ class AgentService:
                             for tid in ids_for_second_pass[:5]:  # Max 5 second pass calls
                                 page_num = get_tipologia_page(tid, parsed["tipologias"])
                                 try:
-                                    # Get crop of this tipología's page
+                                    # Get crop of this tipología's specific page
                                     from app.modules.agent.tools.plan_tool import read_plan as _read_plan_fn
+                                    page_num = get_tipologia_page(tid, parsed["tipologias"])
                                     crop_result = await _read_plan_fn(plan_filename, [{
                                         "label": f"{tid} planta+corte",
                                         "x1": 30, "y1": 10, "x2": 700, "y2": 700,
-                                    }])
+                                    }], page=page_num)
 
                                     # Get existing extraction for this tipología
                                     existing = next(

--- a/api/app/modules/agent/tools/plan_tool.py
+++ b/api/app/modules/agent/tools/plan_tool.py
@@ -61,11 +61,14 @@ def _image_to_b64(img: Image.Image, max_width: int, quality: int = CROP_JPEG_QUA
     return base64.b64encode(buf.getvalue()).decode()
 
 
-async def read_plan(filename: str, crop_instructions: list) -> list:
+async def read_plan(filename: str, crop_instructions: list, page: int = 1) -> list:
     """Rasterize a plan file at 200 DPI and return crops as native image content blocks.
 
     AUXILIARY tool for tactical zoom/crop only. PDF visual analysis should
     use native vision on the document already attached inline.
+
+    Args:
+        page: 1-indexed page number for multi-page PDFs. Default=1.
 
     Returns a LIST of Anthropic-native content blocks (type: "image" + type: "text")
     instead of a JSON dict, so images don't inflate the text context.
@@ -91,7 +94,10 @@ async def read_plan(filename: str, crop_instructions: list) -> list:
                 fmt="jpeg",
             )
             if pages:
-                base_image = pages[0]
+                # Use specified page (1-indexed), fallback to first
+                page_idx = max(0, min(page - 1, len(pages) - 1))
+                base_image = pages[page_idx]
+                logging.info(f"[read_plan] Rasterized page {page_idx + 1}/{len(pages)} of {filename}")
         else:
             base_image = Image.open(plan_path)
     except Exception as e:

--- a/api/app/modules/quote_engine/visual_quote_builder.py
+++ b/api/app/modules/quote_engine/visual_quote_builder.py
@@ -903,7 +903,7 @@ def render_visual_extraction_summary(
     if validation.soft_field_warnings:
         lines.append("")
         lines.append("**Campos que requieren confirmación:**")
-        for w in validation.soft_field_warnings[:5]:  # Max 5 warnings
+        for w in validation.soft_field_warnings:  # Show ALL warnings
             lines.append(f"- {w}")
 
     lines.append("")


### PR DESCRIPTION
3 bugs fixed:

1. **read_plan page 1 only** → added `page` param, second pass uses correct page per tipología
2. **DC-02/DC-03 cross-contamination** → each tipología now crops its own page
3. **warnings[:5] truncation** → removed limit, DC-07/DC-08 now visible

100/100 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)