### PR TITLE
fix: smart backsplash confirmation + segment inversion guard

### DIFF
--- a/api/app/modules/quote_engine/visual_quote_builder.py
+++ b/api/app/modules/quote_engine/visual_quote_builder.py
@@ -354,9 +354,11 @@ def validate_visual_extraction(tipologias: list[dict]) -> ValidationResult:
         else:
             unusable.append(t)
 
-        # Soft field warnings
-        if conf.backsplash < CONF_HIGH:
-            warnings.append(f"{t.get('id', '?')}: zócalo/backsplash requiere confirmación")
+        # Soft field warnings — only warn about backsplash if incoherent
+        bl = t.get("backsplash_ml")
+        segs = t.get("segments_m", [])
+        if backsplash_needs_confirmation(bl, segs, t.get("shape", "linear")):
+            warnings.append(f"{t.get('id', '?')}: zócalo/backsplash valor incoherente — requiere confirmación")
         if conf.sink < CONF_HIGH:
             warnings.append(f"{t.get('id', '?')}: cantidad de piletas requiere confirmación")
         if conf.hob < CONF_HIGH:
@@ -546,10 +548,12 @@ def build_visual_pending_questions(
     if services.pegadopileta_qty > 0:
         questions.append("pileta_provision")
 
-    # Low confidence backsplash — list ALL tipologías that need confirmation
+    # Only ask about backsplash if value is incoherent (not just low confidence)
     for t in tipologias:
-        conf = t.get("_confidence", {})
-        if conf.get("backsplash", 0) < CONF_HIGH:
+        bl = t.get("backsplash_ml")
+        segs = t.get("segments_m", [])
+        shape = t.get("shape", "linear")
+        if backsplash_needs_confirmation(bl, segs, shape):
             questions.append(f"confirm_backsplash_{t.get('id', '?')}")
 
     # Tipologías with non-direct extraction need review
@@ -625,6 +629,17 @@ def merge_second_pass(
             for field in mergeable_fields:
                 if field in second_pass:
                     updated[field] = second_pass[field]
+
+            # Guard: reject segments where tramo1 < tramo2 (inverted L)
+            new_segs = updated.get("segments_m", [])
+            if len(new_segs) == 2 and new_segs[0] < new_segs[1]:
+                logging.warning(
+                    f"[merge] {tipologia_id}: tramo1 ({new_segs[0]}) < tramo2 ({new_segs[1]}) "
+                    f"— rejecting second pass segments, keeping original"
+                )
+                updated["segments_m"] = t.get("segments_m", new_segs)
+                updated["extraction_method"] = "inferred"
+
             updated["second_pass_notes"] = second_pass.get("second_pass_notes", "")
             result.append(updated)
         else:
@@ -832,6 +847,32 @@ def apply_corrections(tipologias: list[dict], corrections: list[dict]) -> list[d
 
 # ── 8. Render Functions ────────────────────────────────────────────────────────
 
+def backsplash_needs_confirmation(
+    backsplash_ml: Optional[float],
+    segments_m: list[float],
+    shape: str,
+) -> bool:
+    """Only ask confirmation if backsplash value is incoherent.
+
+    Reasonable range: between 50% of longest segment and 150% of sum.
+    If within range → use silently. If outside → confirm.
+    """
+    if backsplash_ml is None:
+        return False  # Will use fallback, which is conservative — OK
+    if not segments_m:
+        return True
+
+    max_possible = sum(segments_m) * 1.5
+    min_possible = max(segments_m) * 0.5
+
+    if backsplash_ml > max_possible:
+        return True
+    if backsplash_ml < min_possible:
+        return True
+
+    return False
+
+
 def render_field(value: str, conf: float, method: str) -> str:
     """Render a field value with confidence marker.
 
@@ -896,8 +937,11 @@ def render_visual_extraction_summary(
 
         lines.append(f"- **{tid}** ×{qty} — {shape_str} — {seg_str} — {depth_str}")
 
-        # Backsplash always needs review (visually weak)
-        bl_str = render_field(f"zócalo {bl}ml" if bl else "zócalo sin dato", conf.get("backsplash", 0), "inferred")
+        # Backsplash: only flag if incoherent, otherwise show as OK
+        if backsplash_needs_confirmation(bl, segs, shape):
+            bl_str = f"zócalo {bl}ml ⚠️ requiere confirmación" if bl else "zócalo sin dato ⚠️"
+        else:
+            bl_str = f"zócalo {bl}ml ✅" if bl else "zócalo (fallback conservador) ✅"
         lines.append(f"  ↳ {bl_str}")
 
     if validation.soft_field_warnings:

--- a/api/tests/test_visual_quote_builder.py
+++ b/api/tests/test_visual_quote_builder.py
@@ -16,6 +16,7 @@ from app.modules.quote_engine.visual_quote_builder import (
     merge_second_pass,
     get_tipologia_page,
     parse_focused_response,
+    backsplash_needs_confirmation,
     render_field,
     infer_visual_services,
     build_visual_pending_questions,
@@ -226,21 +227,23 @@ class TestPendingQuestions:
         assert "DC-05_extraction_needs_review" in pending
 
     def test_all_backsplash_confirmations_listed(self):
-        """ALL tipologías with low backsplash conf should appear, not just first."""
+        """Tipologías with INCOHERENT backsplash should appear in pending."""
         mat = MaterialResolution("x", ["Silestone"], "single", [], 20)
         tipologias = [
             {"id": "DC-02", "qty": 2, "shape": "L", "segments_m": [2.35, 1.15],
              "depth_m": 0.62, "extraction_method": "direct_read",
+             "backsplash_ml": 9.0,  # Incoherent: > 1.5 × (2.35+1.15) = 5.25
              "_confidence": {"backsplash": 0.6, "shape": 0.9, "depth": 0.9, "segments": 0.9}},
             {"id": "DC-07", "qty": 6, "shape": "L", "segments_m": [1.96, 1.54],
              "depth_m": 0.62, "extraction_method": "direct_read",
+             "backsplash_ml": 8.0,  # Incoherent: > 1.5 × (1.96+1.54) = 5.25
              "_confidence": {"backsplash": 0.5, "shape": 0.9, "depth": 0.9, "segments": 0.9}},
         ]
         geo = compute_visual_geometry(tipologias, mat)
         services = infer_visual_services(tipologias, geo)
         pending = build_visual_pending_questions(mat, services, tipologias, {"client_name": "X"})
         assert "confirm_backsplash_DC-02" in pending
-        assert "confirm_backsplash_DC-07" in pending  # Must NOT be skipped by break
+        assert "confirm_backsplash_DC-07" in pending
 
     def test_large_obra_all_in_needs_review(self):
         """When total units > threshold, ALL tipologías go to needs_review."""
@@ -406,8 +409,48 @@ class TestRender:
         text = render_visual_extraction_summary(validation, mat)
         # Segments should have ✅ (high conf + direct_read)
         assert "2.35m ✅" in text
-        # Backsplash always ⚠️ (inferred)
-        assert "⚠️" in text
+        # Backsplash 4.12ml with segments [2.35, 1.15] is reasonable → ✅
+        assert "zócalo 4.12ml ✅" in text
+
+
+# ── Backsplash Confirmation ──────────────────────────────────────────────────
+
+class TestBacksplashConfirmation:
+    def test_reasonable_no_confirmation(self):
+        assert backsplash_needs_confirmation(3.91, [2.35, 0.94], "L") is False
+
+    def test_too_large_needs_confirmation(self):
+        assert backsplash_needs_confirmation(8.0, [2.35, 0.94], "L") is True
+
+    def test_too_small_needs_confirmation(self):
+        assert backsplash_needs_confirmation(0.3, [2.35, 0.94], "L") is True
+
+    def test_none_no_confirmation(self):
+        assert backsplash_needs_confirmation(None, [2.35], "linear") is False
+
+    def test_linear_reasonable(self):
+        assert backsplash_needs_confirmation(2.0, [2.35], "linear") is False
+
+
+# ── Merge Segment Guard ──────────────────────────────────────────────────────
+
+class TestMergeSegmentGuard:
+    def test_merge_rejects_inverted_segments(self):
+        """Second pass must not accept tramo1 < tramo2."""
+        original = [{"id": "DC-02", "segments_m": [2.35, 0.94], "shape": "L"}]
+        bad_pass = {"shape": "L", "segments_m": [0.75, 0.94],
+                    "depth_m": 0.62, "extraction_method": "direct_read"}
+        result = merge_second_pass(original, bad_pass, "DC-02")
+        assert result[0]["segments_m"] == [2.35, 0.94]  # Original kept
+        assert result[0]["extraction_method"] == "inferred"  # Downgraded
+
+    def test_merge_accepts_valid_segments(self):
+        """Valid tramo1 > tramo2 should be accepted."""
+        original = [{"id": "DC-02", "segments_m": [2.35, 0.94], "shape": "L"}]
+        good_pass = {"shape": "L", "segments_m": [2.40, 0.87],
+                     "depth_m": 0.62, "extraction_method": "direct_read"}
+        result = merge_second_pass(original, good_pass, "DC-02")
+        assert result[0]["segments_m"] == [2.40, 0.87]  # Updated
 
 
 # ── Second Pass ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Backsplash solo ⚠️ si incoherente. Segments rechazados si tramo1 < tramo2. 107/107 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)