### PR TITLE
fix: inline cotas rules + natural page confirmation tone

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -2106,15 +2106,28 @@ class AgentService:
                                 '"shape": "L", "depth_m": 0.62, "segments_m": [2.35, 1.15], '
                                 '"backsplash_ml": 4.12, "embedded_sink_count": 1, "hob_count": 1, '
                                 '"notes": [], "extraction_method": "direct_read", "page": 1}]}\n\n'
-                                "Reglas:\n"
+                                "Reglas de campos:\n"
                                 "- shape: 'L' si tiene retorno con cota visible en planta, 'linear' si es recta, 'unknown' si ambiguo\n"
                                 "- segments_m: en METROS (no cm). Para L: [tramo principal, retorno]. Para linear: [largo total]\n"
+                                "  Si hay cotas encadenadas (ej: 55+60+60+75 cm), sumarlas y convertir a metros: 2.50m\n"
                                 "- depth_m: profundidad en METROS (no cm). Típico: 0.55-0.65\n"
                                 "- embedded_sink_count: piletas empotradas por unidad (leer de simbología sa-01, etc)\n"
                                 "- hob_count: anafes por unidad. Mesada continua + anafe empotrado = 1\n"
                                 "- extraction_method: 'direct_read' si la cota es visible, 'inferred' si se dedujo\n"
                                 "- Filtrar SOLO MESADAS — ignorar muebles/carpintería/herrería/instalaciones\n"
-                                "- NO calcular m² — el código lo hace"
+                                "- NO calcular m² — el código lo hace\n\n"
+                                "REGLAS DE LECTURA DE COTAS:\n"
+                                "1. Cota explícita con línea y extremos marcados → usar directamente como medida de mesada\n"
+                                "2. Cota embebida en texto descriptivo (ej: 'proyección alacena 120') con línea de alcance "
+                                "sobre mesada → extraer el número aunque el texto describa otro elemento. Ese número mide el tramo de mesada.\n"
+                                "3. Cota de objeto propio (número dentro de rectángulo de anafe/pileta/heladera) → IGNORAR. "
+                                "No es medida de mesada.\n"
+                                "4. Cotas encadenadas alineadas → sumar todos los tramos para obtener el largo total\n"
+                                "5. Cota perpendicular a pared → es la profundidad de la mesada\n\n"
+                                "REGLA DE ORO: número con línea que conecta dos puntos = cota de distancia → usar. "
+                                "Número flotando dentro de objeto = dimensión del objeto → ignorar.\n\n"
+                                "IGNORAR SIEMPRE: cotas de espacios para heladera/lavarropas/microondas, "
+                                "nichos técnicos, ancho total del ambiente, carpintería, herrería, muebles bajo mesada."
                             )
                             logging.info(f"[visual-pages] Crop content blocks: {len(extraction_content)}")
                             logging.info(f"[visual-pages] Extraction system prompt: {_extraction_system[:200]}")

--- a/api/app/modules/quote_engine/visual_quote_builder.py
+++ b/api/app/modules/quote_engine/visual_quote_builder.py
@@ -1209,63 +1209,64 @@ def render_page_confirmation(
     geometries: list,
     zone_was_auto: bool,
 ) -> str:
-    """Render page confirmation message for operator."""
+    """Render page confirmation message for operator — natural, conversational tone."""
     lines = []
 
-    lines.append(f"**Página {page}/{total_pages}**")
-    zone_label = f"(auto: {selected_zone['name']})" if zone_was_auto else f"({selected_zone['name']})"
-    lines.append(f"Zona analizada: {zone_label}")
-    lines.append("")
-
     if not tipologias:
-        lines.append("No se detectaron tipologías de marmolería en esta zona.")
+        lines.append(f"Leí la página {page}/{total_pages} (zona: {selected_zone['name']}) pero no encontré mesadas de marmolería.")
         lines.append("")
-        lines.append("Si hay marmolería en otra zona, indicá: `zona = CORTE 1-1`")
-        lines.append("Si no hay marmolería en esta página: `skip`")
+        lines.append("Si la marmolería está en otra zona de esta página, indicame cuál: `zona = CORTE 1-1`")
+        lines.append("Si en esta página no hay marmolería: `skip`")
         return "\n".join(lines)
 
     for tip, geo in zip(tipologias, geometries):
         tid = tip.get("id", "?")
         qty = tip.get("qty", 1)
         shape = tip.get("shape", "?")
-        method = tip.get("extraction_method", "fallback")
-        conf = tip.get("_confidence", {})
-
-        # Segments with markers
         segs = tip.get("segments_m", [])
-        seg_parts = [render_field(f"{s}m", conf.get("segments", 0), method) for s in segs]
-        seg_str = " + ".join(seg_parts) if seg_parts else "?"
-
         depth = tip.get("depth_m", 0)
-        depth_str = render_field(f"prof {depth}m", conf.get("depth", 0), method)
+        bl = tip.get("backsplash_ml")
+        notes = tip.get("notes", [])
 
-        # Shape
-        if shape == "unknown":
-            shape_str = f"{shape} ❌"
-        elif conf.get("shape", 0) >= CONF_HIGH:
-            shape_str = f"{shape} ✅"
-        else:
-            shape_str = f"{shape} ⚠️"
+        # Header
+        shape_desc = "mesada en L" if shape == "L" else "mesada lineal" if shape == "linear" else "mesada (forma a confirmar)"
+        lines.append(f"Leí la página {page}/{total_pages} — encontré la {shape_desc} de **{tid}** (×{qty} unidades).")
+        lines.append("")
 
-        lines.append(f"**{tid}** ×{qty} — {shape_str} — {seg_str} — {depth_str}")
+        # Segments in natural language
+        if shape == "L" and len(segs) == 2:
+            lines.append(f"Tiene dos tramos:")
+            lines.append(f"- Tramo principal: {segs[0]}m")
+            lines.append(f"- Retorno: {segs[1]}m")
+        elif segs:
+            if len(segs) == 1:
+                lines.append(f"- Largo: {segs[0]}m")
+            else:
+                lines.append(f"- Tramos: {' + '.join(f'{s}m' for s in segs)}")
 
-        # Geometry summary
+        lines.append(f"- Profundidad: {depth}m")
+
+        # Geometry
         if hasattr(geo, "m2_unit"):
-            lines.append(f"  m² unit: {geo.m2_unit} — m² total: {geo.m2_total}")
+            lines.append(f"- Superficie unitaria: {geo.m2_unit} m² → total {qty} unidades: {geo.m2_total} m²")
 
         # Backsplash
-        bl = tip.get("backsplash_ml")
-        if backsplash_needs_confirmation(bl, segs, shape):
-            lines.append(f"  ↳ zócalo {bl}ml ⚠️" if bl else "  ↳ zócalo sin dato ⚠️")
+        if bl:
+            lines.append(f"- Zócalo estimado: {bl}ml")
         else:
-            lines.append(f"  ↳ zócalo {bl}ml ✅" if bl else "  ↳ zócalo (fallback) ✅")
+            lines.append(f"- Zócalo: se calcula automáticamente")
+
+        # Notes
+        if notes:
+            lines.append("")
+            for n in notes:
+                lines.append(f"⚠️ Nota del plano: \"{n}\"")
 
         lines.append("")
 
-    lines.append("¿Confirmás? Si hay que corregir:")
-    lines.append("- Medidas: `DC-02 profundidad = 0.65`")
-    lines.append("- Zona: `zona = CORTE 1-1`")
-    lines.append("- Sin marmolería: `skip`")
+    lines.append("¿Es correcto? Avanzo con la página siguiente.")
+    lines.append("Si algo está mal: `DC-02 tramo2 = 1.20` o `DC-02 profundidad = 0.65`")
+    lines.append("Si la marmolería está en otra zona: `zona = CORTE 1-1`")
 
     return "\n".join(lines)
 

--- a/api/tests/test_visual_quote_builder.py
+++ b/api/tests/test_visual_quote_builder.py
@@ -702,7 +702,7 @@ class TestParsePageConfirmation:
 
 
 class TestRenderPageConfirmation:
-    def test_contains_progress(self):
+    def test_contains_progress_and_tipologia(self):
         zone = {"name": "PLANTA", "bbox": [0,0,600,400]}
         tips = [{"id": "DC-02", "qty": 2, "shape": "L", "segments_m": [2.35, 0.87],
                  "depth_m": 0.62, "extraction_method": "direct_read",
@@ -710,14 +710,31 @@ class TestRenderPageConfirmation:
         mat = MaterialResolution("x", ["Silestone"], "single", [], 20)
         geos = compute_visual_geometry(tips, mat).tipologias
         text = render_page_confirmation(1, 7, zone, tips, geos, True)
-        assert "Página 1/7" in text
+        assert "1/7" in text
         assert "DC-02" in text
-        assert "auto: PLANTA" in text
+        assert "mesada en L" in text
+        assert "Tramo principal" in text
+        assert "Retorno" in text
+        assert "Profundidad" in text
+        assert "m²" in text
+
+    def test_natural_tone_no_markers(self):
+        """Output should NOT contain ✅/⚠️/❌ markers — those are for logs only."""
+        zone = {"name": "PLANTA", "bbox": [0,0,600,400]}
+        tips = [{"id": "DC-02", "qty": 2, "shape": "L", "segments_m": [2.35, 0.87],
+                 "depth_m": 0.62, "extraction_method": "direct_read",
+                 "_confidence": {"shape": 0.9, "segments": 0.9, "depth": 0.9, "backsplash": 0.6}}]
+        mat = MaterialResolution("x", ["Silestone"], "single", [], 20)
+        geos = compute_visual_geometry(tips, mat).tipologias
+        text = render_page_confirmation(1, 7, zone, tips, geos, True)
+        assert "✅" not in text
+        assert "⚠️" not in text
+        assert "❌" not in text
 
     def test_no_tipologias_shows_options(self):
         zone = {"name": "PLANTA", "bbox": [0,0,600,400]}
         text = render_page_confirmation(3, 7, zone, [], [], True)
-        assert "No se detectaron" in text
+        assert "no encontré mesadas" in text
         assert "skip" in text
 
 


### PR DESCRIPTION
Cotas rules inline in extraction prompt (Claude couldn't access the .md). Page confirmation rewritten as natural conversation. 136/136 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)