### PR TITLE
feat: U-shape mesada support

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -359,9 +359,14 @@ Reglas de extracción:
 - `shape`:
   - "linear" si el corte 1-1 muestra módulos en una sola línea sin cambio de dirección
   - "L" SOLO si hay cota explícita del retorno en planta O un corte lateral confirma el segundo tramo con medida visible
+  - "U" si la mesada cubre 3 paredes (lateral izq + fondo + lateral der). Detectar cuando hay mesada en forma de U o C.
   - "unknown" si hay ambigüedad — NUNCA inventar shape ni retorno sin cota visible
   - Ejemplo: 5 módulos en línea recta (59+60+60+60+60) → "linear" siempre, aunque haya espacio vacío al lado
-- `segments_m`: para L, [tramo largo, tramo corto] — el tramo corto DEBE tener cota explícita en planta. Si no hay cota del retorno → no inventarlo, poner shape "unknown" y agregar nota. Para linear, [largo total]. Leer de cotas de planta y cortes. Si hay módulos (55+60+60), sumar: 1.75m. Si son (55+60+60+60), sumar: 2.35m
+- `segments_m`:
+  - Para linear: [largo total]
+  - Para L: [tramo principal, retorno] — el retorno DEBE tener cota explícita en planta
+  - Para U: [tramo_izq, tramo_fondo_neto, tramo_der] — el fondo YA tiene las esquinas restadas (total_fondo - prof_izq - prof_der)
+  - Leer de cotas de planta y cortes. Si hay módulos (55+60+60), sumar: 1.75m. Si son (55+60+60+60), sumar: 2.35m
 - `depth_m`: profundidad de la mesada (ancho). Leer de planta o corte transversal.
 - `backsplash_ml`: metros lineales de zócalo estimados. Si no podés determinar, omitir (el código usa fallback conservador).
 - `embedded_sink_count`: piletas empotradas por unidad. Leer de simbología (sa-01, etc).

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -2107,8 +2107,9 @@ class AgentService:
                                 '"backsplash_ml": 4.12, "embedded_sink_count": 1, "hob_count": 1, '
                                 '"notes": [], "extraction_method": "direct_read", "page": 1}]}\n\n'
                                 "Reglas de campos:\n"
-                                "- shape: 'L' si tiene retorno con cota visible en planta, 'linear' si es recta, 'unknown' si ambiguo\n"
-                                "- segments_m: en METROS (no cm). Para L: [tramo principal, retorno]. Para linear: [largo total]\n"
+                                "- shape: 'L' si tiene retorno con cota visible, 'linear' si es recta, 'U' si cubre 3 paredes, 'unknown' si ambiguo\n"
+                                "- segments_m: en METROS (no cm). Para L: [tramo principal, retorno]. Para linear: [largo total]. "
+                                "Para U: [tramo_izq, tramo_fondo_neto, tramo_der] — fondo ya con esquinas restadas\n"
                                 "  Si hay cotas encadenadas (ej: 55+60+60+75 cm), sumarlas y convertir a metros: 2.50m\n"
                                 "- depth_m: profundidad en METROS (no cm). Típico: 0.55-0.65\n"
                                 "- embedded_sink_count: piletas empotradas por unidad (leer de simbología sa-01, etc)\n"

--- a/api/app/modules/quote_engine/visual_quote_builder.py
+++ b/api/app/modules/quote_engine/visual_quote_builder.py
@@ -269,7 +269,7 @@ def compute_field_confidence(tipologia: dict) -> FieldConfidence:
     conf = FieldConfidence()
 
     # Shape: must be explicit
-    if shape in ("L", "linear"):
+    if shape in ("L", "linear", "U"):
         conf.shape = 0.9
     elif shape == "unknown":
         conf.shape = 0.3  # Needs review
@@ -280,6 +280,8 @@ def compute_field_confidence(tipologia: dict) -> FieldConfidence:
     if shape == "L" and len(segs) != 2:
         conf.segments = 0.3
     elif shape == "linear" and len(segs) != 1:
+        conf.segments = 0.3
+    elif shape == "U" and len(segs) != 3:
         conf.segments = 0.3
     elif all(0.3 <= s <= 5.0 for s in segs) and len(segs) > 0:
         conf.segments = 0.9
@@ -429,10 +431,15 @@ def compute_visual_geometry(
         depth = t.get("depth_m", 0.60)
         notes = t.get("notes", [])
 
-        # m² per unit — L-shape subtracts corner overlap
+        # m² per unit — shape-dependent calculation
         if shape == "L" and len(segs) == 2:
+            # L-shape: subtract corner overlap (depth × depth)
             m2_unit = (segs[0] * depth) + (segs[1] * depth) - (depth * depth)
+        elif shape == "U" and len(segs) == 3:
+            # U-shape: 3 tramos, corners already subtracted in seg_fondo
+            m2_unit = sum(s * depth for s in segs)
         else:
+            # Linear or unknown: simple sum
             m2_unit = sum(s * depth for s in segs)
         m2_unit = round(m2_unit, 2)
         m2_total = round(m2_unit * qty, 2)
@@ -440,11 +447,12 @@ def compute_visual_geometry(
         # Backsplash ml per unit
         backsplash_ml = t.get("backsplash_ml")
         if backsplash_ml is None:
-            # Fallback: conservative (all segments + depth for L)
-            # TODO: this overestimates if not all sides have backsplash
+            # Fallback: conservative — all back walls get backsplash
             backsplash_ml = sum(segs)
             if shape == "L":
                 backsplash_ml += depth  # return side
+            elif shape == "U":
+                pass  # U already has all 3 walls in segments — sum is correct
         backsplash_m2_unit = round(backsplash_ml * backsplash_height_m, 2)
         backsplash_m2_total = round(backsplash_m2_unit * qty, 2)
 
@@ -684,7 +692,7 @@ def parse_focused_response(text: str) -> Optional[dict]:
         if not isinstance(data["shape"], str):
             logging.warning(f"[parse_focused] shape is {type(data['shape']).__name__} ({data['shape']}), not str — discarding")
             del data["shape"]
-        elif data["shape"] not in ("L", "linear", "unknown"):
+        elif data["shape"] not in ("L", "linear", "U", "unknown"):
             logging.warning(f"[parse_focused] invalid shape value: {data['shape']} — discarding")
             del data["shape"]
 
@@ -1229,7 +1237,8 @@ def render_page_confirmation(
         notes = tip.get("notes", [])
 
         # Header
-        shape_desc = "mesada en L" if shape == "L" else "mesada lineal" if shape == "linear" else "mesada (forma a confirmar)"
+        _shape_map = {"L": "mesada en L", "linear": "mesada lineal", "U": "mesada en U"}
+        shape_desc = _shape_map.get(shape, "mesada (forma a confirmar)")
         lines.append(f"Leí la página {page}/{total_pages} — encontré la {shape_desc} de **{tid}** (×{qty} unidades).")
         lines.append("")
 
@@ -1238,6 +1247,11 @@ def render_page_confirmation(
             lines.append(f"Tiene dos tramos:")
             lines.append(f"- Tramo principal: {segs[0]}m")
             lines.append(f"- Retorno: {segs[1]}m")
+        elif shape == "U" and len(segs) == 3:
+            lines.append(f"Tiene tres tramos:")
+            lines.append(f"- Lateral izquierdo: {segs[0]}m")
+            lines.append(f"- Fondo: {segs[1]}m")
+            lines.append(f"- Lateral derecho: {segs[2]}m")
         elif segs:
             if len(segs) == 1:
                 lines.append(f"- Largo: {segs[0]}m")
@@ -1395,7 +1409,7 @@ def parse_visual_extraction(claude_response: str) -> Optional[dict]:
             qty = 1
 
         shape = t.get("shape", "linear")
-        if shape not in ("L", "linear", "unknown"):
+        if shape not in ("L", "linear", "U", "unknown"):
             shape = "unknown"
 
         segs = t.get("segments_m", [])

--- a/api/rules/plan-reading-cotas.md
+++ b/api/rules/plan-reading-cotas.md
@@ -52,3 +52,22 @@ Cota perpendicular a la pared. Mide qué tan fondo entra la mesada desde la pare
 | Cotas encadenadas alineadas | Sumar → largo total del tramo |
 | Cota perpendicular a pared | Profundidad de mesada |
 | Cota ausente en un tramo | NO inferir → dejar como "unknown" y preguntar |
+
+## Mesadas en U
+
+Una mesada en U tiene 3 tramos: lateral izquierdo + fondo + lateral derecho. Se detecta cuando la mesada cubre 3 paredes o tiene 2 tramos laterales conectados por un fondo.
+
+### Cómo calcular los tramos
+
+1. **Total fondo**: sumar todas las cotas horizontales de la pared del fondo (incluir el espacio del anafe si lo hay — se cobra como material completo)
+2. **Tramo fondo neto**: total_fondo - profundidad_izq - profundidad_der (restar las esquinas)
+3. **Tramo izquierdo**: largo del lateral izquierdo (cotas verticales)
+4. **Tramo derecho**: largo del lateral derecho (cotas verticales)
+
+### Formato en segments_m
+Para U: `segments_m = [tramo_izq, tramo_fondo_neto, tramo_der]`
+
+El tramo fondo YA tiene las esquinas restadas, por lo que el cálculo de m² es simplemente la suma de los 3 tramos × profundidad, sin restar esquinas adicionales.
+
+### Anafe en tramo fondo
+Si el anafe está en el tramo del fondo, el material se cobra completo (incluyendo el espacio del anafe) porque el desperdicio es inevitable — la piedra se compra entera y se corta.

--- a/api/tests/test_visual_quote_builder.py
+++ b/api/tests/test_visual_quote_builder.py
@@ -134,6 +134,31 @@ class TestGeometry:
         expected = round((2.35 * 0.62) + (1.15 * 0.62) - (0.62 * 0.62), 2)
         assert geo.tipologias[0].m2_unit == expected
 
+    def test_u_shape_three_segments(self):
+        """U-shape: 3 tramos × depth, no corner deduction (already in seg_fondo)."""
+        mat = MaterialResolution("x", ["Silestone Blanco Norte"], "single", [], 20)
+        geo = compute_visual_geometry([{
+            "id": "DC-04", "qty": 1, "shape": "U",
+            "segments_m": [0.80, 1.50, 0.80], "depth_m": 0.62,
+        }], mat)
+        expected = round((0.80 + 1.50 + 0.80) * 0.62, 2)
+        assert geo.tipologias[0].m2_unit == expected
+
+    def test_u_shape_confidence(self):
+        """U with 3 segments should have high shape+segments confidence."""
+        conf = compute_field_confidence({
+            "shape": "U", "segments_m": [0.80, 1.50, 0.80], "depth_m": 0.62,
+        })
+        assert conf.shape >= CONF_HIGH
+        assert conf.segments >= CONF_HIGH
+
+    def test_u_shape_wrong_segments(self):
+        """U with != 3 segments should drop confidence."""
+        conf = compute_field_confidence({
+            "shape": "U", "segments_m": [1.50, 0.80], "depth_m": 0.62,
+        })
+        assert conf.segments < CONF_REVIEW
+
     def test_total_closes_with_rows(self):
         """Total m² must equal sum of all row totals."""
         mat = MaterialResolution("x", ["Silestone Blanco Norte"], "single", [], 20)


### PR DESCRIPTION
New shape U for 3-wall mesadas. Full pipeline: cotas guide, schema, geometry (no corner deduction — already in fondo neto), confidence, render. 139/139 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)