### PR TITLE
fix: import re + text extraction tokens 800→1500

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -3,6 +3,7 @@ import asyncio
 import json
 import base64
 import logging
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import AsyncGenerator, Optional
@@ -2043,7 +2044,7 @@ class AgentService:
                             })
                             _text_resp = await self.client.messages.create(
                                 model="claude-opus-4-6",
-                                max_tokens=800,
+                                max_tokens=1500,  # 800 was too low — artefactos list gets truncated
                                 system="Extraer información textual de una lámina de plano CAD. Solo JSON.",
                                 messages=[{"role": "user", "content": _text_content}],
                             )


### PR DESCRIPTION
re not imported → text parse crashed. max_tokens too low → artefactos truncated. 144/144 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)