### PR TITLE
fix: architect discount + Drive links + sink matching

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -533,8 +533,9 @@ Ver calculation-formulas.md. Minimo 1 m² | Sobre total m² incluyendo zocalos |
 
 ### ⛔ Auto-deteccion descuento arquitecta
 - SIEMPRE llamar `check_architect(client_name)` antes de calcular
-- Match exacto → aplicar: 5% USD / 8% ARS
-- Match parcial → sugerir al operador
+- Match exacto o parcial → **APLICAR SIEMPRE**: 5% USD / 8% ARS
+- **SIN MINIMO DE M²** — arquitecta = descuento obligatorio, aunque sean 0.5 m²
+- La regla de >6m² NO aplica a arquitectas. Solo aplica a clientes que NO son arquitectas.
 - Pasar `discount_pct` a `calculate_quote`
 
 ### Mesada >3m

--- a/api/catalog/materials-purastone.json
+++ b/api/catalog/materials-purastone.json
@@ -9,7 +9,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PURACANA.png",
-    "price_usd": 286.0,
+    "price_usd": 286,
     "currency": "USD",
     "plate_size": "estandar",
     "plate_m2": 4.2
@@ -39,7 +39,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PURANUBE.png",
-    "price_usd": 363.0,
+    "price_usd": 363,
     "currency": "USD",
     "plate_size": "estandar",
     "plate_m2": 4.2
@@ -159,7 +159,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PALOMA.png",
-    "price_usd": 286.0,
+    "price_usd": 286,
     "currency": "USD",
     "plate_size": "estandar",
     "plate_m2": 4.2
@@ -174,7 +174,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PURACALACATTADOR.png",
-    "price_usd": 528.0,
+    "price_usd": 528,
     "currency": "USD",
     "plate_size": "especial",
     "plate_m2": 5.12
@@ -189,7 +189,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PURACALACATAGOLD.png",
-    "price_usd": 528.0,
+    "price_usd": 528,
     "currency": "USD",
     "plate_size": "especial",
     "plate_m2": 5.12
@@ -204,7 +204,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PURACALACATTAVER.png",
-    "price_usd": 528.0,
+    "price_usd": 528,
     "currency": "USD",
     "plate_size": "estandar",
     "plate_m2": 4.2
@@ -354,7 +354,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PURASTATUARIETTO.png",
-    "price_usd": 528.0,
+    "price_usd": 528,
     "currency": "USD",
     "plate_size": "especial",
     "plate_m2": 5.12
@@ -369,7 +369,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PURASTATUARIO.png",
-    "price_usd": 528.0,
+    "price_usd": 528,
     "currency": "USD",
     "plate_size": "especial",
     "plate_m2": 5.12
@@ -384,7 +384,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PURATAJ.png",
-    "price_usd": 575.0,
+    "price_usd": 575,
     "currency": "USD",
     "plate_size": "estandar",
     "plate_m2": 4.2
@@ -414,7 +414,22 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PURAVENATINO.png",
-    "price_usd": 407.0,
+    "price_usd": 407,
+    "currency": "USD",
+    "plate_size": "estandar",
+    "plate_m2": 4.2
+  },
+  {
+    "sku": "PURAPALOMA",
+    "name": "TERRAZO",
+    "material_type": "purastone",
+    "category": "cuarzo",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "13/04/2026",
+    "photo": "media/materials/purastone/PURAPALOMA.png",
+    "price_usd": 337.17,
     "currency": "USD",
     "plate_size": "estandar",
     "plate_m2": 4.2

--- a/api/catalog/materials-purastone.json
+++ b/api/catalog/materials-purastone.json
@@ -9,7 +9,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PURACANA.png",
-    "price_usd": 286,
+    "price_usd": 286.0,
     "currency": "USD",
     "plate_size": "estandar",
     "plate_m2": 4.2
@@ -39,7 +39,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PURANUBE.png",
-    "price_usd": 363,
+    "price_usd": 363.0,
     "currency": "USD",
     "plate_size": "estandar",
     "plate_m2": 4.2
@@ -159,7 +159,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PALOMA.png",
-    "price_usd": 286,
+    "price_usd": 286.0,
     "currency": "USD",
     "plate_size": "estandar",
     "plate_m2": 4.2
@@ -174,7 +174,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PURACALACATTADOR.png",
-    "price_usd": 528,
+    "price_usd": 528.0,
     "currency": "USD",
     "plate_size": "especial",
     "plate_m2": 5.12
@@ -189,7 +189,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PURACALACATAGOLD.png",
-    "price_usd": 528,
+    "price_usd": 528.0,
     "currency": "USD",
     "plate_size": "especial",
     "plate_m2": 5.12
@@ -204,7 +204,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PURACALACATTAVER.png",
-    "price_usd": 528,
+    "price_usd": 528.0,
     "currency": "USD",
     "plate_size": "estandar",
     "plate_m2": 4.2
@@ -354,7 +354,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PURASTATUARIETTO.png",
-    "price_usd": 528,
+    "price_usd": 528.0,
     "currency": "USD",
     "plate_size": "especial",
     "plate_m2": 5.12
@@ -369,7 +369,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PURASTATUARIO.png",
-    "price_usd": 528,
+    "price_usd": 528.0,
     "currency": "USD",
     "plate_size": "especial",
     "plate_m2": 5.12
@@ -384,7 +384,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PURATAJ.png",
-    "price_usd": 575,
+    "price_usd": 575.0,
     "currency": "USD",
     "plate_size": "estandar",
     "plate_m2": 4.2
@@ -414,22 +414,7 @@
     "price_includes_vat": false,
     "last_updated": "13/04/2026",
     "photo": "media/materials/purastone/PURAVENATINO.png",
-    "price_usd": 407,
-    "currency": "USD",
-    "plate_size": "estandar",
-    "plate_m2": 4.2
-  },
-  {
-    "sku": "PURAPALOMA",
-    "name": "TERRAZO",
-    "material_type": "purastone",
-    "category": "cuarzo",
-    "thickness_mm": 20,
-    "unit": "m2",
-    "price_includes_vat": false,
-    "last_updated": "13/04/2026",
-    "photo": "media/materials/purastone/PURAPALOMA.png",
-    "price_usd": 337.17,
+    "price_usd": 407.0,
     "currency": "USD",
     "plate_size": "estandar",
     "plate_m2": 4.2

--- a/api/rules/commercial-conditions.md
+++ b/api/rules/commercial-conditions.md
@@ -23,8 +23,12 @@ Dif <= 0.5 m2 → mantener original
 
 ## Descuentos
 - Importado USD: **5%** | Nacional ARS: **8%** (parametrizable config.json)
-- Solo material, nunca MO | Aplica: >6m² o arquitecta (architects.json)
-- **SIEMPRE verificar si el cliente está en architects.json** usando catalog_lookup("architects", client_name) ANTES de calcular precios. Si está → aplicar descuento automáticamente sin preguntar al operador. Buscar por nombre parcial (ej: "MUNGE" matchea "ESTUDIO MUNGE").
+- Solo material, nunca MO
+- **Condiciones de aplicación (OR, NO AND):**
+  - Si cliente está en architects.json → **DESCUENTO SIEMPRE, sin importar m²**. No hay mínimo de m² para arquitectas.
+  - Si NO es arquitecta → descuento solo si >6 m²
+- **SIEMPRE verificar si el cliente está en architects.json** usando `check_architect(client_name)` ANTES de calcular precios. Si está → aplicar descuento automáticamente sin preguntar al operador. Buscar por nombre parcial (ej: "MUNGE" matchea "ESTUDIO MUNGE").
+- ⛔ **NUNCA** ignorar el descuento de arquitecta por m² bajo. Si es arquitecta, aplica aunque sea 0.5 m².
 - Presentacion: linea separada en bloque material, "DESC" en col precio, monto en col total, TOTAL muestra neto
 
 ## Flete compartido

--- a/api/rules/plan-reading.md
+++ b/api/rules/plan-reading.md
@@ -113,6 +113,16 @@ Hatching/rayado = pared → NO canto expuesto → NO frentin. Lados sin tachar =
 - "DESAGUE" sin modelo → apoyo (AGUJEROAPOYO) | Con modelo → empotrada (PEGADOPILETA)
 - 3 puntitos junto a ovalo → empotrada (PEGADOPILETA)
 
+### ⛔ Modelo de pileta — NUNCA inventar
+- **SIEMPRE** buscar el modelo exacto en `sinks.json` con `catalog_lookup("sinks", sku)`
+- Si el plano/enunciado dice un nombre que no matchea exacto → hacer **fuzzy match**:
+  - Extraer palabras clave del nombre (marca, serie, numero)
+  - Ej: "LUXOR COMPACT SI71" → buscar "LUXOR" + "171" → PILETA JOHNSON LUXOR S171
+  - Ej: "Johnson Simple SI37" → buscar "Q37" → PILETA JOHNSON QUADRA Q37
+  - Los numeros de modelo suelen coincidir con permutaciones: SI71→S171, Q71→Q71A
+- Si no hay match claro → **PREGUNTAR al operador** con las opciones mas parecidas de sinks.json
+- **NUNCA** usar un nombre de pileta que no exista en sinks.json en el presupuesto final
+
 ---
 
 ## Deteccion de anafe/tomas

--- a/api/rules/quote-process-buildings.md
+++ b/api/rules/quote-process-buildings.md
@@ -93,7 +93,8 @@ Operador tiene ultima palabra.
 
 ### Descuentos — reglas
 - `precio x (1 - desc%)` | NO acumulativos — 1 por presupuesto, el mayor %
-- Tipos: arquitecta 5% USD, cantidad 5% USD/>6m² o 8% ARS/>6m², edificio 18%/>15m², manual
+- Tipos: arquitecta 5% USD (**SIN minimo m²**), cantidad 5% USD/>6m² o 8% ARS/>6m², edificio 18%/>15m², manual
+- ⛔ El mínimo de 6m² solo aplica a descuento por cantidad, NUNCA a descuento de arquitecta
 - Mostrar fila DESC | Solo material, nunca MO
 
 ### Descuento arquitecta

--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -321,7 +321,8 @@ export default function QuotePage() {
         </div>
         <div className="flex gap-2 flex-wrap">
           {quote?.pdf_url && <FileLink href={quote.pdf_url} label="PDF" cls="border-red-400/20 text-red-400" />}
-          {quote?.drive_url && <FileLink href={quote.drive_url} label="Drive" cls="border-acc/20 text-acc" />}
+          {quote?.drive_pdf_url && <FileLink href={quote.drive_pdf_url} label="PDF Drive" cls="border-acc/20 text-acc" />}
+          {quote?.drive_excel_url && <FileLink href={quote.drive_excel_url} label="Excel Drive" cls="border-emerald-400/20 text-emerald-400" />}
         </div>
       </div>
 

--- a/web/src/components/quote/QuoteHeader.tsx
+++ b/web/src/components/quote/QuoteHeader.tsx
@@ -39,7 +39,8 @@ export default function QuoteHeader({ quote, onBack }: Props) {
       </div>
       <div style={{ display: "flex", gap: 8 }}>
         {quote?.pdf_url && <FileLink href={quote.pdf_url} label="PDF" color="#ff6b63" />}
-        {quote?.drive_url && <FileLink href={quote.drive_url} label="Drive" color="var(--acc)" />}
+        {quote?.drive_pdf_url && <FileLink href={quote.drive_pdf_url} label="PDF Drive" color="var(--acc)" />}
+        {quote?.drive_excel_url && <FileLink href={quote.drive_excel_url} label="Excel Drive" color="#34d399" />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- **Architect discount always applies** — clarified in all rules that architect discount has NO m² minimum. The agent was incorrectly skipping the 5% discount for Munge because total m² < 6, but the 6m² threshold only applies to quantity discounts.
- **Drive links split** — replaced single "Drive" button with separate "PDF Drive" and "Excel Drive" buttons, each pointing to the correct file.
- **Sink model matching** — added rule to never invent sink models. Must fuzzy match against sinks.json (e.g. "LUXOR COMPACT SI71" → LUXOR S171). Ask operator if unsure.

## Test plan
- [ ] Create quote with architect client (e.g. Munge) with < 6m² — verify 5% discount is applied
- [ ] Verify "PDF Drive" and "Excel Drive" buttons open correct files
- [ ] Verify sink model names in quotes match sinks.json entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)