### PR TITLE
fix: 7 bugs — piece layout, unicode, delivery, PUL, drive, sinks + tests

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -511,6 +511,7 @@ Ver calculation-formulas.md. Minimo 1 m² | Sobre total m² incluyendo zocalos |
 - Excepciones (no cobran): Rosario, Funes, Roldan
 - Sin colocacion o retiro en fabrica → no aplica
 - Configurado por zona en config.json → zone_aliases → pulido_extra: true/false
+- ⛔ **IMPORTANTE:** El pulido lo maneja `calculate_quote()` automaticamente segun la zona. Si el resultado de calculate_quote() NO incluye "Pulido de cantos" en mo_items, NUNCA mencionarlo ni agregarlo en tu respuesta. NO inventar items de MO que el calculador no incluyó.
 
 ### Flete
 - Default: siempre cobrar flete. Solo omitir si el operador dice "retiro en fabrica" / "lo busco yo" (skip_flete=true)

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -2509,10 +2509,10 @@ class AgentService:
                     })
                 else:
                     try:
-                        result_json = json.dumps(result)
+                        result_json = json.dumps(result, ensure_ascii=False)
                     except (TypeError, ValueError) as e:
                         logging.error(f"JSON serialization error for tool {tool_use.name}: {e}")
-                        result_json = json.dumps({"ok": False, "error": f"Error serializando resultado de {tool_use.name}"})
+                        result_json = json.dumps({"ok": False, "error": f"Error serializando resultado de {tool_use.name}"}, ensure_ascii=False)
 
                     tool_results.append({
                         "type": "tool_result",
@@ -2784,6 +2784,9 @@ class AgentService:
                         drive_info = {}
                         if local_path:
                             try:
+                                import os as _os_drive
+                                _file_size = _os_drive.path.getsize(local_path) if _os_drive.path.exists(local_path) else -1
+                                logging.info(f"Drive upload starting: {kind} | path={local_path} | size={_file_size} bytes | subfolder={subfolder}")
                                 dr = await upload_single_file_to_drive(local_path, subfolder)
                                 if dr.get("ok"):
                                     drive_info = {
@@ -2798,8 +2801,11 @@ class AgentService:
                                         _drive_pdf_url = dr["drive_url"]
                                     elif kind == "excel":
                                         _drive_excel_url = dr["drive_url"]
+                                    logging.info(f"Drive upload OK: {kind} | file_id={dr['file_id']} | url={dr['drive_url']}")
+                                else:
+                                    logging.error(f"Drive upload returned error: {kind} | {dr.get('error', 'unknown')}")
                             except Exception as e:
-                                logging.warning(f"Drive upload failed for {filename}: {e}")
+                                logging.error(f"Drive upload EXCEPTION for {filename}: {e}", exc_info=True)
 
                         files_v2_items.append({
                             "kind": kind,

--- a/api/app/modules/agent/tools/catalog_tool.py
+++ b/api/app/modules/agent/tools/catalog_tool.py
@@ -244,7 +244,8 @@ def check_architect(client_name: str) -> dict:
         item_words = set(item_name.replace("arq.", "").replace("arq ", "").strip().split())
 
         # Substring match: "munge" in "estudio munge" or vice versa
-        if name_lower in item_name or name_lower in item_firm or item_name in name_lower or item_firm in name_lower:
+        # Guard against empty strings (empty in anything is always True)
+        if (name_lower and name_lower in item_name) or (name_lower and item_firm and name_lower in item_firm) or (item_name and item_name in name_lower) or (item_firm and item_firm in name_lower):
             partial.append({"name": item["name"], "firm": item.get("firm"), "discount": item.get("discount", True)})
             continue
 
@@ -258,6 +259,55 @@ def check_architect(client_name: str) -> dict:
         return {"found": True, "exact": len(partial) == 1, "name": partial[0]["name"], "firm": partial[0].get("firm"), "discount": partial[0].get("discount", True), "matches": partial, "message": f"Arquitecta encontrada: {', '.join(p['name'] for p in partial)}. Aplicar descuento."}
 
     return {"found": False, "message": f"'{client_name}' no está en architects.json"}
+
+
+def fuzzy_sink_lookup(query: str) -> dict:
+    """Fuzzy match a sink by brand keywords + model number patterns.
+
+    E.g. "LUXOR COMPACT SI71" → matches LUXOR171 (PILETA JOHNSON LUXOR S171)
+    by extracting brand "LUXOR" and numeric "171" from "SI71".
+    """
+    import re
+    items = _load_catalog("sinks")
+    query_upper = query.upper().strip()
+
+    # Extract brand keywords (>3 chars, not generic words)
+    skip_words = {"PILETA", "JOHNSON", "COMPACT", "MINI", "DOBLE", "SIMPLE", "BACHA"}
+    words = [w for w in query_upper.split() if len(w) > 2 and w not in skip_words]
+
+    # Extract numeric patterns (2-3 digits, possibly with prefix/suffix letters)
+    nums = re.findall(r'\d{2,3}', query_upper)
+
+    if not words and not nums:
+        return {"found": False, "message": f"No se pudo extraer datos de búsqueda de '{query}'"}
+
+    candidates = []
+    for item in items:
+        name = (item.get("name") or "").upper()
+        sku = (item.get("sku") or "").upper()
+        score = 0
+        # Brand match
+        for w in words:
+            if w in name or w in sku:
+                score += 2
+        # Numeric match (most important)
+        for n in nums:
+            if n in name or n in sku:
+                score += 3
+        if score > 0:
+            candidates.append((score, item))
+
+    if not candidates:
+        return {"found": False, "message": f"Ninguna pileta matchea con '{query}' en sinks.json"}
+
+    candidates.sort(key=lambda x: -x[0])
+    best = candidates[0][1]
+    # Do a proper catalog_lookup to get price with IVA
+    result = catalog_lookup("sinks", best.get("sku", ""))
+    if result.get("found"):
+        result["matched_by"] = "fuzzy"
+        result["original_query"] = query
+    return result
 
 
 def check_stock(material_sku: str) -> dict:

--- a/api/app/modules/agent/tools/document_tool.py
+++ b/api/app/modules/agent/tools/document_tool.py
@@ -1168,18 +1168,12 @@ def _generate_pdf(pdf_path: Path, data: dict) -> None:
     pdf.cell(w[3], rh, total_mat_fmt, align="R", fill=f, new_x="LMARGIN", new_y="NEXT")
     row_done()
 
-    # Sectors + pieces (group duplicates)
-    # First piece row shows: DESC (if discount) then TOTAL (net)
-    is_first_piece = True
+    # Collect all pieces across sectors for consecutive layout
+    all_piece_rows = []  # list of (is_sector_header, display_text)
     for sector in sectors:
-        f = row_fill()
-        pdf.set_font("Helvetica", "B", 8)
-        pdf.cell(total_w, rh, sector.get("label", ""), fill=f, new_x="LMARGIN", new_y="NEXT")
-        row_done()
-        # Group identical pieces: "1.20 × 3.38 Solía" × 8 → "1.20 × 3.38 Solía (×8)"
+        all_piece_rows.append((True, sector.get("label", "")))
         raw_pieces = sector.get("pieces", [])
-        grouped = []
-        seen = {}
+        grouped, seen = [], {}
         for p in raw_pieces:
             if p in seen:
                 seen[p] += 1
@@ -1189,40 +1183,59 @@ def _generate_pdf(pdf_path: Path, data: dict) -> None:
         for piece in grouped:
             count = seen[piece]
             display = f"{piece} (×{count})" if count > 1 else piece
-            f = row_fill()
+            all_piece_rows.append((False, display))
+
+    # Build right-side overlay rows (Descuento + TOTAL) for USD
+    right_rows = []
+    if currency == "USD":
+        if discount_pct:
+            desc_amount = round(total_mat_bruto * discount_pct / 100)
+            right_rows.append(("I", f"Descuento {discount_pct}%", f"- {fmt_price(desc_amount)}"))
+        right_rows.append(("B", f"TOTAL {currency}", fmt_price(total_mat)))
+
+    # Calculate which piece rows get right-side content
+    # Overlay on last N piece rows (N = len(right_rows))
+    piece_indices = [i for i, (is_hdr, _) in enumerate(all_piece_rows) if not is_hdr]
+    overlay_start = max(0, len(piece_indices) - len(right_rows))
+    overlay_map = {}  # piece_index -> right_row_index
+    for ri, pi_offset in enumerate(range(overlay_start, len(piece_indices))):
+        if ri < len(right_rows):
+            overlay_map[piece_indices[pi_offset]] = ri
+
+    # Render all rows consecutively
+    for idx, (is_hdr, text) in enumerate(all_piece_rows):
+        f = row_fill()
+        if is_hdr:
+            pdf.set_font("Helvetica", "B", 8)
+            pdf.cell(total_w, rh, text, fill=f, new_x="LMARGIN", new_y="NEXT")
+        else:
             pdf.set_font("Helvetica", "", 8)
-            pdf.cell(w[0], rh, display, fill=f)
-            if is_first_piece:
-                if currency == "USD":
-                    if discount_pct:
-                        # Discount row on the first piece line
-                        desc_amount = round(total_mat_bruto * discount_pct / 100)
-                        pdf.set_font("Helvetica", "I", 8)
-                        pdf.cell(w[1], rh, "", fill=f)
-                        pdf.cell(w[2], rh, f"Descuento {discount_pct}%", align="R", fill=f)
-                        pdf.cell(w[3], rh, f"- {fmt_price(desc_amount)}", align="R", fill=f)
-                        pdf.ln()
-                        row_done()
-                        # Net total row
-                        f = row_fill()
-                        pdf.cell(w[0], rh, "", fill=f)
-                        pdf.set_font("Helvetica", "B", 8)
-                        pdf.cell(w[1], rh, "", fill=f)
-                        pdf.cell(w[2], rh, f"TOTAL {currency}", align="R", fill=f)
-                        pdf.cell(w[3], rh, fmt_price(total_mat), align="R", fill=f)
-                    else:
-                        # No discount — show bruto total directly
-                        pdf.set_font("Helvetica", "B", 8)
-                        pdf.cell(w[1], rh, "", fill=f)
-                        pdf.cell(w[2], rh, f"TOTAL {currency}", align="R", fill=f)
-                        pdf.cell(w[3], rh, fmt_price(total_mat), align="R", fill=f)
-                else:
-                    pdf.cell(w[1] + w[2] + w[3], rh, "", fill=f)
-                is_first_piece = False
+            pdf.cell(w[0], rh, text, fill=f)
+            if idx in overlay_map:
+                style, label, value = right_rows[overlay_map[idx]]
+                pdf.set_font("Helvetica", style, 8)
+                pdf.cell(w[1], rh, "", fill=f)
+                pdf.cell(w[2], rh, label, align="R", fill=f)
+                pdf.cell(w[3], rh, value, align="R", fill=f)
             else:
                 pdf.cell(w[1] + w[2] + w[3], rh, "", fill=f)
             pdf.ln()
-            row_done()
+        row_done()
+
+    # If fewer pieces than right_rows, add remaining right-side rows
+    remaining = len(right_rows) - len([pi for pi in overlay_map])
+    if remaining < len(right_rows) and len(piece_indices) < len(right_rows):
+        for ri in range(len(right_rows)):
+            if ri not in overlay_map.values():
+                f = row_fill()
+                style, label, value = right_rows[ri]
+                pdf.set_font("Helvetica", style, 8)
+                pdf.cell(w[0], rh, "", fill=f)
+                pdf.cell(w[1], rh, "", fill=f)
+                pdf.cell(w[2], rh, label, align="R", fill=f)
+                pdf.cell(w[3], rh, value, align="R", fill=f)
+                pdf.ln()
+                row_done()
 
     # Spacer row
     pdf.ln(3)
@@ -1391,51 +1404,38 @@ def _generate_excel(output_path: Path, data: dict) -> None:
             all_pieces.append(p)
     all_pieces = [f"{p} (×{seen_xl[p]})" if seen_xl[p] > 1 else p for p in all_pieces]
 
-    # Row 23: first piece — discount + TOTAL on the right side
+    # Build right-side overlay (Descuento + TOTAL) for USD
     italic_sm = Font(name="Calibri", italic=True, size=9)
-    r = 23
-    if len(all_pieces) > 0:
-        ws.cell(r, 1).value = all_pieces[0]
-        if currency == "USD" and discount_pct:
-            # Discount on the first piece row
+    right_rows_xl = []
+    if currency == "USD":
+        if discount_pct:
             desc_amount = round(total_mat * discount_pct / 100)
-            ws.cell(r, 5).value = f"Descuento {discount_pct}%"
-            ws.cell(r, 5).font = italic_sm
-            ws.cell(r, 6).value = f"- {_fmt_usd(desc_amount)}"
-            ws.cell(r, 6).font = italic_sm
+            right_rows_xl.append(("I", f"Descuento {discount_pct}%", f"- {_fmt_usd(desc_amount)}"))
+        right_rows_xl.append(("B", f"TOTAL {currency}", _fmt_usd(total_mat_net)))
+
+    # Overlay on last N pieces
+    overlay_start_xl = max(0, len(all_pieces) - len(right_rows_xl))
+    r = 23
+    for i, piece in enumerate(all_pieces):
+        ws.cell(r, 1).value = piece
+        ri = i - overlay_start_xl
+        if 0 <= ri < len(right_rows_xl):
+            style, label, value = right_rows_xl[ri]
+            ws.cell(r, 5).value = label
+            ws.cell(r, 5).font = italic_sm if style == "I" else bold
+            ws.cell(r, 6).value = value
+            ws.cell(r, 6).font = italic_sm if style == "I" else bold
+        r += 1
+
+    # If fewer pieces than right_rows, add remaining
+    if len(all_pieces) < len(right_rows_xl):
+        for ri in range(len(all_pieces), len(right_rows_xl)):
+            style, label, value = right_rows_xl[ri]
+            ws.cell(r, 5).value = label
+            ws.cell(r, 5).font = italic_sm if style == "I" else bold
+            ws.cell(r, 6).value = value
+            ws.cell(r, 6).font = italic_sm if style == "I" else bold
             r += 1
-            # Net total row
-            ws.cell(r, 1).value = all_pieces[1] if len(all_pieces) > 1 else None
-            ws.cell(r, 5).value = f"TOTAL {currency}"
-            ws.cell(r, 5).font = bold
-            ws.cell(r, 6).value = _fmt_usd(total_mat_net)
-            ws.cell(r, 6).font = bold
-            r += 1
-            # Remaining pieces
-            for piece in all_pieces[2:]:
-                ws.cell(r, 1).value = piece
-                r += 1
-        elif currency == "USD":
-            # No discount — TOTAL on second row
-            r += 1
-            ws.cell(r, 1).value = all_pieces[1] if len(all_pieces) > 1 else None
-            ws.cell(r, 5).value = f"TOTAL {currency}"
-            ws.cell(r, 5).font = bold
-            ws.cell(r, 6).value = _fmt_usd(total_mat_net)
-            ws.cell(r, 6).font = bold
-            r += 1
-            for piece in all_pieces[2:]:
-                ws.cell(r, 1).value = piece
-                r += 1
-        else:
-            # ARS-only: no TOTAL USD row
-            r += 1
-            if len(all_pieces) > 1:
-                ws.cell(r, 1).value = all_pieces[1]
-            r += 1
-            for piece in all_pieces[2:]:
-                ws.cell(r, 1).value = piece
-                r += 1
 
     # MO items — template has 4 slots (rows 28-31). Insert extra rows if needed.
     MO_HEADER_ROW = 27

--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -486,11 +486,20 @@ def calculate_quote(input_data: dict) -> dict:
     if pileta == "empotrada_johnson":
         sink_result = None
         if pileta_sku:
-            # Specific model requested
+            # Specific model requested — exact lookup first
             sink_result = catalog_lookup("sinks", pileta_sku)
+            if not sink_result or not sink_result.get("found"):
+                # Fuzzy match by brand + model number
+                from app.modules.agent.tools.catalog_tool import fuzzy_sink_lookup
+                sink_result = fuzzy_sink_lookup(pileta_sku)
+                if sink_result and sink_result.get("found"):
+                    logging.info(f"Sink fuzzy matched: '{pileta_sku}' → {sink_result.get('name')} (SKU: {sink_result.get('sku')})")
+                    warnings.append(f"Pileta '{pileta_sku}' no encontrada exacta. Se usó: {sink_result.get('name')}")
         if not sink_result or not sink_result.get("found"):
-            # Try default Johnson search
+            # Last resort: default model with warning
             sink_result = catalog_lookup("sinks", "QUADRAQ71A")
+            if pileta_sku:
+                warnings.append(f"Pileta '{pileta_sku}' no encontrada. Se usó QUADRA Q71A por defecto. Verificar con operador.")
         if sink_result and sink_result.get("found"):
             sink_price = sink_result.get("price_ars", 0)
             sinks.append({
@@ -549,12 +558,13 @@ def calculate_quote(input_data: dict) -> dict:
     if piece_labels:
         sectors.append({"label": project or "Cocina", "pieces": piece_labels})
 
-    # ── Delivery days: apply tier by m² if plazo matches the config default (numeric) ──
+    # ── Delivery days: apply tier by m² only if range_enabled in config ──
     import re as _re_plazo
     default_days = cfg("delivery_days.default", 40)
+    range_enabled = cfg("delivery_days.range_enabled", False)
     _plazo_match = _re_plazo.search(r'(\d+)', plazo or "")
     _plazo_days = int(_plazo_match.group(1)) if _plazo_match else None
-    if _plazo_days == default_days:
+    if range_enabled and _plazo_days == default_days:
         tiers = cfg("delivery_days.tiers", [])
         for tier in sorted(tiers, key=lambda t: t.get("max_m2", 999)):
             if total_m2 <= tier.get("max_m2", 999):

--- a/api/tests/test_seven_fixes.py
+++ b/api/tests/test_seven_fixes.py
@@ -1,0 +1,236 @@
+"""Tests for the 7 fixes: piece layout, unicode, PUL, delivery, drive, sink, architect."""
+import json
+import math
+import os
+import shutil
+import pytest
+
+# ── Fix environment before app imports ──
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test-fake")
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("APP_ENV", "test")
+
+from app.modules.agent.tools.catalog_tool import (
+    check_architect,
+    catalog_lookup,
+    fuzzy_sink_lookup,
+)
+
+OUTPUT_DIR = None
+try:
+    from app.core.static import OUTPUT_DIR
+except Exception:
+    from pathlib import Path
+    OUTPUT_DIR = Path(__file__).parent.parent / "output"
+
+
+# ═══════════════════════════════════════════════════════
+# Fix 2: Unicode — json.dumps preserves accented chars
+# ═══════════════════════════════════════════════════════
+
+class TestUnicode:
+    def test_json_dumps_ensure_ascii_false(self):
+        """ensure_ascii=False must preserve ó, é, í, etc."""
+        data = {"piece": "Zócalo fondo", "desc": "Pieza especial"}
+        result = json.dumps(data, ensure_ascii=False)
+        assert "Zócalo" in result
+        assert "\\u00f3" not in result
+
+    def test_json_dumps_default_escapes(self):
+        """Default json.dumps escapes — this is what we're fixing."""
+        data = {"piece": "Zócalo"}
+        result = json.dumps(data)  # default ensure_ascii=True
+        assert "\\u00f3" in result  # confirms the bug exists without fix
+
+
+# ═══════════════════════════════════════════════════════
+# Fix 4: Delivery days — respect range_enabled from config
+# ═══════════════════════════════════════════════════════
+
+class TestDeliveryDays:
+    def test_small_quote_gets_default_days_when_range_disabled(self):
+        """With range_enabled=false, even 2.5m² should get 40 days."""
+        from app.modules.quote_engine.calculator import calculate_quote
+
+        result = calculate_quote({
+            "client_name": "Test Client",
+            "project": "Cocina",
+            "material": "Blanco Paloma",
+            "catalog": "materials-purastone",
+            "sku": "PALOMA",
+            "pieces": [{"largo": 2.0, "ancho": 0.60, "descripcion": "Mesada"}],
+            "localidad": "Rosario",
+            "colocacion": True,
+            "pileta": "empotrada_cliente",
+            "plazo": "40 dias desde la toma de medidas",
+        })
+        assert result.get("ok") is True
+        delivery = result.get("delivery_days", "")
+        assert "40" in str(delivery), f"Expected 40 days, got: {delivery}"
+
+
+# ═══════════════════════════════════════════════════════
+# Fix 6: Sink fuzzy matching
+# ═══════════════════════════════════════════════════════
+
+class TestFuzzySinkLookup:
+    def test_luxor_compact_si71_matches_luxor_s171(self):
+        """LUXOR COMPACT SI71 → should fuzzy match LUXOR171 (S171)."""
+        result = fuzzy_sink_lookup("LUXOR COMPACT SI71")
+        assert result["found"] is True
+        assert "LUXOR" in result["name"].upper()
+        assert "171" in result.get("sku", "").upper() or "171" in result["name"].upper()
+
+    def test_quadra_q71_matches(self):
+        """QUADRA Q71 → should match QUADRAQ71A."""
+        result = fuzzy_sink_lookup("QUADRA Q71")
+        assert result["found"] is True
+        assert "QUADRA" in result["name"].upper()
+        assert "71" in result.get("sku", "")
+
+    def test_nonsense_returns_not_found(self):
+        """Random text should not match any sink."""
+        result = fuzzy_sink_lookup("XYZNONEXISTENT999")
+        assert result["found"] is False
+
+    def test_exact_sku_still_works(self):
+        """catalog_lookup exact match should still work for known SKUs."""
+        result = catalog_lookup("sinks", "LUXOR171")
+        assert result["found"] is True
+        assert "LUXOR" in result["name"].upper()
+
+
+# ═══════════════════════════════════════════════════════
+# Architect discount — partial match + no m² minimum
+# ═══════════════════════════════════════════════════════
+
+class TestArchitectDiscount:
+    def test_munge_partial_match(self):
+        """MUNGE should match ESTUDIO MUNGE in architects.json."""
+        result = check_architect("MUNGE")
+        assert result["found"] is True
+
+    def test_munge_case_insensitive(self):
+        result = check_architect("munge")
+        assert result["found"] is True
+
+    def test_nonexistent_architect(self):
+        result = check_architect("ZZZNONEXISTENT999")
+        assert result["found"] is False
+
+    def test_architect_discount_no_m2_minimum(self):
+        """Architect discount should apply regardless of m² (even 0.5 m²)."""
+        from app.modules.quote_engine.calculator import calculate_quote
+
+        result = calculate_quote({
+            "client_name": "ESTUDIO MUNGE",
+            "project": "Obra Munge",
+            "material": "Blanco Paloma",
+            "catalog": "materials-purastone",
+            "sku": "PALOMA",
+            "pieces": [{"largo": 1.0, "ancho": 0.50, "descripcion": "Mesada pequeña"}],
+            "localidad": "Rosario",
+            "colocacion": True,
+            "pileta": "empotrada_cliente",
+            "plazo": "40 dias desde la toma de medidas",
+            "is_architect": True,
+            "discount_pct": 5,
+        })
+        assert result.get("ok") is True
+        assert result.get("discount_pct", 0) == 5, f"Expected 5% discount, got: {result.get('discount_pct')}"
+
+
+# ═══════════════════════════════════════════════════════
+# Fix 1: PDF piece layout — pieces consecutive, no gap
+# ═══════════════════════════════════════════════════════
+
+class TestPDFPieceLayout:
+    @pytest.fixture(autouse=True)
+    def cleanup(self):
+        yield
+        if OUTPUT_DIR:
+            for d in OUTPUT_DIR.glob("test-layout-*"):
+                shutil.rmtree(d, ignore_errors=True)
+
+    @pytest.mark.asyncio
+    async def test_pdf_created_with_discount(self):
+        """PDF with discount should be created successfully."""
+        from app.modules.agent.tools.document_tool import generate_documents
+
+        data = {
+            "client_name": "Test Layout",
+            "project": "Cocina",
+            "material_name": "PURASTONE BLANCO PALOMA",
+            "material_m2": 2.5,
+            "material_price_unit": 346,
+            "material_currency": "USD",
+            "discount_pct": 5,
+            "thickness_mm": 20,
+            "sectors": [{"label": "Cocina", "pieces": [
+                "1.55 × 0.60 Mesada cocina tramo 1",
+                "1.72 × 0.75 Mesada cocina tramo 2",
+                "1.74ML X 0.07 ZOC",
+                "1.55ML X 0.07 ZOC",
+                "0.75ML X 0.07 ZOC",
+            ]}],
+            "sinks": [],
+            "mo_items": [
+                {"description": "Colocación", "quantity": 2.5, "unit_price": 60135, "total": 150338},
+                {"description": "Flete + toma medidas Rosario", "quantity": 1, "unit_price": 52000, "total": 52000},
+            ],
+            "total_ars": 202338,
+            "total_usd": 822,
+            "delivery_days": "40 dias desde la toma de medidas",
+        }
+        quote_id = "test-layout-001"
+        result = await generate_documents(quote_id, data)
+        assert result["ok"] is True
+        assert result["pdf_url"].endswith(".pdf")
+        assert result["excel_url"].endswith(".xlsx")
+
+    @pytest.mark.asyncio
+    async def test_excel_created_with_discount(self):
+        """Excel with discount should be created successfully."""
+        from app.modules.agent.tools.document_tool import generate_documents
+
+        data = {
+            "client_name": "Test Excel",
+            "project": "Cocina",
+            "material_name": "PURASTONE BLANCO PALOMA",
+            "material_m2": 2.5,
+            "material_price_unit": 346,
+            "material_currency": "USD",
+            "discount_pct": 5,
+            "thickness_mm": 20,
+            "sectors": [{"label": "Cocina", "pieces": [
+                "pieza 1",
+                "pieza 2",
+                "zocalo 1",
+            ]}],
+            "sinks": [],
+            "mo_items": [
+                {"description": "Colocación", "quantity": 2.5, "unit_price": 60135, "total": 150338},
+            ],
+            "total_ars": 150338,
+            "total_usd": 822,
+            "delivery_days": "40 dias",
+        }
+        quote_id = "test-layout-002"
+        result = await generate_documents(quote_id, data)
+        assert result["ok"] is True
+
+        # Verify Excel content: pieces + discount + total in correct order
+        import zipfile
+        from pathlib import Path
+        xlsx_files = list((OUTPUT_DIR / quote_id).glob("*.xlsx"))
+        assert len(xlsx_files) == 1
+        with zipfile.ZipFile(str(xlsx_files[0]), 'r') as z:
+            sheet = z.read("xl/worksheets/sheet1.xml").decode("utf-8")
+            # All pieces should be present
+            assert "pieza 1" in sheet
+            assert "pieza 2" in sheet
+            assert "zocalo 1" in sheet
+            # Discount and TOTAL should be present
+            assert "Descuento 5%" in sheet
+            assert "TOTAL USD" in sheet


### PR DESCRIPTION
## Summary — 7 fixes con causa raíz y tests

### 1. PDF/Excel: piezas sin hueco
- **Bug:** Descuento/TOTAL se metían entre pieza 1 y pieza 2, dejando un espacio
- **Causa:** `is_first_piece` flag ponía Desc en la fila de pieza 1 y TOTAL en la siguiente, desplazando pieza 2
- **Fix:** Collect all pieces, overlay Desc/TOTAL en las últimas filas de piezas. Todo seguido.

### 2. Unicode: "Z\u00f3calo" → "Zócalo"
- **Bug:** El chat mostraba `Z\u00f3calo` con escape unicode
- **Causa:** `json.dumps(result)` en agent.py línea 2512 sin `ensure_ascii=False`
- **Fix:** Agregado `ensure_ascii=False` en ambos json.dumps

### 3. PUL: nunca para Rosario
- **Bug:** El agente mencionaba "Pulido de cantos" aunque el calculador no lo incluía
- **Causa:** El LLM inventaba MO items. El calculador ya era correcto (solo zonas con `pulido_extra: true`)
- **Fix:** Regla explícita en CONTEXT.md: si calculate_quote() no incluye Pulido, NUNCA mencionarlo

### 4. Demora: 40 días siempre
- **Bug:** Mostraba 20 días para <3m² aunque `range_enabled: false` en config
- **Causa:** calculator.py ignoraba `range_enabled`, siempre aplicaba tiers
- **Fix:** Agregado check de `range_enabled` antes de aplicar tiers

### 5. Drive: logging + causa raíz
- **Bug:** Carpeta Drive vacía, sin diagnóstico
- **Causa:** Sin logging de éxito/fallo detallado. Probablemente upload fallando silenciosamente
- **Fix:** Logging de file size, path, éxito con file_id+URL, traceback completo en fallo

### 6. Pileta: fuzzy matching
- **Bug:** "LUXOR COMPACT SI71" → usaba QUADRA Q71A en vez de LUXOR S171
- **Causa:** Lookup exacto fallaba, fallback hardcoded a QUADRAQ71A sin buscar alternativas
- **Fix:** Nuevo `fuzzy_sink_lookup()` que matchea por marca+número. Warning cuando usa fallback.

### 7. Tests: 13 nuevos
- Unicode (ensure_ascii)
- Delivery days (range_enabled respetado)
- Fuzzy sink (LUXOR, QUADRA, nonsense)
- Architect partial match (MUNGE)
- Architect discount sin mínimo m²
- PDF/Excel creación con descuento

### Bug bonus: check_architect empty string
- `"" in "anything"` es siempre True en Python. Corregido con guard.

## Test plan
```bash
cd api && python -m pytest tests/test_seven_fixes.py -v  # 13/13 passing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)