### PR TITLE
feat: deterministic Paso 2 — no more invented MO items

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -92,7 +92,7 @@ Cuando el operador pide cambio sobre presupuesto con breakdown:
 
 **2. NUNCA por iniciativa propia:** agregar piezas/MO, cambiar medidas/precios, agregar descuentos/merma/zocalos/pulidos, crear quotes nuevos
 
-**⛔ REGLA ABSOLUTA DE MO:** En Paso 2, la tabla de Mano de Obra debe contener EXACTAMENTE los items que devolvió `calculate_quote()` en `mo_items`. NUNCA agregar PUL, CORTE45, ANAFE ni ningún otro item que el calculador no haya incluido. Si el calculador no lo puso, NO VA. El calculador maneja pulido automáticamente según la zona — si no está en mo_items, es porque esa zona no lo cobra.
+**⛔ REGLA ABSOLUTA DE PASO 2:** Cuando `calculate_quote()` devuelve `_paso2_rendered`, usá ese texto EXACTO como tu Paso 2. NO modifiques precios, MO items, totales, ni descuentos. Podés agregar notas o warnings adicionales DESPUÉS del texto, pero la tabla de precios y MO es intocable. Este texto es generado determinísticamente desde el calculador y es la fuente de verdad.
 
 **3. DEPENDENCIAS:** cambio material → recalcular precio (mismos m²) | cambio medida → recalcular m² esa pieza | eliminar pieza → restar m²
 

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -3117,6 +3117,11 @@ class AgentService:
                         "5. ¿El flete es para la zona correcta?"
                     )
 
+                # Build deterministic Paso 2 text — Claude must use this verbatim
+                from app.modules.quote_engine.calculator import build_deterministic_paso2
+                calc_result["_paso2_rendered"] = build_deterministic_paso2(calc_result)
+                logging.info(f"Deterministic Paso 2 built for {save_to_qid} ({len(calc_result['_paso2_rendered'])} chars)")
+
             # Persist breakdown + change history to DB
             if calc_result.get("ok"):
                 try:

--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -621,3 +621,117 @@ def calculate_quote(input_data: dict) -> dict:
             "frentin_ml": frentin_ml if frentin else 0,
         }} if is_edificio else {}),
     }
+
+
+def build_deterministic_paso2(calc: dict) -> str:
+    """Build Paso 2 markdown from calculate_quote output — 100% deterministic.
+
+    This is the source of truth for Paso 2 display. Claude must use this
+    text verbatim and NOT modify prices, MO items, or totals.
+    """
+    mat_name = calc.get("material_name", "")
+    mat_m2 = calc.get("material_m2", 0)
+    price_unit = calc.get("material_price_unit", 0)
+    price_base = calc.get("material_price_base", 0)
+    currency = calc.get("material_currency", "USD")
+    mat_total_bruto = round(mat_m2 * price_unit)
+    discount_pct = calc.get("discount_pct", 0)
+    discount_amount = calc.get("discount_amount", 0)
+    mat_total_net = calc.get("material_total", mat_total_bruto)
+    delivery = calc.get("delivery_days", "")
+    client = calc.get("client_name", "")
+    project = calc.get("project", "")
+    pieces = calc.get("piece_details", [])
+    mo_items = calc.get("mo_items", [])
+    sinks = calc.get("sinks", [])
+    merma = calc.get("merma", {})
+    total_ars = calc.get("total_ars", 0)
+    total_usd = calc.get("total_usd", 0)
+    warnings = calc.get("warnings", [])
+
+    def fmt_ars(v): return f"${v:,.0f}".replace(",", ".")
+    def fmt_usd(v): return f"USD {v:,.0f}".replace(",", ".")
+
+    lines = []
+    lines.append(f"## PASO 2 — Validación — {client} / {project}")
+    lines.append(f"Fecha: {calc.get('date', '')} | Demora: {delivery} | {calc.get('localidad', 'Rosario')}")
+    lines.append("")
+
+    # Material header
+    lines.append(f"**MATERIAL — {mat_name} — {mat_m2:.2f} m²**".replace(".", ","))
+    lines.append("")
+    lines.append("| Pieza | Medida | m² |")
+    lines.append("|---|---|---|")
+    for p in pieces:
+        desc = p.get("description", "")
+        largo = p.get("largo", 0)
+        dim2 = p.get("dim2", p.get("prof", 0))
+        m2 = p.get("m2", 0)
+        lines.append(f"| {desc} | {largo} x {dim2} | {m2:.2f} |".replace(".", ","))
+    lines.append(f"| **TOTAL** | | **{mat_m2:.2f} m²** |".replace(".", ","))
+    lines.append("")
+
+    # Precio
+    lines.append("**Precio unitario:**")
+    if currency == "USD":
+        lines.append(f"- Sin IVA: USD {price_base:.0f} | Con IVA: {fmt_usd(price_unit)} | Total: {fmt_usd(mat_total_bruto)}")
+    else:
+        lines.append(f"- Con IVA: {fmt_ars(price_unit)} | Total: {fmt_ars(mat_total_bruto)}")
+    lines.append("")
+
+    # Merma
+    if merma.get("aplica"):
+        lines.append("**MERMA — APLICA**")
+        lines.append(f"- {merma.get('motivo', '')}")
+        if merma.get("sobrante_m2"):
+            sob_m2 = merma["sobrante_m2"]
+            sob_total = round(sob_m2 * price_unit)
+            lines.append(f"- Sobrante disponible: {sob_m2:.2f} m² ({fmt_usd(sob_total) if currency == 'USD' else fmt_ars(sob_total)})".replace(".", ","))
+    lines.append("")
+
+    # Descuento
+    if discount_pct:
+        lines.append(f"**DESCUENTO — {discount_pct}%**")
+        lines.append(f"- {fmt_usd(discount_amount) if currency == 'USD' else fmt_ars(discount_amount)} sobre material")
+        lines.append(f"- Total material neto: {fmt_usd(mat_total_net) if currency == 'USD' else fmt_ars(mat_total_net)}")
+    else:
+        lines.append("**DESCUENTOS — NO APLICA**")
+    lines.append("")
+
+    # Piletas
+    if sinks:
+        lines.append("**PILETAS**")
+        lines.append("| Item | Cant | Precio c/IVA | Total |")
+        lines.append("|---|---|---|---|")
+        for s in sinks:
+            total_s = round(s["unit_price"] * s["quantity"])
+            lines.append(f"| {s['name']} | {s['quantity']} | {fmt_ars(s['unit_price'])} | {fmt_ars(total_s)} |")
+        lines.append("")
+
+    # Mano de obra
+    lines.append("**MANO DE OBRA**")
+    lines.append("| Item | Cant | Precio c/IVA | Total |")
+    lines.append("|---|---|---|---|")
+    for mo in mo_items:
+        qty = mo["quantity"]
+        qty_str = f"{qty:.2f} m²".replace(".", ",") if isinstance(qty, float) and qty != int(qty) else str(int(qty))
+        lines.append(f"| {mo['description']} | {qty_str} | {fmt_ars(mo['unit_price'])} | {fmt_ars(mo['total'])} |")
+    lines.append(f"| **TOTAL MO** | | | **{fmt_ars(total_ars)}** |")
+    lines.append("")
+
+    # Grand total
+    lines.append("**GRAND TOTAL**")
+    if currency == "USD" and total_usd:
+        lines.append(f"{fmt_ars(total_ars)} mano de obra + piletas + {fmt_usd(total_usd)} material")
+    else:
+        lines.append(f"{fmt_ars(total_ars)} total")
+    lines.append("")
+
+    # Warnings
+    for w in warnings:
+        lines.append(f"⚠️ {w}")
+
+    lines.append("")
+    lines.append("¿Confirmás para generar PDF y Excel?")
+
+    return "\n".join(lines)

--- a/api/tests/test_seven_fixes.py
+++ b/api/tests/test_seven_fixes.py
@@ -151,6 +151,91 @@ class TestArchitectDiscount:
 # Fix 1: PDF piece layout — pieces consecutive, no gap
 # ═══════════════════════════════════════════════════════
 
+# ═══════════════════════════════════════════════════════
+# Deterministic Paso 2 — no invented MO items
+# ═══════════════════════════════════════════════════════
+
+class TestDeterministicPaso2:
+    def test_paso2_no_pulido_rosario(self):
+        """Paso 2 for Rosario must NOT contain Pulido."""
+        from app.modules.quote_engine.calculator import calculate_quote, build_deterministic_paso2
+        result = calculate_quote({
+            "client_name": "Test", "project": "Cocina",
+            "material": "Blanco Paloma", "catalog": "materials-purastone", "sku": "PALOMA",
+            "pieces": [{"largo": 1.72, "prof": 0.75, "descripcion": "Mesada"}],
+            "localidad": "Rosario", "colocacion": True,
+            "pileta": "empotrada_cliente",
+            "plazo": "30 dias desde la toma de medidas",
+        })
+        assert result["ok"]
+        paso2 = build_deterministic_paso2(result)
+        assert "Pulido" not in paso2
+        assert "PUL" not in paso2
+
+    def test_paso2_has_discount_when_architect(self):
+        """Paso 2 must show 5% discount for architects."""
+        from app.modules.quote_engine.calculator import calculate_quote, build_deterministic_paso2
+        result = calculate_quote({
+            "client_name": "ESTUDIO MUNGE", "project": "Obra",
+            "material": "Blanco Paloma", "catalog": "materials-purastone", "sku": "PALOMA",
+            "pieces": [{"largo": 1.0, "prof": 0.5, "descripcion": "Mesada"}],
+            "localidad": "Rosario", "colocacion": True,
+            "pileta": "empotrada_cliente",
+            "plazo": "30 dias",
+            "discount_pct": 5, "is_architect": True,
+        })
+        assert result["ok"]
+        paso2 = build_deterministic_paso2(result)
+        assert "5%" in paso2
+        assert "DESCUENTO" in paso2
+
+    def test_paso2_delivery_matches_config(self):
+        """Paso 2 delivery days must match what calculator returns."""
+        from app.modules.quote_engine.calculator import calculate_quote, build_deterministic_paso2
+        result = calculate_quote({
+            "client_name": "Test", "project": "Cocina",
+            "material": "Blanco Paloma", "catalog": "materials-purastone", "sku": "PALOMA",
+            "pieces": [{"largo": 2.0, "prof": 0.6, "descripcion": "Mesada"}],
+            "localidad": "Rosario", "colocacion": True,
+            "pileta": "empotrada_cliente",
+            "plazo": "30 dias desde la toma de medidas",
+        })
+        assert result["ok"]
+        paso2 = build_deterministic_paso2(result)
+        assert result["delivery_days"] in paso2
+
+    def test_paso2_mo_items_match_calculator(self):
+        """Paso 2 MO items must be exactly what calculator returned."""
+        from app.modules.quote_engine.calculator import calculate_quote, build_deterministic_paso2
+        result = calculate_quote({
+            "client_name": "Test", "project": "Cocina",
+            "material": "Blanco Paloma", "catalog": "materials-purastone", "sku": "PALOMA",
+            "pieces": [{"largo": 1.72, "prof": 0.75, "descripcion": "Mesada"}],
+            "localidad": "Rosario", "colocacion": True,
+            "pileta": "empotrada_johnson", "pileta_sku": "LUXOR171",
+            "plazo": "30 dias",
+        })
+        assert result["ok"]
+        paso2 = build_deterministic_paso2(result)
+        for mo in result["mo_items"]:
+            assert mo["description"] in paso2, f"MO item '{mo['description']}' missing from Paso 2"
+
+    def test_paso2_correct_price(self):
+        """Paso 2 must show correct price USD 346 for Paloma."""
+        from app.modules.quote_engine.calculator import calculate_quote, build_deterministic_paso2
+        result = calculate_quote({
+            "client_name": "Test", "project": "Cocina",
+            "material": "Blanco Paloma", "catalog": "materials-purastone", "sku": "PALOMA",
+            "pieces": [{"largo": 1.72, "prof": 0.75, "descripcion": "Mesada"}],
+            "localidad": "Rosario", "colocacion": True,
+            "pileta": "empotrada_cliente",
+            "plazo": "30 dias",
+        })
+        assert result["ok"]
+        paso2 = build_deterministic_paso2(result)
+        assert "USD 346" in paso2
+
+
 class TestPDFPieceLayout:
     @pytest.fixture(autouse=True)
     def cleanup(self):


### PR DESCRIPTION
## Summary
Nuevo `build_deterministic_paso2()` genera Paso 2 desde datos del calculator, no desde Claude. Inyectado como `_paso2_rendered` en el tool result. Claude debe usar ese texto exacto.

**Previene:**
- PUL para Rosario (Claude lo inventaba)
- Delivery days incorrecto
- Precios/totales inventados
- MO items que no existen

**Tests:** 5 nuevos + 656 baseline passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)