### PR TITLE
feat: M2 combinatorial solver — auto-correct wrong plan dimensions

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -2520,19 +2520,50 @@ class AgentService:
                     _lp_m2 = result.get("total_m2", 0)
                     if _expected_m2 is not None and _expected_m2 > 0:
                         _m2_diff = abs(_lp_m2 - _expected_m2)
-                        _m2_pct = _m2_diff / _expected_m2 * 100
-                        if _m2_pct > 5:
-                            _m2_warning = (
-                                f"⛔ SUPERFICIE NO COINCIDE: tus piezas suman {_lp_m2:.2f} m² "
-                                f"pero la planilla dice {_expected_m2:.2f} m². "
-                                f"Diferencia: {_m2_diff:.2f} m² ({_m2_pct:.0f}%). "
-                                f"Revisá las medidas — probablemente leíste mal alguna cota del plano. "
-                                f"Las cotas extraídas del texto del PDF son la fuente de verdad."
-                            )
-                            result["_m2_validation_error"] = _m2_warning
-                            logging.warning(f"[m2-validator] {_m2_warning}")
+                        if _m2_diff > 0.1:
+                            # M2 doesn't match — try to solve combinatorially
+                            from app.modules.quote_engine.calculator import solve_m2_from_dims
+                            _all_dims = []
+                            if extracted_text:
+                                import re as _re_dims
+                                _raw_nums = _re_dims.findall(r'\d+[.,]\d+', extracted_text)
+                                _all_dims = list(set(
+                                    float(n.replace(",", "."))
+                                    for n in _raw_nums
+                                    if 0.04 <= float(n.replace(",", ".")) <= 5.0 and float(n.replace(",", ".")) != _expected_m2
+                                ))
+                            # Extract zócalo height from text
+                            _zoc_h = 0.05
+                            _zoc_match = _re_dims.search(r'(?:ZOCALOS?|zócalos?)\s*(\d+)\s*cm', extracted_text) if extracted_text else None
+                            if _zoc_match:
+                                _zoc_h = int(_zoc_match.group(1)) / 100
+
+                            solutions = solve_m2_from_dims(_all_dims, _expected_m2, _zoc_h) if _all_dims else None
+                            if solutions:
+                                best = solutions[0]
+                                _correction = (
+                                    f"⛔ SUPERFICIE NO COINCIDE: tus piezas suman {_lp_m2:.2f} m² "
+                                    f"pero la planilla dice {_expected_m2:.2f} m². "
+                                    f"SOLUCIÓN ENCONTRADA — usá estas medidas:\n"
+                                )
+                                for i, p in enumerate(best["pieces"]):
+                                    _correction += f"  Mesada {i+1}: {p['largo']} x {p['ancho']} = {p['largo']*p['ancho']:.2f} m²\n"
+                                for z in best["zocalos"]:
+                                    _correction += f"  Zócalo: {z}ml x {_zoc_h}\n"
+                                _correction += f"  Total: {best['total']} m² (diff: {best['diff']:.4f})\n"
+                                _correction += "Volvé a llamar list_pieces con estas medidas corregidas."
+                                result["_m2_validation_error"] = _correction
+                                result["_m2_correction"] = best
+                                logging.warning(f"[m2-solver] Solved: {best['pieces']} + zocs {best['zocalos']} = {best['total']}")
+                            else:
+                                result["_m2_validation_error"] = (
+                                    f"⛔ SUPERFICIE NO COINCIDE: tus piezas suman {_lp_m2:.2f} m² "
+                                    f"pero la planilla dice {_expected_m2:.2f} m². "
+                                    f"No se encontró combinación automática. Revisá las cotas del plano."
+                                )
+                                logging.warning(f"[m2-solver] No solution found for {_expected_m2} from dims {_all_dims}")
                         else:
-                            logging.info(f"[m2-validator] OK: pieces={_lp_m2:.2f} vs planilla={_expected_m2:.2f} (diff={_m2_pct:.1f}%)")
+                            logging.info(f"[m2-validator] OK: pieces={_lp_m2:.2f} vs planilla={_expected_m2:.2f} (diff={_m2_diff:.2f})")
 
                 # read_plan returns native content blocks (list of image/text dicts)
                 # to avoid inflating context with base64 inside JSON strings.

--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -643,6 +643,115 @@ def calculate_quote(input_data: dict) -> dict:
     }
 
 
+def solve_m2_from_dims(dims: list[float], expected_m2: float, zoc_h: float = 0.07,
+                        tolerance: float = 0.02) -> list[dict] | None:
+    """Find combinations of mesada pieces + zócalos that sum to expected_m2.
+
+    Each dim can be used max 2 times (once as mesada dim, once as zócalo length).
+    Returns sorted list of solutions (best first) or None if no solution found.
+    """
+    from itertools import product
+    from collections import Counter
+
+    if not dims or expected_m2 <= 0:
+        return None
+
+    # Remove very small values (< 0.05m = 5cm) — not useful as mesada dims
+    mesada_dims = [d for d in dims if d >= 0.15]
+    # All dims can be zócalo lengths
+    zoc_dims = [d for d in dims if d >= 0.10]
+
+    solutions = []
+
+    # Generate mesada pairs (largo × ancho, largo >= ancho)
+    mesada_pairs = [(a, b) for a in mesada_dims for b in mesada_dims if a >= b]
+
+    # Try 2 mesadas (most common case)
+    for p1 in mesada_pairs:
+        for p2 in mesada_pairs:
+            mesada_m2 = p1[0] * p1[1] + p2[0] * p2[1]
+            remaining = expected_m2 - mesada_m2
+            if remaining < -tolerance or remaining > 1.0:
+                continue
+            # Try 1-5 zócalos
+            for n_z in range(1, 6):
+                for zoc_combo in product(zoc_dims, repeat=n_z):
+                    total = mesada_m2 + sum(z * zoc_h for z in zoc_combo)
+                    diff = abs(total - expected_m2)
+                    if diff <= tolerance:
+                        # Count total uses of each dim
+                        all_used = list(p1) + list(p2) + list(zoc_combo)
+                        usage = Counter(all_used)
+                        # Penalize: each dim used max 3x
+                        max_usage = max(usage.values())
+                        if max_usage > 3:
+                            continue  # too many reuses
+                        # Penalize: same ancho for both mesadas (unrealistic)
+                        anchos = [min(p1), min(p2)]
+                        same_ancho_penalty = 0.3 if anchos[0] == anchos[1] else 0
+                        # Score: prefer smaller diff, then diverse dims, then fewer reuses
+                        score = diff + same_ancho_penalty + (max_usage - 1) * 0.2 + n_z * 0.01
+                        norm_p = tuple(sorted([(min(p1), max(p1)), (min(p2), max(p2))]))
+                        norm_z = tuple(sorted(zoc_combo))
+                        solutions.append({
+                            "score": score,
+                            "diff": diff,
+                            "pieces": [{"largo": max(p1), "ancho": min(p1)}, {"largo": max(p2), "ancho": min(p2)}],
+                            "zocalos": list(norm_z),
+                            "total": round(total, 4),
+                            "n_zocalos": n_z,
+                        })
+
+    # Also try 1 mesada
+    for p1 in mesada_pairs:
+        mesada_m2 = p1[0] * p1[1]
+        remaining = expected_m2 - mesada_m2
+        if remaining < -tolerance or remaining > 0.5:
+            continue
+        # Check if mesada alone matches (0 zócalos)
+        if abs(remaining) <= tolerance:
+            solutions.append({
+                "score": abs(remaining),
+                "diff": abs(remaining),
+                "pieces": [{"largo": max(p1), "ancho": min(p1)}],
+                "zocalos": [],
+                "total": round(mesada_m2, 4),
+                "n_zocalos": 0,
+            })
+        for n_z in range(1, 6):
+            for zoc_combo in product(zoc_dims, repeat=n_z):
+                total = mesada_m2 + sum(z * zoc_h for z in zoc_combo)
+                diff = abs(total - expected_m2)
+                if diff <= tolerance:
+                    all_used = list(p1) + list(zoc_combo)
+                    usage = Counter(all_used)
+                    if max(usage.values()) > 3:
+                        continue
+                    score = diff + n_z * 0.1 + (max(usage.values()) - 1) * 0.5
+                    solutions.append({
+                        "score": score,
+                        "diff": diff,
+                        "pieces": [{"largo": max(p1), "ancho": min(p1)}],
+                        "zocalos": list(sorted(zoc_combo)),
+                        "total": round(total, 4),
+                        "n_zocalos": n_z,
+                    })
+
+    if not solutions:
+        return None
+
+    # Deduplicate
+    seen = set()
+    unique = []
+    for s in sorted(solutions, key=lambda x: x["score"]):
+        key = (tuple(tuple(sorted([p["largo"], p["ancho"]])) for p in s["pieces"]), tuple(s["zocalos"]))
+        if key not in seen:
+            seen.add(key)
+            unique.append(s)
+
+    return unique[:5]  # Return top 5 solutions
+
+
 def build_deterministic_paso2(calc: dict) -> str:
     """Build Paso 2 markdown from calculate_quote output — 100% deterministic.
 

--- a/api/tests/test_seven_fixes.py
+++ b/api/tests/test_seven_fixes.py
@@ -291,6 +291,48 @@ class TestM2SurfaceParser:
         text = "MESADA COCINA sin superficie indicada"
         assert self._extract_m2(text) is None
 
+
+class TestM2Solver:
+    def test_munge_case_finds_correct_solution(self):
+        """Dims from Munge plan should solve to 2.50 m²."""
+        from app.modules.quote_engine.calculator import solve_m2_from_dims
+        dims = [1.74, 1.72, 1.55, 0.75, 0.6]
+        solutions = solve_m2_from_dims(dims, expected_m2=2.50, zoc_h=0.07)
+        assert solutions is not None
+        assert len(solutions) > 0
+        best = solutions[0]
+        assert abs(best["total"] - 2.50) <= 0.05
+        # Should have 2 mesada pieces
+        assert len(best["pieces"]) == 2
+
+    def test_munge_all_solutions_sum_correctly(self):
+        """All solutions should sum within tolerance of 2.50 m²."""
+        from app.modules.quote_engine.calculator import solve_m2_from_dims
+        dims = [1.74, 1.72, 1.55, 0.75, 0.6]
+        solutions = solve_m2_from_dims(dims, expected_m2=2.50, zoc_h=0.07)
+        assert solutions is not None
+        for sol in solutions:
+            assert abs(sol["total"] - 2.50) <= 0.05, f"Solution total {sol['total']} too far from 2.50"
+            # Each solution should use different anchos (diverse dims)
+            assert len(sol["pieces"]) >= 1
+
+    def test_simple_single_piece(self):
+        """Single mesada 2.0x0.6 = 1.20 m² with no zócalos."""
+        from app.modules.quote_engine.calculator import solve_m2_from_dims
+        dims = [2.0, 0.6]
+        solutions = solve_m2_from_dims(dims, expected_m2=1.20, zoc_h=0.05)
+        assert solutions is not None
+        best = solutions[0]
+        assert abs(best["total"] - 1.20) <= 0.02
+
+    def test_no_solution_returns_none(self):
+        """Impossible target should return None."""
+        from app.modules.quote_engine.calculator import solve_m2_from_dims
+        dims = [0.5, 0.3]
+        solutions = solve_m2_from_dims(dims, expected_m2=99.0, zoc_h=0.07)
+        assert solutions is None
+
+
     def test_validation_passes_when_close(self):
         """2.49 vs 2.50 = 0.4% diff → should pass (< 5%)."""
         expected = 2.50


### PR DESCRIPTION
## Summary
When Claude misreads plan dimensions and total m2 doesn't match planilla (diff > 0.1 m2), a combinatorial solver finds the correct combination of mesada pieces + zócalos from the PDF text dimensions.

**Munge case:** Claude read 2.75 m2, planilla says 2.50. Solver extracts dims [1.74, 1.72, 1.55, 0.75, 0.60] and finds valid combos that sum to 2.50.

30 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)