### PR TITLE
fix: planilla crop uses word positions for accurate split

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1300,13 +1300,17 @@ class AgentService:
                             # Try to detect planilla layout (table on right side)
                             if not _planilla_data and tables:
                                 try:
-                                    from app.modules.quote_engine.planilla_parser import parse_planilla_table
+                                    from app.modules.quote_engine.planilla_parser import parse_planilla_table, detect_table_x_from_words
                                     table_objects = page.find_tables()
                                     _planilla_data = parse_planilla_table(
                                         tables, page_width=page.width, page_height=page.height,
                                         table_bboxes=table_objects
                                     )
                                     if _planilla_data:
+                                        # Use word positions for accurate table x (bbox is unreliable)
+                                        _word_x = detect_table_x_from_words(page)
+                                        if _word_x > 0:
+                                            _planilla_data.table_x0 = _word_x
                                         logging.info(f"[planilla] Detected: material={_planilla_data.material}, "
                                                      f"m2={_planilla_data.m2}, table_x0={_planilla_data.table_x0:.0f}")
                                         if _planilla_data.m2:

--- a/api/app/modules/quote_engine/planilla_parser.py
+++ b/api/app/modules/quote_engine/planilla_parser.py
@@ -122,13 +122,18 @@ def parse_planilla_table(tables: list, page_width: float = 0, page_height: float
                         setattr(data, field_name, raw_val)
                     break
 
-        # Store bbox if available
+        # Store bbox — use keyword positions if available, fallback to table bbox
+        # The table bbox often covers the whole page (including drawing),
+        # so we use word positions to find where the characteristics table starts
+        data.table_x0 = 0
+        data.table_y0 = 0
+        data.table_x1 = page_width
+        data.table_y1 = page_height
+
         if table_bboxes and t_idx < len(table_bboxes):
             bbox = table_bboxes[t_idx]
             if hasattr(bbox, 'bbox'):
                 bbox = bbox.bbox
-            data.table_x0 = bbox[0]
-            data.table_y0 = bbox[1]
             data.table_x1 = bbox[2]
             data.table_y1 = bbox[3]
 
@@ -189,6 +194,30 @@ def build_planilla_context(data: PlanillaData) -> str:
     lines.append("Usá las cotas del dibujo para largo × ancho de cada pieza.")
 
     return "\n".join(lines)
+
+
+def detect_table_x_from_words(page) -> float:
+    """Detect where the characteristics table starts using word positions.
+
+    Looks for planilla keywords (UBICACIÓN, MATERIAL, etc.) and returns
+    the minimum x0 of those words. This is more reliable than table bbox
+    which often spans the entire page including the drawing.
+    """
+    keywords = ["ubicación", "ubicacion", "material", "espesor", "cantos",
+                "pileta", "griferia", "grifería", "zocalos", "zócalos", "características"]
+    try:
+        words = page.extract_words()
+        keyword_x = []
+        for w in words:
+            if w.get("text", "").lower().strip() in keywords:
+                keyword_x.append(w["x0"])
+        if keyword_x:
+            x = min(keyword_x)
+            logger.info(f"[planilla] Table starts at x={x:.0f} (from {len(keyword_x)} keyword positions)")
+            return x
+    except Exception as e:
+        logger.warning(f"[planilla] Word position detection failed: {e}")
+    return 0
 
 
 def crop_drawing_from_page(page_img, planilla_data: PlanillaData, dpi: int = 200) -> "Image":

--- a/api/tests/test_planilla_parser.py
+++ b/api/tests/test_planilla_parser.py
@@ -11,6 +11,7 @@ from app.modules.quote_engine.planilla_parser import (
     parse_planilla_table,
     build_planilla_context,
     crop_drawing_from_page,
+    detect_table_x_from_words,
     PlanillaData,
 )
 
@@ -159,7 +160,11 @@ class TestWithRealPDF:
             assert result.m2 == 2.50, f"Expected 2.50 m2, got {result.m2}"
             assert "PALOMA" in result.material.upper()
             assert "LUXOR" in result.pileta.upper()
-            assert result.table_x0 > 0, "Should have table bbox"
+            # Use word positions for accurate table x
+            word_x = detect_table_x_from_words(page)
+            if word_x > 0:
+                result.table_x0 = word_x
+            assert result.table_x0 > 100, f"Table should start well into the page, got x0={result.table_x0}"
             print(f"\nReal planilla parsed:")
             print(f"  Material: {result.material}")
             print(f"  M2: {result.m2}")


### PR DESCRIPTION
Table bbox was wrong. Now uses word positions. Drawing crops correctly.