### PR TITLE
feat: dual read — Sonnet first + Opus on demand + reconciliation

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1623,11 +1623,15 @@ class AgentService:
                                         except Exception as e:
                                             logging.warning(f"[dual-read] Failed to save result: {e}")
                                         logging.info(f"[dual-read] Result sent: source={_dual_result.get('source')}, review={_dual_result.get('requires_human_review')}")
+                                        # ── STOP: agent terminates turn, waits for operator confirmation ──
+                                        yield {"type": "done", "content": ""}
+                                        return
                                     else:
                                         logging.warning(f"[dual-read] Error: {_dual_result.get('error')}")
+                                        # Error → fall through to normal Claude flow
                                 except Exception as e:
                                     logging.error(f"[dual-read] Exception: {e}", exc_info=True)
-                                    # Non-fatal — continue with normal Claude flow
+                                    # Non-fatal — fall through to normal Claude flow
 
                         except Exception as e:
                             logging.warning(f"[planilla] Drawing crop failed, falling back to full PDF: {e}")

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -658,6 +658,18 @@ class AgentService:
 
         system_prompt = build_system_prompt(has_plan=has_plan, is_building=is_building, user_message=user_message, conversation_history=messages)
 
+        # ── Inject verified measurements if available ──
+        try:
+            _qr_vm = await db.execute(select(Quote).where(Quote.id == quote_id))
+            _q_vm = _qr_vm.scalar_one_or_none()
+            if _q_vm and _q_vm.quote_breakdown and _q_vm.quote_breakdown.get("verified_context"):
+                _vc = _q_vm.quote_breakdown["verified_context"]
+                # Append to system prompt as additional context block
+                system_prompt.append({"type": "text", "text": _vc, "cache_control": {"type": "ephemeral"}})
+                logging.info(f"[dual-read] Injected verified measurements into system prompt ({len(_vc)} chars)")
+        except Exception:
+            pass
+
         # ── EDIFICIO STATE MACHINE: Paso 2, 3 — all server-side ──
         # "step1_review" → confirm → render Paso 2 → "step2_quote"
         # "step2_quote"  → confirm → generate documents → "step3_done"
@@ -1584,6 +1596,39 @@ class AgentService:
                                     },
                                 })
                                 logging.info(f"[planilla] Sending cropped drawing only ({_drawing_img.width}x{_drawing_img.height}, {len(_draw_bytes)} bytes)")
+
+                                # ── DUAL READ: send crop to Sonnet (+ Opus if unsure) ──
+                                try:
+                                    from app.modules.quote_engine.dual_reader import dual_read_crop
+                                    _dual_enabled = ai_cfg.get("dual_read_enabled", True) if 'ai_cfg' in dir() else get_ai_config().get("dual_read_enabled", True)
+                                    yield {"type": "action", "content": "📐 Leyendo medidas del plano..."}
+                                    _dual_result = await dual_read_crop(
+                                        _draw_bytes,
+                                        crop_label=_planilla_data.ubicacion or "cocina",
+                                        planilla_m2=_planilla_data.m2,
+                                        dual_enabled=_dual_enabled,
+                                    )
+                                    if not _dual_result.get("error"):
+                                        # Send to frontend
+                                        yield {"type": "dual_read_result", "content": json.dumps(_dual_result, ensure_ascii=False)}
+                                        # Store in quote breakdown
+                                        try:
+                                            _qr = await db.execute(select(Quote).where(Quote.id == quote_id))
+                                            _q = _qr.scalar_one_or_none()
+                                            if _q:
+                                                _bd = dict(_q.quote_breakdown or {})
+                                                _bd["dual_read_result"] = _dual_result
+                                                await db.execute(update(Quote).where(Quote.id == quote_id).values(quote_breakdown=_bd))
+                                                await db.commit()
+                                        except Exception as e:
+                                            logging.warning(f"[dual-read] Failed to save result: {e}")
+                                        logging.info(f"[dual-read] Result sent: source={_dual_result.get('source')}, review={_dual_result.get('requires_human_review')}")
+                                    else:
+                                        logging.warning(f"[dual-read] Error: {_dual_result.get('error')}")
+                                except Exception as e:
+                                    logging.error(f"[dual-read] Exception: {e}", exc_info=True)
+                                    # Non-fatal — continue with normal Claude flow
+
                         except Exception as e:
                             logging.warning(f"[planilla] Drawing crop failed, falling back to full PDF: {e}")
                             content.append({
@@ -1782,6 +1827,30 @@ class AgentService:
         # Append user message to history (injected for Claude, clean for DB)
         # System triggers are internal — don't pass them to Claude or save as user message
         _is_system_trigger = user_message.startswith("[SYSTEM_TRIGGER:")
+
+        # ── Handle DUAL_READ_CONFIRMED: inject verified measurements ──
+        if user_message.startswith("[DUAL_READ_CONFIRMED]"):
+            try:
+                _confirmed_json = json.loads(user_message[len("[DUAL_READ_CONFIRMED]"):])
+                from app.modules.quote_engine.dual_reader import build_verified_context
+                _verified_ctx = build_verified_context(_confirmed_json)
+                # Save to breakdown
+                _qr = await db.execute(select(Quote).where(Quote.id == quote_id))
+                _q = _qr.scalar_one_or_none()
+                if _q:
+                    _bd = dict(_q.quote_breakdown or {})
+                    _bd["verified_measurements"] = _confirmed_json
+                    _bd["verified_context"] = _verified_ctx
+                    await db.execute(update(Quote).where(Quote.id == quote_id).values(quote_breakdown=_bd))
+                    await db.commit()
+                logging.info(f"[dual-read] Verified measurements saved for {quote_id}")
+                yield {"type": "text", "content": "✅ Medidas verificadas guardadas en contexto."}
+                yield {"type": "done", "content": ""}
+                return
+            except Exception as e:
+                logging.error(f"[dual-read] Confirmation failed: {e}")
+                # Fall through to normal processing
+
         if _is_system_trigger:
             new_messages = clean_messages  # No user message for Claude
             db_messages = clean_messages   # No user message in DB

--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -1125,6 +1125,8 @@ async def chat(
                     yield f"data: {json.dumps(chunk)}\n\n"
                 elif chunk["type"] == "zone_selector":
                     yield f"data: {json.dumps(chunk)}\n\n"
+                elif chunk["type"] == "dual_read_result":
+                    yield f"data: {json.dumps(chunk)}\n\n"
                 elif chunk["type"] == "done":
                     logging.info(f"[SSE] Sending done for quote {quote_id}")
                     yield f"data: {json.dumps(chunk)}\n\n"

--- a/api/app/modules/agent/tools/catalog_tool.py
+++ b/api/app/modules/agent/tools/catalog_tool.py
@@ -15,7 +15,7 @@ def get_ai_config() -> dict:
     global _ai_config_cache
     if _ai_config_cache is not None:
         return _ai_config_cache
-    defaults = {"use_opus_for_plans": True, "rotate_plan_images": False, "max_examples": 1, "monthly_budget_usd": 300, "enable_hard_limit": True}
+    defaults = {"use_opus_for_plans": True, "rotate_plan_images": False, "max_examples": 1, "monthly_budget_usd": 300, "enable_hard_limit": True, "dual_read_enabled": True}
     try:
         from sqlalchemy import create_engine, text
         from app.core.config import settings

--- a/api/app/modules/quote_engine/dual_reader.py
+++ b/api/app/modules/quote_engine/dual_reader.py
@@ -1,0 +1,526 @@
+"""Dual vision reader for marble workshop plans.
+
+Sends the same cropped plan image to Claude Sonnet (fast) first.
+If Sonnet reports high confidence (≥0.9), uses that result directly.
+If Sonnet is unsure, also sends to Claude Opus and reconciles.
+
+All measurement extraction is via structured JSON with strict enum
+for zócalo sides — no fuzzy matching needed in reconciliation.
+
+Flag: dual_read_enabled (config.json ai_engine section)
+  - true  → Sonnet first, Opus on demand, reconciliation
+  - false → Sonnet only, direct result, no reconciliation
+"""
+import asyncio
+import base64
+import json
+import logging
+import re
+from typing import Optional
+
+import anthropic
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# ═══════════════════════════════════════════════════════
+# System prompt — same for both models (comparison limpia)
+# ═══════════════════════════════════════════════════════
+
+PLAN_READER_SYSTEM_PROMPT = """# SYSTEM PROMPT — LECTOR DE PLANOS DE MARMOLERÍA
+## Versión 1.0 | DevLabs
+
+Sos un lector experto de planos de marmolería con criterio de arquitecto.
+Antes de cualquier cálculo, RENDERIZÁ cada sector individualmente a 300 DPI con crop.
+Nunca confíes en la vista general del plano. Sin excepción.
+
+## PROTOCOLO DE LECTURA — 4 PASADAS OBLIGATORIAS
+
+**Pasada 1 — Inventario**
+Identificá todos los sectores presentes (cocina, baño, lavadero, etc.)
+
+**Pasada 2 — Geometría por sector**
+Determiná el tipo de mesada:
+- RECTA     : 1 tramo. Tomá largo × ancho del rectángulo total.
+- EN L      : 2 tramos COMPLEMENTARIOS. Verificá: prof_tramo1 + largo_tramo2 ≈ dim exterior. NO sumes piezas completas — se solaparían.
+- EN U      : 3 tramos complementarios. Mismo criterio.
+- ISLA      : rectángulo total. Recortes internos son merma — NO reducen m².
+
+**Pasada 3 — Cotas**
+- VISTA EN PLANTA    : largo (eje horizontal) × ancho (profundidad)
+- VISTA EN ELEVACIÓN : dimensión SOBRE línea de mesada = zócalo | dimensión BAJO = frentin/faldón
+- Z antes de número  = longitud de zócalo en cm
+
+**Pasada 4 — Validación**
+Verificá consistencia entre vistas. Si hay contradicción → anotá en ambiguedades.
+
+## REGLA CRÍTICA — DIMENSIÓN DE PLACA vs. ML DE ZÓCALO
+
+Son dos medidas DISTINTAS. NUNCA las confundas.
+- **Placa (tramo):** dimensión del mármol. Define el rectángulo de la pieza. Usala para calcular m².
+- **Zócalo (ml):** longitud de la pared donde va el zócalo. Puede ser MAYOR que la placa. Usala para m² de zócalo.
+
+## REGLA — ZÓCALOS: SOLO POR COTA EXPLÍCITA
+
+NUNCA derives zócalos de los lados de la pieza. Un zócalo existe SOLO si el plano muestra:
+- Cota etiquetada como Z, ZOC, ZÓCALO o similar
+- Dimensión explícita con altura (ej: 1.74 ML × 0.07)
+- Indicación textual en tabla de características
+Si no hay cota → ese lado no tiene zócalo. No inferir.
+Altura default: 0.07m si se indica "zócalos 7 cm".
+
+## REGLA — FRENTIN / FALDÓN: SOLO POR EVIDENCIA EXPLÍCITA
+
+Frentin/faldón SOLO si el plano muestra vista de elevación con cota debajo de la línea de mesada.
+Si no hay vista de elevación → frentin = [].
+
+## REGLA — REGRUESO
+
+Regrueso = terminación lateral del zócalo en receptáculos de ducha.
+Si no hay duchas → regrueso = 0. SIMPLE por default.
+
+## REGLAS DE COGNICIÓN VISUAL Y OCR
+
+1. Escaneá rótulo/notas en márgenes para unidades, espesores, materiales.
+2. LÍNEAS DE CONTORNO (gruesas) ≠ LÍNEAS DE COTA (finas con flechas).
+3. Textos rotados: leé paralelo a su línea de cota.
+4. Cuidado OCR: 5 vs S, 6 vs 8, 1 vs 7.
+5. Si cota < 10 y otra > 50 → normalizar a metros.
+6. Validar proporciones visuales: si 60 y 120, el segundo debe verse el doble.
+
+## OTRAS REGLAS FIJAS
+
+- Mesada > 3m → "SE REALIZA EN 2 TRAMOS"
+- m² redondeados a 2 decimales
+- Signo ambiguo → NO interpretes, anotar en ambiguedades
+- NUNCA asumir simetría
+- Johnson (pileta) → PEGADOPILETA
+
+## REGLA DE ESQUINAS — SIN SUPERFICIE DOBLE
+
+EN L: Un tramo FULL (con esquina), otro NETO (empieza donde termina el full).
+EN U: Laterales FULL, medio NETO (restar depth de ambos laterales).
+Verificar: depth_full + largo_neto = dim exterior total.
+
+## FORMATO DE SALIDA — SOLO JSON
+
+Lado de zócalos DEBE ser uno de: "izquierdo", "derecho", "trasero", "frontal", "lateral"
+
+```json
+{
+  "sectores": [
+    {
+      "id": "cocina",
+      "tipo": "recta | recta_2_tramos | L | U | isla",
+      "tramos": [
+        {
+          "id": "tramo_1",
+          "descripcion": "Mesada cocina tramo 1",
+          "largo_m": 1.55,
+          "ancho_m": 0.60,
+          "m2": 0.93,
+          "zocalos": [
+            { "lado": "frontal", "ml": 1.55, "alto_m": 0.07 }
+          ],
+          "frentin": [],
+          "regrueso": [],
+          "notas": []
+        }
+      ],
+      "m2_placas": 0.93,
+      "m2_zocalos": 0.11,
+      "m2_total": 1.04,
+      "ambiguedades": [],
+      "confident": 0.95
+    }
+  ]
+}
+```
+
+confident: 0.0 a 1.0 por sector. Ambiguedades → confident < 0.8.
+"""
+
+VALID_LADOS = {"izquierdo", "derecho", "trasero", "frontal", "lateral"}
+
+# Reconciliation thresholds
+DELTA_PERCENT_ALERTA = 0.05   # 5%
+CONFIDENCE_THRESHOLD = 0.7
+SONNET_CONFIDENCE_SKIP_OPUS = 0.9
+OPUS_TIMEOUT_SECONDS = 15
+
+
+# ═══════════════════════════════════════════════════════
+# Vision API call
+# ═══════════════════════════════════════════════════════
+
+async def _call_vision(crop_bytes: bytes, model: str, timeout: float = OPUS_TIMEOUT_SECONDS) -> dict:
+    """Call Claude Vision API with plan reader prompt. Returns parsed JSON."""
+    client = anthropic.AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY)
+    try:
+        response = await asyncio.wait_for(
+            client.messages.create(
+                model=model,
+                max_tokens=3000,
+                system=PLAN_READER_SYSTEM_PROMPT,
+                messages=[{
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/jpeg",
+                                "data": base64.b64encode(crop_bytes).decode(),
+                            },
+                        },
+                        {
+                            "type": "text",
+                            "text": "Extraé las medidas de este plano de marmolería. Devolvé SOLO JSON según el schema indicado.",
+                        },
+                    ],
+                }],
+            ),
+            timeout=timeout,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(f"[dual-read] {model} timed out after {timeout}s")
+        return {"error": f"Timeout after {timeout}s", "model": model}
+    except Exception as e:
+        logger.error(f"[dual-read] {model} API error: {e}")
+        return {"error": str(e), "model": model}
+
+    # Extract text from response
+    text = ""
+    for block in response.content:
+        if hasattr(block, "text"):
+            text += block.text
+
+    # Parse JSON — strip markdown fences if present
+    text = text.strip()
+    text = re.sub(r'^```(?:json)?\s*', '', text)
+    text = re.sub(r'\s*```$', '', text)
+
+    try:
+        result = json.loads(text)
+        result["_model"] = model
+        result["_raw_length"] = len(text)
+        return result
+    except json.JSONDecodeError as e:
+        # Try to find JSON object in response
+        match = re.search(r'\{[\s\S]*\}', text)
+        if match:
+            try:
+                result = json.loads(match.group())
+                result["_model"] = model
+                return result
+            except json.JSONDecodeError:
+                pass
+        logger.error(f"[dual-read] {model} JSON parse failed: {e}\nRaw: {text[:500]}")
+        return {"error": f"JSON parse failed: {e}", "model": model, "_raw": text[:500]}
+
+
+# ═══════════════════════════════════════════════════════
+# Reconciliation
+# ═══════════════════════════════════════════════════════
+
+def _compare_float(a: float, b: float) -> tuple[str, float]:
+    """Compare two float values, return (status, reconciled_value)."""
+    if a == b:
+        return "CONFIRMADO", a
+    if a == 0 and b == 0:
+        return "CONFIRMADO", 0
+    avg = (a + b) / 2
+    max_val = max(abs(a), abs(b))
+    if max_val == 0:
+        return "CONFIRMADO", 0
+    delta_pct = abs(a - b) / max_val
+    if delta_pct < DELTA_PERCENT_ALERTA:
+        return "ALERTA", round(avg, 4)
+    return "CONFLICTO", None  # Operator must choose
+
+
+def _compare_zocalos(a_list: list, b_list: list) -> list[dict]:
+    """Compare zócalo arrays by matching 'lado' field (strict ==)."""
+    result = []
+    a_by_lado = {z.get("lado", ""): z for z in a_list}
+    b_by_lado = {z.get("lado", ""): z for z in b_list}
+    all_lados = set(a_by_lado.keys()) | set(b_by_lado.keys())
+
+    for lado in sorted(all_lados):
+        za = a_by_lado.get(lado)
+        zb = b_by_lado.get(lado)
+        if za and zb:
+            status, ml = _compare_float(za.get("ml", 0), zb.get("ml", 0))
+            result.append({
+                "lado": lado,
+                "opus_ml": za.get("ml", 0),
+                "sonnet_ml": zb.get("ml", 0),
+                "ml": ml if ml is not None else za.get("ml", 0),
+                "alto_m": za.get("alto_m", 0.07),
+                "status": status,
+            })
+        elif za:
+            result.append({
+                "lado": lado, "opus_ml": za.get("ml", 0), "sonnet_ml": None,
+                "ml": za.get("ml", 0), "alto_m": za.get("alto_m", 0.07),
+                "status": "SOLO_OPUS",
+            })
+        elif zb:
+            result.append({
+                "lado": lado, "opus_ml": None, "sonnet_ml": zb.get("ml", 0),
+                "ml": zb.get("ml", 0), "alto_m": zb.get("alto_m", 0.07),
+                "status": "SOLO_SONNET",
+            })
+    return result
+
+
+def reconcile(opus: dict, sonnet: dict) -> dict:
+    """Reconcile results from two models. Returns reconciled data with status per field."""
+    opus_sectores = opus.get("sectores", [])
+    sonnet_sectores = sonnet.get("sectores", [])
+
+    # Match sectors by id
+    opus_by_id = {s.get("id", f"s{i}"): s for i, s in enumerate(opus_sectores)}
+    sonnet_by_id = {s.get("id", f"s{i}"): s for i, s in enumerate(sonnet_sectores)}
+    all_ids = list(dict.fromkeys(list(opus_by_id.keys()) + list(sonnet_by_id.keys())))
+
+    reconciled_sectores = []
+    requires_review = False
+    conflict_fields = []
+
+    for sid in all_ids:
+        os = opus_by_id.get(sid, {})
+        ss = sonnet_by_id.get(sid, {})
+
+        # Match tramos by id
+        o_tramos = {t.get("id", f"t{i}"): t for i, t in enumerate(os.get("tramos", []))}
+        s_tramos = {t.get("id", f"t{i}"): t for i, t in enumerate(ss.get("tramos", []))}
+        all_tramo_ids = list(dict.fromkeys(list(o_tramos.keys()) + list(s_tramos.keys())))
+
+        rec_tramos = []
+        for tid in all_tramo_ids:
+            ot = o_tramos.get(tid, {})
+            st = s_tramos.get(tid, {})
+
+            # Compare numeric fields
+            fields = {}
+            for field in ["largo_m", "ancho_m", "m2"]:
+                ov = ot.get(field, 0)
+                sv = st.get(field, 0)
+                status, val = _compare_float(ov, sv)
+
+                # Check confidence
+                o_conf = os.get("confident", 1.0)
+                s_conf = ss.get("confident", 1.0)
+                if min(o_conf, s_conf) < CONFIDENCE_THRESHOLD:
+                    status = "DUDOSO"
+
+                if status in ("CONFLICTO", "DUDOSO"):
+                    requires_review = True
+                    conflict_fields.append(f"{sid}.{tid}.{field}")
+
+                fields[field] = {
+                    "opus": ov, "sonnet": sv,
+                    "valor": val if val is not None else ov,
+                    "status": status,
+                }
+
+            # Compare zócalos
+            o_zocs = ot.get("zocalos", [])
+            s_zocs = st.get("zocalos", [])
+            rec_zocs = _compare_zocalos(o_zocs, s_zocs)
+            for z in rec_zocs:
+                if z["status"] in ("CONFLICTO", "DUDOSO"):
+                    requires_review = True
+                    conflict_fields.append(f"{sid}.{tid}.zocalo_{z['lado']}")
+
+            rec_tramos.append({
+                "id": tid,
+                "descripcion": ot.get("descripcion", st.get("descripcion", "")),
+                **fields,
+                "zocalos": rec_zocs,
+                "frentin": ot.get("frentin", st.get("frentin", [])),
+                "regrueso": ot.get("regrueso", st.get("regrueso", [])),
+            })
+
+        # Sector-level m2
+        o_m2 = os.get("m2_total", 0)
+        s_m2 = ss.get("m2_total", 0)
+        m2_status, m2_val = _compare_float(o_m2, s_m2)
+
+        reconciled_sectores.append({
+            "id": sid,
+            "tipo": os.get("tipo", ss.get("tipo", "")),
+            "tramos": rec_tramos,
+            "m2_total": {"opus": o_m2, "sonnet": s_m2, "valor": m2_val or o_m2, "status": m2_status},
+            "ambiguedades": list(set(os.get("ambiguedades", []) + ss.get("ambiguedades", []))),
+        })
+
+    return {
+        "sectores": reconciled_sectores,
+        "requires_human_review": requires_review,
+        "conflict_fields": conflict_fields,
+        "source": "DUAL",
+    }
+
+
+def _build_single_result(data: dict, source: str) -> dict:
+    """Wrap a single-model result as a reconciled result (all CONFIRMADO)."""
+    sectores = []
+    for s in data.get("sectores", []):
+        tramos = []
+        for t in s.get("tramos", []):
+            tramos.append({
+                "id": t.get("id", ""),
+                "descripcion": t.get("descripcion", ""),
+                "largo_m": {"opus": None, "sonnet": None, source.lower(): t.get("largo_m", 0),
+                            "valor": t.get("largo_m", 0), "status": source},
+                "ancho_m": {"opus": None, "sonnet": None, source.lower(): t.get("ancho_m", 0),
+                            "valor": t.get("ancho_m", 0), "status": source},
+                "m2": {"opus": None, "sonnet": None, source.lower(): t.get("m2", 0),
+                       "valor": t.get("m2", 0), "status": source},
+                "zocalos": [
+                    {**z, "status": source, "opus_ml": None, "sonnet_ml": None}
+                    for z in t.get("zocalos", [])
+                ],
+                "frentin": t.get("frentin", []),
+                "regrueso": t.get("regrueso", []),
+            })
+        sectores.append({
+            "id": s.get("id", ""),
+            "tipo": s.get("tipo", ""),
+            "tramos": tramos,
+            "m2_total": {"valor": s.get("m2_total", 0), "status": source},
+            "ambiguedades": s.get("ambiguedades", []),
+        })
+    return {
+        "sectores": sectores,
+        "requires_human_review": False,
+        "conflict_fields": [],
+        "source": source,
+    }
+
+
+# ═══════════════════════════════════════════════════════
+# Orchestrator
+# ═══════════════════════════════════════════════════════
+
+async def dual_read_crop(
+    crop_bytes: bytes,
+    crop_label: str = "cocina",
+    planilla_m2: Optional[float] = None,
+    dual_enabled: bool = True,
+) -> dict:
+    """Read a crop with Sonnet first, Opus on demand. Reconcile results.
+
+    dual_read_enabled semantics:
+      True  → Sonnet first, if confident < 0.9 → also Opus, then reconcile
+      False → Sonnet ONLY, direct result, no Opus, no reconciliation
+    """
+    sonnet_model = settings.ANTHROPIC_MODEL  # claude-sonnet-4-5-20250514
+    opus_model = "claude-opus-4-6"
+
+    # Step 1: Always call Sonnet (fast, ~3-5s)
+    logger.info(f"[dual-read] Calling Sonnet for '{crop_label}'...")
+    sonnet_result = await _call_vision(crop_bytes, sonnet_model, timeout=30)
+
+    if sonnet_result.get("error"):
+        logger.error(f"[dual-read] Sonnet failed: {sonnet_result['error']}")
+        if dual_enabled:
+            # Fallback to Opus
+            logger.info(f"[dual-read] Falling back to Opus...")
+            opus_result = await _call_vision(crop_bytes, opus_model, timeout=OPUS_TIMEOUT_SECONDS)
+            if opus_result.get("error"):
+                return {"error": "Both models failed", "sonnet_error": sonnet_result["error"], "opus_error": opus_result["error"]}
+            return _build_single_result(opus_result, "SOLO_OPUS")
+        return {"error": f"Sonnet failed: {sonnet_result['error']}"}
+
+    # If dual_read_enabled=false → return Sonnet directly, no reconciliation
+    if not dual_enabled:
+        logger.info(f"[dual-read] dual_read_enabled=false → returning Sonnet directly")
+        result = _build_single_result(sonnet_result, "SOLO_SONNET")
+        result["m2_warning"] = _check_m2(result, planilla_m2)
+        return result
+
+    # Step 2: Check Sonnet confidence
+    min_confidence = min(
+        (s.get("confident", 1.0) for s in sonnet_result.get("sectores", [{"confident": 0}])),
+        default=0,
+    )
+    logger.info(f"[dual-read] Sonnet confidence: {min_confidence:.2f}")
+
+    if min_confidence >= SONNET_CONFIDENCE_SKIP_OPUS:
+        # Sonnet is confident → skip Opus, save cost
+        logger.info(f"[dual-read] Sonnet confident ≥{SONNET_CONFIDENCE_SKIP_OPUS} → skipping Opus")
+        result = _build_single_result(sonnet_result, "SOLO_SONNET")
+        result["m2_warning"] = _check_m2(result, planilla_m2)
+        return result
+
+    # Step 3: Sonnet unsure → call Opus with timeout
+    logger.info(f"[dual-read] Sonnet unsure ({min_confidence:.2f}) → calling Opus (timeout={OPUS_TIMEOUT_SECONDS}s)...")
+    opus_result = await _call_vision(crop_bytes, opus_model, timeout=OPUS_TIMEOUT_SECONDS)
+
+    if opus_result.get("error"):
+        # Opus failed/timed out → use Sonnet alone
+        logger.warning(f"[dual-read] Opus failed: {opus_result['error']} → using Sonnet only")
+        result = _build_single_result(sonnet_result, "SOLO_SONNET")
+        result["m2_warning"] = _check_m2(result, planilla_m2)
+        return result
+
+    # Step 4: Both succeeded → reconcile
+    logger.info(f"[dual-read] Both models responded → reconciling...")
+    reconciled = reconcile(opus_result, sonnet_result)
+    reconciled["m2_warning"] = _check_m2(reconciled, planilla_m2)
+    return reconciled
+
+
+def _check_m2(result: dict, planilla_m2: Optional[float]) -> Optional[str]:
+    """Check if calculated m2 matches planilla m2."""
+    if planilla_m2 is None:
+        return None
+    total = sum(
+        s.get("m2_total", {}).get("valor", 0) if isinstance(s.get("m2_total"), dict) else s.get("m2_total", 0)
+        for s in result.get("sectores", [])
+    )
+    if total == 0:
+        return None
+    diff_pct = abs(total - planilla_m2) / planilla_m2
+    if diff_pct > 0.10:
+        return f"⚠️ M² calculado ({total:.2f}) no coincide con planilla ({planilla_m2:.2f}). Diferencia: {diff_pct*100:.0f}%"
+    return None
+
+
+# ═══════════════════════════════════════════════════════
+# Context injection
+# ═══════════════════════════════════════════════════════
+
+def build_verified_context(confirmed_data: dict) -> str:
+    """Build injection text from operator-confirmed measurements."""
+    lines = [
+        "[MEDIDAS VERIFICADAS POR DOBLE LECTURA + OPERADOR — FUENTE DE VERDAD]",
+        "⛔ Estos valores son definitivos. NO leas la imagen. Usá estos valores exactos.",
+        "",
+    ]
+
+    for sector in confirmed_data.get("sectores", []):
+        sid = sector.get("id", "sector")
+        lines.append(f"SECTOR: {sid.upper()}")
+        for tramo in sector.get("tramos", []):
+            tid = tramo.get("id", "")
+            desc = tramo.get("descripcion", tid)
+            largo = tramo.get("largo_m", {})
+            ancho = tramo.get("ancho_m", {})
+            m2 = tramo.get("m2", {})
+            largo_v = largo.get("valor", 0) if isinstance(largo, dict) else largo
+            ancho_v = ancho.get("valor", 0) if isinstance(ancho, dict) else ancho
+            m2_v = m2.get("valor", 0) if isinstance(m2, dict) else m2
+            lines.append(f"  {desc}: {largo_v}m × {ancho_v}m = {m2_v} m²")
+            for z in tramo.get("zocalos", []):
+                ml = z.get("ml", 0)
+                alto = z.get("alto_m", 0.07)
+                lado = z.get("lado", "?")
+                lines.append(f"  Zócalo {lado}: {ml}ml × {alto}m")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/api/app/modules/quote_engine/dual_reader.py
+++ b/api/app/modules/quote_engine/dual_reader.py
@@ -414,12 +414,19 @@ async def dual_read_crop(
 ) -> dict:
     """Read a crop with Sonnet first, Opus on demand. Reconcile results.
 
-    dual_read_enabled semantics:
+    Flag semantics (dual_read_enabled in config.json):
       True  → Sonnet first, if confident < 0.9 → also Opus, then reconcile
-      False → Sonnet ONLY, direct result, no Opus, no reconciliation
+      False → Sonnet ONLY, direct result, NO Opus call, NO reconciliation
+
+    NOTE: This flag is INDEPENDENT of use_opus_for_plans (which controls the
+    main agent loop model). dual_read_enabled controls only this dual vision
+    reader module. Both can be true/false independently.
     """
     sonnet_model = settings.ANTHROPIC_MODEL  # claude-sonnet-4-5-20250514
-    opus_model = "claude-opus-4-6"
+    # Opus model from config (not hardcoded) — allows changing without code deploy
+    from app.modules.agent.tools.catalog_tool import get_ai_config
+    _ai = get_ai_config()
+    opus_model = _ai.get("opus_model", "claude-opus-4-6")
 
     # Step 1: Always call Sonnet (fast, ~3-5s)
     logger.info(f"[dual-read] Calling Sonnet for '{crop_label}'...")

--- a/api/catalog/config.json
+++ b/api/catalog/config.json
@@ -112,7 +112,8 @@
   "ai_engine": {
     "use_opus_for_plans": true,
     "rotate_plan_images": false,
-    "max_examples": 1
+    "max_examples": 1,
+    "dual_read_enabled": true
   },
   "zone_aliases": {
     "_comment": "sku: SKU en delivery-zones.json. pulido_extra: true si hay colocación cobra pulido de cantos (= flete/2). Zonas cercanas a Rosario: false.",

--- a/api/tests/test_dual_reader.py
+++ b/api/tests/test_dual_reader.py
@@ -1,0 +1,276 @@
+"""Tests for dual vision reader — reconciliation, flow control, context injection."""
+import asyncio
+import os
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test-fake")
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("APP_ENV", "test")
+
+from app.modules.quote_engine.dual_reader import (
+    reconcile,
+    dual_read_crop,
+    build_verified_context,
+    _compare_float,
+    _build_single_result,
+    _check_m2,
+)
+
+
+# ═══════════════════════════════════════════════════════
+# Helper: sample model outputs
+# ═══════════════════════════════════════════════════════
+
+def _sample_result(largo=1.55, ancho=0.60, m2=0.93, confident=0.95,
+                   zocalos=None, tipo="recta"):
+    if zocalos is None:
+        zocalos = [{"lado": "frontal", "ml": 1.55, "alto_m": 0.07}]
+    return {
+        "sectores": [{
+            "id": "cocina",
+            "tipo": tipo,
+            "tramos": [{
+                "id": "tramo_1",
+                "descripcion": "Mesada cocina tramo 1",
+                "largo_m": largo,
+                "ancho_m": ancho,
+                "m2": m2,
+                "zocalos": zocalos,
+                "frentin": [],
+                "regrueso": [],
+                "notas": [],
+            }],
+            "m2_placas": m2,
+            "m2_zocalos": sum(z["ml"] * z.get("alto_m", 0.07) for z in zocalos),
+            "m2_total": round(m2 + sum(z["ml"] * z.get("alto_m", 0.07) for z in zocalos), 2),
+            "ambiguedades": [],
+            "confident": confident,
+        }],
+    }
+
+
+# ═══════════════════════════════════════════════════════
+# Reconciliation tests
+# ═══════════════════════════════════════════════════════
+
+class TestReconciliacion:
+    def test_confirmado(self):
+        """Identical results → all CONFIRMADO."""
+        opus = _sample_result(largo=1.55, ancho=0.60, m2=0.93)
+        sonnet = _sample_result(largo=1.55, ancho=0.60, m2=0.93)
+        result = reconcile(opus, sonnet)
+        assert result["requires_human_review"] is False
+        assert result["source"] == "DUAL"
+        tramo = result["sectores"][0]["tramos"][0]
+        assert tramo["largo_m"]["status"] == "CONFIRMADO"
+        assert tramo["ancho_m"]["status"] == "CONFIRMADO"
+        assert tramo["m2"]["status"] == "CONFIRMADO"
+
+    def test_alerta(self):
+        """Delta < 5% → ALERTA, value = average."""
+        opus = _sample_result(largo=1.55, ancho=0.60)
+        sonnet = _sample_result(largo=1.55, ancho=0.58)  # 3.3% diff
+        result = reconcile(opus, sonnet)
+        tramo = result["sectores"][0]["tramos"][0]
+        assert tramo["ancho_m"]["status"] == "ALERTA"
+        assert tramo["ancho_m"]["valor"] == pytest.approx(0.59, abs=0.01)
+
+    def test_conflicto(self):
+        """Delta > 5% → CONFLICTO, requires review."""
+        opus = _sample_result(largo=1.55, ancho=0.60)
+        sonnet = _sample_result(largo=1.55, ancho=0.50)  # 16.7% diff
+        result = reconcile(opus, sonnet)
+        assert result["requires_human_review"] is True
+        tramo = result["sectores"][0]["tramos"][0]
+        assert tramo["ancho_m"]["status"] == "CONFLICTO"
+        assert "ancho_m" in result["conflict_fields"][0]
+
+    def test_dudoso(self):
+        """Low confidence → DUDOSO."""
+        opus = _sample_result(confident=0.5)
+        sonnet = _sample_result(confident=0.5)
+        result = reconcile(opus, sonnet)
+        assert result["requires_human_review"] is True
+        tramo = result["sectores"][0]["tramos"][0]
+        assert tramo["largo_m"]["status"] == "DUDOSO"
+
+    def test_zocalos_match(self):
+        """Matching zócalos by lado with ==."""
+        zocs = [{"lado": "frontal", "ml": 1.74, "alto_m": 0.07}]
+        opus = _sample_result(zocalos=zocs)
+        sonnet = _sample_result(zocalos=zocs)
+        result = reconcile(opus, sonnet)
+        z = result["sectores"][0]["tramos"][0]["zocalos"][0]
+        assert z["status"] == "CONFIRMADO"
+        assert z["lado"] == "frontal"
+
+    def test_zocalos_conflicto(self):
+        """Different zócalo ml → CONFLICTO."""
+        opus = _sample_result(zocalos=[{"lado": "frontal", "ml": 1.74, "alto_m": 0.07}])
+        sonnet = _sample_result(zocalos=[{"lado": "frontal", "ml": 1.55, "alto_m": 0.07}])
+        result = reconcile(opus, sonnet)
+        z = result["sectores"][0]["tramos"][0]["zocalos"][0]
+        assert z["status"] == "CONFLICTO"
+
+
+# ═══════════════════════════════════════════════════════
+# Flow control tests
+# ═══════════════════════════════════════════════════════
+
+class TestFlowControl:
+    @pytest.mark.asyncio
+    async def test_sonnet_confiado_no_llama_opus(self):
+        """Sonnet confident ≥0.9 → Opus NOT called."""
+        confident_result = _sample_result(confident=0.95)
+
+        with patch("app.modules.quote_engine.dual_reader._call_vision", new_callable=AsyncMock) as mock:
+            mock.return_value = confident_result
+            result = await dual_read_crop(b"fake_image", "cocina", dual_enabled=True)
+
+        # Sonnet called once, Opus never (total 1 call)
+        assert mock.call_count == 1
+        assert result["source"] == "SOLO_SONNET"
+
+    @pytest.mark.asyncio
+    async def test_sonnet_dudoso_llama_opus(self):
+        """Sonnet confident < 0.9 → Opus called."""
+        unsure_result = _sample_result(confident=0.7)
+
+        call_count = {"sonnet": 0, "opus": 0}
+        async def mock_vision(crop_bytes, model, timeout=15):
+            if "sonnet" in model.lower():
+                call_count["sonnet"] += 1
+                return unsure_result
+            else:
+                call_count["opus"] += 1
+                return _sample_result(confident=0.95)
+
+        with patch("app.modules.quote_engine.dual_reader._call_vision", side_effect=mock_vision):
+            result = await dual_read_crop(b"fake_image", "cocina", dual_enabled=True)
+
+        assert call_count["sonnet"] == 1
+        assert call_count["opus"] == 1
+        assert result["source"] == "DUAL"
+
+    @pytest.mark.asyncio
+    async def test_opus_timeout(self):
+        """Opus timeout → returns SOLO_SONNET."""
+        async def mock_vision(crop_bytes, model, timeout=15):
+            if "sonnet" in model.lower():
+                return _sample_result(confident=0.7)
+            else:
+                return {"error": "Timeout after 15s", "model": model}
+
+        with patch("app.modules.quote_engine.dual_reader._call_vision", side_effect=mock_vision):
+            result = await dual_read_crop(b"fake_image", "cocina", dual_enabled=True)
+
+        assert result["source"] == "SOLO_SONNET"
+
+    @pytest.mark.asyncio
+    async def test_dual_read_disabled(self):
+        """dual_read_enabled=false → ONLY Sonnet, no Opus, no reconciliation."""
+        call_models = []
+
+        async def mock_vision(crop_bytes, model, timeout=15):
+            call_models.append(model)
+            return _sample_result(confident=0.95)
+
+        with patch("app.modules.quote_engine.dual_reader._call_vision", side_effect=mock_vision):
+            result = await dual_read_crop(b"fake_image", "cocina", dual_enabled=False)
+
+        # Only Sonnet called
+        assert len(call_models) == 1
+        assert "sonnet" in call_models[0].lower()
+        # No reconciliation
+        assert result["source"] == "SOLO_SONNET"
+        assert result["requires_human_review"] is False
+
+    @pytest.mark.asyncio
+    async def test_both_fail(self):
+        """Both models fail → error result."""
+        with patch("app.modules.quote_engine.dual_reader._call_vision", new_callable=AsyncMock) as mock:
+            mock.return_value = {"error": "API error"}
+            result = await dual_read_crop(b"fake_image", "cocina", dual_enabled=True)
+
+        assert "error" in result
+
+
+# ═══════════════════════════════════════════════════════
+# M2 validation
+# ═══════════════════════════════════════════════════════
+
+class TestM2Validation:
+    def test_m2_warning_when_mismatch(self):
+        result = _build_single_result(_sample_result(m2=1.50), "SOLO_SONNET")
+        warning = _check_m2(result, planilla_m2=2.50)
+        assert warning is not None
+        assert "no coincide" in warning
+
+    def test_m2_no_warning_when_close(self):
+        result = _build_single_result(_sample_result(m2=0.93), "SOLO_SONNET")
+        # m2_total ≈ 0.93 + zocalo area ≈ 1.04
+        warning = _check_m2(result, planilla_m2=1.04)
+        assert warning is None
+
+    def test_m2_skip_when_null(self):
+        result = _build_single_result(_sample_result(), "SOLO_SONNET")
+        warning = _check_m2(result, planilla_m2=None)
+        assert warning is None
+
+
+# ═══════════════════════════════════════════════════════
+# Context injection
+# ═══════════════════════════════════════════════════════
+
+class TestBuildVerifiedContext:
+    def test_contains_verified_header(self):
+        data = _build_single_result(_sample_result(), "SOLO_SONNET")
+        ctx = build_verified_context(data)
+        assert "VERIFICADAS" in ctx
+        assert "FUENTE DE VERDAD" in ctx
+
+    def test_contains_measurements(self):
+        data = _build_single_result(
+            _sample_result(largo=1.55, ancho=0.60, m2=0.93),
+            "SOLO_SONNET",
+        )
+        ctx = build_verified_context(data)
+        assert "1.55" in ctx
+        assert "0.6" in ctx
+        assert "0.93" in ctx
+
+    def test_contains_zocalos(self):
+        data = _build_single_result(
+            _sample_result(zocalos=[{"lado": "frontal", "ml": 1.74, "alto_m": 0.07}]),
+            "SOLO_SONNET",
+        )
+        ctx = build_verified_context(data)
+        assert "frontal" in ctx
+        assert "1.74" in ctx
+
+
+# ═══════════════════════════════════════════════════════
+# Compare float helper
+# ═══════════════════════════════════════════════════════
+
+class TestCompareFloat:
+    def test_exact_match(self):
+        status, val = _compare_float(1.55, 1.55)
+        assert status == "CONFIRMADO"
+        assert val == 1.55
+
+    def test_small_delta(self):
+        status, val = _compare_float(1.55, 1.53)  # 1.3% diff
+        assert status == "ALERTA"
+        assert val == pytest.approx(1.54, abs=0.01)
+
+    def test_large_delta(self):
+        status, val = _compare_float(1.55, 1.20)  # 22% diff
+        assert status == "CONFLICTO"
+        assert val is None
+
+    def test_both_zero(self):
+        status, val = _compare_float(0, 0)
+        assert status == "CONFIRMADO"

--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -236,6 +236,11 @@ export default function QuotePage() {
             acc = `__ZONE_SELECTOR__${chunk.content}`;
             setMessages(p => p.map(m => m.id === aid ? { ...m, content: acc, isStreaming: false } : m));
           } catch { /* ignore parse errors */ }
+        } else if (chunk.type === "dual_read_result") {
+          try {
+            acc = `__DUAL_READ__${chunk.content}`;
+            setMessages(p => p.map(m => m.id === aid ? { ...m, content: acc, isStreaming: false } : m));
+          } catch { /* ignore parse errors */ }
         } else if (chunk.type === "action") {
           if (fromDetail) setInlineActionText(chunk.content); else setActionText(chunk.content);
         } else if (chunk.type === "done") {
@@ -398,6 +403,8 @@ export default function QuotePage() {
               })();
               // Short confirmation messages render as compact badges
               const isShortConfirm = msg.role === "user" && /^(confirmo|sí|si|dale|ok|listo)$/i.test(msg.content.trim());
+              // Hide DUAL_READ_CONFIRMED raw JSON — show green pill instead
+              const isDualConfirm = msg.role === "user" && msg.content.startsWith("[DUAL_READ_CONFIRMED]");
 
               // Hide ghost messages (dots from sanitization)
               const isDot = msg.content.trim() === "." || msg.content.trim() === "..";
@@ -405,7 +412,13 @@ export default function QuotePage() {
 
               return (
                 <div key={msg.id}>
-                  {isShortConfirm ? (
+                  {isDualConfirm ? (
+                    <div className="flex justify-end">
+                      <span className="px-3 py-1 rounded-full text-[11px] font-medium bg-grn/20 text-grn border border-grn/30">
+                        Medidas verificadas {"\u2705"}
+                      </span>
+                    </div>
+                  ) : isShortConfirm ? (
                     <div className="flex justify-end">
                       <span className="px-3 py-1 rounded-full text-[11px] font-medium bg-grn/20 text-grn border border-grn/30">
                         {msg.content.trim()}
@@ -429,6 +442,25 @@ export default function QuotePage() {
                                   } catch (err) {
                                     console.error("zone-select failed:", err);
                                   }
+                                }}
+                              />
+                            </div>
+                          </div>
+                        );
+                      } catch { return null; }
+                    })()
+                  ) : msg.content.startsWith("__DUAL_READ__") ? (
+                    (() => {
+                      try {
+                        const DualReadResult = require("@/components/chat/DualReadResult").default;
+                        const dualData = JSON.parse(msg.content.replace("__DUAL_READ__", ""));
+                        return (
+                          <div className="msg-anim flex gap-3 items-start">
+                            <div className="max-w-full">
+                              <DualReadResult
+                                data={dualData}
+                                onConfirm={(verified: unknown) => {
+                                  send(`[DUAL_READ_CONFIRMED]${JSON.stringify(verified)}`);
                                 }}
                               />
                             </div>

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -1,0 +1,198 @@
+"use client";
+import React, { useState } from "react";
+
+interface FieldValue {
+  opus?: number | null;
+  sonnet?: number | null;
+  valor: number;
+  status: string;
+}
+
+interface Zocalo {
+  lado: string;
+  opus_ml?: number | null;
+  sonnet_ml?: number | null;
+  ml: number;
+  alto_m: number;
+  status: string;
+}
+
+interface Tramo {
+  id: string;
+  descripcion: string;
+  largo_m: FieldValue;
+  ancho_m: FieldValue;
+  m2: FieldValue;
+  zocalos: Zocalo[];
+  frentin: unknown[];
+  regrueso: unknown[];
+}
+
+interface Sector {
+  id: string;
+  tipo: string;
+  tramos: Tramo[];
+  m2_total: FieldValue;
+  ambiguedades: string[];
+}
+
+interface DualReadData {
+  sectores: Sector[];
+  requires_human_review: boolean;
+  conflict_fields: string[];
+  source: string;
+  m2_warning?: string | null;
+}
+
+interface Props {
+  data: DualReadData;
+  onConfirm: (verified: DualReadData) => void;
+}
+
+const STATUS_ICONS: Record<string, string> = {
+  CONFIRMADO: "\u2705",
+  ALERTA: "\u26A0\uFE0F",
+  CONFLICTO: "\u274C",
+  DUDOSO: "\uD83D\uDFE0",
+  SOLO_SONNET: "\uD83D\uDD35",
+  SOLO_OPUS: "\uD83D\uDFE3",
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  CONFIRMADO: "text-green-400",
+  ALERTA: "text-yellow-400",
+  CONFLICTO: "text-red-400",
+  DUDOSO: "text-orange-400",
+  SOLO_SONNET: "text-blue-400",
+  SOLO_OPUS: "text-purple-400",
+};
+
+function FieldRow({ label, field, onEdit }: {
+  label: string;
+  field: FieldValue;
+  onEdit?: (val: number) => void;
+}) {
+  const icon = STATUS_ICONS[field.status] || "";
+  const color = STATUS_COLORS[field.status] || "text-t2";
+  const editable = field.status === "CONFLICTO" || field.status === "DUDOSO";
+
+  return (
+    <div className="flex items-center gap-2 py-1 px-2 text-[13px]">
+      <span className="w-5 text-center">{icon}</span>
+      <span className="text-t3 w-24 shrink-0">{label}</span>
+      {editable ? (
+        <div className="flex gap-2 items-center">
+          {field.opus != null && (
+            <button
+              className="px-2 py-0.5 rounded text-xs border border-purple-400/30 text-purple-400 hover:bg-purple-400/10"
+              onClick={() => onEdit?.(field.opus!)}
+            >
+              Opus: {field.opus}
+            </button>
+          )}
+          {field.sonnet != null && (
+            <button
+              className="px-2 py-0.5 rounded text-xs border border-blue-400/30 text-blue-400 hover:bg-blue-400/10"
+              onClick={() => onEdit?.(field.sonnet!)}
+            >
+              Sonnet: {field.sonnet}
+            </button>
+          )}
+          <input
+            type="number"
+            step="0.01"
+            defaultValue={field.valor}
+            className="w-20 px-1.5 py-0.5 bg-s1 border border-b2 rounded text-xs text-t1"
+            onChange={(e) => onEdit?.(parseFloat(e.target.value) || 0)}
+          />
+        </div>
+      ) : (
+        <span className={`${color} font-medium`}>
+          {field.valor}m
+          {field.status === "ALERTA" && " (promedio)"}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export default function DualReadResult({ data, onConfirm }: Props) {
+  const [editedData, setEditedData] = useState<DualReadData>(data);
+
+  const updateField = (sectorIdx: number, tramoIdx: number, field: string, val: number) => {
+    setEditedData(prev => {
+      const next = JSON.parse(JSON.stringify(prev));
+      const tramo = next.sectores[sectorIdx].tramos[tramoIdx];
+      if (field.startsWith("zocalo_")) {
+        const zIdx = parseInt(field.split("_")[1]);
+        tramo.zocalos[zIdx].ml = val;
+      } else {
+        tramo[field].valor = val;
+      }
+      return next;
+    });
+  };
+
+  const hasConflicts = editedData.requires_human_review;
+
+  return (
+    <div className="rounded-[10px] border border-b1 bg-s2 p-3 my-2 max-w-lg">
+      <div className="text-[13px] font-semibold text-t1 mb-2">
+        {data.source === "DUAL" ? "Doble lectura del plano" : `Lectura ${data.source.replace("SOLO_", "")}`}
+      </div>
+
+      {data.m2_warning && (
+        <div className="text-[12px] text-yellow-400 bg-yellow-400/10 rounded px-2 py-1 mb-2">
+          {data.m2_warning}
+        </div>
+      )}
+
+      {editedData.sectores.map((sector, si) => (
+        <div key={sector.id} className="mb-3">
+          <div className="text-[12px] text-t3 uppercase tracking-wide mb-1">
+            {sector.id} — {sector.tipo}
+          </div>
+          {sector.tramos.map((tramo, ti) => (
+            <div key={tramo.id} className="ml-2 border-l border-b1 pl-2 mb-2">
+              <div className="text-[12px] text-t2 font-medium mb-1">{tramo.descripcion || tramo.id}</div>
+              <FieldRow label="Largo" field={tramo.largo_m} onEdit={(v) => updateField(si, ti, "largo_m", v)} />
+              <FieldRow label="Ancho" field={tramo.ancho_m} onEdit={(v) => updateField(si, ti, "ancho_m", v)} />
+              <FieldRow label="m\u00B2" field={tramo.m2} onEdit={(v) => updateField(si, ti, "m2", v)} />
+              {tramo.zocalos.map((z, zi) => (
+                <div key={zi} className="flex items-center gap-2 py-1 px-2 text-[13px]">
+                  <span className="w-5 text-center">{STATUS_ICONS[z.status] || ""}</span>
+                  <span className="text-t3 w-24 shrink-0">Z\u00F3c. {z.lado}</span>
+                  {z.status === "CONFLICTO" || z.status === "DUDOSO" ? (
+                    <input
+                      type="number"
+                      step="0.01"
+                      defaultValue={z.ml}
+                      className="w-20 px-1.5 py-0.5 bg-s1 border border-b2 rounded text-xs text-t1"
+                      onChange={(e) => updateField(si, ti, `zocalo_${zi}`, parseFloat(e.target.value) || 0)}
+                    />
+                  ) : (
+                    <span className={STATUS_COLORS[z.status] || "text-t2"}>
+                      {z.ml}ml \u00D7 {z.alto_m}m
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          ))}
+          {sector.ambiguedades.length > 0 && (
+            <div className="text-[11px] text-orange-400 mt-1 ml-2">
+              {sector.ambiguedades.map((a, i) => <div key={i}>\u26A0\uFE0F {a}</div>)}
+            </div>
+          )}
+        </div>
+      ))}
+
+      <button
+        className="w-full mt-2 py-2 rounded-lg text-[13px] font-medium bg-green-600 hover:bg-green-500 text-white transition"
+        onClick={() => onConfirm(editedData)}
+      >
+        Confirmar medidas
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -133,8 +133,6 @@ export default function DualReadResult({ data, onConfirm }: Props) {
     });
   };
 
-  const hasConflicts = editedData.requires_human_review;
-
   return (
     <div className="rounded-[10px] border border-b1 bg-s2 p-3 my-2 max-w-lg">
       <div className="text-[13px] font-semibold text-t1 mb-2">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -268,7 +268,7 @@ export async function updateUsageBudget(data: { monthly_budget_usd?: number; ena
 // ── Chat SSE ──────────────────────────────────────────────────────────────────
 
 export interface ChatChunk {
-  type: "text" | "action" | "done" | "zone_selector";
+  type: "text" | "action" | "done" | "zone_selector" | "dual_read_result";
   content: string;
 }
 


### PR DESCRIPTION
## Summary
Lectura dual de planos: Sonnet primero (rápido), si duda → Opus. Reconciliación determinística campo por campo. Operador confirma → medidas inyectadas en contexto.

### Backend
- `dual_reader.py`: prompt estricto con enum de lados, Sonnet first, reconciliación `==`
- `agent.py`: integración SSE + handler de confirmación + inyección en system prompt
- `config.json`: flag `dual_read_enabled` (true=dual, false=solo Sonnet)

### Frontend
- `DualReadResult.tsx`: tabla ✅⚠️❌, campos editables, botón confirmar
- `page.tsx`: SSE handler + filtro de `[DUAL_READ_CONFIRMED]` (muestra pill verde)

### Tests
21 tests: reconciliación (confirmado/alerta/conflicto/dudoso), flow control (Sonnet confiado/dudoso, timeout Opus, disabled), M2 warning, context injection.

⚠️ **NO MERGEAR** — pendiente de revisión manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)