### PR TITLE
fix: unicode labels + force Opus when m2 doesn't match planilla

### DIFF
--- a/api/app/modules/quote_engine/dual_reader.py
+++ b/api/app/modules/quote_engine/dual_reader.py
@@ -457,12 +457,18 @@ async def dual_read_crop(
     )
     logger.info(f"[dual-read] Sonnet confidence: {min_confidence:.2f}")
 
-    if min_confidence >= SONNET_CONFIDENCE_SKIP_OPUS:
-        # Sonnet is confident → skip Opus, save cost
-        logger.info(f"[dual-read] Sonnet confident ≥{SONNET_CONFIDENCE_SKIP_OPUS} → skipping Opus")
-        result = _build_single_result(sonnet_result, "SOLO_SONNET")
-        result["m2_warning"] = _check_m2(result, planilla_m2)
-        return result
+    # Check M2 mismatch with planilla BEFORE deciding to skip Opus
+    _sonnet_preview = _build_single_result(sonnet_result, "SOLO_SONNET")
+    _m2_mismatch = _check_m2(_sonnet_preview, planilla_m2)
+
+    if min_confidence >= SONNET_CONFIDENCE_SKIP_OPUS and not _m2_mismatch:
+        # Sonnet is confident AND m2 matches planilla → skip Opus, save cost
+        logger.info(f"[dual-read] Sonnet confident ≥{SONNET_CONFIDENCE_SKIP_OPUS} + m2 OK → skipping Opus")
+        _sonnet_preview["m2_warning"] = None
+        return _sonnet_preview
+
+    if _m2_mismatch:
+        logger.warning(f"[dual-read] M2 mismatch with planilla → forcing Opus call: {_m2_mismatch}")
 
     # Step 3: Sonnet unsure → call Opus with timeout
     logger.info(f"[dual-read] Sonnet unsure ({min_confidence:.2f}) → calling Opus (timeout={OPUS_TIMEOUT_SECONDS}s)...")

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -155,11 +155,11 @@ export default function DualReadResult({ data, onConfirm }: Props) {
               <div className="text-[12px] text-t2 font-medium mb-1">{tramo.descripcion || tramo.id}</div>
               <FieldRow label="Largo" field={tramo.largo_m} onEdit={(v) => updateField(si, ti, "largo_m", v)} />
               <FieldRow label="Ancho" field={tramo.ancho_m} onEdit={(v) => updateField(si, ti, "ancho_m", v)} />
-              <FieldRow label="m\u00B2" field={tramo.m2} onEdit={(v) => updateField(si, ti, "m2", v)} />
+              <FieldRow label="m²" field={tramo.m2} onEdit={(v) => updateField(si, ti, "m2", v)} />
               {tramo.zocalos.map((z, zi) => (
                 <div key={zi} className="flex items-center gap-2 py-1 px-2 text-[13px]">
                   <span className="w-5 text-center">{STATUS_ICONS[z.status] || ""}</span>
-                  <span className="text-t3 w-24 shrink-0">Z\u00F3c. {z.lado}</span>
+                  <span className="text-t3 w-24 shrink-0">Zóc. {z.lado}</span>
                   {z.status === "CONFLICTO" || z.status === "DUDOSO" ? (
                     <input
                       type="number"


### PR DESCRIPTION
Sonnet confidence is unreliable when calculated m2 contradicts planilla — now forces Opus in that case.