### PR TITLE
feat: operator retry button for Opus second pass

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1609,6 +1609,16 @@ class AgentService:
                                         dual_enabled=_dual_enabled,
                                     )
                                     if not _dual_result.get("error"):
+                                        # Save crop to disk for potential Opus retry
+                                        try:
+                                            from app.core.static import OUTPUT_DIR as _OUT
+                                            _crop_dir = _OUT / quote_id
+                                            _crop_dir.mkdir(parents=True, exist_ok=True)
+                                            _crop_path = _crop_dir / "dual_read_crop.jpg"
+                                            _crop_path.write_bytes(_draw_bytes)
+                                            _dual_result["_crop_path"] = str(_crop_path)
+                                        except Exception as e:
+                                            logging.warning(f"[dual-read] Failed to save crop: {e}")
                                         # Send to frontend
                                         yield {"type": "dual_read_result", "content": json.dumps(_dual_result, ensure_ascii=False)}
                                         # Store in quote breakdown
@@ -1618,6 +1628,8 @@ class AgentService:
                                             if _q:
                                                 _bd = dict(_q.quote_breakdown or {})
                                                 _bd["dual_read_result"] = _dual_result
+                                                _bd["dual_read_planilla_m2"] = _planilla_data.m2
+                                                _bd["dual_read_crop_label"] = _planilla_data.ubicacion or "cocina"
                                                 await db.execute(update(Quote).where(Quote.id == quote_id).values(quote_breakdown=_bd))
                                                 await db.commit()
                                         except Exception as e:

--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -962,6 +962,77 @@ async def zone_select(
     return {"ok": True, "bbox_px": bbox_px, "image_size": [real_w, real_h]}
 
 
+@router.post("/quotes/{quote_id}/dual-read-retry")
+async def dual_read_retry(
+    quote_id: str,
+    db: AsyncSession = Depends(get_db),
+):
+    """Operator-triggered second pass with Opus when measurements don't match.
+
+    Called from DualReadResult component when operator clicks
+    'Las medidas no coinciden' button. Uses the saved crop to call Opus
+    and reconcile with the previously saved Sonnet result.
+    """
+    import logging
+    from app.modules.quote_engine.dual_reader import _call_vision, reconcile, _check_m2
+    from app.core.config import settings
+    from app.modules.agent.tools.catalog_tool import get_ai_config
+
+    result = await db.execute(select(Quote).where(Quote.id == quote_id))
+    quote = result.scalar_one_or_none()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Quote not found")
+
+    bd = quote.quote_breakdown or {}
+    prev_result = bd.get("dual_read_result")
+    if not prev_result:
+        raise HTTPException(status_code=400, detail="No prior dual read result found")
+
+    crop_path = prev_result.get("_crop_path")
+    if not crop_path:
+        raise HTTPException(status_code=400, detail="Crop not saved — cannot retry")
+
+    import os
+    if not os.path.exists(crop_path):
+        raise HTTPException(status_code=400, detail="Crop file missing on disk")
+
+    with open(crop_path, "rb") as f:
+        crop_bytes = f.read()
+
+    # Call Opus directly
+    opus_model = get_ai_config().get("opus_model", "claude-opus-4-6")
+    logging.info(f"[dual-read-retry] Quote {quote_id}: calling Opus for second opinion")
+    opus_result = await _call_vision(crop_bytes, opus_model, timeout=30)
+
+    if opus_result.get("error"):
+        raise HTTPException(status_code=500, detail=f"Opus failed: {opus_result['error']}")
+
+    # Retrieve original Sonnet result (saved as _sonnet_raw in prev result)
+    sonnet_raw = prev_result.get("_sonnet_raw")
+    planilla_m2 = bd.get("dual_read_planilla_m2")
+
+    if sonnet_raw:
+        # Reconcile Opus with original Sonnet
+        new_result = reconcile(opus_result, sonnet_raw)
+        new_result["source"] = "DUAL"
+    else:
+        # No original Sonnet raw — just return Opus alone
+        from app.modules.quote_engine.dual_reader import _build_single_result
+        new_result = _build_single_result(opus_result, "SOLO_OPUS")
+
+    new_result["m2_warning"] = _check_m2(new_result, planilla_m2)
+    new_result["_crop_path"] = crop_path
+    new_result["_retry"] = True
+
+    # Save updated result
+    bd["dual_read_result"] = new_result
+    await db.execute(update(Quote).where(Quote.id == quote_id).values(quote_breakdown=bd))
+    await db.commit()
+
+    logging.info(f"[dual-read-retry] Quote {quote_id}: Opus retry complete, source={new_result['source']}")
+    return new_result
+
+
 # ── CHAT — SSE STREAMING ──────────────────────────────────────────────────────
 
 @router.post("/quotes/{quote_id}/chat")

--- a/api/app/modules/quote_engine/dual_reader.py
+++ b/api/app/modules/quote_engine/dual_reader.py
@@ -465,6 +465,7 @@ async def dual_read_crop(
         # Sonnet is confident AND m2 matches planilla → skip Opus, save cost
         logger.info(f"[dual-read] Sonnet confident ≥{SONNET_CONFIDENCE_SKIP_OPUS} + m2 OK → skipping Opus")
         _sonnet_preview["m2_warning"] = None
+        _sonnet_preview["_sonnet_raw"] = sonnet_result  # preserve for operator retry
         return _sonnet_preview
 
     if _m2_mismatch:
@@ -479,12 +480,14 @@ async def dual_read_crop(
         logger.warning(f"[dual-read] Opus failed: {opus_result['error']} → using Sonnet only")
         result = _build_single_result(sonnet_result, "SOLO_SONNET")
         result["m2_warning"] = _check_m2(result, planilla_m2)
+        result["_sonnet_raw"] = sonnet_result
         return result
 
     # Step 4: Both succeeded → reconcile
     logger.info(f"[dual-read] Both models responded → reconciling...")
     reconciled = reconcile(opus_result, sonnet_result)
     reconciled["m2_warning"] = _check_m2(reconciled, planilla_m2)
+    reconciled["_sonnet_raw"] = sonnet_result
     return reconciled
 
 

--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -459,8 +459,13 @@ export default function QuotePage() {
                             <div className="max-w-full">
                               <DualReadResult
                                 data={dualData}
+                                quoteId={String(id)}
                                 onConfirm={(verified: unknown) => {
                                   send(`[DUAL_READ_CONFIRMED]${JSON.stringify(verified)}`);
+                                }}
+                                onRetry={(newData: unknown) => {
+                                  const updated = `__DUAL_READ__${JSON.stringify(newData)}`;
+                                  setMessages(prev => prev.map(m => m.id === msg.id ? { ...m, content: updated } : m));
                                 }}
                               />
                             </div>

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -42,11 +42,14 @@ interface DualReadData {
   conflict_fields: string[];
   source: string;
   m2_warning?: string | null;
+  _retry?: boolean;
 }
 
 interface Props {
   data: DualReadData;
+  quoteId: string;
   onConfirm: (verified: DualReadData) => void;
+  onRetry?: (newData: DualReadData) => void;
 }
 
 const STATUS_ICONS: Record<string, string> = {
@@ -116,7 +119,33 @@ function FieldRow({ label, field, onEdit }: {
   );
 }
 
-export default function DualReadResult({ data, onConfirm }: Props) {
+export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Props) {
+  const [retrying, setRetrying] = useState(false);
+  const [retryError, setRetryError] = useState<string | null>(null);
+
+  const handleRetry = async () => {
+    setRetrying(true);
+    setRetryError(null);
+    try {
+      const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
+      const res = await fetch(`${API_URL}/api/quotes/${quoteId}/dual-read-retry`, {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.detail || `HTTP ${res.status}`);
+      }
+      const newData = await res.json();
+      if (onRetry) onRetry(newData);
+    } catch (e: unknown) {
+      setRetryError(e instanceof Error ? e.message : "Error");
+    } finally {
+      setRetrying(false);
+    }
+  };
+
+
   const [editedData, setEditedData] = useState<DualReadData>(data);
 
   const updateField = (sectorIdx: number, tramoIdx: number, field: string, val: number) => {
@@ -179,11 +208,22 @@ export default function DualReadResult({ data, onConfirm }: Props) {
           ))}
           {sector.ambiguedades.length > 0 && (
             <div className="text-[11px] text-orange-400 mt-1 ml-2">
-              {sector.ambiguedades.map((a, i) => <div key={i}>\u26A0\uFE0F {a}</div>)}
+              {sector.ambiguedades.map((a, i) => <div key={i}>⚠️ {a}</div>)}
             </div>
           )}
         </div>
       ))}
+
+      {data.source !== "DUAL" && !data._retry && (
+        <button
+          className="w-full mt-2 py-2 rounded-lg text-[12px] font-medium bg-orange-600/20 hover:bg-orange-600/30 border border-orange-600/40 text-orange-200 transition disabled:opacity-50"
+          onClick={handleRetry}
+          disabled={retrying}
+        >
+          {retrying ? "Consultando a Opus..." : "⚠️ Las medidas no coinciden — verificar con Opus"}
+        </button>
+      )}
+      {retryError && <div className="text-[11px] text-red-400 mt-1">{retryError}</div>}
 
       <button
         className="w-full mt-2 py-2 rounded-lg text-[13px] font-medium bg-green-600 hover:bg-green-500 text-white transition"


### PR DESCRIPTION
Solves the 'planilla has no m2' case. Operator sees Sonnet result + button 'Las medidas no coinciden — verificar con Opus'. Click → endpoint calls Opus with saved crop → reconciles with Sonnet → updates UI.