### PR TITLE
fix: UnboundLocalError en generate_documents cuando falla la generación

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -2947,6 +2947,10 @@ class AgentService:
                 _cur = _qr.scalar_one_or_none()
                 existing_drive_url = _cur.drive_url if _cur else None
 
+                first_drive_url = None
+                first_drive_file_id = None
+                _drive_pdf_url = None
+                _drive_excel_url = None
                 if result.get("ok"):
                     # Only promote status to VALIDATED on first generation
                     # (draft/pending). On regeneration (already validated/sent),


### PR DESCRIPTION
## Summary
- `first_drive_url` (y `_drive_pdf_url`/`_drive_excel_url`) solo se definían dentro del `if result.get("ok")`, pero se usaban después en línea 3064 → `UnboundLocalError` cuando la generación fallaba.
- Se inicializan a `None` antes del branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)