### PR TITLE
fix: edificio bugs — merma, flete count, dims validation

### DIFF
--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -244,8 +244,16 @@ def list_pieces(pieces: list, is_edificio: bool = False) -> dict:
     }
 
 
-def calculate_merma(m2_needed: float, material_type: str) -> dict:
-    """Calculate merma for synthetic materials."""
+def calculate_merma(m2_needed: float, material_type: str, is_edificio: bool = False) -> dict:
+    """Calculate merma for synthetic materials.
+
+    Edificios NEVER apply merma — the operator handles piece cutting
+    per tipología manually. Only residential quotes have merma logic.
+    """
+    # Edificio: no merma regardless of material
+    if is_edificio:
+        return {"aplica": False, "desperdicio": 0, "sobrante_m2": 0, "motivo": "Edificio — sin merma"}
+
     mat_lower = material_type.lower()
 
     # Negro Brasil: never merma
@@ -361,6 +369,22 @@ def calculate_quote(input_data: dict) -> dict:
             if auto_ml > 0:
                 input_data["frentin_ml"] = round(auto_ml, 2)
                 logging.info(f"Edificio guardrail: auto-detected {auto_ml:.2f} ml of frentín from piece descriptions")
+
+        # Validate pieces have largo and prof/dim2 — never accept pre-multiplied m² only.
+        # If operator passes only m² without dimensions, the breakdown is opaque and the
+        # agent will invent fake dimensions (e.g. "6.0 × 1.0" for a 6 m² piece).
+        _pieces_missing_dims = []
+        for _idx, _p in enumerate((pp if isinstance(pp, dict) else pp.model_dump() for pp in pieces)):
+            _largo = _p.get("largo", 0) or 0
+            _prof = _p.get("prof", 0) or _p.get("dim2", 0) or _p.get("ancho", 0) or 0
+            if _largo <= 0 or _prof <= 0:
+                _pieces_missing_dims.append(_p.get("description", f"pieza #{_idx}"))
+        if _pieces_missing_dims:
+            warnings.append(
+                "⛔ Edificio: todas las piezas deben tener largo y prof (no solo m²). "
+                f"Faltan dimensiones en: {', '.join(_pieces_missing_dims[:5])}. "
+                "Pedí al operador las medidas completas del despiece (ej: 2.34 × 0.62)."
+            )
     date_str = input_data.get("date") or datetime.now().strftime("%d.%m.%Y")
 
     # 1. Find material
@@ -383,7 +407,7 @@ def calculate_quote(input_data: dict) -> dict:
     total_m2, piece_details = calculate_m2([p if isinstance(p, dict) else p.model_dump() for p in pieces])
 
     # 3. Merma
-    merma = calculate_merma(total_m2, mat_result.get("name", material_name))
+    merma = calculate_merma(total_m2, mat_result.get("name", material_name), is_edificio=is_edificio)
 
     # 4. Auto-apply architect discount if detected
     if input_data.get("_auto_architect_discount") and not discount_pct:
@@ -468,10 +492,15 @@ def calculate_quote(input_data: dict) -> dict:
             flete_price = flete_result.get("price_ars", 0)
             flete_base = flete_result.get("price_ars_base", 0)
             if is_edificio:
-                physical_pieces = [p for p in (pp if isinstance(pp, dict) else pp.model_dump() for pp in pieces)
-                                   if not any(kw in (p.get("description") or "").lower() for kw in ["faldón", "faldon", "frentín", "frentin"])]
-                num_pieces = len(physical_pieces)
-                _per_trip = cfg("building.flete_mesadas_per_trip", 8)
+                # Sum quantity per piece, not just len() — a DC-04 × 8 is 8 physical pieces, not 1.
+                # Also exclude zócalos (they travel with mesadas, not as separate pieces).
+                physical_pieces = [
+                    p for p in (pp if isinstance(pp, dict) else pp.model_dump() for pp in pieces)
+                    if not any(kw in (p.get("description") or "").lower()
+                               for kw in ["faldón", "faldon", "frentín", "frentin", "zócalo", "zocalo"])
+                ]
+                num_pieces = sum(int(p.get("quantity", 1) or 1) for p in physical_pieces)
+                _per_trip = cfg("building.flete_mesadas_per_trip", 6)
                 flete_qty = math.ceil(num_pieces / _per_trip)
                 flete_qty = max(1, flete_qty)
                 logging.info(f"Edificio flete: {num_pieces} piezas físicas ÷ {_per_trip} = {flete_qty} fletes")

--- a/api/catalog/config.json
+++ b/api/catalog/config.json
@@ -94,7 +94,7 @@
   "building": {
     "_comment": "Reglas para obras de edificio",
     "colocacion": false,
-    "flete_mesadas_per_trip": 8,
+    "flete_mesadas_per_trip": 6,
     "discount_percentage": 18,
     "discount_min_m2": 15
   },

--- a/api/rules/quote-process-buildings.md
+++ b/api/rules/quote-process-buildings.md
@@ -117,6 +117,26 @@ En edificios NO agregar leyenda "(SE REALIZA EN 2 TRAMOS)" — las tipologías
 ya vienen listadas como DC-02 X 6, DC-03 X 8, etc. y la leyenda genera ruido.
 Alzada en enunciado → 1 TOMAS.
 
+### ⛔ Sin merma en edificios
+Edificios NUNCA llevan merma. El operador maneja el corte por tipología
+manualmente. `calculate_quote()` con `is_edificio=True` fuerza
+`merma.aplica = false` automáticamente.
+
+### ⛔ Despiece completo — largo y prof obligatorios
+NUNCA aceptar solo m² por pieza. Cada tipología debe tener dimensiones
+completas (ej: `largo: 2.34, prof: 0.62`). Si el operador/planilla solo
+da m² sin dimensiones:
+1. Pedir al operador: "¿Cuáles son las medidas completas (largo × prof)
+   de cada tipología?"
+2. NO inventar dimensiones que multipliquen al m² (ej: 6.00 × 1.00).
+3. `calculate_quote()` emite warning si detecta piezas sin `largo` o `prof`.
+
+### Flete edificio
+`ceil(piezas_fisicas_totales / flete_mesadas_per_trip)`.
+- Contar unidades físicas reales: DC-04 × 8 son 8 piezas, no 1.
+- Zócalos viajan con mesadas, NO cuentan como piezas para flete.
+- Default `flete_mesadas_per_trip = 6` (config.json, building.flete_mesadas_per_trip).
+
 ### Material no encontrado
 Informar operador. Preguntar cual usar — no sugerir alternativas.
 

--- a/api/tests/test_edificio_parser.py
+++ b/api/tests/test_edificio_parser.py
@@ -292,7 +292,8 @@ class TestComputeEdificioAggregates:
     def test_flete(self):
         _, _, summary = _get_full_pipeline()
         physical = summary["totals"]["pieces_physical_total"]
-        assert summary["totals"]["flete_qty"] == math.ceil(physical / 8)
+        # flete_mesadas_per_trip changed from 8 to 6 (operator's rule)
+        assert summary["totals"]["flete_qty"] == math.ceil(physical / 6)
 
     def test_escalones_quantity(self):
         _, norm, summary = _get_full_pipeline()

--- a/api/tests/test_edificio_paso2.py
+++ b/api/tests/test_edificio_paso2.py
@@ -59,7 +59,8 @@ class TestESHPaso2:
     def test_flete_qty(self, result):
         mo = next((m for m in result["mo_items"] if "flete" in m["desc"].lower()), None)
         assert mo is not None
-        assert mo["qty"] == 7
+        # flete_mesadas_per_trip: 8→6. Was ceil(49/8)=7, now ceil(49/6)=9.
+        assert mo["qty"] == 9
 
     # ── No forbidden content ─────────────────────────────────────────────
 

--- a/api/tests/test_five_fixes.py
+++ b/api/tests/test_five_fixes.py
@@ -338,3 +338,114 @@ class TestFleteWarnings:
         result = calculate_quote(_base_input(skip_flete=True))
         assert result["ok"]
         assert result.get("warnings") is None or len(result.get("warnings", [])) == 0
+
+
+# ══════════════════════════════════════════════════════════════════
+# Edificio fixes: merma + flete count + dims validation
+# ══════════════════════════════════════════════════════════════════
+
+class TestEdificioMerma:
+    def test_edificio_never_applies_merma(self):
+        """Edificios NEVER apply merma regardless of material."""
+        result = calculate_quote(_base_input(
+            is_edificio=True,
+            pieces=[{"description": "DC-02 mesada", "largo": 3.0, "prof": 1.0, "quantity": 2}],
+        ))
+        assert result["ok"]
+        assert result["merma"]["aplica"] is False
+        assert "edificio" in result["merma"]["motivo"].lower()
+
+    def test_residential_silestone_still_applies_merma(self):
+        """Residential Silestone must still apply merma (no regression)."""
+        result = calculate_quote(_base_input(
+            pieces=[{"description": "Mesada", "largo": 2.0, "prof": 0.6}],
+        ))
+        assert result["ok"]
+        # Silestone residential triggers merma logic (may or may not have sobrante)
+        assert "motivo" in result["merma"]
+
+    def test_calculate_merma_function_direct(self):
+        """Direct test of calculate_merma with is_edificio flag.
+
+        is_edificio=True short-circuits BEFORE any material classification:
+        even if the material would normally merma (Silestone with big desperdicio),
+        the edificio branch wins.
+        """
+        from app.modules.quote_engine.calculator import calculate_merma
+        # Size that triggers merma for Silestone (desperdicio > 1.0)
+        # Silestone uses media placa (2.10 m²). 1.3 m² → needs 1 media → desperdicio 0.80
+        # Use 2.8 m² → needs 2 medias = 4.20 → desperdicio 1.40 > 1.0 → aplica
+        result_edif = calculate_merma(2.8, "Silestone Blanco Norte", is_edificio=True)
+        assert result_edif["aplica"] is False
+        assert "edificio" in result_edif["motivo"].lower()
+        result_res = calculate_merma(2.8, "Silestone Blanco Norte", is_edificio=False)
+        assert result_res["aplica"] is True
+
+
+class TestEdificioFleteCount:
+    def test_flete_counts_quantity_not_descriptions(self):
+        """DC-04 × 8 must count as 8 physical pieces, not 1."""
+        # 25 total pieces (2+6+8+1+1+6+1) ÷ 6 per trip → 5 fletes
+        result = calculate_quote(_base_input(
+            is_edificio=True,
+            pileta=None,
+            pieces=[
+                {"description": "DC-02 mesada", "largo": 3.0, "prof": 1.0, "quantity": 2},
+                {"description": "DC-03 mesada", "largo": 2.96, "prof": 1.0, "quantity": 6},
+                {"description": "DC-04 mesada", "largo": 2.87, "prof": 1.0, "quantity": 8},
+                {"description": "DC-05 mesada", "largo": 1.17, "prof": 1.0, "quantity": 1},
+                {"description": "DC-06 mesada", "largo": 1.12, "prof": 1.0, "quantity": 1},
+                {"description": "DC-07 mesada", "largo": 2.60, "prof": 1.0, "quantity": 6},
+                {"description": "DC-08 mesada", "largo": 1.79, "prof": 1.0, "quantity": 1},
+            ],
+        ))
+        assert result["ok"]
+        flete_item = next((m for m in result["mo_items"] if "flete" in m["description"].lower()), None)
+        assert flete_item is not None, "flete mo_item missing"
+        assert flete_item["quantity"] == 5, (
+            f"25 pieces ÷ 6 per trip → ceil=5, got {flete_item['quantity']}"
+        )
+
+    def test_flete_excludes_zocalos(self):
+        """Zócalos travel with mesadas, don't count as separate pieces for flete."""
+        result = calculate_quote(_base_input(
+            is_edificio=True,
+            pileta=None,
+            pieces=[
+                {"description": "DC-02 mesada", "largo": 3.0, "prof": 1.0, "quantity": 2},
+                {"description": "DC-02 zócalo", "largo": 4.85, "alto": 0.075, "quantity": 2},
+            ],
+        ))
+        assert result["ok"]
+        flete_item = next((m for m in result["mo_items"] if "flete" in m["description"].lower()), None)
+        # 2 mesadas only → ceil(2/6) = 1
+        assert flete_item["quantity"] == 1
+
+
+class TestEdificioDimsValidation:
+    def test_missing_dims_produces_warning(self):
+        """Pieces without largo/prof in edificio must produce a warning."""
+        result = calculate_quote(_base_input(
+            is_edificio=True,
+            pieces=[
+                # Missing prof
+                {"description": "DC-02 mesada", "largo": 3.0, "quantity": 2},
+            ],
+        ))
+        assert result["ok"]
+        warnings = result.get("warnings", [])
+        assert any("largo y prof" in w.lower() or "dimensiones" in w.lower() for w in warnings), (
+            f"Expected validation warning, got: {warnings}"
+        )
+
+    def test_complete_dims_no_warning(self):
+        """Pieces with full largo + prof should not trigger this warning."""
+        result = calculate_quote(_base_input(
+            is_edificio=True,
+            pieces=[
+                {"description": "DC-02 mesada", "largo": 3.0, "prof": 1.0, "quantity": 2},
+            ],
+        ))
+        assert result["ok"]
+        warnings = result.get("warnings", [])
+        assert not any("largo y prof" in w.lower() for w in warnings)


### PR DESCRIPTION
## Causas raíz y fixes

### 1) Merma aplicada en edificios
`calculate_merma()` decidía solo por material. Ahora recibe `is_edificio=True` y retorna \`aplica=false\`.

### 2) Flete mal calculado (2 fletes en vez de 5)
- **(a)** Config: \`flete_mesadas_per_trip\` 8 → 6
- **(b)** Contaba descripciones (len), no unidades físicas (sum quantity). DC-04 × 8 debía contar como 8 piezas
- **(c)** Excluye zócalos (viajan con mesadas)

### 3) Dimensiones inventadas (6.0 × 1.0)
Agregada validación: si pieza edificio no tiene \`largo\` y \`prof\` → warning para que el agente pida medidas completas, no acepte solo m².

## Tests
- 7 tests nuevos en \`test_five_fixes.py\` (34 passing)
- 2 tests pre-existentes actualizados por cambio de divisor (8→6)
- 793 baseline tests OK

## Archivos
- \`api/app/modules/quote_engine/calculator.py\`
- \`api/catalog/config.json\`
- \`api/rules/quote-process-buildings.md\`
- \`api/tests/test_five_fixes.py\`
- \`api/tests/test_edificio_parser.py\` (assert actualizado)
- \`api/tests/test_edificio_paso2.py\` (assert actualizado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)