### PR TITLE
fix: DB crash rompe Paso 2 — VARCHAR(500) overflow en material

### DIFF
--- a/api/app/models/quote.py
+++ b/api/app/models/quote.py
@@ -19,7 +19,7 @@ class Quote(Base):
     id: Mapped[str] = mapped_column(String, primary_key=True)
     client_name: Mapped[str] = mapped_column(String(500))
     project: Mapped[str] = mapped_column(String(500))
-    material: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    material: Mapped[str | None] = mapped_column(Text, nullable=True)
     total_ars: Mapped[float | None] = mapped_column(Float, nullable=True)
     total_usd: Mapped[float | None] = mapped_column(Float, nullable=True)
     status: Mapped[QuoteStatus] = mapped_column(

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -479,13 +479,21 @@ def _extract_quote_info(user_message: str) -> dict:
         if kw in msg_lower:
             # Find the full material name around the keyword
             idx = msg_lower.index(kw)
-            # Grab surrounding words for context
+            # Grab surrounding words for context. Hard-cap both sides to
+            # prevent runaway extraction when message has no comma/space.
             start = max(0, user_message.rfind(" ", 0, max(0, idx - 1)) + 1)
-            end = user_message.find(",", idx)
-            if end == -1:
-                end = user_message.find(" con ", idx)
-            if end == -1:
-                end = min(len(user_message), idx + 30)
+            # Limit start to at most 10 chars before idx (avoid capturing
+            # markdown headers like "**MATERIAL:**" or prior lines).
+            start = max(start, idx - 10)
+            # End: prefer newline/comma/" con ", fallback to +40 chars
+            candidates = []
+            for delim in ["\n", "\r", ",", " con ", " — ", " - "]:
+                p = user_message.find(delim, idx)
+                if p != -1:
+                    candidates.append(p)
+            end = min(candidates) if candidates else min(len(user_message), idx + 40)
+            # Hard cap: material name never > 100 chars
+            end = min(end, idx + 100)
             info["material"] = user_message[start:end].strip()
             break
 
@@ -2769,12 +2777,25 @@ class AgentService:
             current_quote = result.scalar_one_or_none()
             if current_quote:
                 extracted = _extract_quote_info(user_message)
-                if not current_quote.client_name and extracted.get("client_name"):
-                    save_values["client_name"] = extracted["client_name"]
-                if not current_quote.material and extracted.get("material"):
-                    save_values["material"] = extracted["material"]
-                if not current_quote.project and extracted.get("project"):
-                    save_values["project"] = extracted["project"]
+                # DB columns are VARCHAR(500). Truncate defensively to prevent
+                # StringDataRightTruncationError when regex over-extracts a long span
+                # (e.g. operator paste with no comma delimiter hitting end-of-message).
+                _MAX_FIELD = 450
+                _cn = (extracted.get("client_name") or "")[:_MAX_FIELD]
+                _mat = (extracted.get("material") or "")[:_MAX_FIELD]
+                _prj = (extracted.get("project") or "")[:_MAX_FIELD]
+                # Sanitize: remove newlines and markdown noise from extracted values
+                import re as _re_clean
+                def _clean(s: str) -> str:
+                    s = _re_clean.sub(r"[\r\n]+", " ", s)
+                    s = _re_clean.sub(r"\*+", "", s)
+                    return s.strip()
+                if not current_quote.client_name and _cn:
+                    save_values["client_name"] = _clean(_cn)[:_MAX_FIELD]
+                if not current_quote.material and _mat:
+                    save_values["material"] = _clean(_mat)[:_MAX_FIELD]
+                if not current_quote.project and _prj:
+                    save_values["project"] = _clean(_prj)[:_MAX_FIELD]
 
             await db.execute(
                 update(Quote)

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -3328,34 +3328,94 @@ class AgentService:
                     logging.info(f"Auto-set skip_flete=True from conversation keywords for {save_to_qid}")
 
             # ── Paso 1 ↔ Paso 2 consistency guardrail ──
-            # If Paso 1 persisted pieces (via list_pieces), use them as source of truth.
-            # This prevents Claude from inventing a different despiece in Paso 2 when
-            # it got distracted by examples or lost context.
+            # Two layers:
+            #   A) paso1_pieces persisted by list_pieces (residencial — list_pieces siempre se llama)
+            #   B) operator_declared_m2 parseado del texto del operador (edificios — list_pieces deshabilitado)
             try:
                 _gq = await db.execute(select(Quote).where(Quote.id == save_to_qid))
                 _gquote = _gq.scalar_one_or_none()
                 if _gquote:
                     _gbd = _gquote.quote_breakdown or {}
+
+                    # Calculate m2 of what Claude is trying to pass now
+                    _current_m2 = 0
+                    for _p in inputs.get("pieces", []):
+                        _pl = _p.get("largo", 0) or 0
+                        _pp = _p.get("prof", 0) or _p.get("dim2", 0) or _p.get("alto", 0) or 0
+                        _pq = _p.get("quantity", 1) or 1
+                        _current_m2 += _pl * _pp * _pq
+
+                    # Layer A: residencial (list_pieces persisted)
                     _paso1_pieces = _gbd.get("paso1_pieces")
                     _paso1_m2 = _gbd.get("paso1_total_m2") or 0
                     if _paso1_pieces:
-                        # Calculate m2 of what Claude is trying to pass now
-                        _current_m2 = 0
-                        for _p in inputs.get("pieces", []):
-                            _pl = _p.get("largo", 0) or 0
-                            _pp = _p.get("prof", 0) or _p.get("dim2", 0) or _p.get("alto", 0) or 0
-                            _pq = _p.get("quantity", 1) or 1
-                            _current_m2 += _pl * _pp * _pq
                         _diff_m2 = abs(_current_m2 - _paso1_m2)
                         _diff_count = abs(len(inputs.get("pieces", [])) - len(_paso1_pieces))
                         if _diff_m2 > 0.5 or _diff_count > 0:
                             logging.error(
-                                f"[guardrail] PASO1↔PASO2 mismatch for {save_to_qid}: "
+                                f"[guardrail-A] PASO1↔PASO2 mismatch for {save_to_qid}: "
                                 f"paso1={len(_paso1_pieces)}p/{_paso1_m2:.2f}m² "
                                 f"vs paso2={len(inputs.get('pieces', []))}p/{_current_m2:.2f}m². "
                                 "OVERRIDING with paso1 pieces."
                             )
                             inputs["pieces"] = _paso1_pieces
+
+                    # Layer B: edificios — parse operator text for declared m²
+                    # Examples: "TOTAL MATERIAL: 66.57 m²", "Total: 74.10 m²", "Subtotal: 58.66 m²"
+                    import re as _re_m2op
+                    _op_text = ""
+                    if conversation_history:
+                        for _m in conversation_history:
+                            if _m.get("role") == "user":
+                                _c = _m.get("content", "")
+                                if isinstance(_c, str):
+                                    _op_text += " " + _c
+                                elif isinstance(_c, list):
+                                    for _b in _c:
+                                        if isinstance(_b, dict) and _b.get("type") == "text":
+                                            _op_text += " " + _b.get("text", "")
+                    _op_text += " " + (current_user_message or "")
+
+                    _total_patterns = [
+                        r'total\s+material[:\s]+([\d.,]+)\s*m[²2]',
+                        r'material\s+total[:\s]+([\d.,]+)\s*m[²2]',
+                        r'total[:\s]+([\d.,]+)\s*m[²2]',
+                    ]
+                    _declared_m2 = None
+                    for _pat in _total_patterns:
+                        _m = _re_m2op.search(_pat, _op_text, _re_m2op.IGNORECASE)
+                        if _m:
+                            try:
+                                _declared_m2 = float(_m.group(1).replace(".", "").replace(",", ".")
+                                                     if _m.group(1).count(",") == 1 and _m.group(1).count(".") > 1
+                                                     else _m.group(1).replace(",", "."))
+                                break
+                            except ValueError:
+                                continue
+
+                    if _declared_m2 and _declared_m2 > 1:
+                        _diff_op = abs(_current_m2 - _declared_m2)
+                        _diff_pct = _diff_op / _declared_m2
+                        # Abort only on significant mismatch (>10% or >2m²)
+                        if _diff_pct > 0.10 and _diff_op > 2.0:
+                            logging.error(
+                                f"[guardrail-B] Operator declared {_declared_m2:.2f} m² but agent is "
+                                f"passing {_current_m2:.2f} m² ({_diff_pct*100:.0f}% diff). ABORTING calculate_quote."
+                            )
+                            # Return error to agent so it re-reads the message
+                            return {
+                                "ok": False,
+                                "error": (
+                                    f"⛔ El despiece que pasaste a calculate_quote ({_current_m2:.2f} m²) "
+                                    f"NO coincide con el total declarado por el operador ({_declared_m2:.2f} m²). "
+                                    "Re-leer el mensaje ORIGINAL del operador (NO los ejemplos) y pasar "
+                                    "EXACTAMENTE las piezas listadas ahí. En edificio son múltiples tipologías "
+                                    "(DC-02 × 2, DC-03 × 6, etc.), NO inventes datos residenciales."
+                                ),
+                                "_guardrail_aborted": True,
+                                "_current_m2": _current_m2,
+                                "_declared_m2": _declared_m2,
+                            }
             except Exception as e:
                 logging.warning(f"[guardrail] paso1↔paso2 check failed: {e}")
 

--- a/api/tests/test_paso1_paso2_consistency.py
+++ b/api/tests/test_paso1_paso2_consistency.py
@@ -49,6 +49,50 @@ class TestExampleFilterByContext:
             )
 
 
+class TestOperatorDeclaredM2Parser:
+    """Regex-based extraction of operator's declared m² from message text.
+
+    This is the Layer B guardrail: works for edificios where list_pieces
+    is disabled and there's no paso1_pieces persisted.
+    """
+
+    def _extract(self, text: str):
+        import re
+        patterns = [
+            r'total\s+material[:\s]+([\d.,]+)\s*m[²2]',
+            r'material\s+total[:\s]+([\d.,]+)\s*m[²2]',
+            r'total[:\s]+([\d.,]+)\s*m[²2]',
+        ]
+        for pat in patterns:
+            m = re.search(pat, text, re.IGNORECASE)
+            if m:
+                raw = m.group(1)
+                if raw.count(",") == 1 and raw.count(".") > 1:
+                    return float(raw.replace(".", "").replace(",", "."))
+                return float(raw.replace(",", "."))
+        return None
+
+    def test_total_material_spanish(self):
+        assert self._extract("TOTAL MATERIAL: 66.57 m²") == 66.57
+
+    def test_total_plain(self):
+        assert self._extract("Total: 74.10 m²") == 74.10
+
+    def test_comma_decimal(self):
+        assert self._extract("TOTAL MATERIAL: 66,57 m²") == 66.57
+
+    def test_no_total_returns_none(self):
+        assert self._extract("Just some text without total") is None
+
+    def test_big_diff_triggers_abort(self):
+        """Operator 66.57 m² vs agent 1.90 m² → 97% diff → must abort."""
+        declared = 66.57
+        current = 1.90
+        diff = abs(current - declared)
+        pct = diff / declared
+        assert pct > 0.10 and diff > 2.0, "This case must trigger abort"
+
+
 class TestPaso1Paso2Mismatch:
     """Direct logic test: a big m2 mismatch means Claude invented data."""
 


### PR DESCRIPTION
Causa raíz del bug persistente del Ventus. Regex extraía 2162 chars como material, DB tira StringDataRightTruncationError, transacción falla, agente se desorienta e inventa Paso 2. Fix con truncate defensivo + regex más estricto + Text en model.