### PR TITLE
fix: pileta fantasma QUADRA Q71A cuando operador dice 'sin producto'

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -111,6 +111,24 @@ Asumir forma compuesta (L, U) SOLO si:
 
 Ejemplo: planilla con "Mesada A 1.55×0.60" + "Mesada B 1.72×0.75" y sin más indicación → son **dos mesadas rectas independientes**, no una L. Si dudás, PREGUNTÁ: "¿Son dos mesadas independientes o forman una L?"
 
+**⛔ PILETA SIN PRODUCTO — REGLA LITERAL:**
+Cuando el operador dice EXPLÍCITO en el enunciado:
+- "sin producto de pileta"
+- "sin pileta producto"
+- "sin pileta Johnson"
+- "PEGADOPILETA MO" (sin mención de producto Johnson)
+- "D'Angelo no provee la pileta"
+- "el cliente trae la pileta"
+
+→ **Pasar `pileta: "empotrada_cliente"` a `calculate_quote`**, NO `"empotrada_johnson"`.
+→ NO buscar ningún SKU en sinks.json.
+→ NO pasar `pileta_sku`.
+→ El calculator va a cargar la MO de PEGADOPILETA por cantidad pero NO va a agregar producto pileta al bloque PILETAS.
+
+⛔ **NUNCA inventar un modelo de pileta** (QUADRA Q71A u otro) cuando el operador dijo "sin producto". Es una orden LITERAL. Si el agente agrega pileta producto después de esa instrucción, ESTÁ MAL y hay que corregir.
+
+Solo usar `pileta: "empotrada_johnson"` cuando el operador especifica un MODELO Johnson ("Johnson LUXOR S171", "Johnson QUADRA Q84A", etc.) — ahí sí, con `pileta_sku`.
+
 **3. DEPENDENCIAS:** cambio material → recalcular precio (mismos m²) | cambio medida → recalcular m² esa pieza | eliminar pieza → restar m²
 
 **4. AMBIGUEDAD → PREGUNTAR**

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -3310,20 +3310,45 @@ class AgentService:
                 except Exception as e:
                     logging.warning(f"Could not read pileta field from quote {save_to_qid}: {e}")
 
+            # Gather all operator text for keyword detection (used in multiple checks)
+            _pileta_all_text = current_user_message.lower()
+            if conversation_history:
+                for msg in conversation_history:
+                    if msg.get("role") == "user":
+                        c = msg.get("content", "")
+                        if isinstance(c, str):
+                            _pileta_all_text += " " + c.lower()
+                        elif isinstance(c, list):
+                            for blk in c:
+                                if isinstance(blk, dict) and blk.get("type") == "text":
+                                    _pileta_all_text += " " + blk.get("text", "").lower()
+
+            # ⛔ LITERAL RULE: if operator says "sin producto de pileta" / "sin pileta
+            # producto" / "cliente trae la pileta" / "D'Angelo no provee la pileta"
+            # → force pileta=empotrada_cliente, regardless of what the agent passed.
+            # This prevents the calculator from adding a default QUADRA Q71A sink
+            # when the operator explicitly said the product is NOT included.
+            _no_product_phrases = [
+                "sin producto de pileta", "sin producto pileta",
+                "sin pileta producto", "sin pileta-producto",
+                "cliente trae la pileta", "cliente trae pileta",
+                "no provee la pileta", "no provee pileta",
+                "d'angelo no provee", "dangelo no provee",
+                "(sin producto", "pegadopileta mo",
+            ]
+            if any(phrase in _pileta_all_text for phrase in _no_product_phrases):
+                if inputs.get("pileta") != "empotrada_cliente":
+                    logging.warning(
+                        f"Forcing pileta=empotrada_cliente (operator said 'sin producto'). "
+                        f"Was: {inputs.get('pileta')} for {save_to_qid}"
+                    )
+                    inputs["pileta"] = "empotrada_cliente"
+                # Ensure no pileta_sku leaks through and triggers sink lookup
+                inputs.pop("pileta_sku", None)
+
             if not inputs.get("pileta"):
                 # 2. Keyword fallback: scan conversation for pileta/bacha mentions
-                all_text = current_user_message.lower()
-                if conversation_history:
-                    for msg in conversation_history:
-                        if msg.get("role") == "user":
-                            c = msg.get("content", "")
-                            if isinstance(c, str):
-                                all_text += " " + c.lower()
-                            elif isinstance(c, list):
-                                for blk in c:
-                                    if isinstance(blk, dict) and blk.get("type") == "text":
-                                        all_text += " " + blk.get("text", "").lower()
-                if any(kw in all_text for kw in ["bacha", "pileta", "cotizar bacha", "con bacha",
+                if any(kw in _pileta_all_text for kw in ["bacha", "pileta", "cotizar bacha", "con bacha",
                                                   "compra la bacha", "compra bacha", "compra pileta",
                                                   "la compra en", "la pide"]):
                     inputs["pileta"] = "empotrada_johnson"

--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -598,8 +598,24 @@ def calculate_quote(input_data: dict) -> dict:
                 if sink_result and sink_result.get("found"):
                     logging.info(f"Sink fuzzy matched: '{pileta_sku}' → {sink_result.get('name')} (SKU: {sink_result.get('sku')})")
                     warnings.append(f"Pileta '{pileta_sku}' no encontrada exacta. Se usó: {sink_result.get('name')}")
+        # ⛔ NO default to QUADRAQ71A when no sku provided. This was causing phantom
+        # sinks on edificio quotes where operator says "sin producto de pileta".
+        # If empotrada_johnson but no sku → skip product (treat as empotrada_cliente),
+        # only labor is charged. Add a warning so operator sees what happened.
         if not sink_result or not sink_result.get("found"):
-            # Last resort: default model with warning
+            if pileta_sku:
+                warnings.append(
+                    f"⚠️ Pileta '{pileta_sku}' no encontrada en catálogo. "
+                    "No se incluyó producto. Si debería ir, especificá el SKU correcto."
+                )
+            else:
+                warnings.append(
+                    "ℹ️ Pileta empotrada sin SKU específico → solo MO PEGADOPILETA, "
+                    "sin producto. Si Johnson debe proveerla, pasar pileta_sku."
+                )
+            sink_result = None  # explicit: no sink product added
+        # DEPRECATED: QUADRAQ71A default removed. Kept as no-op branch for safety.
+        if False and (not sink_result or not sink_result.get("found")):
             sink_result = catalog_lookup("sinks", "QUADRAQ71A")
             if pileta_sku:
                 warnings.append(f"Pileta '{pileta_sku}' no encontrada. Se usó QUADRA Q71A por defecto. Verificar con operador.")

--- a/api/tests/test_fase1_regresion.py
+++ b/api/tests/test_fase1_regresion.py
@@ -375,6 +375,36 @@ class TestVentusEdificioEndToEnd:
         import math
         assert flete_item["quantity"] == math.ceil(61 / 6)
 
+    def test_empotrada_johnson_without_sku_does_not_add_sink(self):
+        """Si pileta=empotrada_johnson pero no hay pileta_sku, NO debe agregar
+        QUADRA Q71A default (el bug Ventus)."""
+        result = calculate_quote({
+            "client_name": "Test sin producto",
+            "material": "Silestone Blanco Norte",
+            "pieces": [{"description": "Mesada", "largo": 2.0, "prof": 0.6}],
+            "localidad": "Rosario",
+            "colocacion": True,
+            "pileta": "empotrada_johnson",  # Johnson but NO sku → no product
+            "plazo": "30 dias",
+        })
+        assert result["ok"] is True
+        sinks = result.get("sinks", [])
+        assert sinks == [], f"No sink product expected, got: {sinks}"
+
+    def test_empotrada_cliente_never_adds_sink(self):
+        """pileta=empotrada_cliente jamás agrega producto pileta."""
+        result = calculate_quote({
+            "client_name": "Test",
+            "material": "Silestone Blanco Norte",
+            "pieces": [{"description": "Mesada", "largo": 2.0, "prof": 0.6}],
+            "localidad": "Rosario",
+            "colocacion": True,
+            "pileta": "empotrada_cliente",
+            "plazo": "30 dias",
+        })
+        assert result["ok"] is True
+        assert result.get("sinks", []) == []
+
     def test_flete_qty_override_residential(self):
         """Override también funciona en residencial (no solo edificio)."""
         result = calculate_quote({


### PR DESCRIPTION
Eliminado fallback a QUADRAQ71A. Detección literal de 'sin producto' en agent.py fuerza empotrada_cliente. Regla en CONTEXT.md.