### PR TITLE
fix(agent): detectar 'sacar pileta el producto' → empotrada_cliente

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -3335,6 +3335,14 @@ class AgentService:
                 "no provee la pileta", "no provee pileta",
                 "d'angelo no provee", "dangelo no provee",
                 "(sin producto", "pegadopileta mo",
+                # Operator explicit removal phrases (mid-conversation edit)
+                "sacar pileta el producto", "sacar el producto pileta",
+                "sacar el producto de pileta", "sacar producto pileta",
+                "sacar producto de pileta", "sacar la pileta producto",
+                "quitar pileta producto", "quitar producto pileta",
+                "eliminar pileta producto", "eliminar producto pileta",
+                "remover producto pileta", "remover pileta producto",
+                "sin la pileta producto", "sin pileta como producto",
             ]
             if any(phrase in _pileta_all_text for phrase in _no_product_phrases):
                 if inputs.get("pileta") != "empotrada_cliente":


### PR DESCRIPTION
## Summary
- Operador pedía mid-chat \"sacar PILETA el producto\" y el agente acknowledgeaba sin re-ejecutar calculate_quote → phantom QUADRA Q71A quedaba en el total
- Ampliado \`_no_product_phrases\` con variantes de sacar/quitar/eliminar/remover producto pileta para forzar \`pileta=empotrada_cliente\`

## Test plan
- [ ] Regresión: decir \"sacar PILETA el producto\" → Paso 2 y PDF sin pileta en material
- [ ] MO agujero/pegado pileta se mantiene

🤖 Generated with [Claude Code](https://claude.com/claude-code)