### PR TITLE
fix(excel): reset de alturas + rows ocultas heredadas del template

### DIFF
--- a/api/app/modules/agent/tools/document_tool.py
+++ b/api/app/modules/agent/tools/document_tool.py
@@ -1350,6 +1350,21 @@ def _generate_excel(output_path: Path, data: dict) -> None:
     for mc in list(ws.merged_cells.ranges):
         ws.unmerge_cells(str(mc))
 
+    # Reset any hidden rows + row heights in the dynamic band so the output
+    # never inherits stale 0-height / hidden rows from the source template.
+    # openpyxl stores row settings in ws.row_dimensions[idx].
+    for _rd_idx in range(20, 200):
+        _rd = ws.row_dimensions.get(_rd_idx)
+        if _rd is not None:
+            _rd.hidden = False
+            _rd.height = None  # Let Excel auto-size
+    # Also clear any workbook-level conditional formatting that applies to the
+    # dynamic band (template zebra rules fire on rows we write to).
+    try:
+        ws.conditional_formatting._cf_rules.clear()
+    except Exception:
+        pass
+
     client_name = data.get("client_name", "")
     project = data.get("project", "")
     date_str = datetime.now().strftime("%d/%m/%Y")


### PR DESCRIPTION
## Summary
- Template Excel llevaba rows con alturas 0 y hidden=True para su layout original; al generar Ventus aparecían filas invisibles (rows 33, 46) y celdas con texto cortado
- Fix de raíz: al inicio de \`_generate_excel\` resetear \`row_dimensions[i].hidden=False\` y \`.height=None\` para rows 20-200, y clear de conditional formatting

## Test plan
- [ ] Regenerar Ventus → Excel sin filas ocultas, alturas uniformes
- [ ] Presupuesto residencial simple sigue correcto
- [ ] Las 2 leyendas edificio se ven bien

🤖 Generated with [Claude Code](https://claude.com/claude-code)