### PR TITLE
feat(operator): regla 1 material = 1 presupuesto

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -147,6 +147,22 @@ Sin otros cambios.
 
 ---
 
+## ⛔ REGLA — 1 MATERIAL POR PRESUPUESTO (OPERADOR WEB)
+
+Siempre crear UN SOLO presupuesto por conversación.
+
+Si el operador menciona 2+ materiales en el brief → **preguntar cuál usar antes de continuar**. NO generar variantes ni comparativas desde el operador web.
+
+Ejemplo correcto:
+> Operador: "Cotizar cocina en Silestone Blanco Norte o Granito Ceara, 2 mesadas de 2,5 × 0,62"
+> Valentina: "Detecté 2 materiales: Silestone Blanco Norte, Granito Blanco Ceara. Regla: 1 material = 1 presupuesto. ¿Procedo con Silestone Blanco Norte? Para el otro generá un presupuesto nuevo."
+
+El sistema detecta esto automáticamente y responde antes de llamar `calculate_quote`. Una vez elegido el material, el flow continúa normalmente.
+
+> Nota: la API externa del chatbot (`/api/v1/quote`) mantiene soporte multi-material por diseño y no se ve afectada por esta regla.
+
+---
+
 ## 2. Flujo de trabajo — 3 PASOS
 
 ### PASO 1 — Piezas y medidas (SIN precios)

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -673,6 +673,63 @@ class AgentService:
 
         system_prompt = build_system_prompt(has_plan=has_plan, is_building=is_building, user_message=user_message, conversation_history=messages)
 
+        # ── Operator web: 1 material / 1 presupuesto guardrail ──
+        # If the fresh brief mentions 2+ distinct canonical materials (and the
+        # quote has not locked a material yet), interrupt and ask which one to
+        # use. The chatbot flow (/api/v1/quote) does NOT pass through here and
+        # keeps its multi-material array support intact.
+        #
+        # Fail-open: detector only flags when it is sure (full canonical names
+        # or valid SKUs). Partial words like "blanco"/"norte" do not trigger.
+        try:
+            from app.modules.agent.material_detector import detect_materials_in_brief
+
+            _mm_quote_row = await db.execute(select(Quote).where(Quote.id == quote_id))
+            _mm_q = _mm_quote_row.scalar_one_or_none()
+            _mm_has_material = bool(_mm_q and (_mm_q.material or "").strip())
+            _mm_has_calc = bool(
+                _mm_q
+                and isinstance(_mm_q.quote_breakdown, dict)
+                and _mm_q.quote_breakdown.get("calc_results")
+            )
+            # Skip guardrail once a material or calc exists, or if in edificio
+            # flow (edificio may legitimately have multiple materials per the
+            # existing building parser and runs through its own state machine).
+            if not is_building and not _mm_has_material and not _mm_has_calc:
+                _detected = detect_materials_in_brief(user_message)
+                if len(_detected) >= 2:
+                    _materials_list = ", ".join(_detected[:5])
+                    _first = _detected[0]
+                    _reply = (
+                        f"Detecté {len(_detected)} materiales en el brief: "
+                        f"{_materials_list}.\n\n"
+                        f"Regla: 1 material = 1 presupuesto.\n"
+                        f"¿Procedo con **{_first}**? "
+                        f"Para los demás materiales generá un presupuesto nuevo."
+                    )
+                    try:
+                        await db.execute(
+                            update(Quote).where(Quote.id == quote_id).values(
+                                messages=list(_mm_q.messages or []) + [
+                                    {"role": "user", "content": [{"type": "text", "text": user_message}]},
+                                    {"role": "assistant", "content": [{"type": "text", "text": _reply}]},
+                                ],
+                            )
+                        )
+                        await db.commit()
+                    except Exception as _e_persist:
+                        logging.warning(f"[multi-material] failed to persist reply: {_e_persist}")
+                    logging.info(
+                        f"[multi-material] operator brief mentioned {len(_detected)} materials "
+                        f"for quote {quote_id}: {_detected}"
+                    )
+                    yield {"type": "text", "content": _reply}
+                    yield {"type": "done", "content": ""}
+                    return
+        except Exception as _e_mm:
+            # Fail-open: never let the detector block a valid flow
+            logging.warning(f"[multi-material] detector error (fail-open): {_e_mm}")
+
         # ── Inject verified measurements if available ──
         try:
             _qr_vm = await db.execute(select(Quote).where(Quote.id == quote_id))

--- a/api/app/modules/agent/material_detector.py
+++ b/api/app/modules/agent/material_detector.py
@@ -1,0 +1,141 @@
+"""Detect distinct canonical materials mentioned in an operator brief.
+
+Used by the operator web flow (POST /api/quotes/:id/chat) to enforce the rule
+"1 material = 1 presupuesto". The chatbot flow (POST /api/v1/quote) is NOT
+affected — it still supports multi-material arrays.
+
+Design goals (restrictions from operator feedback):
+- Match ONLY against canonical catalog names (same source as catalog_lookup)
+- Case-insensitive match, requires the FULL canonical name or a valid SKU
+- NO loose substring matching ("blanco", "norte" alone must NEVER trigger)
+- Fail-open: if the detector is unsure, return a single match — better to let
+  a valid case through than to interrupt the operator unnecessarily
+- Threshold: the caller only interrupts when >=2 distinct materials detected
+"""
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+
+
+# Catalog files that contain materials. Order does not matter.
+_MATERIAL_CATALOGS = (
+    "materials-silestone",
+    "materials-granito-nacional",
+    "materials-granito-importado",
+    "materials-marmol",
+    "materials-dekton",
+    "materials-neolith",
+    "materials-purastone",
+    "materials-puraprima",
+    "materials-laminatto",
+)
+
+
+def _load_all_materials() -> list[dict]:
+    """Load every material row across catalog files. Lazy + errors swallowed."""
+    from app.modules.agent.tools.catalog_tool import _load_catalog
+
+    items: list[dict] = []
+    for cat in _MATERIAL_CATALOGS:
+        try:
+            for row in _load_catalog(cat):
+                if isinstance(row, dict):
+                    items.append(row)
+        except Exception:
+            continue
+    return items
+
+
+@lru_cache(maxsize=1)
+def _build_index() -> tuple[tuple[str, str], ...]:
+    """Return tuple of (normalized_key, canonical_name) for every material.
+
+    Keys include:
+      - the full canonical name (lowered, collapsed spaces)
+      - the SKU (lowered)
+
+    Cached at process level. If catalogs change at runtime, clear with
+    invalidate_material_detector_cache().
+    """
+    pairs: list[tuple[str, str]] = []
+    for row in _load_all_materials():
+        name = (row.get("name") or "").strip()
+        sku = (row.get("sku") or "").strip()
+        if name:
+            key = _normalize(name)
+            if key:
+                pairs.append((key, name))
+        if sku:
+            key = _normalize(sku)
+            if key:
+                pairs.append((key, name or sku))
+    return tuple(pairs)
+
+
+def invalidate_material_detector_cache() -> None:
+    """Clear the cached index (call after catalog updates)."""
+    _build_index.cache_clear()
+
+
+def _normalize(text: str) -> str:
+    """Lowercase + collapse whitespace. Preserves all letters/digits."""
+    if not text:
+        return ""
+    # Collapse whitespace sequences (spaces/tabs/newlines) into single space
+    return re.sub(r"\s+", " ", text.strip().lower())
+
+
+def detect_materials_in_brief(
+    text: str, min_sku_length: int = 5
+) -> list[str]:
+    """Return list of canonical material names distinctly mentioned in `text`.
+
+    Matching rules (strict, fail-open):
+    - Text is normalized (lowercased, whitespace collapsed).
+    - A material is "mentioned" only if the full canonical name appears as a
+      whole-word sequence in the normalized text, OR a SKU of length >=
+      min_sku_length appears (word-boundary aware).
+    - Duplicates collapsed — each canonical name returned at most once,
+      preserving order of first match.
+    - Partial / substring matches ("blanco", "norte", etc. alone) are ignored.
+
+    Fail-open behavior:
+    - If the catalog index cannot be built or is empty, returns [].
+    - If normalization fails, returns [].
+    - Callers must treat the empty/single result as "do not interrupt".
+    """
+    if not text:
+        return []
+    try:
+        norm = _normalize(text)
+        if not norm:
+            return []
+        index = _build_index()
+    except Exception:
+        return []
+    if not index:
+        return []
+
+    found: list[str] = []
+    seen: set[str] = set()
+    for key, canonical in index:
+        if not key:
+            continue
+        # SKUs are short; require a minimum length to avoid matching generic
+        # tokens like "m2" or "20" as if they were SKUs.
+        if len(key) < min_sku_length and canonical != key:
+            # This is likely a short SKU. Keep the guard but do not outright
+            # skip — catalogs rarely have SKUs shorter than 5 chars.
+            pass
+        if len(key) < 4:
+            # Never try to match 1-3 char tokens (too ambiguous).
+            continue
+        # Word-boundary match: key must appear surrounded by non-word chars
+        # (or start/end of string).
+        pattern = r"(?<![\w])" + re.escape(key) + r"(?![\w])"
+        if re.search(pattern, norm):
+            if canonical not in seen:
+                seen.add(canonical)
+                found.append(canonical)
+    return found

--- a/api/tests/test_multi_material_detection.py
+++ b/api/tests/test_multi_material_detection.py
@@ -1,0 +1,155 @@
+"""Tests for operator-web multi-material detection.
+
+These assert the rule "1 material = 1 presupuesto" for the operator flow.
+The chatbot endpoint (/api/v1/quote) is intentionally NOT exercised here —
+it is asserted to be independent in the integration layer.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.modules.agent.material_detector import (
+    detect_materials_in_brief,
+    invalidate_material_detector_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    invalidate_material_detector_cache()
+    yield
+    invalidate_material_detector_cache()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Happy paths: canonical names trigger detection
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_two_full_canonical_names_triggers():
+    """Two distinct full canonical names must yield 2 matches."""
+    brief = "Cotizar en Silestone Blanco Norte o Granito Ceara"
+    found = detect_materials_in_brief(brief)
+    # Detector may match case-insensitive; accept >=2 distinct names
+    assert len(found) >= 2
+    lower = [n.lower() for n in found]
+    assert any("silestone blanco norte" in n for n in lower)
+    assert any("granito ceara" in n for n in lower)
+
+
+def test_single_full_name_passes():
+    """A single material mention must not trip the guardrail."""
+    brief = "Cotizar en Silestone Blanco Norte — 2 mesadas"
+    found = detect_materials_in_brief(brief)
+    # Must be exactly 1 (the Silestone Blanco Norte)
+    assert len(found) == 1
+    assert "silestone blanco norte" in found[0].lower()
+
+
+def test_same_name_different_casing_counts_once():
+    """Mixed casing of the same material collapses to a single canonical."""
+    brief = "silestone blanco norte para la cocina, y SILESTONE BLANCO NORTE para el baño"
+    found = detect_materials_in_brief(brief)
+    assert len(found) == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# False-positive guards (partial / substring words)
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_no_false_positive_bathroom_and_kitchen():
+    """'baño' must never match 'BAÑO' or partials that live inside catalog names."""
+    brief = "Silestone Blanco Norte para la cocina y baño"
+    found = detect_materials_in_brief(brief)
+    assert len(found) == 1
+    assert "silestone blanco norte" in found[0].lower()
+
+
+def test_no_false_positive_partial_color_word():
+    """A lone color word must NOT match a catalog material."""
+    brief = "Color blanco, medidas 2.5 x 0.62"
+    found = detect_materials_in_brief(brief)
+    assert found == []
+
+
+def test_no_false_positive_norte_alone():
+    """'norte' alone must not match SILESTONE BLANCO NORTE."""
+    brief = "entrega en la zona norte"
+    found = detect_materials_in_brief(brief)
+    assert found == []
+
+
+def test_no_false_positive_with_typo():
+    """A typo in a material name must fail-open (no match)."""
+    brief = "cotizar en silestone blnaco norte"
+    found = detect_materials_in_brief(brief)
+    # typo → no canonical match → empty (fail-open behavior, operator keeps going)
+    assert found == []
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Boundary cases
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_empty_text_returns_empty():
+    assert detect_materials_in_brief("") == []
+    assert detect_materials_in_brief("   \n  ") == []
+
+
+def test_none_text_safe():
+    assert detect_materials_in_brief(None) == []  # type: ignore[arg-type]
+
+
+def test_material_surrounded_by_punctuation_still_matches():
+    """Word-boundary regex should recognize names inside punctuation."""
+    brief = "(Silestone Blanco Norte). Pieza 1."
+    found = detect_materials_in_brief(brief)
+    assert len(found) == 1
+
+
+def test_short_tokens_never_match():
+    """2-3 char tokens (even if they existed in catalog somehow) are ignored."""
+    # This is a behavioral guard — the detector drops keys < 4 chars.
+    brief = "usa el m2 para calcular"
+    found = detect_materials_in_brief(brief)
+    assert found == []
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# SKU recognition (if present as a complete token)
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_sku_as_whole_token_matches():
+    """A full catalog SKU appearing as its own token should match."""
+    # Use an SKU guaranteed to exist in the current catalog.
+    brief = "usar SILESTONENORTE para la cocina"
+    found = detect_materials_in_brief(brief)
+    assert len(found) >= 1
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Fail-open semantics
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_detector_never_raises_on_garbled_input():
+    """Any input, no matter how weird, must return a list (possibly empty)."""
+    for junk in [
+        "",
+        "🔥🔥🔥",
+        "<script>alert(1)</script>",
+        "\x00\x00\x00",
+        "a" * 10000,
+    ]:
+        out = detect_materials_in_brief(junk)
+        assert isinstance(out, list)
+
+
+def test_threshold_interpretation_is_callers_job():
+    """
+    The detector returns WHAT it saw; the >=2 threshold for interrupting is
+    applied by the caller (agent.py). This test pins that contract.
+    """
+    brief = "Silestone Blanco Norte"
+    found = detect_materials_in_brief(brief)
+    # Caller only interrupts when len(found) >= 2 — detector is free to
+    # return 0 or 1 without side effects.
+    assert len(found) < 2


### PR DESCRIPTION
## Summary
- Nueva guardrail en flujo operador web: si el brief menciona 2+ materiales canónicos, interrumpe con pregunta antes de llamar \`calculate_quote\`
- Chatbot externo (\`/api/v1/quote\`) intacto — sigue con su array multi-material
- \`variant_option\` no se deshabilita; el guardrail corta antes de llegar a invocarlo en el path operador

## Restricciones implementadas (feedback operador)
- Match solo contra nombres canónicos del catálogo + SKUs (mismo source que \`catalog_lookup\`)
- Word-boundary regex — jamás matchea substrings sueltos (\"blanco\", \"norte\", \"baño\"…)
- Umbral min 4 chars para descartar tokens como \"m2\"
- Fail-open: cualquier excepción del detector → \`[]\` y el flujo sigue normal

## Tests (14)
- Full canonical names disparan
- Mismo material en distinto casing → 1
- False-positives: baño/cocina/colores sueltos/typos → no dispara
- SKU como token entero → matchea
- Inputs garbled (emojis, XSS, bytes nulos, 10k chars) → list, jamás raise
- Threshold >=2 contract pin

## No rompe nada
- Flow edificio sigue igual (guardrail excluye \`is_building=True\`)
- Quote con material ya seteado → guardrail skip
- Paso 2/3 state machine sin cambios

🤖 Generated with [Claude Code](https://claude.com/claude-code)