### PR TITLE
feat(resumen-obra): endpoint POST /api/quotes/resumen-obra + migración DB

### DIFF
--- a/api/app/core/database.py
+++ b/api/app/core/database.py
@@ -66,6 +66,8 @@ async def init_db():
             "ALTER TABLE quotes ADD COLUMN IF NOT EXISTS comparison_group_id VARCHAR(200)",
             "ALTER TABLE quotes ADD COLUMN IF NOT EXISTS drive_pdf_url VARCHAR(500)",
             "ALTER TABLE quotes ADD COLUMN IF NOT EXISTS drive_excel_url VARCHAR(500)",
+            "ALTER TABLE quotes ADD COLUMN IF NOT EXISTS resumen_obra JSON",
+            "ALTER TABLE quotes ADD COLUMN IF NOT EXISTS email_draft JSON",
         ]:
             try:
                 await conn.execute(__import__("sqlalchemy").text(col_sql))

--- a/api/app/models/quote.py
+++ b/api/app/models/quote.py
@@ -79,6 +79,18 @@ class Quote(Base):
     # Change history — log of modifications in patch mode
     change_history: Mapped[list | None] = mapped_column(JSON, nullable=True, default=list)
 
+    # Consolidated site summary (resumen de obra) — generated from N quotes of
+    # the same client/project, attached back to each selected quote.
+    # Schema: { pdf_url, drive_url, notes, generated_at, quote_ids,
+    #           client_name, project }
+    resumen_obra: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+
+    # Commercial email draft (AI-generated) for the client.
+    # Schema: { subject, body, generated_at, validated,
+    #           quote_updated_at_snapshot, resumen_updated_at_snapshot,
+    #           sibling_updated_at_snapshots: { quote_id: iso_str } }
+    email_draft: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+
     # Full chat history as JSON array
     messages: Mapped[list] = mapped_column(JSON, default=list)
 

--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -751,6 +751,43 @@ async def delete_quote(quote_id: str, db: AsyncSession = Depends(get_db)):
 
 # ── CREATE QUOTE (new chat) ───────────────────────────────────────────────────
 
+class ResumenObraRequest(BaseModel):
+    quote_ids: List[str]
+    notes: Optional[str] = None
+
+
+@router.post("/quotes/resumen-obra")
+async def generate_resumen_obra_endpoint(
+    body: ResumenObraRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    """Generate a consolidated 'resumen de obra' PDF from N selected quotes.
+
+    - Validates: same client, all validated, 1<=N<=20, notes<=1000 chars
+    - Generates PDF (no Excel), uploads to Drive (non-fatal)
+    - Persists record in each selected quote's `resumen_obra` field
+    - Invalidates each quote's `email_draft` cache (regen on next GET)
+    """
+    from app.modules.agent.tools.resumen_obra_tool import (
+        generate_resumen_obra,
+        ResumenObraError,
+    )
+
+    try:
+        record = await generate_resumen_obra(
+            db=db,
+            quote_ids=body.quote_ids,
+            notes_raw=body.notes,
+        )
+    except ResumenObraError as e:
+        raise HTTPException(status_code=e.status, detail=e.message)
+    except Exception as e:
+        logging.error(f"[resumen-obra] unexpected error: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Error interno generando el resumen")
+
+    return record
+
+
 @router.post("/quotes")
 async def create_quote(
     db: AsyncSession = Depends(get_db),

--- a/api/app/modules/agent/tools/document_tool.py
+++ b/api/app/modules/agent/tools/document_tool.py
@@ -455,6 +455,15 @@ def _generate_resumen_obra_pdf(pdf_path: Path, data: dict) -> None:
         pdf.cell(0, 4, f"  - {name}", new_x="LMARGIN", new_y="NEXT")
     pdf.ln(3)
 
+    # ── 4b. Operator notes (optional) ──
+    _notes = (data.get("notes") or "").strip()
+    if _notes:
+        pdf.set_font("Helvetica", "B", 9)
+        pdf.cell(0, 5, "NOTAS ADICIONALES", new_x="LMARGIN", new_y="NEXT")
+        pdf.set_font("Helvetica", "", 8)
+        pdf.multi_cell(180, 4, _notes, new_x="LMARGIN", new_y="NEXT")
+        pdf.ln(3)
+
     # ── 5. Conditions ──
     pdf.set_font("Helvetica", "", 7)
     pdf.multi_cell(180, 3.5, "Forma de pago: Contado", new_x="LMARGIN", new_y="NEXT")

--- a/api/app/modules/agent/tools/resumen_obra_tool.py
+++ b/api/app/modules/agent/tools/resumen_obra_tool.py
@@ -1,0 +1,303 @@
+"""Consolidated site summary ("resumen de obra") generation.
+
+Builds a single PDF that consolidates N quotes of the same client + project,
+attaches the generated file back to each quote's `resumen_obra` field, and
+invalidates their email_draft cache so it regenerates on next read.
+
+Invoked from the operator web dashboard after multi-select.
+The chatbot flow is NOT affected.
+
+Contract:
+- Min 1, max 20 quotes
+- All quotes must be status = validated
+- All quotes must share client_name (case-insensitive, trimmed)
+- Notes: optional, max 1000 chars, sanitized for PDF
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.static import OUTPUT_DIR
+from app.models.quote import Quote, QuoteStatus
+
+
+MAX_QUOTES = 20
+MAX_NOTES_LEN = 1000
+
+
+class ResumenObraError(Exception):
+    """Validation / generation error with user-safe message."""
+
+    def __init__(self, status: int, message: str):
+        self.status = status
+        self.message = message
+        super().__init__(message)
+
+
+def _sanitize_notes(raw: str | None) -> str:
+    """Trim, strip control chars, cap length. Never raises."""
+    if not raw:
+        return ""
+    s = str(raw).strip()
+    if len(s) > MAX_NOTES_LEN:
+        raise ResumenObraError(400, f"Las notas superan {MAX_NOTES_LEN} caracteres.")
+    # Drop ASCII control chars (except \n and \t)
+    s = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", s)
+    return s
+
+
+def _normalize_client(name: str | None) -> str:
+    return re.sub(r"\s+", " ", (name or "").strip()).lower()
+
+
+def _validate_quotes(quotes: list[Quote], requested_ids: list[str]) -> None:
+    """Raise ResumenObraError on any contract violation."""
+    found_ids = {q.id for q in quotes}
+    missing = [qid for qid in requested_ids if qid not in found_ids]
+    if missing:
+        raise ResumenObraError(404, f"Presupuestos no encontrados: {missing}")
+
+    non_validated = [
+        q.id for q in quotes if q.status != QuoteStatus.VALIDATED
+    ]
+    if non_validated:
+        raise ResumenObraError(
+            400,
+            f"Todos los presupuestos deben estar validados. "
+            f"No validados: {non_validated}",
+        )
+
+    # Same client (normalized)
+    normalized = {_normalize_client(q.client_name) for q in quotes}
+    if len(normalized) > 1:
+        raise ResumenObraError(
+            400,
+            "Todos los presupuestos deben ser del mismo cliente. "
+            f"Detectados: {sorted(normalized)}",
+        )
+
+
+def _collect_material_row(q: Quote) -> dict[str, Any] | None:
+    """Flatten a quote's calc into a single material row for the summary.
+
+    Returns None if the quote has no usable calc data (fail-soft: the quote
+    contributes to client totals but not to the material breakdown).
+    """
+    bd = q.quote_breakdown or {}
+    if not isinstance(bd, dict):
+        return None
+
+    # Edificios: calc_results keyed by material name
+    calc_results = bd.get("calc_results") or {}
+    if isinstance(calc_results, dict) and calc_results:
+        # Operator-web quotes are 1 material per PR #145 rule, but legacy or
+        # chatbot quotes may have several. Emit one row per material.
+        rows = []
+        for mat_name, mr in calc_results.items():
+            if not isinstance(mr, dict) or not mr.get("ok"):
+                continue
+            rows.append({
+                "name": mr.get("catalog_name", mat_name),
+                "m2": mr.get("m2", 0),
+                "currency": mr.get("currency", "USD"),
+                "price_unit": mr.get("price_unit", 0),
+                "subtotal": mr.get("material_total", 0),
+                "discount_pct": mr.get("discount_pct", 0),
+                "discount_amount": mr.get("discount_amount", 0),
+                "net": mr.get("material_net", 0),
+            })
+        return {"rows": rows}
+
+    # Standard residential: single material flat fields on breakdown
+    mat_name = bd.get("material_name") or q.material or ""
+    m2 = bd.get("material_m2") or 0
+    price = bd.get("material_price_unit") or 0
+    cur = bd.get("material_currency") or "USD"
+    disc_pct = bd.get("discount_pct") or 0
+    if m2 and price and mat_name:
+        subtotal = round(m2 * price)
+        disc_amount = round(subtotal * disc_pct / 100) if disc_pct else 0
+        return {
+            "rows": [{
+                "name": mat_name,
+                "m2": m2,
+                "currency": cur,
+                "price_unit": price,
+                "subtotal": subtotal,
+                "discount_pct": disc_pct,
+                "discount_amount": disc_amount,
+                "net": subtotal - disc_amount,
+            }]
+        }
+    return None
+
+
+def _build_resumen_data(
+    quotes: list[Quote], notes: str
+) -> dict[str, Any]:
+    """Shape the dict expected by _generate_resumen_obra_pdf from N quotes."""
+    client_name = next((q.client_name for q in quotes if q.client_name), "")
+    project = next((q.project for q in quotes if q.project), "")
+
+    material_rows: list[dict] = []
+    material_names: list[str] = []
+    mo_items_all: list[dict] = []
+    total_mat_ars = 0
+    total_mat_usd = 0
+    mo_total = 0
+    grand_total_ars = 0
+    grand_total_usd = 0
+
+    for q in quotes:
+        info = _collect_material_row(q) or {}
+        for row in info.get("rows", []):
+            material_rows.append(row)
+            material_names.append(row["name"])
+            if row["currency"] == "ARS":
+                total_mat_ars += row["net"]
+            else:
+                total_mat_usd += row["net"]
+
+        bd = q.quote_breakdown or {}
+        if isinstance(bd, dict):
+            for mo in bd.get("mo_items") or []:
+                mo_items_all.append({
+                    "desc": mo.get("description") or mo.get("desc", ""),
+                    "qty": mo.get("quantity") or mo.get("qty", 1),
+                    "price": mo.get("unit_price") or mo.get("price", 0),
+                    "total": mo.get("total", 0),
+                })
+            mo_total += bd.get("mo_total", 0) or 0
+
+        grand_total_ars += q.total_ars or 0
+        grand_total_usd += q.total_usd or 0
+
+    return {
+        "client_name": client_name,
+        "project": project,
+        "materials": material_rows,
+        "material_names": sorted(set(material_names)),
+        "mo_items": mo_items_all,
+        "mo_total": mo_total,
+        "total_mat_ars": total_mat_ars,
+        "total_mat_usd": total_mat_usd,
+        "grand_total_ars": grand_total_ars,
+        "grand_total_usd": grand_total_usd,
+        "notes": notes,
+    }
+
+
+def _safe_filename(client_name: str, project: str) -> str:
+    base = f"{client_name} - {project} - Resumen Obra".strip()
+    base = re.sub(r"[/\\:*?\"<>|]", "-", base)
+    date_str = datetime.now().strftime("%d.%m.%Y")
+    return f"{base} - {date_str}.pdf"
+
+
+async def _upload_to_drive_safe(pdf_path: Path, subfolder: str) -> dict:
+    """Upload wrapper that returns {} on failure instead of raising."""
+    try:
+        from app.modules.agent.tools.drive_tool import (
+            upload_single_file_to_drive,
+        )
+        r = await upload_single_file_to_drive(str(pdf_path), subfolder)
+        if r.get("ok"):
+            return {
+                "file_id": r.get("file_id"),
+                "drive_url": r.get("drive_url"),
+                "drive_download_url": r.get("drive_download_url"),
+            }
+    except Exception as e:
+        logging.warning(f"[resumen-obra] Drive upload failed: {e}")
+    return {}
+
+
+async def generate_resumen_obra(
+    db: AsyncSession,
+    quote_ids: list[str],
+    notes_raw: str | None,
+) -> dict:
+    """Validate, generate PDF, upload, persist — atomic-ish.
+
+    Returns { pdf_url, drive_url (optional), quote_ids, generated_at,
+              client_name, project, notes }.
+
+    Raises ResumenObraError on contract violations. Drive upload failure does
+    NOT raise — it just means drive_url is absent; the local PDF is still
+    generated and persisted.
+    """
+    if not isinstance(quote_ids, list) or not quote_ids:
+        raise ResumenObraError(400, "quote_ids no puede estar vacío.")
+    if len(quote_ids) > MAX_QUOTES:
+        raise ResumenObraError(
+            400, f"Máximo {MAX_QUOTES} presupuestos por resumen."
+        )
+    # Dedup + preserve order
+    seen: set[str] = set()
+    deduped = [q for q in quote_ids if not (q in seen or seen.add(q))]
+
+    notes = _sanitize_notes(notes_raw)
+
+    # Load quotes
+    result = await db.execute(select(Quote).where(Quote.id.in_(deduped)))
+    quotes = list(result.scalars().all())
+    _validate_quotes(quotes, deduped)
+
+    # Order quotes to match requested order for deterministic output
+    by_id = {q.id: q for q in quotes}
+    quotes = [by_id[qid] for qid in deduped]
+
+    data = _build_resumen_data(quotes, notes)
+
+    # Output dir: use the first quote's folder as anchor
+    anchor_id = deduped[0]
+    out_dir = OUTPUT_DIR / anchor_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    filename = _safe_filename(data["client_name"], data["project"])
+    pdf_path = out_dir / filename
+
+    # Generate PDF (import late to avoid circular)
+    from app.modules.agent.tools.document_tool import (
+        _generate_resumen_obra_pdf,
+    )
+    await asyncio.to_thread(_generate_resumen_obra_pdf, pdf_path, data)
+
+    # Upload to Drive (non-fatal)
+    drive_info = await _upload_to_drive_safe(
+        pdf_path, data["client_name"] or "Sin cliente"
+    )
+
+    generated_at = datetime.now(timezone.utc).isoformat()
+    pdf_url = f"/files/{anchor_id}/{filename}"
+    drive_url = drive_info.get("drive_url") or None
+
+    record = {
+        "pdf_url": pdf_url,
+        "drive_url": drive_url,
+        "drive_file_id": drive_info.get("file_id"),
+        "notes": notes,
+        "generated_at": generated_at,
+        "quote_ids": deduped,
+        "client_name": data["client_name"],
+        "project": data["project"],
+    }
+
+    # Persist: attach record to each quote; invalidate email_draft.
+    for qid in deduped:
+        await db.execute(
+            update(Quote)
+            .where(Quote.id == qid)
+            .values(resumen_obra=record, email_draft=None)
+        )
+    await db.commit()
+
+    return record

--- a/api/tests/test_resumen_obra_endpoint.py
+++ b/api/tests/test_resumen_obra_endpoint.py
@@ -1,0 +1,342 @@
+"""Contract tests for POST /api/quotes/resumen-obra.
+
+Drive uploads are mocked to fail-quiet — we assert the endpoint never depends
+on Drive being reachable. Local PDF generation is the single source of truth.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.models.quote import Quote, QuoteStatus
+
+
+def _mk_breakdown(material: str, m2: float, price: float) -> dict:
+    return {
+        "material_name": material,
+        "material_m2": m2,
+        "material_price_unit": price,
+        "material_currency": "USD",
+        "discount_pct": 18,
+        "mo_items": [
+            {"description": "Agujero y pegado pileta", "quantity": 25,
+             "unit_price": 62045, "total": 1551125},
+            {"description": "Flete", "quantity": 5,
+             "unit_price": 52000, "total": 260000},
+        ],
+        "mo_total": 1811125,
+    }
+
+
+@pytest_asyncio.fixture
+async def validated_quote_factory(db_session):
+    """Factory that creates a validated quote and returns its id."""
+    async def _make(
+        client_name: str = "Estudio 72",
+        project: str = "Fideicomiso Ventus",
+        material: str = "SILESTONE BLANCO NORTE",
+        m2: float = 66.5,
+        price: float = 519,
+        total_ars: float = 2_708_376,
+        total_usd: float = 28_301,
+        status: QuoteStatus = QuoteStatus.VALIDATED,
+    ) -> str:
+        q = Quote(
+            id=str(uuid.uuid4()),
+            client_name=client_name,
+            project=project,
+            material=material,
+            total_ars=total_ars,
+            total_usd=total_usd,
+            status=status,
+            quote_breakdown=_mk_breakdown(material, m2, price),
+            messages=[],
+        )
+        db_session.add(q)
+        await db_session.commit()
+        return q.id
+    return _make
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Happy path
+# ─────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_generate_single_quote_ok(client, validated_quote_factory):
+    qid = await validated_quote_factory()
+    with patch(
+        "app.modules.agent.tools.resumen_obra_tool._upload_to_drive_safe",
+        return_value={},
+    ):
+        r = await client.post(
+            "/api/quotes/resumen-obra",
+            json={"quote_ids": [qid], "notes": "Coordinar con obra civil."},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["quote_ids"] == [qid]
+    assert body["client_name"] == "Estudio 72"
+    assert body["pdf_url"].startswith("/files/")
+    assert body["notes"] == "Coordinar con obra civil."
+    assert "generated_at" in body
+
+
+@pytest.mark.asyncio
+async def test_generate_multi_quote_same_client_ok(
+    client, validated_quote_factory, db_session
+):
+    qid1 = await validated_quote_factory(material="SILESTONE BLANCO NORTE")
+    qid2 = await validated_quote_factory(material="GRANITO CEARA", price=357)
+    with patch(
+        "app.modules.agent.tools.resumen_obra_tool._upload_to_drive_safe",
+        return_value={"drive_url": "https://drive/x", "file_id": "x"},
+    ):
+        r = await client.post(
+            "/api/quotes/resumen-obra",
+            json={"quote_ids": [qid1, qid2]},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert set(body["quote_ids"]) == {qid1, qid2}
+    assert body["drive_url"] == "https://drive/x"
+    # Both quotes get the same resumen record
+    db_session.expire_all()
+    for qid in (qid1, qid2):
+        row = (await db_session.execute(
+            select(Quote).where(Quote.id == qid)
+        )).scalar_one()
+        assert row.resumen_obra is not None
+        assert row.resumen_obra["drive_url"] == "https://drive/x"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Validation rejections
+# ─────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_reject_empty_quote_ids(client):
+    r = await client.post("/api/quotes/resumen-obra", json={"quote_ids": []})
+    assert r.status_code == 400
+    assert "vac" in r.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_reject_too_many_quote_ids(client, validated_quote_factory):
+    ids = [await validated_quote_factory() for _ in range(21)]
+    r = await client.post("/api/quotes/resumen-obra", json={"quote_ids": ids})
+    assert r.status_code == 400
+    assert "20" in r.json()["detail"] or "Máximo" in r.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_reject_nonexistent_quote_id(client, validated_quote_factory):
+    qid_real = await validated_quote_factory()
+    fake = str(uuid.uuid4())
+    r = await client.post(
+        "/api/quotes/resumen-obra",
+        json={"quote_ids": [qid_real, fake]},
+    )
+    assert r.status_code == 404
+    assert fake in r.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_reject_non_validated_quote(client, validated_quote_factory):
+    qid_ok = await validated_quote_factory()
+    qid_draft = await validated_quote_factory(status=QuoteStatus.DRAFT)
+    r = await client.post(
+        "/api/quotes/resumen-obra",
+        json={"quote_ids": [qid_ok, qid_draft]},
+    )
+    assert r.status_code == 400
+    assert qid_draft in r.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_reject_mixed_clients(client, validated_quote_factory):
+    qa = await validated_quote_factory(client_name="Estudio 72")
+    qb = await validated_quote_factory(client_name="Juan Perez")
+    r = await client.post(
+        "/api/quotes/resumen-obra",
+        json={"quote_ids": [qa, qb]},
+    )
+    assert r.status_code == 400
+    assert "mismo cliente" in r.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_same_client_different_casing_accepted(
+    client, validated_quote_factory
+):
+    qa = await validated_quote_factory(client_name="Estudio 72")
+    qb = await validated_quote_factory(client_name="  ESTUDIO 72  ")
+    with patch(
+        "app.modules.agent.tools.resumen_obra_tool._upload_to_drive_safe",
+        return_value={},
+    ):
+        r = await client.post(
+            "/api/quotes/resumen-obra",
+            json={"quote_ids": [qa, qb]},
+        )
+    assert r.status_code == 200, r.text
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Notes sanitization
+# ─────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_notes_max_length(client, validated_quote_factory):
+    qid = await validated_quote_factory()
+    r = await client.post(
+        "/api/quotes/resumen-obra",
+        json={"quote_ids": [qid], "notes": "x" * 1001},
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_notes_control_chars_stripped(
+    client, validated_quote_factory, db_session
+):
+    qid = await validated_quote_factory()
+    with patch(
+        "app.modules.agent.tools.resumen_obra_tool._upload_to_drive_safe",
+        return_value={},
+    ):
+        r = await client.post(
+            "/api/quotes/resumen-obra",
+            json={"quote_ids": [qid], "notes": "Hola\x00\x07 mundo"},
+        )
+    assert r.status_code == 200
+    assert "\x00" not in r.json()["notes"]
+    assert "\x07" not in r.json()["notes"]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Idempotency / overwrite
+# ─────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_overwrite_existing_resumen(
+    client, validated_quote_factory, db_session
+):
+    qid = await validated_quote_factory()
+    with patch(
+        "app.modules.agent.tools.resumen_obra_tool._upload_to_drive_safe",
+        return_value={},
+    ):
+        r1 = await client.post(
+            "/api/quotes/resumen-obra",
+            json={"quote_ids": [qid], "notes": "first"},
+        )
+        assert r1.status_code == 200
+        first_ts = r1.json()["generated_at"]
+        r2 = await client.post(
+            "/api/quotes/resumen-obra",
+            json={"quote_ids": [qid], "notes": "second"},
+        )
+    assert r2.status_code == 200
+    second_ts = r2.json()["generated_at"]
+    assert r2.json()["notes"] == "second"
+    assert second_ts >= first_ts
+    # DB reflects the latest
+    db_session.expire_all()
+    row = (await db_session.execute(
+        select(Quote).where(Quote.id == qid)
+    )).scalar_one()
+    assert row.resumen_obra["notes"] == "second"
+
+
+@pytest.mark.asyncio
+async def test_dedup_same_id(client, validated_quote_factory):
+    qid = await validated_quote_factory()
+    with patch(
+        "app.modules.agent.tools.resumen_obra_tool._upload_to_drive_safe",
+        return_value={},
+    ):
+        r = await client.post(
+            "/api/quotes/resumen-obra",
+            json={"quote_ids": [qid, qid, qid]},
+        )
+    assert r.status_code == 200
+    assert r.json()["quote_ids"] == [qid]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Email draft invalidation
+# ─────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_invalidates_email_draft(
+    client, validated_quote_factory, db_session
+):
+    qid = await validated_quote_factory()
+    # Pre-seed email_draft
+    q = (await db_session.execute(
+        select(Quote).where(Quote.id == qid)
+    )).scalar_one()
+    q.email_draft = {"subject": "x", "body": "y"}
+    await db_session.commit()
+
+    with patch(
+        "app.modules.agent.tools.resumen_obra_tool._upload_to_drive_safe",
+        return_value={},
+    ):
+        r = await client.post(
+            "/api/quotes/resumen-obra",
+            json={"quote_ids": [qid]},
+        )
+    assert r.status_code == 200
+    # Expire session cache so we re-read from DB instead of the pre-commit state
+    db_session.expire_all()
+    row = (await db_session.execute(
+        select(Quote).where(Quote.id == qid)
+    )).scalar_one()
+    assert row.email_draft is None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Resilience: Drive failure does not break PDF generation
+# ─────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_drive_failure_does_not_break_generation(
+    client, validated_quote_factory, db_session
+):
+    qid = await validated_quote_factory()
+    with patch(
+        "app.modules.agent.tools.resumen_obra_tool._upload_to_drive_safe",
+        side_effect=Exception("Drive down"),
+    ):
+        r = await client.post(
+            "/api/quotes/resumen-obra",
+            json={"quote_ids": [qid]},
+        )
+    # Drive failure must NOT cascade — endpoint returns 500 because the
+    # wrapper re-raises. To confirm the non-fatal path, patch the wrapper
+    # itself to simulate the real 'return {}' behavior:
+    assert r.status_code == 500  # sanity: uncaught side_effect surfaces
+
+
+@pytest.mark.asyncio
+async def test_drive_failure_wrapped_returns_200(
+    client, validated_quote_factory, db_session
+):
+    qid = await validated_quote_factory()
+    # Patch the underlying drive upload to fail; _upload_to_drive_safe swallows it
+    with patch(
+        "app.modules.agent.tools.drive_tool.upload_single_file_to_drive",
+        side_effect=Exception("Drive down"),
+    ):
+        r = await client.post(
+            "/api/quotes/resumen-obra",
+            json={"quote_ids": [qid]},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["drive_url"] is None


### PR DESCRIPTION
## Summary
PR 2 del feature Resumen de Obra + Email IA.

Endpoint para generar un PDF consolidado a partir de N presupuestos del mismo cliente, adjuntarlo a cada uno y dejar todo listo para que el frontend (PR 3) lo invoque.

### Cambios
- Modelo \`Quote\`: 2 columnas JSON nullable (\`resumen_obra\`, \`email_draft\`). Migración idempotente \`ALTER TABLE IF NOT EXISTS\` — zero downtime.
- \`resumen_obra_tool.py\`: orquestador con validaciones estrictas, sanitización de notes, dedup de ids, rollback-safe por commit transaccional.
- \`POST /api/quotes/resumen-obra\`: body \`{ quote_ids, notes }\`, devuelve el record completo con pdf_url/drive_url.
- \`_generate_resumen_obra_pdf\`: agregado bloque opcional \"NOTAS ADICIONALES\".

### Validaciones
- 1 ≤ len(quote_ids) ≤ 20
- Todos \`status == VALIDATED\`
- Mismo \`client_name\` (normalizado case-insensitive + trim)
- Notes ≤ 1000 chars, control chars stripped
- Drive upload non-fatal (fail-soft, drive_url=None)

### Tests (15)
- Happy single/multi-quote
- Rechazos: vacío, >20, id inexistente, no validado, clientes mezclados, notes >1000
- Same client different casing acepta
- Notes control chars stripped
- Overwrite sobreescribe
- Dedup same id
- Invalida email_draft de los quotes seleccionados
- Drive failure NO rompe generación

### No rompe nada
- Schema: columnas nullable — zero downtime
- Chatbot API \`/api/v1/quote\` no se toca
- Resto del flow operador sin cambios

🤖 Generated with [Claude Code](https://claude.com/claude-code)