### PR TITLE
feat(client-match): fuzzy match + override + merge-client (back)

### DIFF
--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -754,6 +754,104 @@ async def delete_quote(quote_id: str, db: AsyncSession = Depends(get_db)):
 class ResumenObraRequest(BaseModel):
     quote_ids: List[str]
     notes: Optional[str] = None
+    force_same_client: Optional[bool] = False
+
+
+class MergeClientRequest(BaseModel):
+    quote_ids: List[str]
+    canonical_client_name: str
+
+
+class ClientMatchCheckRequest(BaseModel):
+    quote_ids: List[str]
+
+
+@router.post("/quotes/client-match-check")
+async def client_match_check(
+    body: ClientMatchCheckRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    """Preview: do these quotes look like the same client?
+
+    Returns { same: bool, reason: "exact"|"fuzzy"|"ambiguous",
+              distinct_names: [...] }
+
+    The frontend uses this to decide whether to show a confirmation dialog
+    before POSTing to /resumen-obra.
+    """
+    from app.modules.agent.tools.client_match import are_fuzzy_same_client
+    from app.modules.agent.tools.resumen_obra_tool import _normalize_client
+
+    if not body.quote_ids:
+        raise HTTPException(status_code=400, detail="quote_ids vacío")
+    res = await db.execute(select(Quote).where(Quote.id.in_(body.quote_ids)))
+    quotes = list(res.scalars().all())
+    if len(quotes) < len(set(body.quote_ids)):
+        found = {q.id for q in quotes}
+        missing = [qid for qid in body.quote_ids if qid not in found]
+        raise HTTPException(status_code=404, detail=f"Presupuestos no encontrados: {missing}")
+
+    distinct = sorted({q.client_name or "" for q in quotes})
+    if len(quotes) <= 1:
+        return {"same": True, "reason": "exact", "distinct_names": distinct}
+
+    anchor = quotes[0].client_name
+    normalized_anchor = _normalize_client(anchor)
+    all_exact = all(
+        _normalize_client(q.client_name) == normalized_anchor for q in quotes
+    )
+    if all_exact:
+        return {"same": True, "reason": "exact", "distinct_names": distinct}
+
+    all_fuzzy = all(
+        are_fuzzy_same_client(q.client_name, anchor) for q in quotes[1:]
+    )
+    if all_fuzzy:
+        return {"same": True, "reason": "fuzzy", "distinct_names": distinct}
+
+    return {"same": False, "reason": "ambiguous", "distinct_names": distinct}
+
+
+@router.post("/quotes/merge-client")
+async def merge_client_endpoint(
+    body: MergeClientRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    """Rename the client_name of N quotes to a single canonical value.
+
+    Used when the operator confirms that several quotes with different raw
+    names all belong to the same client. This unifies future grouping
+    without touching any numeric data.
+    """
+    name = (body.canonical_client_name or "").strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="canonical_client_name requerido")
+    if len(name) > 500:
+        raise HTTPException(status_code=400, detail="canonical_client_name demasiado largo")
+    if not body.quote_ids:
+        raise HTTPException(status_code=400, detail="quote_ids vacío")
+
+    res = await db.execute(select(Quote).where(Quote.id.in_(body.quote_ids)))
+    quotes = list(res.scalars().all())
+    found = {q.id for q in quotes}
+    missing = [qid for qid in body.quote_ids if qid not in found]
+    if missing:
+        raise HTTPException(status_code=404, detail=f"Presupuestos no encontrados: {missing}")
+
+    # Apply rename + invalidate email_draft (names affect the prompt).
+    updated = []
+    for q in quotes:
+        if q.client_name != name:
+            updated.append(q.id)
+        q.client_name = name
+        q.email_draft = None
+    await db.commit()
+    return {
+        "ok": True,
+        "updated_ids": updated,
+        "client_name": name,
+        "quote_ids": body.quote_ids,
+    }
 
 
 @router.get("/quotes/{quote_id}/email-draft")
@@ -820,6 +918,7 @@ async def generate_resumen_obra_endpoint(
             db=db,
             quote_ids=body.quote_ids,
             notes_raw=body.notes,
+            force_same_client=bool(body.force_same_client),
         )
     except ResumenObraError as e:
         raise HTTPException(status_code=e.status, detail=e.message)

--- a/api/app/modules/agent/tools/client_match.py
+++ b/api/app/modules/agent/tools/client_match.py
@@ -1,0 +1,133 @@
+"""Fuzzy matching helpers for client names.
+
+Real operator data has a lot of variance:
+  "Estudio MUNGE" vs "Munge" vs "Arq. Munge"  → same client
+  "Juan Carlos Perez" vs "Arq. Perez"          → likely same client
+  "Estudio Perez" vs "Juan Perez"              → AMBIGUOUS — accept as same,
+                                                  but UI shows a warning
+
+Strategy:
+  1. Normalize: lowercase, strip accents, collapse whitespace.
+  2. Tokenize on whitespace.
+  3. Drop stopwords (professional/legal prefixes and short connectors).
+  4. Drop tokens shorter than 3 chars.
+  5. Return the set of core tokens.
+
+Two names are "fuzzy-same" when their core-token sets share at least one
+token of length >= 4 (the 4-char floor prevents collisions on tiny tokens
+like "bsa" or "del").
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+
+# Professional titles, legal forms, common short connectors.
+# Kept conservative — when in doubt, leave the token in.
+_STOPWORDS: frozenset[str] = frozenset(
+    {
+        # Professional titles
+        "arq", "arquitecto", "arquitecta",
+        "dr", "dra", "doctor", "doctora",
+        "sr", "sra", "srta", "senor", "senora",
+        "ing", "ingeniero", "ingeniera",
+        "lic", "licenciado", "licenciada",
+        "cont", "cdor", "contador", "contadora",
+        # Studio / company words
+        "estudio", "consultora", "consultoria",
+        "empresa", "compania",
+        "grupo", "inmobiliaria",
+        # Legal forms
+        "sa", "srl", "sl", "sas", "sac", "sacifia",
+        "cia", "ltd", "ltda",
+        # Connectors
+        "y", "e", "o", "u", "de", "del", "la", "el", "los", "las",
+        "al", "en", "a",
+        # Currency / project noise we sometimes see
+        "para", "por",
+    }
+)
+
+MIN_TOKEN_LEN = 3
+MIN_MATCH_LEN = 4
+
+
+def _strip_accents(text: str) -> str:
+    """Remove accents/diacritics and the Spanish 'ñ' (→ 'n')."""
+    # NFKD decomposition separates base letters from diacritics.
+    decomposed = unicodedata.normalize("NFKD", text)
+    # Drop combining marks + convert 'ñ' to 'n' (already handled by NFKD).
+    return "".join(c for c in decomposed if not unicodedata.combining(c))
+
+
+def normalize_client_name(raw: str | None) -> str:
+    """Lowercase + strip accents + collapse whitespace + trim."""
+    if not raw:
+        return ""
+    s = _strip_accents(str(raw))
+    s = s.lower().strip()
+    s = re.sub(r"\s+", " ", s)
+    return s
+
+
+def client_core_tokens(raw: str | None) -> frozenset[str]:
+    """Return the meaningful tokens of a client name (no stopwords, len>=3).
+
+    Punctuation and digits are stripped. Empty input yields an empty set.
+    """
+    norm = normalize_client_name(raw)
+    if not norm:
+        return frozenset()
+    # Split on anything that's not a letter (drops dots, commas, digits, etc.)
+    tokens = [t for t in re.split(r"[^a-z]+", norm) if t]
+    core = {t for t in tokens if len(t) >= MIN_TOKEN_LEN and t not in _STOPWORDS}
+    return frozenset(core)
+
+
+def are_fuzzy_same_client(a: str | None, b: str | None) -> bool:
+    """True iff two raw names likely refer to the same client.
+
+    Decision rule:
+      1. If both normalize to equal strings → same (fast path).
+      2. Else, their core-token sets must share at least one token of len>=4.
+
+    This is intentionally a bit permissive. A false positive the operator
+    can always dismiss; a false negative (blocking a valid group) is more
+    annoying, so we err on the lenient side.
+    """
+    if a is None and b is None:
+        return True
+    na = normalize_client_name(a)
+    nb = normalize_client_name(b)
+    if na and na == nb:
+        return True
+    ca = client_core_tokens(a)
+    cb = client_core_tokens(b)
+    shared = ca & cb
+    if not shared:
+        return False
+    return any(len(tok) >= MIN_MATCH_LEN for tok in shared)
+
+
+def group_quotes_by_client(
+    quotes: list, *, name_attr: str = "client_name"
+) -> list[list]:
+    """Cluster a flat list of quotes into fuzzy same-client groups.
+
+    Greedy single-pass: each quote joins an existing group when fuzzy-matches
+    its first member; otherwise starts a new group. O(N·G) which is fine for
+    dashboard-sized lists.
+    """
+    groups: list[list] = []
+    for q in quotes:
+        name = getattr(q, name_attr, None)
+        placed = False
+        for g in groups:
+            anchor_name = getattr(g[0], name_attr, None)
+            if are_fuzzy_same_client(name, anchor_name):
+                g.append(q)
+                placed = True
+                break
+        if not placed:
+            groups.append([q])
+    return groups

--- a/api/app/modules/agent/tools/resumen_obra_tool.py
+++ b/api/app/modules/agent/tools/resumen_obra_tool.py
@@ -58,8 +58,22 @@ def _normalize_client(name: str | None) -> str:
     return re.sub(r"\s+", " ", (name or "").strip()).lower()
 
 
-def _validate_quotes(quotes: list[Quote], requested_ids: list[str]) -> None:
-    """Raise ResumenObraError on any contract violation."""
+def _validate_quotes(
+    quotes: list[Quote],
+    requested_ids: list[str],
+    force_same_client: bool = False,
+) -> None:
+    """Raise ResumenObraError on any contract violation.
+
+    Client-name matching is layered:
+      1. Exact normalized match (old strict behavior).
+      2. Else fuzzy match via client_match.are_fuzzy_same_client — covers
+         variants like "Estudio MUNGE" vs "Munge".
+      3. Else, if force_same_client=True, the operator explicitly confirmed
+         they are the same client → allow anyway.
+    """
+    from app.modules.agent.tools.client_match import are_fuzzy_same_client
+
     found_ids = {q.id for q in quotes}
     missing = [qid for qid in requested_ids if qid not in found_ids]
     if missing:
@@ -75,14 +89,31 @@ def _validate_quotes(quotes: list[Quote], requested_ids: list[str]) -> None:
             f"No validados: {non_validated}",
         )
 
-    # Same client (normalized)
-    normalized = {_normalize_client(q.client_name) for q in quotes}
-    if len(normalized) > 1:
-        raise ResumenObraError(
-            400,
-            "Todos los presupuestos deben ser del mismo cliente. "
-            f"Detectados: {sorted(normalized)}",
-        )
+    if len(quotes) <= 1:
+        return
+
+    anchor_name = quotes[0].client_name
+    normalized_anchor = _normalize_client(anchor_name)
+    distinct_raw: set[str] = {anchor_name or ""}
+    fuzzy_ok = True
+    for q in quotes[1:]:
+        distinct_raw.add(q.client_name or "")
+        if _normalize_client(q.client_name) == normalized_anchor:
+            continue
+        if are_fuzzy_same_client(q.client_name, anchor_name):
+            continue
+        fuzzy_ok = False
+
+    if fuzzy_ok:
+        return
+    if force_same_client:
+        return
+    raise ResumenObraError(
+        400,
+        "Todos los presupuestos deben ser del mismo cliente. "
+        f"Detectados: {sorted(distinct_raw)}. "
+        "Si confirmás que son el mismo, reintentá con force_same_client=true.",
+    )
 
 
 def _collect_material_row(q: Quote) -> dict[str, Any] | None:
@@ -224,6 +255,7 @@ async def generate_resumen_obra(
     db: AsyncSession,
     quote_ids: list[str],
     notes_raw: str | None,
+    force_same_client: bool = False,
 ) -> dict:
     """Validate, generate PDF, upload, persist — atomic-ish.
 
@@ -249,7 +281,7 @@ async def generate_resumen_obra(
     # Load quotes
     result = await db.execute(select(Quote).where(Quote.id.in_(deduped)))
     quotes = list(result.scalars().all())
-    _validate_quotes(quotes, deduped)
+    _validate_quotes(quotes, deduped, force_same_client=force_same_client)
 
     # Order quotes to match requested order for deterministic output
     by_id = {q.id: q for q in quotes}

--- a/api/tests/test_client_match.py
+++ b/api/tests/test_client_match.py
@@ -1,0 +1,114 @@
+"""Tests for fuzzy client-name matching."""
+from __future__ import annotations
+
+import pytest
+
+from app.modules.agent.tools.client_match import (
+    are_fuzzy_same_client,
+    client_core_tokens,
+    group_quotes_by_client,
+    normalize_client_name,
+)
+
+
+# ── normalize ────────────────────────────────────────────────────────────
+
+def test_normalize_lowercases_and_strips_accents():
+    assert normalize_client_name("Estudio MUÑGE") == "estudio munge"
+    assert normalize_client_name("  María  Pérez  ") == "maria perez"
+
+
+def test_normalize_empty():
+    assert normalize_client_name(None) == ""
+    assert normalize_client_name("") == ""
+    assert normalize_client_name("   ") == ""
+
+
+# ── core tokens ──────────────────────────────────────────────────────────
+
+def test_core_tokens_strips_professional_prefixes():
+    assert client_core_tokens("Estudio Munge") == frozenset({"munge"})
+    assert client_core_tokens("Arq. Pérez") == frozenset({"perez"})
+
+
+def test_core_tokens_strips_legal_forms():
+    assert client_core_tokens("Munge SA") == frozenset({"munge"})
+    assert client_core_tokens("Constructora SRL") == frozenset({"constructora"})
+
+
+def test_core_tokens_drops_connectors_and_short_tokens():
+    assert client_core_tokens("Juan y María de la Nada") == frozenset(
+        {"juan", "maria", "nada"}
+    )
+
+
+def test_core_tokens_drops_digits_and_punctuation():
+    assert client_core_tokens("Estudio 72 — Ventus") == frozenset({"ventus"})
+
+
+# ── fuzzy same client ────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        ("Estudio Munge", "Munge"),
+        ("Arq. Munge", "Estudio Munge"),
+        ("MUNGE", "munge"),
+        ("Juan Pérez", "Sr. Pérez"),
+        ("Estudio 72 Fideicomiso Ventus", "Fideicomiso Ventus"),
+        ("Estudio Scalone", "Arq Scalone"),
+    ],
+)
+def test_fuzzy_same_positive(a, b):
+    assert are_fuzzy_same_client(a, b) is True
+
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        ("Juan Pérez", "María González"),
+        ("Estudio Munge", "Estudio Ventus"),
+        ("Constructora SRL", "Inmobiliaria SA"),
+        ("", "Estudio Munge"),
+    ],
+)
+def test_fuzzy_same_negative(a, b):
+    assert are_fuzzy_same_client(a, b) is False
+
+
+def test_fuzzy_same_short_token_does_not_bridge():
+    """Tokens shorter than 4 chars should not be enough to claim same client."""
+    # "Ana" is len 3 — match threshold is 4, so:
+    assert are_fuzzy_same_client("Ana Pérez", "Ana Suárez") is False
+
+
+def test_fuzzy_same_both_none_is_true():
+    """Edge: two quotes without any client name → treat as same (operator
+    can always unify them later)."""
+    assert are_fuzzy_same_client(None, None) is True
+
+
+# ── grouping ─────────────────────────────────────────────────────────────
+
+class _Q:
+    def __init__(self, client_name):
+        self.client_name = client_name
+
+
+def test_group_quotes_collapses_variants():
+    qs = [
+        _Q("Estudio Munge"),
+        _Q("Munge"),
+        _Q("Arq. Munge"),
+        _Q("Juan Pérez"),
+        _Q("Sr. Pérez"),
+        _Q("Estudio Ventus"),
+    ]
+    groups = group_quotes_by_client(qs)
+    # Expect 3 groups: Munge (3), Pérez (2), Ventus (1)
+    sizes = sorted(len(g) for g in groups)
+    assert sizes == [1, 2, 3]
+
+
+def test_group_quotes_empty():
+    assert group_quotes_by_client([]) == []

--- a/api/tests/test_client_match_endpoints.py
+++ b/api/tests/test_client_match_endpoints.py
@@ -1,0 +1,209 @@
+"""Tests for the fuzzy-match + merge-client endpoints.
+
+Covers:
+  - /quotes/client-match-check (preview: exact / fuzzy / ambiguous)
+  - /quotes/merge-client       (rename to canonical)
+  - /quotes/resumen-obra       (force_same_client override)
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.models.quote import Quote, QuoteStatus
+
+
+@pytest_asyncio.fixture
+async def mk_quote(db_session):
+    async def _mk(client_name: str, status=QuoteStatus.VALIDATED) -> str:
+        q = Quote(
+            id=str(uuid.uuid4()),
+            client_name=client_name,
+            project="Proyecto",
+            material="SILESTONE BLANCO NORTE",
+            total_ars=1000,
+            total_usd=100,
+            status=status,
+            quote_breakdown={
+                "material_name": "SILESTONE BLANCO NORTE",
+                "material_m2": 1.0,
+                "material_price_unit": 500,
+                "material_currency": "USD",
+            },
+            messages=[],
+        )
+        db_session.add(q)
+        await db_session.commit()
+        return q.id
+    return _mk
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# client-match-check
+# ─────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_match_check_exact(client, mk_quote):
+    a = await mk_quote("Estudio Munge")
+    b = await mk_quote("Estudio Munge")
+    r = await client.post("/api/quotes/client-match-check", json={"quote_ids": [a, b]})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["same"] is True
+    assert body["reason"] == "exact"
+
+
+@pytest.mark.asyncio
+async def test_match_check_fuzzy(client, mk_quote):
+    a = await mk_quote("Estudio Munge")
+    b = await mk_quote("Munge")
+    r = await client.post("/api/quotes/client-match-check", json={"quote_ids": [a, b]})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["same"] is True
+    assert body["reason"] == "fuzzy"
+    assert set(body["distinct_names"]) == {"Estudio Munge", "Munge"}
+
+
+@pytest.mark.asyncio
+async def test_match_check_ambiguous(client, mk_quote):
+    a = await mk_quote("Estudio Munge")
+    b = await mk_quote("Juan Pérez")
+    r = await client.post("/api/quotes/client-match-check", json={"quote_ids": [a, b]})
+    assert r.status_code == 200
+    assert r.json()["same"] is False
+    assert r.json()["reason"] == "ambiguous"
+
+
+@pytest.mark.asyncio
+async def test_match_check_missing_ids(client):
+    r = await client.post(
+        "/api/quotes/client-match-check",
+        json={"quote_ids": [str(uuid.uuid4())]},
+    )
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_match_check_empty(client):
+    r = await client.post("/api/quotes/client-match-check", json={"quote_ids": []})
+    assert r.status_code == 400
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# merge-client
+# ─────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_merge_client_renames_all(client, mk_quote, db_session):
+    a = await mk_quote("Estudio Munge")
+    b = await mk_quote("Munge")
+    r = await client.post(
+        "/api/quotes/merge-client",
+        json={
+            "quote_ids": [a, b],
+            "canonical_client_name": "Estudio MUNGE",
+        },
+    )
+    assert r.status_code == 200, r.text
+    db_session.expire_all()
+    rows = (
+        await db_session.execute(select(Quote).where(Quote.id.in_([a, b])))
+    ).scalars().all()
+    assert all(q.client_name == "Estudio MUNGE" for q in rows)
+
+
+@pytest.mark.asyncio
+async def test_merge_client_invalidates_email_draft(client, mk_quote, db_session):
+    qid = await mk_quote("Munge")
+    q = (await db_session.execute(select(Quote).where(Quote.id == qid))).scalar_one()
+    q.email_draft = {"subject": "x", "body": "y"}
+    await db_session.commit()
+    r = await client.post(
+        "/api/quotes/merge-client",
+        json={"quote_ids": [qid], "canonical_client_name": "Estudio Munge"},
+    )
+    assert r.status_code == 200
+    db_session.expire_all()
+    q2 = (await db_session.execute(select(Quote).where(Quote.id == qid))).scalar_one()
+    assert q2.email_draft is None
+
+
+@pytest.mark.asyncio
+async def test_merge_client_rejects_empty_name(client, mk_quote):
+    qid = await mk_quote("Estudio Munge")
+    r = await client.post(
+        "/api/quotes/merge-client",
+        json={"quote_ids": [qid], "canonical_client_name": "   "},
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_merge_client_rejects_too_long(client, mk_quote):
+    qid = await mk_quote("Estudio Munge")
+    r = await client.post(
+        "/api/quotes/merge-client",
+        json={"quote_ids": [qid], "canonical_client_name": "x" * 501},
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_merge_client_missing_id(client, mk_quote):
+    real = await mk_quote("Estudio Munge")
+    fake = str(uuid.uuid4())
+    r = await client.post(
+        "/api/quotes/merge-client",
+        json={"quote_ids": [real, fake], "canonical_client_name": "X"},
+    )
+    assert r.status_code == 404
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# resumen-obra — fuzzy + override
+# ─────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_resumen_accepts_fuzzy_variants(client, mk_quote):
+    a = await mk_quote("Estudio Munge")
+    b = await mk_quote("Munge")
+    with patch(
+        "app.modules.agent.tools.resumen_obra_tool._upload_to_drive_safe",
+        return_value={},
+    ):
+        r = await client.post(
+            "/api/quotes/resumen-obra",
+            json={"quote_ids": [a, b]},
+        )
+    assert r.status_code == 200, r.text
+
+
+@pytest.mark.asyncio
+async def test_resumen_ambiguous_requires_force(client, mk_quote):
+    a = await mk_quote("Estudio Munge")
+    b = await mk_quote("Juan Pérez")
+    # Without force → rejected
+    with patch(
+        "app.modules.agent.tools.resumen_obra_tool._upload_to_drive_safe",
+        return_value={},
+    ):
+        r1 = await client.post(
+            "/api/quotes/resumen-obra",
+            json={"quote_ids": [a, b]},
+        )
+    assert r1.status_code == 400
+    # With force → accepted
+    with patch(
+        "app.modules.agent.tools.resumen_obra_tool._upload_to_drive_safe",
+        return_value={},
+    ):
+        r2 = await client.post(
+            "/api/quotes/resumen-obra",
+            json={"quote_ids": [a, b], "force_same_client": True},
+        )
+    assert r2.status_code == 200, r2.text


### PR DESCRIPTION
## Summary
Desbloquea la generación de resumen de obra cuando Valentina escribe el cliente con variantes ('Estudio MUNGE' vs 'Munge').

### 3 layers
1. **Exact** (comportamiento anterior)
2. **Fuzzy**: tokens núcleo (sin stopwords) comparten ≥1 token de len>=4 → auto-accepta
3. **Override**: si ni exact ni fuzzy, \`force_same_client=true\` desde el front permite continuar

### Endpoints nuevos
- \`POST /api/quotes/client-match-check\` → preview (exact / fuzzy / ambiguous)
- \`POST /api/quotes/merge-client\` → renombra N quotes al mismo canonical, invalida email_draft

### Tests (32)
- client_match unit: normalize, core_tokens, fuzzy same (MUNGE variants, Ventus, Scalone, etc.), negatives, edge cases (tokens <4 chars, ambos None)
- endpoints: match-check (exact/fuzzy/ambiguous/missing/empty), merge-client (rename/invalidate/reject empty|long|missing), resumen-obra (fuzzy auto, ambiguous requires force)

### No rompe
- Chatbot \`/api/v1/quote\` intacto
- 85/85 tests verdes (incluye PR 1-5)
- Zero downtime: no cambios de schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)