### PR TITLE
chore(deps): psycopg2-binary para silenciar warnings en prod

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -6,6 +6,9 @@ python-multipart==0.0.12
 # Database
 sqlalchemy[asyncio]==2.0.36
 asyncpg==0.30.0
+# psycopg2-binary: sync driver used by catalog_tool for side-channel DB reads
+# (avoids the 'No module named psycopg2' warnings that pollute Railway logs).
+psycopg2-binary==2.9.10
 
 # Anthropic
 anthropic==0.40.0


### PR DESCRIPTION
## Summary
Cada request en Railway producía ~10 warnings \`No module named psycopg2\` porque el catálogo hace lecturas sync (side-channel) que requieren el driver sync de psycopg2, pero solo estaba asyncpg.

El sistema ya caía al fallback JSON → cero cambio funcional, solo limpia logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)