### PR TITLE
fix(pdf): no colapsar 'Mesada c/zócalo' como ZOC

### DIFF
--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -251,8 +251,14 @@ def list_pieces(pieces: list, is_edificio: bool = False) -> dict:
     formatted = []
     for pd in piece_details:
         desc = pd.get("description", "")
-        desc_lower = desc.lower()
-        is_zocalo = "zócalo" in desc_lower or "zocalo" in desc_lower
+        desc_lower = desc.lower().lstrip()
+        # Pure zócalo: description starts with "zócalo". Mesadas que mencionan
+        # "c/zócalo h:Xcm" son mesadas, no zócalos — deben conservar su label.
+        is_zocalo = (
+            desc_lower.startswith("zócalo")
+            or desc_lower.startswith("zocalo")
+            or desc_lower.startswith("zoc ")
+        )
         qty = pd.get("quantity", 1)
 
         if is_zocalo:
@@ -691,8 +697,17 @@ def calculate_quote(input_data: dict) -> dict:
     has_m2_override = False
     for pd in piece_details:
         if pd["m2"] > 0:
-            desc_lower = (pd["description"] or "").lower()
-            is_zocalo = "zócalo" in desc_lower or "zocalo" in desc_lower
+            desc_lower = (pd["description"] or "").lower().lstrip()
+            # Pure zócalo pieces have descriptions that START with "zócalo"
+            # (e.g. "Zócalo 1.50 × 0.05"). Pieces like "Mesada recta c/zócalo
+            # h:10cm" are MESADAS that happen to include a zócalo in their
+            # m² — they must render with the full label, not collapsed to
+            # a ZOC row. Check start-of-string only.
+            is_zocalo = (
+                desc_lower.startswith("zócalo")
+                or desc_lower.startswith("zocalo")
+                or desc_lower.startswith("zoc ")
+            )
             if is_zocalo:
                 label = f'{pd["largo"]:.2f}ML X {pd["dim2"]:.2f} ZOC'
             else:

--- a/api/tests/test_list_pieces.py
+++ b/api/tests/test_list_pieces.py
@@ -146,6 +146,72 @@ class TestListPiecesToolDispatch:
         assert "ZOC" in zocalo[0]
 
 
+class TestMesadaConZocaloNoCollapsed:
+    """Regression: 'Mesada recta c/zócalo h:10cm' must render as MESADA, not ZOC.
+
+    Bug DINALE 14/04/2026: el PDF colapsaba todas las tipologías edificio
+    (ME01-B, ME02-B, etc.) con descripciones tipo "Mesada recta c/zócalo h:10cm"
+    a filas "X.XXML X 0.60 ZOC" porque el check `"zócalo" in desc` matcheaba
+    la palabra dentro de la descripción. Solo deben colapsarse piezas cuya
+    descripción EMPIECE con "zócalo".
+    """
+
+    def test_mesada_con_zocalo_keeps_description(self):
+        result = list_pieces([
+            {"description": "ME01-B Mesada recta c/zócalo h:10cm", "largo": 2.15, "prof": 0.60},
+        ])
+        assert result["ok"]
+        label = result["pieces"][0]["label"]
+        # Must preserve full description, NOT collapse to "ZOC"
+        assert "Mesada recta" in label
+        assert "ME01-B" in label
+        assert "ZOC" not in label
+
+    def test_mesada_con_zocalo_alto_50cm(self):
+        """ME04-B con zócalo h:50cm sigue siendo mesada."""
+        result = list_pieces([
+            {"description": "Mesada recta c/zócalo h:50cm", "largo": 2.30, "prof": 0.60},
+        ])
+        label = result["pieces"][0]["label"]
+        assert "Mesada" in label
+        assert "ZOC" not in label
+
+    def test_pure_zocalo_still_collapses(self):
+        """Zócalo puro (descripción empieza con 'Zócalo') se sigue colapsando."""
+        result = list_pieces([
+            {"description": "Zócalo trasero", "largo": 3.50, "alto": 0.05},
+        ])
+        label = result["pieces"][0]["label"]
+        assert "ZOC" in label
+        assert "ML" in label
+
+    def test_calculate_quote_sectors_keep_mesada_label(self):
+        """calculate_quote (código en sectors) también debe preservar label."""
+        result = calculate_quote({
+            "client_name": "TEST",
+            "material": "GRANITO GRIS MARA EXTRA 2 ESP",
+            "pieces": [
+                {"description": "ME01-B Mesada recta c/zócalo h:10cm",
+                 "largo": 2.15, "prof": 0.60, "m2_override": 1.625},
+                {"description": "ME04-B Mesada recta c/zócalo h:50cm",
+                 "largo": 2.30, "prof": 0.60, "quantity": 4, "m2_override": 3.130},
+            ],
+            "localidad": "rosario",
+            "plazo": "4 meses",
+            "is_edificio": True,
+            "colocacion": False,
+            "pileta": "empotrada_cliente",
+        })
+        assert result.get("ok"), result
+        sectors = result.get("sectors", [])
+        assert sectors
+        labels = sectors[0]["pieces"]
+        # Ninguno debe ser ZOC puro: el brief tiene solo mesadas c/zócalo
+        assert not any(" ZOC" in lbl.split("*")[0].rstrip() for lbl in labels), labels
+        # Debe preservar "Mesada" en los labels
+        assert any("Mesada" in lbl for lbl in labels), labels
+
+
 # ── Verify list_pieces is in TOOLS schema ────────────────────────────────────
 
 class TestListPiecesInToolSchema:


### PR DESCRIPTION
## Bug reproducido en DINALE S.A. (14/04/2026)

El PDF generado para presupuestos con descripciones tipo \`\"Mesada recta c/zócalo h:10cm\"\` colapsaba todas las tipologías en filas genéricas \`X.XXML X 0.60 ZOC\`, perdiendo:
- Código de tipología (ME01-B, ME02-B, ME03-B, …)
- Texto \"Mesada recta\"
- Altura del zócalo (h:10cm, h:50cm, h:34cm)

Además agrupaba tipologías distintas con mismas medidas como si fueran la misma pieza (ej: \`1.70ML X 0.60 ZOC * (×3)\` juntaba ME01-CD + ME01-F1 + ME01-F2).

## Causa

\`\`\`python
is_zocalo = \"zócalo\" in desc_lower or \"zocalo\" in desc_lower
\`\`\`

El check matcheaba la palabra en cualquier posición, incluyendo dentro de \"Mesada recta c/**zócalo** h:10cm\".

## Fix

Detectar solo piezas cuya descripción **empieza** con zócalo. Aplicado en los dos code paths:
- \`list_pieces()\` — Paso 1 del chat (api/app/modules/quote_engine/calculator.py:254)
- \`calculate_quote()\` → sectors del PDF/Excel (api/app/modules/quote_engine/calculator.py:694)

## Tests

Nueva clase \`TestMesadaConZocaloNoCollapsed\` en tests/test_list_pieces.py cubre:
- Mesada c/zócalo preserva código + descripción completa
- Zócalo puro sigue colapsando a fila ZOC
- \`calculate_quote\` sectors también preserva labels de mesada

## Test plan

- [ ] Correr \`pytest tests/test_list_pieces.py\`
- [ ] Regenerar PDF de DINALE y verificar que aparecen los códigos ME01-B..ME01-G con sus descripciones completas
- [ ] Verificar que presupuestos con zócalos puros (ej: Alvaro Torres) siguen renderizando \`X.XXML X 0.05 ZOC\`

## No incluido (otro PR)

- Descuento 15% material no visible como línea en PDF → PR separado
- \`mo_discount_pct\` aplicando a todo MO cuando brief dice \"sobre PEGADOPILETA\" → PR separado
- Espesor no disponible (25mm vs catálogo 20mm) → regla docs-only → PR separado
- Warning \`material_price_base\` → PR separado