### PR TITLE
fix(pdf,excel): mostrar descuento material en ARS (bug DINALE)

### DIFF
--- a/api/app/modules/agent/tools/document_tool.py
+++ b/api/app/modules/agent/tools/document_tool.py
@@ -1326,12 +1326,17 @@ def _generate_pdf(pdf_path: Path, data: dict) -> None:
             display = f"{piece} (×{count})" if count > 1 else piece
             all_piece_rows.append((False, display))
 
-    # Build right-side overlay rows (Descuento + TOTAL) for USD
+    # Build right-side overlay rows (Descuento + TOTAL)
+    # Applies to both USD and ARS — originally gated to USD only which
+    # hid the discount line for ARS edificios (bug DINALE 14/04/2026).
     right_rows = []
-    if currency == "USD":
-        if discount_pct:
-            desc_amount = round(total_mat_bruto * discount_pct / 100)
-            right_rows.append(("I", f"Descuento {discount_pct}%", f"- {fmt_price(desc_amount)}"))
+    if discount_pct:
+        desc_amount = round(total_mat_bruto * discount_pct / 100)
+        right_rows.append(("I", f"Descuento {discount_pct}%", f"- {fmt_price(desc_amount)}"))
+        right_rows.append(("B", f"TOTAL {currency}", fmt_price(total_mat)))
+    elif currency == "USD":
+        # Keep legacy behavior for USD without discount — always show TOTAL USD
+        # row so the user sees the net material total in the material block.
         right_rows.append(("B", f"TOTAL {currency}", fmt_price(total_mat)))
 
     # Calculate which piece rows get right-side content
@@ -1613,14 +1618,18 @@ def _generate_excel(output_path: Path, data: dict) -> None:
             cell.value = None
             cell.fill = no_fill
 
-    # Build right-side overlay (Descuento + TOTAL) for USD
+    # Build right-side overlay (Descuento + TOTAL)
+    # Applies to both USD and ARS — originally gated to USD only which hid
+    # the discount line for ARS edificios (bug DINALE 14/04/2026).
     italic_sm = Font(name="Calibri", italic=True, size=9)
+    _xl_fmt = _fmt_usd if currency == "USD" else _fmt_ars
     right_rows_xl = []
-    if currency == "USD":
-        if discount_pct:
-            desc_amount = round(total_mat * discount_pct / 100)
-            right_rows_xl.append(("I", f"Descuento {discount_pct}%", f"- {_fmt_usd(desc_amount)}"))
-        right_rows_xl.append(("B", f"TOTAL {currency}", _fmt_usd(total_mat_net)))
+    if discount_pct:
+        desc_amount = round(total_mat * discount_pct / 100)
+        right_rows_xl.append(("I", f"Descuento {discount_pct}%", f"- {_xl_fmt(desc_amount)}"))
+        right_rows_xl.append(("B", f"TOTAL {currency}", _xl_fmt(total_mat_net)))
+    elif currency == "USD":
+        right_rows_xl.append(("B", f"TOTAL {currency}", _xl_fmt(total_mat_net)))
 
     # Overlay on last N pieces
     overlay_start_xl = max(0, len(all_pieces) - len(right_rows_xl))

--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -251,8 +251,14 @@ def list_pieces(pieces: list, is_edificio: bool = False) -> dict:
     formatted = []
     for pd in piece_details:
         desc = pd.get("description", "")
-        desc_lower = desc.lower()
-        is_zocalo = "zócalo" in desc_lower or "zocalo" in desc_lower
+        desc_lower = desc.lower().lstrip()
+        # Pure zócalo: description starts with "zócalo". Mesadas que mencionan
+        # "c/zócalo h:Xcm" son mesadas, no zócalos — deben conservar su label.
+        is_zocalo = (
+            desc_lower.startswith("zócalo")
+            or desc_lower.startswith("zocalo")
+            or desc_lower.startswith("zoc ")
+        )
         qty = pd.get("quantity", 1)
 
         if is_zocalo:
@@ -691,8 +697,17 @@ def calculate_quote(input_data: dict) -> dict:
     has_m2_override = False
     for pd in piece_details:
         if pd["m2"] > 0:
-            desc_lower = (pd["description"] or "").lower()
-            is_zocalo = "zócalo" in desc_lower or "zocalo" in desc_lower
+            desc_lower = (pd["description"] or "").lower().lstrip()
+            # Pure zócalo pieces have descriptions that START with "zócalo"
+            # (e.g. "Zócalo 1.50 × 0.05"). Pieces like "Mesada recta c/zócalo
+            # h:10cm" are MESADAS that happen to include a zócalo in their
+            # m² — they must render with the full label, not collapsed to
+            # a ZOC row. Check start-of-string only.
+            is_zocalo = (
+                desc_lower.startswith("zócalo")
+                or desc_lower.startswith("zocalo")
+                or desc_lower.startswith("zoc ")
+            )
             if is_zocalo:
                 label = f'{pd["largo"]:.2f}ML X {pd["dim2"]:.2f} ZOC'
             else:

--- a/api/tests/test_excel_regression.py
+++ b/api/tests/test_excel_regression.py
@@ -462,3 +462,99 @@ class TestExcelPdfParity:
                 pass
             all_text = (xml + shared).lower()
             assert "no se suben mesadas" in all_text, f"Footer missing from {xlsx.name}"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# DISCOUNT LINE IN ARS QUOTES (Bug DINALE 14/04/2026)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestDiscountVisibleForARS:
+    """Regression: material discount line must render for ARS (not only USD).
+
+    Before fix: `if currency == "USD":` gated the entire Descuento + TOTAL
+    overlay rows in both _generate_pdf and _generate_excel, so ARS edificios
+    (e.g. DINALE with Granito Gris Mara + 15% edificio) showed no discount
+    line in the PDF/Excel — only the final Total PESOS reflected the
+    discount numerically, leaving the client confused.
+    """
+
+    def _ars_data_with_discount(self) -> dict:
+        return {
+            "client_name": "DINALE S.A.",
+            "project": "Unidad Penitenciaria N°12",
+            "delivery_days": "4 meses",
+            "material_name": "GRANITO GRIS MARA EXTRA 2 ESP",
+            "material_m2": 31.37,
+            "material_price_unit": 224825,
+            "material_currency": "ARS",
+            "discount_pct": 15,
+            "thickness_mm": 20,
+            "sectors": [{"label": "Obra", "pieces": [
+                "2.15 x 0.60 ME01-B Mesada recta c/zocalo h:10cm",
+                "1.12 x 0.60 ME02-B Mesada recta c/zocalo h:10cm",
+                "4.50 x 0.60 ME03-B Mesada recta c/zocalo h:10cm",
+                "2.30 x 0.60 ME04-B Mesada recta c/zocalo h:50cm",
+            ]}],
+            "sinks": [],
+            "mo_items": [
+                {"description": "Agujero y pegado pileta", "quantity": 19, "unit_price": 62045, "base_price": 51276, "total": 1178855},
+                {"description": "Flete + toma medidas rosario", "quantity": 4, "unit_price": 52000, "base_price": 42975, "total": 208000},
+            ],
+            "total_ars": 7381701,
+            "total_usd": 0,
+            "is_edificio": True,
+        }
+
+    def test_pdf_ars_shows_discount_line(self, tmp_path):
+        """PDF for ARS quote with discount_pct must render 'Descuento N%' + 'TOTAL ARS'."""
+        from app.modules.agent.tools.document_tool import _generate_pdf
+        out = tmp_path / "ars_disc.pdf"
+        _generate_pdf(out, self._ars_data_with_discount())
+        assert out.exists()
+        # Extract text via pdftotext (available in CI + local via poppler)
+        import subprocess
+        try:
+            txt = subprocess.run(
+                ["pdftotext", "-layout", str(out), "-"],
+                capture_output=True, text=True, timeout=15,
+            ).stdout
+        except FileNotFoundError:
+            pytest.skip("pdftotext not installed")
+        assert "Descuento 15%" in txt, f"Expected 'Descuento 15%' in PDF text:\n{txt[:1500]}"
+        assert "TOTAL ARS" in txt, f"Expected 'TOTAL ARS' in PDF text:\n{txt[:1500]}"
+        assert "5.994.846" in txt, f"Expected material net (5.994.846) in PDF:\n{txt[:1500]}"
+
+    def test_excel_ars_shows_discount_line(self, tmp_path):
+        """Excel for ARS quote with discount_pct must include 'Descuento N%' cell."""
+        from app.modules.agent.tools.document_tool import _generate_excel
+        out = tmp_path / "ars_disc.xlsx"
+        _generate_excel(out, self._ars_data_with_discount())
+        assert out.exists()
+        import zipfile
+        with zipfile.ZipFile(str(out)) as z:
+            shared = z.read("xl/sharedStrings.xml").decode("utf-8") if "xl/sharedStrings.xml" in z.namelist() else ""
+            sheet = z.read("xl/worksheets/sheet1.xml").decode("utf-8")
+        all_text = shared + sheet
+        assert "Descuento 15%" in all_text, "'Descuento 15%' label missing from ARS Excel"
+        assert "TOTAL ARS" in all_text, "'TOTAL ARS' row missing from ARS Excel"
+
+    def test_pdf_usd_still_shows_discount(self, tmp_path):
+        """Regression guard: USD discount path must still work unchanged."""
+        from app.modules.agent.tools.document_tool import _generate_pdf
+        data = self._ars_data_with_discount()
+        data["material_currency"] = "USD"
+        data["material_price_unit"] = 519
+        data["total_usd"] = 2507
+        data["total_ars"] = 0
+        out = tmp_path / "usd_disc.pdf"
+        _generate_pdf(out, data)
+        import subprocess
+        try:
+            txt = subprocess.run(
+                ["pdftotext", "-layout", str(out), "-"],
+                capture_output=True, text=True, timeout=15,
+            ).stdout
+        except FileNotFoundError:
+            pytest.skip("pdftotext not installed")
+        assert "Descuento 15%" in txt
+        assert "TOTAL USD" in txt

--- a/api/tests/test_list_pieces.py
+++ b/api/tests/test_list_pieces.py
@@ -146,6 +146,72 @@ class TestListPiecesToolDispatch:
         assert "ZOC" in zocalo[0]
 
 
+class TestMesadaConZocaloNoCollapsed:
+    """Regression: 'Mesada recta c/zócalo h:10cm' must render as MESADA, not ZOC.
+
+    Bug DINALE 14/04/2026: el PDF colapsaba todas las tipologías edificio
+    (ME01-B, ME02-B, etc.) con descripciones tipo "Mesada recta c/zócalo h:10cm"
+    a filas "X.XXML X 0.60 ZOC" porque el check `"zócalo" in desc` matcheaba
+    la palabra dentro de la descripción. Solo deben colapsarse piezas cuya
+    descripción EMPIECE con "zócalo".
+    """
+
+    def test_mesada_con_zocalo_keeps_description(self):
+        result = list_pieces([
+            {"description": "ME01-B Mesada recta c/zócalo h:10cm", "largo": 2.15, "prof": 0.60},
+        ])
+        assert result["ok"]
+        label = result["pieces"][0]["label"]
+        # Must preserve full description, NOT collapse to "ZOC"
+        assert "Mesada recta" in label
+        assert "ME01-B" in label
+        assert "ZOC" not in label
+
+    def test_mesada_con_zocalo_alto_50cm(self):
+        """ME04-B con zócalo h:50cm sigue siendo mesada."""
+        result = list_pieces([
+            {"description": "Mesada recta c/zócalo h:50cm", "largo": 2.30, "prof": 0.60},
+        ])
+        label = result["pieces"][0]["label"]
+        assert "Mesada" in label
+        assert "ZOC" not in label
+
+    def test_pure_zocalo_still_collapses(self):
+        """Zócalo puro (descripción empieza con 'Zócalo') se sigue colapsando."""
+        result = list_pieces([
+            {"description": "Zócalo trasero", "largo": 3.50, "alto": 0.05},
+        ])
+        label = result["pieces"][0]["label"]
+        assert "ZOC" in label
+        assert "ML" in label
+
+    def test_calculate_quote_sectors_keep_mesada_label(self):
+        """calculate_quote (código en sectors) también debe preservar label."""
+        result = calculate_quote({
+            "client_name": "TEST",
+            "material": "GRANITO GRIS MARA EXTRA 2 ESP",
+            "pieces": [
+                {"description": "ME01-B Mesada recta c/zócalo h:10cm",
+                 "largo": 2.15, "prof": 0.60, "m2_override": 1.625},
+                {"description": "ME04-B Mesada recta c/zócalo h:50cm",
+                 "largo": 2.30, "prof": 0.60, "quantity": 4, "m2_override": 3.130},
+            ],
+            "localidad": "rosario",
+            "plazo": "4 meses",
+            "is_edificio": True,
+            "colocacion": False,
+            "pileta": "empotrada_cliente",
+        })
+        assert result.get("ok"), result
+        sectors = result.get("sectors", [])
+        assert sectors
+        labels = sectors[0]["pieces"]
+        # Ninguno debe ser ZOC puro: el brief tiene solo mesadas c/zócalo
+        assert not any(" ZOC" in lbl.split("*")[0].rstrip() for lbl in labels), labels
+        # Debe preservar "Mesada" en los labels
+        assert any("Mesada" in lbl for lbl in labels), labels
+
+
 # ── Verify list_pieces is in TOOLS schema ────────────────────────────────────
 
 class TestListPiecesInToolSchema:


### PR DESCRIPTION
## Bug DINALE 14/04/2026

El PDF generado no mostraba la línea de descuento 15% del material, aunque el total final la reflejaba numéricamente. El cliente veía:

- \`Precio total: \$7.052.760\` (bruto, SIN aplicar descuento visible)
- Luego MO
- \`Total PESOS: \$7.371.446\` (que implícitamente tenía el 15% aplicado al material)

Sin la línea "Descuento 15% -\$1.057.914" + "TOTAL ARS \$5.994.846" entre pieces y MO. Confunde al cliente porque parece que el total no cuadra.

## Causa raíz

Dos code paths con la misma mala gate:

\`\`\`python
# document_tool.py:1331 (_generate_pdf)
if currency == "USD":
    if discount_pct:
        right_rows.append(("I", f"Descuento {discount_pct}%", ...))
    right_rows.append(("B", f"TOTAL {currency}", ...))

# document_tool.py:1624 (_generate_excel)
if currency == "USD":
    if discount_pct:
        right_rows_xl.append(("I", f"Descuento {discount_pct}%", ...))
    right_rows_xl.append(("B", f"TOTAL {currency}", ...))
\`\`\`

Ambos gateados a USD, ignorando el caso ARS con descuento edificio (18%, 15%, etc.).

## Fix

Aplicar el overlay Descuento + TOTAL a ambas monedas cuando hay \`discount_pct > 0\`. Mantener el comportamiento legacy de USD (siempre mostrar "TOTAL USD" incluso sin descuento) para no romper presupuestos existentes.

## Tests

Nueva clase \`TestDiscountVisibleForARS\` en tests/test_excel_regression.py:
- \`test_pdf_ars_shows_discount_line\` — extrae texto del PDF con pdftotext y valida "Descuento 15%" + "TOTAL ARS" + "5.994.846"
- \`test_excel_ars_shows_discount_line\` — lee XML del xlsx y valida mismos strings
- \`test_pdf_usd_still_shows_discount\` — regression guard para USD

## Test plan

- [ ] \`pytest tests/test_excel_regression.py::TestDiscountVisibleForARS\`
- [ ] Regenerar PDF de DINALE real y verificar que aparece la línea "Descuento 15% -\$1.057.914" + "TOTAL ARS \$5.994.846" entre los pieces y el bloque MO
- [ ] Verificar que un presupuesto USD con descuento (ej: arquitecta 5%) sigue renderizando igual
- [ ] Verificar que un presupuesto USD sin descuento sigue mostrando "TOTAL USD" (legacy)

## Continuación

Próximos PRs:
- \`mo_discount_pct\` scope (5% solo sobre PEGADOPILETA, no todo MO)
- Regla de espesor no disponible
- Warning \`material_price_base\` faltante