### PR TITLE
fix(discount): MO discount siempre a todo-MO-menos-flete (invariante)

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -3679,11 +3679,19 @@ class AgentService:
                             except ValueError:
                                 continue
 
-                # MO discount — "5% sobre MO", "descuento 5% sobre mano de obra"
+                # MO discount — "5% sobre MO", "descuento 5% sobre mano de obra",
+                # y también "sobre PEGADOPILETA" / "sobre pileta" / "sobre pegado
+                # pileta" / "sobre subtotal PEGADOPILETA" (scope invariante: el
+                # descuento SIEMPRE aplica a todo MO excepto flete, sin importar
+                # cómo lo enuncie el operador — ver rules/quote-process-buildings.md).
                 if not inputs.get("mo_discount_pct"):
                     _mo_patterns = [
                         r'(\d{1,2})\s*%\s+sobre\s+(?:la\s+)?(?:mo\b|mano\s+de\s+obra)',
                         r'descuento[^\n.]{0,30}?(\d{1,2})\s*%[^\n.]{0,30}?(?:mo\b|mano\s+de\s+obra)',
+                        r'(\d{1,2})\s*%\s+sobre\s+(?:subtotal\s+)?(?:el\s+)?pegadopileta',
+                        r'(\d{1,2})\s*%\s+sobre\s+(?:subtotal\s+)?(?:el\s+)?pegado\s+pileta',
+                        r'descuento[^\n.]{0,40}?(\d{1,2})\s*%[^\n.]{0,40}?pegadopileta',
+                        r'descuento[^\n.]{0,40}?(\d{1,2})\s*%[^\n.]{0,40}?pegado\s+pileta',
                     ]
                     for _pat in _mo_patterns:
                         _m_mo = _re_disc.search(_pat, _disc_text, _re_disc.IGNORECASE)

--- a/api/rules/quote-process-buildings.md
+++ b/api/rules/quote-process-buildings.md
@@ -158,11 +158,24 @@ El calculator excluye automáticamente el flete de ambos descuentos. Si ves un
 total de flete reducido en el preview, es un bug — reportar.
 
 ### Descuento comercial sobre MO (`mo_discount_pct`)
-Cuando el operador declara "descuento X% sobre MO" en un edificio:
+Cuando el operador declara un descuento X% sobre MO en un edificio:
 - Pasar `mo_discount_pct: X` en el input a `calculate_quote`.
-- Se calcula sobre la suma de MO c/IVA (con ÷1.05 ya aplicado), excluyendo flete.
+- Se calcula sobre la suma de MO c/IVA (con ÷1.05 ya aplicado), **excluyendo flete**.
 - Se muestra como línea separada visible en el Paso 2.
 - Default: 0 (no aplicar salvo pedido explícito).
+
+⛔ **SCOPE INVARIANTE — siempre TODO MO menos flete:**
+Sin importar cómo lo enuncie el operador en el brief
+(`"5% sobre MO"`, `"5% sobre PEGADOPILETA"`, `"5% sobre mano de obra"`,
+`"descuento especial 5%"`, `"5% sobre subtotal PEGADOPILETA"`, etc.),
+el descuento se aplica SIEMPRE a la suma de TODA la MO excluyendo flete.
+
+NO interpretar "sobre PEGADOPILETA" como un scope más angosto. NO crear
+campos `pileta_discount_pct` u otros scopes parciales. El descuento MO
+es una sola variable con una sola semántica: **todo-menos-flete**.
+
+Label en PDF/Excel: siempre `"Descuento N% sobre MO (excluye flete)"`,
+nunca `"sobre PEGADOPILETA"` aunque el brief lo diga así.
 
 ### Material no encontrado
 Informar operador. Preguntar cual usar — no sugerir alternativas.

--- a/api/tests/test_discount_parse.py
+++ b/api/tests/test_discount_parse.py
@@ -26,6 +26,12 @@ _MAT_PATTERNS = [
 _MO_PATTERNS = [
     r'(\d{1,2})\s*%\s+sobre\s+(?:la\s+)?(?:mo\b|mano\s+de\s+obra)',
     r'descuento[^\n.]{0,30}?(\d{1,2})\s*%[^\n.]{0,30}?(?:mo\b|mano\s+de\s+obra)',
+    # "sobre PEGADOPILETA" variants — route to mo_discount_pct.
+    # Scope invariante: todo-MO-menos-flete sin importar cómo se enuncie.
+    r'(\d{1,2})\s*%\s+sobre\s+(?:subtotal\s+)?(?:el\s+)?pegadopileta',
+    r'(\d{1,2})\s*%\s+sobre\s+(?:subtotal\s+)?(?:el\s+)?pegado\s+pileta',
+    r'descuento[^\n.]{0,40}?(\d{1,2})\s*%[^\n.]{0,40}?pegadopileta',
+    r'descuento[^\n.]{0,40}?(\d{1,2})\s*%[^\n.]{0,40}?pegado\s+pileta',
 ]
 
 
@@ -151,3 +157,28 @@ def test_no_false_positive_percentage_in_different_context():
     """Percentages unrelated to discount must not match."""
     assert detect_material_discount("IVA 21% sobre el total") is None
     assert detect_material_discount("el material tiene 3% de desperdicio") is None
+
+
+# ── PEGADOPILETA phrasing → still routes to mo_discount_pct ─────────────
+# Scope invariante: el descuento MO aplica SIEMPRE a todo MO excepto flete,
+# independiente del texto del brief. Incluso cuando el operador dice
+# "5% sobre PEGADOPILETA", el descuento se aplica a todo MO (no a un
+# subconjunto angosto). Por eso estos patrones enrutan a `mo_discount_pct`
+# y NO a un hipotético `pileta_discount_pct` (que no existe por diseño).
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("5% sobre PEGADOPILETA", 5),
+        ("5% sobre pegadopileta", 5),
+        ("5% sobre pegado pileta", 5),
+        ("5% sobre subtotal PEGADOPILETA", 5),
+        ("Descuento especial 5% sobre subtotal PEGADOPILETA", 5),
+        ("Descuento 5% solo sobre PEGADOPILETA", 5),
+        ("descuento del 8% sobre pegadopileta", 8),
+    ],
+)
+def test_pegadopileta_phrasing_routes_to_mo_discount(text, expected):
+    """DINALE 14/04/2026 y similares: brief dice 'sobre PEGADOPILETA' pero
+    el scope efectivo es todo-MO-menos-flete."""
+    assert detect_mo_discount(text) == expected

--- a/api/tests/test_fase1_regresion.py
+++ b/api/tests/test_fase1_regresion.py
@@ -241,7 +241,10 @@ class TestMoDiscountAndFleteRules:
         descs = {m["description"].lower() for m in mo}
         # Debe haber al menos pegado + faldon + flete
         assert any("pegado" in d or "pileta" in d for d in descs), descs
-        assert any("faldon" in d or "faldón" in d for d in descs), descs
+        assert any(
+            "faldon" in d or "faldón" in d or "frentin" in d or "frentín" in d
+            for d in descs
+        ), descs
         assert any("flete" in d for d in descs), descs
 
         # Suma esperada del descuento: 5% sobre (todo MO excepto flete)

--- a/api/tests/test_fase1_regresion.py
+++ b/api/tests/test_fase1_regresion.py
@@ -210,6 +210,54 @@ class TestMoDiscountAndFleteRules:
         # Flete unit_price sigue siendo el del catálogo (no reducido)
         assert flete_item["unit_price"] == flete_item["total"] / flete_item["quantity"]
 
+    def test_mo_discount_scope_invariant_dinale(self):
+        """SCOPE INVARIANTE: el descuento MO SIEMPRE aplica a todo MO menos
+        flete, sin importar cómo lo enuncie el brief.
+
+        Caso DINALE 14/04/2026: brief dice 'Descuento 5% solo sobre PEGADOPILETA'
+        + MO incluye PEGADOPILETA + FALDON + Flete. El descuento debe calcularse
+        sobre PEGADOPILETA + FALDON (todo lo que no es flete), NO solo sobre
+        PEGADOPILETA. Ver rules/quote-process-buildings.md → "Descuento
+        comercial sobre MO" → SCOPE INVARIANTE.
+        """
+        result = calculate_quote({
+            "client_name": "DINALE",
+            "material": "Silestone Blanco Norte",
+            "pieces": [
+                {"description": "Mesada", "largo": 2.00, "prof": 0.60, "quantity": 10},
+            ],
+            "localidad": "Rosario",
+            "colocacion": False,
+            "pileta": "empotrada_cliente",
+            "pileta_qty": 19,
+            "frentin": True,
+            "frentin_ml": 2.90,
+            "is_edificio": True,
+            "plazo": "4 meses",
+            "mo_discount_pct": 5,
+        })
+        assert result["ok"] is True
+        mo = result["mo_items"]
+        descs = {m["description"].lower() for m in mo}
+        # Debe haber al menos pegado + faldon + flete
+        assert any("pegado" in d or "pileta" in d for d in descs), descs
+        assert any("faldon" in d or "faldón" in d for d in descs), descs
+        assert any("flete" in d for d in descs), descs
+
+        # Suma esperada del descuento: 5% sobre (todo MO excepto flete)
+        subtotal_excl_flete = sum(
+            m["total"] for m in mo if "flete" not in m["description"].lower()
+        )
+        expected_disc = round(subtotal_excl_flete * 0.05)
+        assert result["mo_discount_amount"] == expected_disc, (
+            f"Scope invariant violated: discount should be 5% of ALL MO "
+            f"except flete (={subtotal_excl_flete}) = {expected_disc}, "
+            f"got {result['mo_discount_amount']}"
+        )
+        # Sanity: flete NO recibe descuento
+        flete = next(m for m in mo if "flete" in m["description"].lower())
+        assert not flete.get("edificio_discount")
+
     def test_no_mo_discount_when_zero(self):
         """Sin mo_discount_pct, mo_discount_amount = 0."""
         result = calculate_quote({


### PR DESCRIPTION
## Contexto

Caso DINALE 14/04/2026: el operador escribió en el brief
\`\"Descuento 5% solo sobre PEGADOPILETA — NUNCA sobre flete\"\`.
El agente calculó el 5% sobre PEGADOPILETA **+ FALDON** (correcto por
regla comercial: todo MO menos flete).

En una revisión inicial se sugirió crear un campo \`pileta_discount_pct\`
para respetar literalmente el brief. **Pero la regla comercial es que
el descuento MO siempre aplica a toda la MO excepto flete, independiente
del texto del operador.** Este PR formaliza ese invariante y bloquea
cualquier drift del agente hacia scopes parciales.

## Cambios

- **\`rules/quote-process-buildings.md\`**: sección \"Descuento comercial
  sobre MO\" actualizada con SCOPE INVARIANTE explícito. Lista frases
  que deben todas enrutar al mismo campo (\`sobre MO\`, \`sobre PEGADOPILETA\`,
  \`sobre subtotal PEGADOPILETA\`, etc.) y label fijo
  \`\"Descuento N% sobre MO (excluye flete)\"\`.
- **\`agent.py\`**: extendidos los regex de detección \`mo_discount_pct\`
  para capturar también \"sobre PEGADOPILETA\" y variantes. Se enrutan al
  mismo \`mo_discount_pct\` (no a un campo separado).
- **Tests**:
  - \`test_discount_parse.py\`: 7 variantes de frases PEGADOPILETA
    parametrizadas.
  - \`test_fase1_regresion.py::test_mo_discount_scope_invariant_dinale\`:
    reproduce PEGADOPILETA + FALDON + Flete con \`mo_discount_pct=5\` y
    verifica que \`mo_discount_amount = 5% × (PEGADOPILETA + FALDON)\`,
    NO solo sobre PEGADOPILETA.

## Por qué no tocar el calculator

El código de [calculator.py:664](api/app/modules/quote_engine/calculator.py:664)
ya implementa el invariante correctamente. Lo que faltaba era bloquear
al agente / futuros desarrolladores de crear un scope parcial basado en
interpretación literal del brief.

## Test plan

- [ ] \`pytest tests/test_discount_parse.py\`
- [ ] \`pytest tests/test_fase1_regresion.py::TestMoDiscountAndFleteRules\`
- [ ] Smoke test conversacional: brief con \"5% sobre PEGADOPILETA\" +
  MO diversa → PDF debe mostrar \"Descuento 5% sobre MO (excluye flete)\"
  con monto = 5% × (suma de todo MO excepto flete)

## Continuación

- **PR #4** — espesor no disponible → default a variante \"EXTRA 2 ESP\"
  (pedido por el usuario)
- **PR #5** — warning \`material_price_base\` faltante