### PR TITLE
feat(material): default 'EXTRA 2 ESP' cuando espesor no coincide

### DIFF
--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -124,12 +124,48 @@ def _find_material(material_name: str) -> dict:
         if not all_materials:
             return {"found": False, "error": f"Material '{material_name}' no encontrado — catálogos vacíos"}
 
-        # Filter out LEATHER variants unless explicitly requested
+        # Filter out acabado variants (LEATHER, FIAMATADO, PULIDO, etc.)
+        # unless the operator explicitly requested them. Default acabado =
+        # "pulido/extra 2 esp" variant.
+        #
+        # Rule (PR #4 — pedido del usuario): cuando el brief no especifica
+        # variante/acabado y existe un variant "EXTRA 2 ESP" del material,
+        # se devuelve esa variante por default. Esto también cubre el caso
+        # de espesor no coincidente (ej: brief "25mm" vs catálogo 20mm):
+        # el filtrado se queda con el EXTRA 2 ESP y `_find_material` lo
+        # retorna sin preguntar. Ver rules/materials-guide.md § Espesor.
         input_lower = material_name.lower()
         has_leather = "leather" in input_lower
-        filtered = [(n, c) for n, c in all_materials if has_leather or "leather" not in n.lower()]
+        has_fiamatado = "fiamatado" in input_lower or "flameado" in input_lower
+        filtered = [
+            (n, c) for n, c in all_materials
+            if (has_leather or "leather" not in n.lower())
+            and (has_fiamatado or "fiamatado" not in n.lower())
+        ]
         names = [m[0] for m in (filtered if filtered else all_materials)]
         match = fuzz_process.extractOne(material_name, names, score_cutoff=70)
+
+        # If matched a non-EXTRA variant but an EXTRA 2 ESP exists for the
+        # same base name, prefer the EXTRA 2 ESP. Detect base name as the
+        # matched name minus the variant suffix.
+        if match:
+            matched_name = match[0]
+            m_upper = matched_name.upper()
+            if "EXTRA 2" not in m_upper and "EXTRA" not in m_upper:
+                # Look for a sibling with EXTRA 2 (ESP) and the same base tokens
+                base_tokens = set(
+                    t for t in m_upper.split()
+                    if t not in {"LEATHER", "FIAMATADO", "FLAMEADO", "PULIDO", "20MM", "-"}
+                )
+                for n, _c in filtered:
+                    n_upper = n.upper()
+                    if ("EXTRA 2" in n_upper or "EXTRA" in n_upper) and base_tokens.issubset(set(n_upper.split())):
+                        logging.info(
+                            f"[variant-default] '{material_name}' → preferring "
+                            f"'{n}' (EXTRA 2 ESP) over '{matched_name}'"
+                        )
+                        match = (n, match[1])
+                        break
 
         if match:
             matched_name, score = match[0], match[1]

--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -134,6 +134,13 @@ def _find_material(material_name: str) -> dict:
         # de espesor no coincidente (ej: brief "25mm" vs catálogo 20mm):
         # el filtrado se queda con el EXTRA 2 ESP y `_find_material` lo
         # retorna sin preguntar. Ver rules/materials-guide.md § Espesor.
+        # Strip thickness tokens from input ("25mm", "— 25mm", "- 25 mm") so
+        # fuzzy doesn't down-score valid matches just because the brief
+        # specifies a thickness the catalog name doesn't carry.
+        import re as _re_thk
+        _clean_input = _re_thk.sub(
+            r'[—\-–]?\s*\d{1,2}\s*mm\b', '', material_name, flags=_re_thk.IGNORECASE,
+        ).strip()
         input_lower = material_name.lower()
         has_leather = "leather" in input_lower
         has_fiamatado = "fiamatado" in input_lower or "flameado" in input_lower
@@ -143,7 +150,7 @@ def _find_material(material_name: str) -> dict:
             and (has_fiamatado or "fiamatado" not in n.lower())
         ]
         names = [m[0] for m in (filtered if filtered else all_materials)]
-        match = fuzz_process.extractOne(material_name, names, score_cutoff=70)
+        match = fuzz_process.extractOne(_clean_input, names, score_cutoff=70)
 
         # If matched a non-EXTRA variant but an EXTRA 2 ESP exists for the
         # same base name, prefer the EXTRA 2 ESP. Detect base name as the

--- a/api/rules/materials-guide.md
+++ b/api/rules/materials-guide.md
@@ -30,6 +30,24 @@
 - **Sinterizada** (Dekton, Neolith, Laminatto, Puraprima): **12mm** → siempre recomendar frentin
 - **Otros:** **20mm** estandar | 30mm en algunos (confirmar)
 
+### ⛔ Espesor del brief no coincide con catálogo
+Cuando el operador especifica un espesor que el catálogo no tiene
+(ej: brief "25mm" cuando solo existe 20mm), **NO preguntar, NO flaguear**:
+cotizar con el espesor disponible del catálogo y, si el material tiene
+una variante **"EXTRA 2 ESP"**, usar esa por default.
+
+`_find_material` (calculator.py) aplica esta regla automáticamente:
+- Filtra variantes LEATHER / FIAMATADO salvo pedido explícito del operador.
+- Si el match devuelto no es EXTRA 2 ESP pero existe una variante EXTRA 2 ESP
+  del mismo material, prefiere la EXTRA 2 ESP.
+
+Ejemplo (DINALE 14/04/2026):
+- Brief: `Granito Gris Mara — 25mm`
+- Catálogo: `GRANITO GRIS MARA EXTRA 2 ESP` (20mm), `FIAMATADO - 20MM`, `LEATHER`
+- Resultado: usar `GRANITO GRIS MARA EXTRA 2 ESP` sin preguntar.
+
+Solo variantes explícitas (LEATHER, FIAMATADO) cambian este default.
+
 ## Orientacion por color
 
 **Blancos/Claros:**

--- a/api/tests/test_quote_engine.py
+++ b/api/tests/test_quote_engine.py
@@ -91,6 +91,44 @@ class TestFindMaterial:
         result = _find_material("Material Inexistente XYZ")
         assert result["found"] is False
 
+    def test_default_variant_extra_2_esp_gris_mara(self):
+        """PR #4 — DINALE 14/04/2026: brief pide 'Granito Gris Mara' genérico
+        (sin variante ni espesor coincidente). Catálogo tiene 3 variantes:
+        EXTRA 2 ESP, FIAMATADO, LEATHER. Default debe ser EXTRA 2 ESP."""
+        result = _find_material("Granito Gris Mara")
+        assert result["found"] is True
+        assert "EXTRA 2" in result["name"].upper(), (
+            f"Expected EXTRA 2 ESP default, got: {result['name']}"
+        )
+
+    def test_default_variant_extra_2_esp_with_mismatched_thickness(self):
+        """Brief pide 25mm pero catálogo solo tiene 20mm → EXTRA 2 ESP default."""
+        result = _find_material("Granito Gris Mara 25mm")
+        assert result["found"] is True
+        assert "EXTRA 2" in result["name"].upper(), (
+            f"Expected EXTRA 2 ESP default on thickness mismatch, got: {result['name']}"
+        )
+
+    def test_explicit_leather_still_routes_to_leather(self):
+        """Si brief dice LEATHER, no aplicar default EXTRA 2 ESP."""
+        result = _find_material("Granito Gris Mara LEATHER")
+        assert result["found"] is True
+        assert "LEATHER" in result["name"].upper()
+
+    def test_explicit_fiamatado_still_routes_to_fiamatado(self):
+        """Si brief dice FIAMATADO, no aplicar default EXTRA 2 ESP."""
+        result = _find_material("Granito Gris Mara Fiamatado")
+        assert result["found"] is True
+        assert "FIAMATADO" in result["name"].upper()
+
+    def test_default_variant_negro_boreal(self):
+        """Segundo material con variante EXTRA 2 ESP: Granito Negro Boreal."""
+        result = _find_material("Granito Negro Boreal")
+        assert result["found"] is True
+        assert "EXTRA" in result["name"].upper(), (
+            f"Expected EXTRA 2 ESP default for Negro Boreal, got: {result['name']}"
+        )
+
 
 # ── _find_flete ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Regla (pedido del usuario)

Cuando el brief especifica un espesor que el catálogo no tiene
(ej: 25mm cuando solo existe 20mm), o cuando el brief no especifica
variante/acabado, usar la variante **EXTRA 2 ESP** por default sin
preguntar ni flaguear.

## Caso DINALE 14/04/2026

- Brief: \`Granito Gris Mara — 25mm\`
- Catálogo:
  - GRANITO GRIS MARA EXTRA 2 ESP (20mm) ✅ default
  - GRANITO GRIS MARA FIAMATADO - 20MM
  - GRANITO GRIS MARA LEATHER
- Comportamiento esperado: cotizar con EXTRA 2 ESP, sin preguntar.

## Cambios

- \`calculator.py::_find_material\`:
  - Filtro existente de LEATHER extendido a FIAMATADO/FLAMEADO
    (mismo patrón: solo matchea si el brief lo menciona explícito).
  - Post-match: si el match inicial no es EXTRA pero existe una variante
    EXTRA 2 ESP con los mismos tokens base, se prefiere la EXTRA 2 ESP.
- \`rules/materials-guide.md\`: sección \"Espesor del brief no coincide con
  catálogo\" con el ejemplo DINALE.
- \`tests/test_quote_engine.py::TestFindMaterial\` — 5 casos nuevos:
  - Genérico (sin variante) → EXTRA 2 ESP
  - Espesor no coincide (25mm) → EXTRA 2 ESP
  - Brief explícito LEATHER → LEATHER (guard)
  - Brief explícito FIAMATADO → FIAMATADO (guard)
  - Segundo material (Negro Boreal) → EXTRA 2 ESP

## Test plan

- [ ] \`pytest tests/test_quote_engine.py::TestFindMaterial\`
- [ ] Smoke test: brief \"Granito Gris Mara 25mm\" → PDF sale con EXTRA 2 ESP
  y precio \$185.806/m² (catálogo vigente)
- [ ] Regresión: presupuestos que explícitamente pedían LEATHER o
  FIAMATADO siguen saliendo con la variante correcta

## Continuación

- **PR #5** — warning \`material_price_base\` faltante