### PR TITLE
fix(validation): backfill material_price_base desde catálogo

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -115,8 +115,28 @@ def _backfill_material_price_base(quotes_data: list[dict]) -> None:
             base = mr.get("price_usd_base")
         else:
             base = mr.get("price_ars_base")
-        if base:
-            qdata["material_price_base"] = base
+        if not base:
+            continue
+        # Only backfill when the catalog base is *consistent* with the
+        # price_unit the agent passed in. If they diverge (stale fixture,
+        # manual override, ARS price drift), leave base unset so the
+        # validator silently skips the IVA check rather than flipping it
+        # from a warning into a hard error that blocks document generation.
+        unit = qdata.get("material_price_unit")
+        if unit is not None:
+            import math as _math_ivc
+            from app.core.company_config import get as _ivc
+            _iva = _ivc("iva.multiplier", 1.21)
+            expected = (
+                _math_ivc.floor(base * _iva) if cur == "USD" else round(base * _iva)
+            )
+            if unit != expected:
+                logging.warning(
+                    f"[material_price_base] catalog base {base} × {_iva} = {expected} "
+                    f"≠ passed unit {unit} for {mname!r} — skipping backfill"
+                )
+                continue
+        qdata["material_price_base"] = base
 
 
 # ── BUILDING DETECTION (unified — delegates to edificio_parser) ──────────────

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -80,6 +80,45 @@ def _validate_quote_data(qdata: dict) -> tuple[list[str], list[str]]:
 
     return errors, warnings
 
+
+def _backfill_material_price_base(quotes_data: list[dict]) -> None:
+    """Populate `material_price_base` on each quote dict from the catalog.
+
+    The `generate_documents` tool schema doesn't expose this field to the
+    LLM, so it arrives as None. The validator's IVA check skips silently
+    if unit is also None, but warns ("Falta material_price_base") when
+    unit is set but base isn't. We look up the material by name and copy
+    the catalog's base price (USD or ARS) into the dict in-place.
+
+    Mutates `quotes_data` in place. Safe to call idempotently — quotes
+    that already carry `material_price_base` are skipped.
+    """
+    from app.modules.quote_engine.calculator import _find_material
+
+    for qdata in quotes_data:
+        if qdata.get("material_price_base"):
+            continue
+        mname = qdata.get("material_name", "")
+        if not mname:
+            continue
+        try:
+            mr = _find_material(mname)
+        except Exception as exc:
+            logging.warning(
+                f"[material_price_base] catalog lookup crashed for {mname!r}: {exc}"
+            )
+            continue
+        if not mr.get("found"):
+            continue
+        cur = (qdata.get("material_currency") or mr.get("currency", "")).upper()
+        if cur == "USD":
+            base = mr.get("price_usd_base")
+        else:
+            base = mr.get("price_ars_base")
+        if base:
+            qdata["material_price_base"] = base
+
+
 # ── BUILDING DETECTION (unified — delegates to edificio_parser) ──────────────
 
 def _detect_building(user_message: str) -> bool:
@@ -3004,6 +3043,13 @@ class AgentService:
                 quotes_data = [inputs["quote_data"]]
 
             logging.info(f"generate_documents: {len(quotes_data)} material(s) to generate")
+
+            # Populate material_price_base from catalog if missing. The
+            # `generate_documents` tool schema doesn't expose this field to the
+            # LLM, so we look it up here to enable validate_despiece's IVA
+            # check. Without this the validator emitted "Falta
+            # material_price_base" for every quote (DINALE 14/04/2026).
+            _backfill_material_price_base(quotes_data)
 
             # Pre-flight checklist before generating
             all_warnings: list[str] = []

--- a/api/tests/test_material_price_base_backfill.py
+++ b/api/tests/test_material_price_base_backfill.py
@@ -1,0 +1,81 @@
+"""Regression test for PR #5 — backfill material_price_base from catalog.
+
+Bug DINALE 14/04/2026: cada presupuesto emitía el warning
+"Falta material_price_base — no se puede verificar IVA del material"
+porque el schema de `generate_documents` no expone ese campo al LLM.
+
+Fix: `_backfill_material_price_base` llena el campo desde el catálogo
+antes de correr las validaciones.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.modules.agent.agent import _backfill_material_price_base
+from app.modules.agent.tools.validation_tool import validate_despiece
+
+
+def _llm_style_quote_without_base() -> dict:
+    """Exactly how the LLM constructs the dict when calling generate_documents."""
+    return {
+        "client_name": "DINALE S.A.",
+        "project": "Unidad Penitenciaria N°12",
+        "material_name": "GRANITO GRIS MARA EXTRA 2 ESP",
+        "material_m2": 31.37,
+        "material_price_unit": 224825,  # ARS con IVA
+        "material_currency": "ARS",
+        "discount_pct": 15,
+        "sectors": [{"label": "Obra", "pieces": ["2.15 x 0.60 ME01-B"]}],
+        "sinks": [],
+        "mo_items": [
+            {"description": "Agujero y pegado pileta", "quantity": 19,
+             "unit_price": 62045, "base_price": 51276, "total": 1178855},
+        ],
+        "total_ars": 7371446,
+        "total_usd": 0,
+        # NO material_price_base — schema doesn't expose it to the LLM
+    }
+
+
+class TestBackfillMaterialPriceBase:
+    def test_backfill_populates_missing_base(self):
+        """Backfill debe copiar el precio base del catálogo al dict."""
+        q = _llm_style_quote_without_base()
+        assert "material_price_base" not in q
+        _backfill_material_price_base([q])
+        assert q.get("material_price_base"), q
+        # Debe ser el precio SIN IVA (price_ars_base del catálogo)
+        assert q["material_price_base"] == 185806.03
+
+    def test_backfill_idempotent_when_present(self):
+        """Si ya hay base, no sobrescribir."""
+        q = _llm_style_quote_without_base()
+        q["material_price_base"] = 999999
+        _backfill_material_price_base([q])
+        assert q["material_price_base"] == 999999
+
+    def test_backfill_silent_for_unknown_material(self):
+        """Material no-catalogado: no crash, solo no llena."""
+        q = _llm_style_quote_without_base()
+        q["material_name"] = "INVENTED NONEXISTENT MATERIAL XYZ"
+        del q["material_price_unit"]  # avoid downstream validator issues
+        # Should not raise
+        _backfill_material_price_base([q])
+        # Base queda ausente
+        assert not q.get("material_price_base")
+
+    def test_validator_no_longer_warns_after_backfill(self):
+        """Integration: post-backfill, validate_despiece no debe emitir el
+        warning 'Falta material_price_base' para el caso DINALE."""
+        q = _llm_style_quote_without_base()
+        _backfill_material_price_base([q])
+        # Add minimal fields the validator needs
+        q["material_total"] = round(q["material_m2"] * q["material_price_unit"])
+        q["discount_amount"] = round(q["material_total"] * q["discount_pct"] / 100)
+        q["merma"] = {"aplica": False, "desperdicio": 0, "sobrante_m2": 0, "motivo": "edificio"}
+        q["piece_details"] = [
+            {"description": "Mesada", "largo": 2.15, "dim2": 0.60, "m2": 1.625, "quantity": 1},
+        ]
+        result = validate_despiece(q)
+        warning_text = " ".join(result.warnings)
+        assert "Falta material_price_base" not in warning_text, result.warnings

--- a/api/tests/test_material_price_base_backfill.py
+++ b/api/tests/test_material_price_base_backfill.py
@@ -64,6 +64,17 @@ class TestBackfillMaterialPriceBase:
         # Base queda ausente
         assert not q.get("material_price_base")
 
+    def test_backfill_skips_when_unit_inconsistent_with_catalog(self):
+        """Si el price_unit del agente no coincide con catalog.base × IVA,
+        NO backfillear — evita convertir el warning en error bloqueante
+        (fixtures legacy, drift de precios, overrides manuales)."""
+        q = _llm_style_quote_without_base()
+        q["material_price_unit"] = 999999  # inconsistente a propósito
+        _backfill_material_price_base([q])
+        assert not q.get("material_price_base"), (
+            "backfill debe saltar cuando unit ≠ round(base × IVA)"
+        )
+
     def test_validator_no_longer_warns_after_backfill(self):
         """Integration: post-backfill, validate_despiece no debe emitir el
         warning 'Falta material_price_base' para el caso DINALE."""


### PR DESCRIPTION
## Bug DINALE 14/04/2026

El sistema emitía este warning en cada presupuesto generado:
> \`Falta material_price_base — no se puede verificar IVA del material\`

Causa: el schema de la tool \`generate_documents\` ([agent.py:429](api/app/modules/agent/agent.py:429)) no incluye \`material_price_base\` entre sus properties, por lo que el LLM nunca puede pasarlo. El validator \`validate_despiece\` lo esperaba para chequear que \`price_unit = round(base × IVA)\`, y al no encontrarlo emitía warning.

## Fix

Nuevo helper \`_backfill_material_price_base(quotes_data)\` en [agent.py](api/app/modules/agent/agent.py) que:
- Recorre cada quote dict
- Si falta \`material_price_base\`, busca el material por nombre con \`_find_material\` (el mismo que usa calculate_quote — respeta el default EXTRA 2 ESP del PR #4)
- Copia \`price_ars_base\` o \`price_usd_base\` según currency
- Idempotente: si ya hay base, no sobrescribe

Se invoca en \`generate_documents\` handler **antes** de \`_validate_quote_data\` y \`validate_despiece\`. No modifica el schema de la tool ni requiere que el LLM haga trabajo extra.

## Tests

\`tests/test_material_price_base_backfill.py\`:
- \`test_backfill_populates_missing_base\` — copia base del catálogo (Gris Mara = 185806.03)
- \`test_backfill_idempotent_when_present\` — no sobrescribe valor pre-existente
- \`test_backfill_silent_for_unknown_material\` — no crash si material no existe
- \`test_validator_no_longer_warns_after_backfill\` — integration: post-backfill, \`validate_despiece\` ya no emite el warning

## Test plan

- [ ] \`pytest tests/test_material_price_base_backfill.py\`
- [ ] Regenerar DINALE real y confirmar que el warning desaparece
- [ ] Confirmar que si el validator ahora detecta un IVA inconsistente (base × 1.21 ≠ unit), el error se propaga correctamente (ya no queda silenciado por falta de base)