### PR TITLE
fix(calculator): faldón/frentín listado como pieza separada = solo MO

### DIFF
--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -251,14 +251,30 @@ def calculate_m2(pieces: list) -> tuple[float, list[dict]]:
         else:
             raw_m2 = largo * dim2
             used_override = False
-        total += raw_m2 * qty_in  # respect input quantity
+
+        # Faldón/frentín: contribuye SOLO a MO (armado frentín × ml), no al
+        # m² de material. Caso DINALE 14/04/2026: la planilla del comitente
+        # ya trae los m² con zócalo/frente incluidos; al listar el frentín
+        # como pieza aparte, sumar su m² al material lo duplica. La regla
+        # del negocio: los ml del frentín van al SKU FALDON (MO), no al
+        # material. Ver rules/calculation-formulas.md § Frentín.
+        _desc_head = (p.get("description") or "").lower().lstrip()
+        is_frentin_piece = (
+            _desc_head.startswith("faldón")
+            or _desc_head.startswith("faldon")
+            or _desc_head.startswith("frentín")
+            or _desc_head.startswith("frentin")
+        )
+        if not is_frentin_piece:
+            total += raw_m2 * qty_in  # respect input quantity
         raw_details.append({
             "description": p.get("description", ""),
             "largo": largo,
             "dim2": dim2,
-            "m2": round(raw_m2, 4),   # m² per unit (not × qty)
+            "m2": round(raw_m2, 4) if not is_frentin_piece else 0,
             "quantity": qty_in,        # preserve explicit qty
             "override": used_override, # renderer uses this to add '*' mark
+            "_is_frentin": is_frentin_piece,
         })
     # Group identical pieces by description+dimensions.
     # If the operator already provided an explicit quantity on each piece,
@@ -306,6 +322,11 @@ def list_pieces(pieces: list, is_edificio: bool = False) -> dict:
 
         if is_zocalo:
             label = f"{pd['largo']:.2f}ML X {pd['dim2']:.2f} ZOC"
+        elif pd.get("_is_frentin"):
+            # Faldón/frentín: solo se contabiliza como MO (armado × ml).
+            # NO sumar m² al material. Render con ml para que el operador
+            # sepa que no aporta al bruto material.
+            label = f"{pd['largo']:.2f}ML FALDON"
         else:
             label = f"{desc} — {pd['largo']:.2f} x {pd['dim2']:.2f}"
             if pd["largo"] >= 3.0 and not is_edificio:

--- a/api/rules/calculation-formulas.md
+++ b/api/rules/calculation-formulas.md
@@ -59,10 +59,26 @@ Cada tramo por separado, sumar.
 
 ## Frentin / Regrueso
 
+### ⛔ Faldón/frentín listado como pieza separada en brief → MO SOLO
+Cuando el operador lista el faldón como **concepto separado de material**
+con solo ml declarados (ej: `"Faldón recto — 2.90 ml"`, sin altura ni
+m²), **NO sumar m² al material**. El material ya está contabilizado en
+las piezas del despiece (planilla de cómputo del comitente). El faldón
+solo aporta MO:
+- SKU `FALDON` (o `FALDONDEKTON/NEOLITH` sinterizados) × ml.
+- CORTE45 solo si operador lo pide explícito.
+
+Caso DINALE 14/04/2026: brief dijo `"Faldón recto — 2.90 ml (listarlo
+como concepto separado de material)"`. Al agregarlo como pieza con altura
+default (0.05m) se duplicaba: sumaba 0.145 m² al material bruto **y**
+se cobraba como Armado frentín. El calculator ahora detecta piezas cuya
+descripción empieza con `faldón`/`frentín` y las excluye del m² de material.
+
 ```
-m2 frentin = largo_frente x alto_frentin
+m2 frentin = largo_frente x alto_frentin   # SOLO si el operador declara altura
 ```
-Si figura en plano → calcular directo. Si NO → preguntar. Sinterizado 12mm → sugerir frentin.
+Si figura en plano con altura → calcular directo y sumar al m². Si solo
+hay ml → MO únicamente. Sinterizado 12mm → sugerir frentin.
 
 ### Mano de obra frentin/regrueso — CRITICO
 

--- a/api/tests/test_list_pieces.py
+++ b/api/tests/test_list_pieces.py
@@ -212,6 +212,78 @@ class TestMesadaConZocaloNoCollapsed:
         assert any("Mesada" in lbl for lbl in labels), labels
 
 
+class TestFrentinDoesNotDoubleCountMaterial:
+    """Regression: faldón/frentín listado como pieza separada NO debe
+    sumar m² al material (DINALE 14/04/2026).
+
+    Antes del fix: brief "Faldón recto — 2.90 ml" se convertía en una
+    pieza con prof=0.05 default → sumaba 0.145 m² al material bruto
+    Y al mismo tiempo se cobraba MO "Armado frentín" por 2.90 ml →
+    doble cobro.
+    """
+
+    def test_faldon_excluded_from_material_m2(self):
+        from app.modules.quote_engine.calculator import calculate_m2
+        total, details = calculate_m2([
+            {"description": "Mesada", "largo": 2.15, "prof": 0.60, "m2_override": 1.625},
+            {"description": "Faldón recto", "largo": 2.90, "prof": 0.05},
+        ])
+        # Solo la mesada debe contribuir: 1.625 ≈ 1.62 (round to 2)
+        assert total == 1.62, f"Expected 1.62 (faldón not summed), got {total}"
+        faldon = next(d for d in details if "Faldón" in d["description"])
+        assert faldon["_is_frentin"] is True
+        assert faldon["m2"] == 0, f"Faldón m² debe ser 0: {faldon}"
+
+    def test_frentin_piece_same_treatment(self):
+        """'Frentín' (sin tilde) debe comportarse igual."""
+        from app.modules.quote_engine.calculator import calculate_m2
+        total, _ = calculate_m2([
+            {"description": "Mesada", "largo": 2.0, "prof": 0.60},
+            {"description": "Frentin recto", "largo": 1.80, "prof": 0.10},
+        ])
+        # Solo mesada: 2.0 × 0.6 = 1.2
+        assert total == 1.2, f"Expected 1.2, got {total}"
+
+    def test_list_pieces_faldon_label_uses_ml(self):
+        """list_pieces para Paso 1 renderiza faldón como 'X.XXML FALDON'."""
+        result = list_pieces([
+            {"description": "Mesada", "largo": 2.15, "prof": 0.60},
+            {"description": "Faldón recto", "largo": 2.90, "prof": 0.05},
+        ])
+        labels = [p["label"] for p in result["pieces"]]
+        faldon = [l for l in labels if "FALDON" in l]
+        assert len(faldon) == 1, f"Expected 1 FALDON label, got: {labels}"
+        assert "2.90ML" in faldon[0], f"Expected 'X.XXML FALDON', got: {faldon[0]}"
+
+    def test_calculate_quote_faldon_as_mo_only(self):
+        """calculate_quote completo: faldón NO suma material, sí genera
+        línea MO 'Armado frentín' con ml (no m²)."""
+        result = calculate_quote({
+            "client_name": "DINALE",
+            "material": "GRANITO GRIS MARA EXTRA 2 ESP",
+            "pieces": [
+                {"description": "Mesada", "largo": 2.0, "prof": 0.60, "m2_override": 31.37},
+                {"description": "Faldón recto", "largo": 2.90, "prof": 0.05},
+            ],
+            "localidad": "rosario",
+            "plazo": "4 meses",
+            "is_edificio": True,
+            "colocacion": False,
+            "pileta": "empotrada_cliente",
+            "frentin": True,
+        })
+        assert result.get("ok"), result
+        # Material m²: solo la mesada (31.37), NO incluye 0.145 del faldón
+        assert result["material_m2"] == 31.37, (
+            f"material_m2 debe ser 31.37, got {result['material_m2']}"
+        )
+        # MO incluye Armado frentín con 2.90 ml
+        mo = result["mo_items"]
+        frentin_mo = [m for m in mo if "frentín" in m["description"].lower() or "frentin" in m["description"].lower()]
+        assert len(frentin_mo) == 1
+        assert frentin_mo[0]["quantity"] == 2.90
+
+
 # ── Verify list_pieces is in TOOLS schema ────────────────────────────────────
 
 class TestListPiecesInToolSchema:


### PR DESCRIPTION
## Bug DINALE 14/04/2026

Brief: \`Faldón recto — 2.90 ml (listarlo como concepto separado de material)\`

Valentina lo procesaba como **pieza de material** (con altura default 0.05m → 0.145 m² extra al bruto) Y además lo cobraba como **MO "Armado frentín"** por 2.90 ml. Doble conteo. El operador confirmó que el faldón listado con solo ml, sin altura, debe ser **únicamente MO** — el m² del material ya está contabilizado en las piezas del despiece de la planilla.

## Fix

- \`calculate_m2\`: detecta piezas cuya descripción empieza con \`faldón\`/\`faldon\`/\`frentín\`/\`frentin\`, les pone \`m2=0\` y marca \`_is_frentin=True\`. No suman al total de material.
- \`list_pieces\`: renderiza como \`2.90ML FALDON\` en Paso 1 (label distinto para que el operador vea claramente que no es material).
- El auto-detect de \`frentin_ml\` (ya existente) sigue escaneando por descripción → recoge el largo para la MO FALDON.
- Los \`sectors\` para PDF/Excel ya filtraban \`m2 > 0\` → las piezas frentín no aparecen como fila material.
- \`rules/calculation-formulas.md\`: regla documentada con ejemplo DINALE.

## Tests

\`tests/test_list_pieces.py::TestFrentinDoesNotDoubleCountMaterial\`:
- \`test_faldon_excluded_from_material_m2\`
- \`test_frentin_piece_same_treatment\` (sin tilde)
- \`test_list_pieces_faldon_label_uses_ml\`
- \`test_calculate_quote_faldon_as_mo_only\` — integration

## Test plan

- [ ] Re-probar DINALE 25/04:
  - Material bruto: \$7.052.760 (solo 31.37 m², sin el 0.145 del faldón)
  - MO incluye "Armado frentín 2.90 ml" × $15.337 s/IVA
  - No aparece fila "Faldón 2.90 × 0.05 → 0.14 m²" en bloque material
- [ ] Regresiones: tests de edificio existentes siguen pasando