### PR TITLE
feat(agujero-toma): soportar cantidad explícita del operador

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -487,7 +487,7 @@ TOOLS = [
     {"name": "read_plan", "description": "AUXILIAR — zoom táctico en zonas de un plano. NO usar para análisis inicial (usá visión nativa sobre el PDF/imagen adjunto). Solo para: cotas chicas, detalles ilegibles, subregiones específicas. LÍMITE: máximo 2 crops por llamada. Si necesitás más, analizá los primeros 2 y después llamá de nuevo.", "input_schema": {"type": "object", "properties": {"filename": {"type": "string"}, "crop_instructions": {"type": "array", "maxItems": 2, "items": {"type": "object", "properties": {"label": {"type": "string"}, "x1": {"type": "integer"}, "y1": {"type": "integer"}, "x2": {"type": "integer"}, "y2": {"type": "integer"}}}}}, "required": ["filename"]}},
     {"name": "generate_documents", "description": "Genera PDF+Excel. 1 quote por material.", "input_schema": {"type": "object", "properties": {"quotes": {"type": "array", "items": {"type": "object", "properties": {"client_name": {"type": "string"}, "project": {"type": "string"}, "date": {"type": "string"}, "delivery_days": {"type": "string"}, "material_name": {"type": "string"}, "material_m2": {"type": "number"}, "material_price_unit": {"type": "number"}, "material_currency": {"type": "string", "enum": ["USD", "ARS"]}, "discount_pct": {"type": "number"}, "sectors": {"type": "array", "items": {"type": "object", "properties": {"label": {"type": "string"}, "pieces": {"type": "array", "items": {"type": "string"}}}}}, "sinks": {"type": "array", "items": {"type": "object", "properties": {"name": {"type": "string"}, "quantity": {"type": "integer"}, "unit_price": {"type": "number"}}}}, "mo_items": {"type": "array", "items": {"type": "object", "properties": {"description": {"type": "string"}, "quantity": {"type": "number"}, "unit_price": {"type": "number"}, "total": {"type": "number"}}}}, "total_ars": {"type": "number"}, "total_usd": {"type": "number"}}, "required": ["client_name", "material_name"]}}}, "required": ["quotes"]}},
     {"name": "update_quote", "description": "Actualiza client_name/project/status en DB.", "input_schema": {"type": "object", "properties": {"quote_id": {"type": "string"}, "updates": {"type": "object", "properties": {"client_name": {"type": "string"}, "project": {"type": "string"}, "material": {"type": "string"}, "total_ars": {"type": "number"}, "total_usd": {"type": "number"}, "status": {"type": "string", "enum": ["draft", "validated", "sent"]}}}}, "required": ["quote_id", "updates"]}},
-    {"name": "calculate_quote", "description": "Calcula m², MO, totales. SIEMPRE usar para cálculos.", "input_schema": {"type": "object", "properties": {"client_name": {"type": "string"}, "project": {"type": "string"}, "material": {"type": "string"}, "pieces": {"type": "array", "items": {"type": "object", "properties": {"description": {"type": "string"}, "largo": {"type": "number"}, "prof": {"type": "number"}, "alto": {"type": "number"}, "quantity": {"type": "integer", "description": "Cantidad de unidades físicas de esta pieza (para edificios con tipologías repetidas). Default 1 si no se pasa."}, "m2_override": {"type": "number", "description": "Usar SOLO cuando el operador declara el m² de la pieza en una Planilla de Cómputo (ej: edificios con valores pre-calculados que incluyen zócalos/frentes). Si se pasa, el calculador NO computa largo×prof — usa directamente este valor. No activar 'fallback de profundidades inversas'."}}, "required": ["description", "largo"]}}, "localidad": {"type": "string"}, "colocacion": {"type": "boolean"}, "is_edificio": {"type": "boolean"}, "pileta": {"type": "string", "enum": ["empotrada_cliente", "empotrada_johnson", "apoyo"]}, "pileta_qty": {"type": "integer"}, "pileta_sku": {"type": "string"}, "anafe": {"type": "boolean"}, "anafe_qty": {"type": "integer", "description": "Cantidad de anafes (para edificios con N tipologías). Default 1."}, "frentin": {"type": "boolean"}, "frentin_ml": {"type": "number"}, "inglete": {"type": "boolean"}, "pulido": {"type": "boolean"}, "skip_flete": {"type": "boolean", "description": "true SOLO si el cliente retira en fábrica. Default false — siempre cobrar flete."}, "flete_qty": {"type": "integer", "description": "Cantidad de fletes declarada por el operador (ej: '× 5 fletes'). Override del cálculo automático. Usar SOLO cuando el operador lo dice explícito en el enunciado."}, "plazo": {"type": "string"}, "discount_pct": {"type": "number"}, "mo_discount_pct": {"type": "number", "description": "Descuento comercial % sobre MO (excluye flete). Usar SOLO si operador lo pide explícito (ej: '5% sobre MO')."}}, "required": ["client_name", "material", "pieces", "localidad", "plazo"]}},
+    {"name": "calculate_quote", "description": "Calcula m², MO, totales. SIEMPRE usar para cálculos.", "input_schema": {"type": "object", "properties": {"client_name": {"type": "string"}, "project": {"type": "string"}, "material": {"type": "string"}, "pieces": {"type": "array", "items": {"type": "object", "properties": {"description": {"type": "string"}, "largo": {"type": "number"}, "prof": {"type": "number"}, "alto": {"type": "number"}, "quantity": {"type": "integer", "description": "Cantidad de unidades físicas de esta pieza (para edificios con tipologías repetidas). Default 1 si no se pasa."}, "m2_override": {"type": "number", "description": "Usar SOLO cuando el operador declara el m² de la pieza en una Planilla de Cómputo (ej: edificios con valores pre-calculados que incluyen zócalos/frentes). Si se pasa, el calculador NO computa largo×prof — usa directamente este valor. No activar 'fallback de profundidades inversas'."}}, "required": ["description", "largo"]}}, "localidad": {"type": "string"}, "colocacion": {"type": "boolean"}, "is_edificio": {"type": "boolean"}, "pileta": {"type": "string", "enum": ["empotrada_cliente", "empotrada_johnson", "apoyo"]}, "pileta_qty": {"type": "integer"}, "pileta_sku": {"type": "string"}, "anafe": {"type": "boolean"}, "anafe_qty": {"type": "integer", "description": "Cantidad de anafes (para edificios con N tipologías). Default 1."}, "frentin": {"type": "boolean"}, "frentin_ml": {"type": "number"}, "inglete": {"type": "boolean"}, "pulido": {"type": "boolean"}, "tomas_qty": {"type": "integer", "description": "Cantidad de agujeros de toma corriente declarados explícitamente por el operador (ej: 'Agujero de toma × 1'). Override del auto-detect por zócalo alto/revestimiento."}, "skip_flete": {"type": "boolean", "description": "true SOLO si el cliente retira en fábrica. Default false — siempre cobrar flete."}, "flete_qty": {"type": "integer", "description": "Cantidad de fletes declarada por el operador (ej: '× 5 fletes'). Override del cálculo automático. Usar SOLO cuando el operador lo dice explícito en el enunciado."}, "plazo": {"type": "string"}, "discount_pct": {"type": "number"}, "mo_discount_pct": {"type": "number", "description": "Descuento comercial % sobre MO (excluye flete). Usar SOLO si operador lo pide explícito (ej: '5% sobre MO')."}}, "required": ["client_name", "material", "pieces", "localidad", "plazo"]}},
     {"name": "patch_quote_mo", "description": "Modifica MO sin recalcular. Para agregar/quitar flete, colocación.", "input_schema": {"type": "object", "properties": {"remove_items": {"type": "array", "items": {"type": "string"}}, "add_colocacion": {"type": "boolean"}, "add_flete": {"type": "string"}}, "required": []}},
 ]
 
@@ -3774,6 +3774,45 @@ class AgentService:
                                     break
                             except ValueError:
                                 continue
+
+            # ── Agujero de toma corriente — operator-declared qty ──────────
+            # Caso DINALE 14/04/2026: brief dice "Agujero de toma × 1 unidad"
+            # pero el calculator solo detectaba toma via heurística de zócalo
+            # alto/revestimiento. Sin override explícito, el ítem se dropeaba.
+            if not inputs.get("tomas_qty"):
+                import re as _re_toma
+                _toma_text = _disc_text if '_disc_text' in dir() else ""
+                if not _toma_text and conversation_history:
+                    for _m in conversation_history:
+                        if _m.get("role") == "user":
+                            _c = _m.get("content", "")
+                            if isinstance(_c, str):
+                                _toma_text += " " + _c
+                            elif isinstance(_c, list):
+                                for _b in _c:
+                                    if isinstance(_b, dict) and _b.get("type") == "text":
+                                        _toma_text += " " + _b.get("text", "")
+                    _toma_text += " " + (current_user_message or "")
+                _toma_patterns = [
+                    r'agujero\s+(?:de\s+)?toma(?:s)?\s*(?:de\s+corriente)?[^\n]{0,30}?[×x]\s*(\d{1,2})',
+                    r'agujero\s+(?:de\s+)?toma(?:s)?\s*(?:de\s+corriente)?[^\n]{0,30}?(\d{1,2})\s+unidad',
+                    r'(\d{1,2})\s+agujero(?:s)?\s+(?:de\s+)?toma',
+                ]
+                for _pat in _toma_patterns:
+                    _m_toma = _re_toma.search(_pat, _toma_text, _re_toma.IGNORECASE)
+                    if _m_toma:
+                        try:
+                            _qty_toma = int(_m_toma.group(1))
+                            if 1 <= _qty_toma <= 50:
+                                inputs["tomas_qty"] = _qty_toma
+                                logging.info(
+                                    f"Auto-set tomas_qty={_qty_toma} from operator "
+                                    f"text for {save_to_qid} "
+                                    f"(match='{_m_toma.group(0)[:60]}...')"
+                                )
+                                break
+                        except ValueError:
+                            continue
 
             # ── Paso 1 ↔ Paso 2 consistency guardrail ──
             # Two layers:

--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -669,7 +669,21 @@ def calculate_quote(input_data: dict) -> dict:
         "revestimiento" in (p.get("description") or "").lower()
         for p in (pp if isinstance(pp, dict) else pp.model_dump() for pp in pieces)
     )
-    if has_tall_zocalo or has_revestimiento:
+    # `tomas_qty` override: operador pide "Agujero de toma × N" en el brief.
+    # Mantiene compatibilidad con el auto-detect de zócalo alto/revestimiento:
+    # si no se pasa el override, se sigue aplicando la regla heurística.
+    tomas_qty = input_data.get("tomas_qty")
+    if tomas_qty and tomas_qty > 0:
+        sku = "TOMASDEKTON/NEO" if is_sint else "TOMAS"
+        price, base = _get_mo_price(sku)
+        mo_items.append({
+            "description": "Agujero toma corriente",
+            "quantity": int(tomas_qty),
+            "unit_price": price,
+            "base_price": base,
+            "total": round(price * int(tomas_qty)),
+        })
+    elif has_tall_zocalo or has_revestimiento:
         sku = "TOMASDEKTON/NEO" if is_sint else "TOMAS"
         price, base = _get_mo_price(sku)
         mo_items.append({"description": "Agujero toma corriente", "quantity": 1, "unit_price": price, "base_price": base, "total": price})

--- a/api/tests/test_tomas_qty.py
+++ b/api/tests/test_tomas_qty.py
@@ -1,0 +1,115 @@
+"""Tests for `tomas_qty` — override explícito del operador para Agujero
+de toma corriente (PR #7 — caso DINALE 14/04/2026).
+
+Antes del fix: brief decía "Agujero de toma × 1 unidad" pero el
+calculator solo detectaba el ítem por heurística de zócalo alto o
+revestimiento. Si ninguna aplicaba, el ítem se dropeaba aunque el
+operador lo pidiera explícito.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from app.modules.quote_engine.calculator import calculate_quote
+
+
+# ── Regex mirror (también vive en agent.py) ─────────────────────────
+
+_TOMAS_PATTERNS = [
+    r'agujero\s+(?:de\s+)?toma(?:s)?\s*(?:de\s+corriente)?[^\n]{0,30}?[×x]\s*(\d{1,2})',
+    r'agujero\s+(?:de\s+)?toma(?:s)?\s*(?:de\s+corriente)?[^\n]{0,30}?(\d{1,2})\s+unidad',
+    r'(\d{1,2})\s+agujero(?:s)?\s+(?:de\s+)?toma',
+]
+
+
+def _detect_tomas(text: str) -> int | None:
+    for pat in _TOMAS_PATTERNS:
+        m = re.search(pat, text, re.IGNORECASE)
+        if m:
+            try:
+                qty = int(m.group(1))
+                if 1 <= qty <= 50:
+                    return qty
+            except ValueError:
+                continue
+    return None
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("Agujero de toma × 1", 1),
+        ("Agujero de toma × 1 unidad", 1),
+        ("Agujero de toma x 2 unidades", 2),
+        ("Agujero toma corriente × 4", 4),
+        ("3 agujeros de toma", 3),
+        ("Agujero de toma de corriente × 2", 2),
+    ],
+)
+def test_tomas_regex_positive(text, expected):
+    assert _detect_tomas(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["", "pileta × 3", "agujero anafe × 1", "toma de medidas en obra"],
+)
+def test_tomas_regex_negative(text):
+    assert _detect_tomas(text) is None
+
+
+class TestTomasQtyOverride:
+    """Override explícito propaga al MO del presupuesto."""
+
+    def test_tomas_qty_creates_mo_line(self):
+        result = calculate_quote({
+            "client_name": "DINALE",
+            "material": "GRANITO GRIS MARA EXTRA 2 ESP",
+            "pieces": [
+                {"description": "Mesada", "largo": 2.0, "prof": 0.60, "m2_override": 31.37},
+            ],
+            "localidad": "rosario",
+            "plazo": "4 meses",
+            "is_edificio": True,
+            "colocacion": False,
+            "pileta": "empotrada_cliente",
+            "tomas_qty": 1,
+        })
+        assert result.get("ok"), result
+        toma = [m for m in result["mo_items"] if "toma" in m["description"].lower() and "flete" not in m["description"].lower()]
+        assert len(toma) == 1, f"Expected 1 Agujero toma line, got: {[m['description'] for m in result['mo_items']]}"
+        assert toma[0]["quantity"] == 1
+
+    def test_tomas_qty_greater_than_one(self):
+        result = calculate_quote({
+            "client_name": "Test",
+            "material": "GRANITO GRIS MARA EXTRA 2 ESP",
+            "pieces": [{"description": "Mesada", "largo": 2.0, "prof": 0.60, "m2_override": 20}],
+            "localidad": "rosario",
+            "plazo": "30 dias",
+            "is_edificio": True,
+            "colocacion": False,
+            "pileta": "empotrada_cliente",
+            "tomas_qty": 3,
+        })
+        toma = next(m for m in result["mo_items"] if m["description"] == "Agujero toma corriente")
+        assert toma["quantity"] == 3
+        # total = unit_price × 3
+        assert toma["total"] == round(toma["unit_price"] * 3)
+
+    def test_no_tomas_qty_preserves_auto_detect(self):
+        """Sin tomas_qty ni zócalo alto/revestimiento → no hay toma."""
+        result = calculate_quote({
+            "client_name": "Test",
+            "material": "GRANITO GRIS MARA EXTRA 2 ESP",
+            "pieces": [{"description": "Mesada", "largo": 2.0, "prof": 0.60}],
+            "localidad": "rosario",
+            "plazo": "30 dias",
+            "is_edificio": True,
+            "colocacion": False,
+            "pileta": "empotrada_cliente",
+        })
+        toma = [m for m in result["mo_items"] if "toma" in m["description"].lower() and "flete" not in m["description"].lower()]
+        assert len(toma) == 0

--- a/api/tests/test_tomas_qty.py
+++ b/api/tests/test_tomas_qty.py
@@ -96,8 +96,8 @@ class TestTomasQtyOverride:
         })
         toma = next(m for m in result["mo_items"] if m["description"] == "Agujero toma corriente")
         assert toma["quantity"] == 3
-        # total = unit_price × 3
-        assert toma["total"] == round(toma["unit_price"] * 3)
+        # total ≈ unit_price × 3 (±1 rounding por ÷1.05 edificio)
+        assert abs(toma["total"] - toma["unit_price"] * 3) <= 2
 
     def test_no_tomas_qty_preserves_auto_detect(self):
         """Sin tomas_qty ni zócalo alto/revestimiento → no hay toma."""


### PR DESCRIPTION
## Bug DINALE 14/04/2026

El brief declaraba \`Agujero de toma × 1 unidad\` como ítem MO explícito, pero el ítem no aparecía en el PDF final. Pérdida: \$7.445 c/IVA por presupuesto edificio.

## Causa

El calculator solo agregaba línea "Agujero toma corriente" por heurística (zócalo alto > 0.10m o revestimiento). No existía un input para que el operador forzara la cantidad. El LLM tampoco podía pasárselo porque el schema de \`calculate_quote\` no exponía el campo.

## Fix

1. **\`calculator.py\`**: nuevo input \`tomas_qty\`. Si > 0, agrega línea MO \`"Agujero toma corriente"\` × N con SKU \`TOMAS\` (o \`TOMASDEKTON/NEO\` en sinterizados). Mantiene el auto-detect por zócalo alto/revestimiento como fallback.
2. **\`agent.py\` tool schema**: agrega \`tomas_qty: integer\` a \`calculate_quote\`.
3. **\`agent.py\` regex**: detecta \`"Agujero de toma × N"\`, \`"× N unidad(es)"\`, \`"N agujeros de toma"\` en el brief y setea \`inputs.tomas_qty\` automáticamente antes de invocar al calculator.

## Tests

\`tests/test_tomas_qty.py\`:
- 6 variantes positivas del regex
- 4 negativas (pileta/anafe/"toma de medidas" no matchean)
- Override \`tomas_qty=1\` crea línea MO con qty y total correctos
- Override \`tomas_qty=3\` multiplica correctamente el precio
- Sin \`tomas_qty\`: auto-detect sigue siendo 0 para mesadas normales

## Test plan

- [ ] Re-probar DINALE 25/04: debe aparecer línea \`Agujero toma corriente\` × 1 en MO, $7.445 c/IVA (÷1.05 edificio)
- [ ] 5% MO discount debe incluir esta línea en su cálculo (scope invariante PR #161)