### PR TITLE
feat(paso2): surface variant_negated del brief al chat

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -3923,6 +3923,54 @@ class AgentService:
 
             calc_result = calculate_quote(inputs)
 
+            # ── Surface variant negations from the brief (PR #10) ──────────
+            # El LLM normaliza el material name antes de pasarlo a
+            # calculate_quote, por lo que `_find_material` no ve frases como
+            # "NO Extra 2" / "sin Fiamatado" del brief original. Detectamos
+            # acá esas negaciones desde el conversation_history y, si la
+            # variante devuelta coincide con la que el operador negó,
+            # agregamos un warning visible al render del Paso 2.
+            if calc_result.get("ok"):
+                _neg_text = (current_user_message or "").lower()
+                if conversation_history:
+                    for _m in conversation_history:
+                        if _m.get("role") == "user":
+                            _c = _m.get("content", "")
+                            if isinstance(_c, str):
+                                _neg_text += " " + _c.lower()
+                            elif isinstance(_c, list):
+                                for _b in _c:
+                                    if isinstance(_b, dict) and _b.get("type") == "text":
+                                        _neg_text += " " + _b.get("text", "").lower()
+                import re as _re_neg
+                _neg_patterns = [
+                    (r'\bno\s+extra\s*2\b', "extra 2"),
+                    (r'\bsin\s+extra\s*2\b', "extra 2"),
+                    (r'\b(?:no|sin)\s+fiamatado\b', "fiamatado"),
+                    (r'\b(?:no|sin)\s+flameado\b', "flameado"),
+                    (r'\b(?:no|sin)\s+leather\b', "leather"),
+                    (r'\b(?:no|sin)\s+pulido\b', "pulido"),
+                ]
+                _matched_name_lower = (calc_result.get("material_name") or "").lower()
+                for _pat, _kw in _neg_patterns:
+                    if _re_neg.search(_pat, _neg_text) and _kw in _matched_name_lower:
+                        _w = (
+                            f"⚠️ VARIANT NEGADA: el operador escribió "
+                            f"'{_kw}' en el brief negándola, pero el catálogo "
+                            f"solo tiene '{calc_result['material_name']}' como "
+                            "opción. Se cotiza con esa variante — confirmar "
+                            "con operador antes de generar PDF."
+                        )
+                        existing = calc_result.setdefault("warnings", [])
+                        if _w not in existing:
+                            existing.append(_w)
+                        logging.warning(
+                            f"[variant-negated-agent] '{_kw}' negado por brief "
+                            f"pero match es '{calc_result['material_name']}' "
+                            f"para {save_to_qid}"
+                        )
+                        break
+
             # ── Post-calculate deterministic validation ──
             if calc_result.get("ok"):
                 validation = validate_despiece(calc_result)

--- a/api/tests/test_quote_engine.py
+++ b/api/tests/test_quote_engine.py
@@ -133,6 +133,32 @@ class TestFindMaterial:
         assert "extra" in vn["requested"].lower()
         assert vn["returned"] == result["name"]
 
+    def test_variant_negated_appears_in_paso2_render(self):
+        """PR #10 — el warning de variant_negated debe terminar en el array
+        `warnings` que renderiza build_deterministic_paso2."""
+        from app.modules.quote_engine.calculator import (
+            calculate_quote, build_deterministic_paso2,
+        )
+        result = calculate_quote({
+            "client_name": "DINALE",
+            "material": "Granito Gris Mara — 25mm (SKU estándar, NO Extra 2)",
+            "pieces": [{"description": "Mesada", "largo": 2.0, "prof": 0.60, "m2_override": 31.37}],
+            "localidad": "rosario",
+            "plazo": "4 meses",
+            "is_edificio": True,
+            "colocacion": False,
+            "pileta": "empotrada_cliente",
+        })
+        assert result.get("ok"), result
+        warnings_text = " ".join(result.get("warnings", []))
+        assert "VARIANT NEGADA" in warnings_text, (
+            f"Expected negation warning in calc warnings, got: {result.get('warnings')}"
+        )
+        paso2 = build_deterministic_paso2(result)
+        assert "VARIANT NEGADA" in paso2, (
+            f"Paso 2 render must surface negation warning:\n{paso2[-800:]}"
+        )
+
     def test_no_negation_no_flag(self):
         """Caso sin negación: no debe haber variant_negated."""
         result = _find_material("Granito Gris Mara")


### PR DESCRIPTION
## Bug

PR #166 agregaba \`variant_negated\` cuando \`_find_material\` detectaba una negación del operador, pero el warning **nunca aparecía en el chat** porque:

1. El LLM normaliza el material name antes de pasarlo a \`calculate_quote\` (ej: \`"Granito Gris Mara — 25mm (SKU estándar, NO Extra 2)"\` → \`"Granito Gris Mara"\`).
2. \`_find_material\` recibía solo el nombre limpio → no detectaba la negación.

## Fix

En \`agent.py\`, después de \`calculate_quote\`, escanear el \`conversation_history\` por patrones de negación. Si el match coincide con la variante que el calculator devolvió, agregar al array \`calc_result["warnings"]\`. \`build_deterministic_paso2\` ya rendea esos warnings al final del Paso 2.

Solo informativo — los warnings van al chat, no al PDF/Excel del cliente.

## Tests

- \`test_variant_negated_appears_in_paso2_render\` — calc.warnings + render Paso 2 incluyen \`VARIANT NEGADA\`