### PR TITLE
fix(paso2): TOTAL MO != GRAND TOTAL, unit 'ml' por SKU, grand total destacado

### DIFF
--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -899,6 +899,10 @@ def calculate_quote(input_data: dict) -> dict:
         "merma": merma,
         "piece_details": piece_details,
         "mo_items": mo_items,
+        # MO subtotal solo (pegado + frentín + flete + ... − mo_discount).
+        # Distinto de total_ars que es el GRAND TOTAL (MO + sinks + material si ARS).
+        # Se expone para que el render del Paso 2 muestre TOTAL MO ≠ GRAND TOTAL.
+        "total_mo_ars": total_mo_ars,
         "total_ars": total_ars,
         "total_usd": total_usd,
         "sectors": sectors,
@@ -1029,50 +1033,74 @@ def build_deterministic_paso2(calc: dict) -> str:
     mo_discount_pct = calc.get("mo_discount_pct", 0)
     mo_discount_amount = calc.get("mo_discount_amount", 0)
 
+    # Helper: pick correct unit label per MO item. SKUs cobrados por
+    # metro lineal (FALDON, REGRUESO, CORTE45, BUÑA, MOLDURAs) usan "ml"
+    # — el resto (Colocación m², piezas count) usan "m²" o sin unidad.
+    def _qty_with_unit(mo: dict) -> str:
+        q = mo["quantity"]
+        d = (mo.get("description") or "").lower()
+        is_per_ml = any(
+            kw in d for kw in (
+                "frentín", "frentin", "faldón", "faldon",
+                "regrueso", "corte 45", "corte45", "buña",
+                "moldura", "media caña",
+            )
+        )
+        unit = "ml" if is_per_ml else "m²"
+        if isinstance(q, float) and q != int(q):
+            return f"{q:.2f} {unit}".replace(".", ",")
+        return str(int(q))
+
+    # TOTAL MO subtotal: priorizar el campo del calc; fallback al cálculo
+    # local sumando mo_items y restando mo_discount (compatibilidad con
+    # data legacy persistida sin total_mo_ars).
+    _total_mo_subtotal = calc.get(
+        "total_mo_ars",
+        sum(m["total"] for m in mo_items) - mo_discount_amount,
+    )
+
     lines.append("**MANO DE OBRA**")
     if is_edificio:
-        # Expanded format showing base price (sin IVA), ÷1.05 applied, and final total.
-        # Flete row shows ✗ in the ÷1.05 column to make the rule explicit.
         lines.append("| Item | Cant | Base s/IVA | ÷1.05 | Total c/IVA |")
         lines.append("|---|---|---|---|---|")
         for mo in mo_items:
-            qty = mo["quantity"]
-            qty_str = f"{qty:.2f} m²".replace(".", ",") if isinstance(qty, float) and qty != int(qty) else str(int(qty))
             base = mo.get("base_price", 0)
             is_flete = "flete" in mo["description"].lower()
             div_mark = "—" if is_flete else "✓"
             lines.append(
-                f"| {mo['description']} | {qty_str} | {fmt_ars(round(base))} | {div_mark} | {fmt_ars(mo['total'])} |"
+                f"| {mo['description']} | {_qty_with_unit(mo)} | {fmt_ars(round(base))} | {div_mark} | {fmt_ars(mo['total'])} |"
             )
         if mo_discount_pct:
             lines.append(
                 f"| **Descuento {mo_discount_pct}% sobre MO (excluye flete)** | | | | **-{fmt_ars(mo_discount_amount)}** |"
             )
-        lines.append(f"| **TOTAL MO** | | | | **{fmt_ars(total_ars)}** |")
+        lines.append(f"| **TOTAL MO** | | | | **{fmt_ars(_total_mo_subtotal)}** |")
     else:
         lines.append("| Item | Cant | Precio c/IVA | Total |")
         lines.append("|---|---|---|---|")
         for mo in mo_items:
-            qty = mo["quantity"]
-            qty_str = f"{qty:.2f} m²".replace(".", ",") if isinstance(qty, float) and qty != int(qty) else str(int(qty))
-            lines.append(f"| {mo['description']} | {qty_str} | {fmt_ars(mo['unit_price'])} | {fmt_ars(mo['total'])} |")
-        lines.append(f"| **TOTAL MO** | | | **{fmt_ars(total_ars)}** |")
+            lines.append(f"| {mo['description']} | {_qty_with_unit(mo)} | {fmt_ars(mo['unit_price'])} | {fmt_ars(mo['total'])} |")
+        lines.append(f"| **TOTAL MO** | | | **{fmt_ars(_total_mo_subtotal)}** |")
     lines.append("")
 
-    # Grand total
+    # Grand total — destacado con separador visual y heading
     # Only mention "+ piletas" when there is an actual sink product line (ARS)
     # bundled into total_ars; otherwise it misleads the reader.
-    lines.append("**GRAND TOTAL**")
+    lines.append("---")
+    lines.append("")
+    lines.append("## 💰 GRAND TOTAL")
     if currency == "USD" and total_usd:
         has_sink_product = bool(sinks) and any(
             (s.get("unit_price", 0) * s.get("quantity", 0)) > 0 for s in sinks
         )
         if has_sink_product:
-            lines.append(f"{fmt_ars(total_ars)} mano de obra + piletas + {fmt_usd(total_usd)} material")
+            lines.append(f"### {fmt_ars(total_ars)} mano de obra + piletas + {fmt_usd(total_usd)} material")
         else:
-            lines.append(f"{fmt_ars(total_ars)} mano de obra + {fmt_usd(total_usd)} material")
+            lines.append(f"### {fmt_ars(total_ars)} mano de obra + {fmt_usd(total_usd)} material")
     else:
-        lines.append(f"{fmt_ars(total_ars)} total")
+        lines.append(f"### {fmt_ars(total_ars)}")
+    lines.append("")
+    lines.append("---")
     lines.append("")
 
     # Warnings

--- a/api/tests/test_list_pieces.py
+++ b/api/tests/test_list_pieces.py
@@ -255,6 +255,84 @@ class TestFrentinDoesNotDoubleCountMaterial:
         assert len(faldon) == 1, f"Expected 1 FALDON label, got: {labels}"
         assert "2.90ML" in faldon[0], f"Expected 'X.XXML FALDON', got: {faldon[0]}"
 
+    def test_total_mo_distinct_from_grand_total(self):
+        """PR #11 — TOTAL MO != GRAND TOTAL. Antes el render usaba total_ars
+        (que es el grand total para ARS) en la fila 'TOTAL MO', dando la
+        impresión de que MO == grand total."""
+        from app.modules.quote_engine.calculator import (
+            calculate_quote, build_deterministic_paso2,
+        )
+        r = calculate_quote({
+            "client_name": "DINALE",
+            "material": "GRANITO GRIS MARA EXTRA 2 ESP",
+            "pieces": [{"description": "Mesada", "largo": 2.0, "prof": 0.60, "m2_override": 31.37}],
+            "localidad": "rosario", "plazo": "4 meses",
+            "is_edificio": True, "colocacion": False,
+            "pileta": "empotrada_cliente", "pileta_qty": 19,
+            "discount_pct": 15, "mo_discount_pct": 5,
+        })
+        # Calc result expone total_mo_ars (subtotal MO solo)
+        assert "total_mo_ars" in r
+        assert r["total_mo_ars"] < r["total_ars"], (
+            f"MO subtotal ({r['total_mo_ars']}) debe ser < grand total "
+            f"({r['total_ars']}) cuando hay material"
+        )
+        out = build_deterministic_paso2(r)
+        # La fila TOTAL MO debe mostrar el subtotal MO, NO el grand total
+        import re
+        mo_row_match = re.search(r'\*\*TOTAL MO\*\*[^|]*\|[^|]*\|[^|]*\|[^|]*\|[^|]*\*\*\$([\d.]+)', out)
+        if not mo_row_match:
+            # try simpler format (residential, fewer columns)
+            mo_row_match = re.search(r'\*\*TOTAL MO\*\*[^|]*\|[^|]*\|[^|]*\|[^|]*\*\*\$([\d.]+)', out)
+        assert mo_row_match, f"No TOTAL MO row found in:\n{out}"
+        rendered_mo = int(mo_row_match.group(1).replace(".", ""))
+        assert rendered_mo == r["total_mo_ars"], (
+            f"TOTAL MO render ({rendered_mo}) debe igualar total_mo_ars "
+            f"({r['total_mo_ars']}), NO total_ars ({r['total_ars']})"
+        )
+
+    def test_grand_total_visually_emphasized(self):
+        """PR #11 — Grand Total debe destacarse visualmente en el render
+        para que el operador lo identifique de un vistazo."""
+        from app.modules.quote_engine.calculator import (
+            calculate_quote, build_deterministic_paso2,
+        )
+        r = calculate_quote({
+            "client_name": "T", "material": "GRANITO GRIS MARA EXTRA 2 ESP",
+            "pieces": [{"description": "Mesada", "largo": 2.0, "prof": 0.60}],
+            "localidad": "rosario", "plazo": "30 dias",
+            "is_edificio": True, "colocacion": False,
+            "pileta": "empotrada_cliente",
+        })
+        out = build_deterministic_paso2(r)
+        assert "## 💰 GRAND TOTAL" in out, "Grand total debe usar heading h2 con emoji"
+        assert "### " in out, "Grand total amount debe usar heading h3"
+
+    def test_frentin_qty_uses_ml_unit(self):
+        """PR #12 — La fila de Armado frentín en MO debe decir 'ml' no 'm²'."""
+        from app.modules.quote_engine.calculator import (
+            calculate_quote, build_deterministic_paso2,
+        )
+        r = calculate_quote({
+            "client_name": "T", "material": "GRANITO GRIS MARA EXTRA 2 ESP",
+            "pieces": [
+                {"description": "Mesada", "largo": 2.0, "prof": 0.60, "m2_override": 5.0},
+                {"description": "Faldón recto", "largo": 2.90, "prof": 0.05},
+            ],
+            "localidad": "rosario", "plazo": "30 dias",
+            "is_edificio": True, "colocacion": False,
+            "pileta": "empotrada_cliente", "frentin": True,
+        })
+        out = build_deterministic_paso2(r)
+        # Buscar la fila de Armado frentín y asegurar 'ml' (no 'm²')
+        for line in out.splitlines():
+            if "Armado frentín" in line or "Armado frentin" in line:
+                assert "ml" in line, f"Frentín debe usar 'ml': {line}"
+                assert "m²" not in line, f"Frentín NO debe decir 'm²': {line}"
+                break
+        else:
+            raise AssertionError(f"No 'Armado frentín' row found:\n{out}")
+
     def test_build_paso2_omits_faldon_row(self):
         """PR #9 — el render del Paso 2 NO debe incluir fila para faldón.
         DINALE 15/04/2026: aparecía 'Faldón recto 2,9 x 0,05 → 0,00' en


### PR DESCRIPTION
## 3 fixes en el render del Paso 2

### 1. TOTAL MO mostraba GRAND TOTAL
La fila \`TOTAL MO\` usaba \`total_ars\` que es el grand total (MO + sinks + material para ARS). DINALE 15/04/2026:
- TOTAL MO: \$7.378.519 ❌
- GRAND TOTAL: \$7.378.519
- (real MO: \$1.383.673)

Brief pedía: *"Mostrar TOTAL MO y GRAND TOTAL por separado y bien etiquetados — no repetir grand total dos veces"*.

Fix: \`calculate_quote\` retorna \`total_mo_ars\` (subtotal MO solo, post mo_discount). \`build_deterministic_paso2\` lo usa en la fila TOTAL MO. Fallback al cálculo local si \`total_mo_ars\` no está presente (compat data legacy).

### 2. Unit por SKU (ml vs m²)
La columna Cant mostraba "m²" hardcodeado para cualquier float. SKUs por metro lineal (FALDON, REGRUESO, CORTE45, BUÑA, MOLDURAs) ahora muestran "ml". Resto sigue "m²".

### 3. Grand Total destacado
Antes:
\`\`\`
**GRAND TOTAL**
$7.378.519 total
\`\`\`

Ahora:
\`\`\`
---
## 💰 GRAND TOTAL
### $7.378.519
---
\`\`\`

Heading h2 con emoji + h3 para el monto + separadores arriba/abajo.

## Tests

- \`test_total_mo_distinct_from_grand_total\` — TOTAL MO render = total_mo_ars ≠ total_ars
- \`test_grand_total_visually_emphasized\` — heading h2/h3 + emoji presentes
- \`test_frentin_qty_uses_ml_unit\` — Armado frentín dice 'ml', no 'm²'