### PR TITLE
fix(generate_documents): canonicalizar sectors desde calc_result persistido

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -139,6 +139,83 @@ def _backfill_material_price_base(quotes_data: list[dict]) -> None:
         qdata["material_price_base"] = base
 
 
+async def _canonicalize_quotes_data_from_db(
+    quote_id: str, quotes_data: list[dict], db,
+) -> None:
+    """Replace LLM-constructed fields with canonical calc_result from DB.
+
+    The `generate_documents` tool schema lets the LLM build `sectors`,
+    `piece_details`, `mo_items`, totals, etc. directly. This is risky:
+    Valentina sometimes mangles labels (truncates descriptions, rounds
+    largos, deduplicates pieces with same dim2 ignoring different
+    largos). Each \`calculate_quote\` call persists its full result into
+    \`quote.quote_breakdown\` — that's the deterministic source of truth.
+
+    For each quote in `quotes_data`, look up the matching persisted
+    calc_result (by material_name match) and override the visual /
+    monetary fields with the canonical values. Identification fields
+    (client_name, project, date, delivery_days) are left untouched.
+
+    Mutates `quotes_data` in place.
+    """
+    from sqlalchemy import select as _sqsel
+    # Collect all candidate calc_results visible from this conversation:
+    # the current quote + any sibling quotes for the same client.
+    cur_res = await db.execute(_sqsel(Quote).where(Quote.id == quote_id))
+    cur = cur_res.scalar_one_or_none()
+    candidates: list[dict] = []
+    if cur and isinstance(cur.quote_breakdown, dict):
+        candidates.append(cur.quote_breakdown)
+    if cur and cur.client_name:
+        sib_res = await db.execute(
+            _sqsel(Quote).where(Quote.client_name == cur.client_name)
+        )
+        for sib in sib_res.scalars().all():
+            if sib.id == quote_id:
+                continue
+            if isinstance(sib.quote_breakdown, dict):
+                candidates.append(sib.quote_breakdown)
+
+    if not candidates:
+        return
+
+    # Fields to copy verbatim from the canonical calc into the LLM dict.
+    # These determine what the PDF/Excel renders.
+    _VISUAL_FIELDS = (
+        "sectors", "piece_details",
+        "material_m2", "material_price_unit", "material_price_base",
+        "material_total", "material_currency",
+        "discount_pct", "discount_amount",
+        "mo_items", "mo_discount_pct", "mo_discount_amount",
+        "total_ars", "total_usd", "total_mo_ars",
+        "thickness_mm",
+    )
+
+    for qdata in quotes_data:
+        mat = (qdata.get("material_name") or "").strip().upper()
+        if not mat:
+            continue
+        # Find best matching calc_result by material name (substring match
+        # in either direction to tolerate slight variations like " 20mm").
+        best = None
+        for c in candidates:
+            cmat = (c.get("material_name") or "").strip().upper()
+            if not cmat:
+                continue
+            if cmat == mat or mat in cmat or cmat in mat:
+                best = c
+                break
+        if not best:
+            continue
+        for f in _VISUAL_FIELDS:
+            if f in best and best[f] is not None:
+                qdata[f] = best[f]
+        logging.info(
+            f"[canonical-sectors] Replaced LLM fields with canonical "
+            f"calc_result for material {mat!r} in quote {quote_id}"
+        )
+
+
 # ── BUILDING DETECTION (unified — delegates to edificio_parser) ──────────────
 
 def _detect_building(user_message: str) -> bool:
@@ -3070,6 +3147,19 @@ class AgentService:
             # check. Without this the validator emitted "Falta
             # material_price_base" for every quote (DINALE 14/04/2026).
             _backfill_material_price_base(quotes_data)
+
+            # ── Override LLM-built fields with canonical calc_result ──────
+            # Issue DINALE 15/04/2026: el LLM construía sectors, piece_details,
+            # mo_items con valores propios (a veces distintos del calc_result
+            # real — ej: largos de mesada inventados/redondeados, descripciones
+            # truncadas a solo el código). Reemplazamos esos campos con los
+            # que persistió calculate_quote en quote.quote_breakdown.
+            try:
+                await _canonicalize_quotes_data_from_db(quote_id, quotes_data, db)
+            except Exception as _ce:
+                logging.warning(
+                    f"[canonical-sectors] Could not canonicalize for {quote_id}: {_ce}"
+                )
 
             # Pre-flight checklist before generating
             all_warnings: list[str] = []

--- a/api/tests/test_canonical_sectors.py
+++ b/api/tests/test_canonical_sectors.py
@@ -1,0 +1,96 @@
+"""PR #12 — canonicalizar sectors/totales desde calc_result persistido.
+
+Bug DINALE 15/04/2026: el LLM construía sectors con largos inventados
+(ME01-B 2.15 → 1.10, ME03-B 4.50 → 2.30) y descripciones truncadas
+('ME01-B' en vez de 'ME01-B Mesada recta c/zócalo h:10cm'). El
+calc_result persistido en quote.quote_breakdown tiene los datos
+correctos — los usamos para sobrescribir lo que pasó el LLM.
+"""
+import pytest
+
+from app.modules.agent.agent import _canonicalize_quotes_data_from_db
+from app.models.quote import Quote
+
+
+@pytest.mark.asyncio
+async def test_canonicalize_overrides_sectors_from_db(db_session):
+    qid = "test-canonical-001"
+    canonical = {
+        "ok": True,
+        "material_name": "GRANITO GRIS MARA EXTRA 2 ESP",
+        "sectors": [{
+            "label": "Cocina",
+            "pieces": [
+                "2.15 × 0.60 ME01-B Mesada recta c/zócalo h:10cm *",
+                "4.50 × 0.60 ME03-B Mesada recta c/zócalo h:10cm *",
+            ],
+        }],
+        "material_m2": 31.37,
+        "material_total": 5994846,
+        "total_ars": 7378519,
+    }
+    q = Quote(
+        id=qid,
+        client_name="DINALE S.A.",
+        material="GRANITO GRIS MARA EXTRA 2 ESP",
+        quote_breakdown=canonical,
+    )
+    db_session.add(q)
+    await db_session.commit()
+
+    # LLM-built dict with mangled sectors (DINALE bug)
+    llm_quotes = [{
+        "client_name": "DINALE S.A.",
+        "material_name": "GRANITO GRIS MARA EXTRA 2 ESP",
+        "sectors": [{"label": "Cocina", "pieces": [
+            "1.10 × 0.60 ME01-B *",   # WRONG largo + truncated desc
+            "2.30 × 0.60 ME03-B *",   # WRONG largo + truncated desc
+        ]}],
+        "material_m2": 99,            # wrong
+        "total_ars": 99999,           # wrong
+    }]
+
+    await _canonicalize_quotes_data_from_db(qid, llm_quotes, db_session)
+
+    # Sectors should now be the canonical ones
+    assert llm_quotes[0]["sectors"] == canonical["sectors"]
+    assert llm_quotes[0]["material_m2"] == 31.37
+    assert llm_quotes[0]["total_ars"] == 7378519
+    # Visual labels preserve full description
+    label = llm_quotes[0]["sectors"][0]["pieces"][0]
+    assert "2.15" in label, f"largo correcto debe estar: {label}"
+    assert "Mesada recta" in label, f"descripción full debe estar: {label}"
+
+
+@pytest.mark.asyncio
+async def test_canonicalize_skips_when_no_match(db_session):
+    """Si no hay calc_result persistido para el material, no toca nada."""
+    qid = "test-canonical-002"
+    q = Quote(
+        id=qid, client_name="OTRO CLIENTE",
+        material="DEKTON KELYA", quote_breakdown={"material_name": "DEKTON KELYA"},
+    )
+    db_session.add(q)
+    await db_session.commit()
+
+    llm_quotes = [{
+        "material_name": "GRANITO COMPLETAMENTE DISTINTO",
+        "sectors": [{"label": "X", "pieces": ["original"]}],
+        "total_ars": 12345,
+    }]
+    await _canonicalize_quotes_data_from_db(qid, llm_quotes, db_session)
+    # Sin match → no debe sobrescribir
+    assert llm_quotes[0]["sectors"] == [{"label": "X", "pieces": ["original"]}]
+    assert llm_quotes[0]["total_ars"] == 12345
+
+
+@pytest.mark.asyncio
+async def test_canonicalize_handles_missing_material_name(db_session):
+    """Defensive: qdata sin material_name no debe crashear."""
+    qid = "test-canonical-003"
+    q = Quote(id=qid, client_name="X", material=None, quote_breakdown={})
+    db_session.add(q)
+    await db_session.commit()
+    llm_quotes = [{"sectors": [{"label": "X", "pieces": ["a"]}]}]
+    # Should not raise
+    await _canonicalize_quotes_data_from_db(qid, llm_quotes, db_session)

--- a/api/tests/test_canonical_sectors.py
+++ b/api/tests/test_canonical_sectors.py
@@ -33,7 +33,7 @@ async def test_canonicalize_overrides_sectors_from_db(db_session):
         id=qid,
         client_name="DINALE S.A.",
         material="GRANITO GRIS MARA EXTRA 2 ESP",
-        quote_breakdown=canonical,
+        project="Test", quote_breakdown=canonical,
     )
     db_session.add(q)
     await db_session.commit()
@@ -68,7 +68,7 @@ async def test_canonicalize_skips_when_no_match(db_session):
     qid = "test-canonical-002"
     q = Quote(
         id=qid, client_name="OTRO CLIENTE",
-        material="DEKTON KELYA", quote_breakdown={"material_name": "DEKTON KELYA"},
+        material="DEKTON KELYA", project="X", quote_breakdown={"material_name": "DEKTON KELYA"},
     )
     db_session.add(q)
     await db_session.commit()
@@ -88,7 +88,7 @@ async def test_canonicalize_skips_when_no_match(db_session):
 async def test_canonicalize_handles_missing_material_name(db_session):
     """Defensive: qdata sin material_name no debe crashear."""
     qid = "test-canonical-003"
-    q = Quote(id=qid, client_name="X", material=None, quote_breakdown={})
+    q = Quote(id=qid, client_name="X", material=None, project="X", quote_breakdown={})
     db_session.add(q)
     await db_session.commit()
     llm_quotes = [{"sectors": [{"label": "X", "pieces": ["a"]}]}]


### PR DESCRIPTION
## Bug DINALE 15/04/2026

El PDF/Excel generado mostraba **dimensiones inventadas** y descripciones truncadas en el despiece:

| Tipología | Brief / Chat | PDF/Excel |
|---|---|---|
| ME01-B | 2,15 × 0,60 | **1,10** × 0,60 ❌ |
| ME02-B | 1,12 × 0,60 | **1,10** × 0,60 ❌ |
| ME03-B | 4,50 × 0,60 | **2,30** × 0,60 ❌ |
| ME01-G | 1,74 × 0,60 | **1,70** × 0,60 ❌ |

Y descripciones truncadas: \`ME01-B *\` en vez de \`ME01-B Mesada recta c/zócalo h:10cm *\`.

## Causa

El schema de la tool \`generate_documents\` deja que el LLM construya \`sectors\`, \`piece_details\`, \`mo_items\`, totales directamente. Valentina pasaba labels mal armados (largos redondeados/inventados, descripciones truncadas) aunque \`calculate_quote\` ya los había construido bien y los había persistido en \`quote.quote_breakdown\`.

## Fix

Nuevo helper \`_canonicalize_quotes_data_from_db\` que, antes del pre-flight de \`generate_documents\`:
1. Busca el \`calc_result\` persistido para cada material (current quote + siblings del mismo cliente, match por \`material_name\`).
2. Sobreescribe los campos visuales/monetarios del dict del LLM con los canónicos:
   - \`sectors\`, \`piece_details\`
   - \`material_m2\`, \`material_price_unit/base\`, \`material_total\`, \`currency\`
   - \`discount_pct/amount\`, \`mo_discount_pct/amount\`
   - \`mo_items\`, \`total_ars/usd/mo_ars\`
   - \`thickness_mm\`
3. Identificación (\`client_name\`, \`project\`, \`date\`, \`delivery_days\`) queda intacta.

## Tests

- \`test_canonicalize_overrides_sectors_from_db\` — reemplaza sectors mangled
- \`test_canonicalize_skips_when_no_match\` — sin calc persistido no toca
- \`test_canonicalize_handles_missing_material_name\` — defensive

## Test plan

- [ ] Re-probar DINALE: PDF/Excel deben mostrar largos correctos (2,15 / 1,12 / 4,50 / 1,74) y descripciones completas
- [ ] Regresión: presupuestos donde el LLM calcula bien (caso normal) deben seguir igual — el helper solo reemplaza con datos del calc, no inventa