### PR TITLE
fix(validator): respetar override y _is_frentin en _check_piece_m2

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -148,8 +148,8 @@ async def _canonicalize_quotes_data_from_db(
     `piece_details`, `mo_items`, totals, etc. directly. This is risky:
     Valentina sometimes mangles labels (truncates descriptions, rounds
     largos, deduplicates pieces with same dim2 ignoring different
-    largos). Each \`calculate_quote\` call persists its full result into
-    \`quote.quote_breakdown\` — that's the deterministic source of truth.
+    largos). Each calculate_quote call persists its full result into
+    quote.quote_breakdown — that's the deterministic source of truth.
 
     For each quote in `quotes_data`, look up the matching persisted
     calc_result (by material_name match) and override the visual /

--- a/api/app/modules/agent/tools/validation_tool.py
+++ b/api/app/modules/agent/tools/validation_tool.py
@@ -207,13 +207,20 @@ def _check_piece_m2(qdata: dict) -> tuple[list[str], list[str]]:
         dim2 = p.get("dim2", 0)
         m2 = p.get("m2", 0)
         qty = p.get("quantity", 1)
-        expected_m2 = largo * dim2
 
-        if abs(m2 - expected_m2) > 0.01:
-            errors.append(
-                f"Pieza '{p.get('description', '?')}': m2={m2} pero "
-                f"largo={largo} × dim2={dim2} = {expected_m2:.4f}"
-            )
+        # Skip largo×dim2 consistency check when:
+        # - override=True (Planilla de Cómputo del comitente: m² incluye
+        #   zócalo/frente, NO se recalcula desde largo×prof). DINALE
+        #   15/04/2026 fallaba cada vez aquí.
+        # - _is_frentin=True (PR #164: faldón/frentín tiene m²=0
+        #   intencional, contribuye solo a MO).
+        if not p.get("override") and not p.get("_is_frentin"):
+            expected_m2 = largo * dim2
+            if abs(m2 - expected_m2) > 0.01:
+                errors.append(
+                    f"Pieza '{p.get('description', '?')}': m2={m2} pero "
+                    f"largo={largo} × dim2={dim2} = {expected_m2:.4f}"
+                )
         total_m2 += m2 * qty
 
     declared_m2 = qdata.get("material_m2")

--- a/api/tests/test_validation.py
+++ b/api/tests/test_validation.py
@@ -332,6 +332,40 @@ class TestPieceM2:
         errors, warnings = _check_piece_m2(qdata)
         assert errors == []
 
+    def test_override_pieces_skip_largo_dim2_check(self):
+        """PR #13 — DINALE 15/04/2026: piezas con m²_override (planilla
+        de cómputo del comitente) NO deben validarse contra largo×dim2.
+        El m² declarado incluye zócalo/frente, no es geometría pura."""
+        qdata = _valid_qdata()
+        # Piece con override flag y m² ≠ largo × dim2
+        qdata["piece_details"] = [
+            {
+                "description": "ME01-B Mesada c/zócalo h:10cm",
+                "largo": 2.15, "dim2": 0.60, "m2": 1.625,
+                "quantity": 1, "override": True,
+            },
+        ]
+        qdata["material_m2"] = 1.625
+        errors, _ = _check_piece_m2(qdata)
+        assert errors == [], (
+            f"Pieza con override=True NO debe fallar largo×dim2 check: {errors}"
+        )
+
+    def test_frentin_pieces_skip_check(self):
+        """Piezas faldón (_is_frentin) tienen m²=0 intencional."""
+        qdata = _valid_qdata()
+        qdata["piece_details"] = [
+            {
+                "description": "Faldón recto", "largo": 2.90, "dim2": 0.05,
+                "m2": 0, "quantity": 1, "_is_frentin": True,
+            },
+        ]
+        qdata["material_m2"] = 0
+        errors, _ = _check_piece_m2(qdata)
+        assert errors == [], (
+            f"Pieza _is_frentin con m²=0 NO debe fallar: {errors}"
+        )
+
 
 # ── TestMOTotals ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Bug DINALE 15/04/2026: cada generate_documents fallaba con 11 errores de validación de m² (largo × dim2 ≠ m²) bloqueando la generación. Valentina loopeaba inventando dimensiones falsas para que cuadre.

Causa: validator hacía largo × dim2 ≈ m2 siempre, ignorando el flag override=True (Planilla de Cómputo: m² incluye zócalo/frente, no es geometría pura) y _is_frentin (m²=0 intencional).

Fix: skipear el check cuando override=True o _is_frentin=True.

Bonus: corregido SyntaxWarning del PR #170 (escapes de backticks).