### PR TITLE
fix(pdf): descripción full + multiplicador (×N) + warning amigable

### DIFF
--- a/api/app/modules/agent/tools/document_tool.py
+++ b/api/app/modules/agent/tools/document_tool.py
@@ -737,7 +737,11 @@ def _generate_edificio_pdf(pdf_path: Path, data: dict) -> None:
     pdf.ln(3)
 
     # Table header
-    w = [92, 22, 38, 38]
+    # PR #14 — ampliar columna Descripción (92→112mm) para que entren labels
+    # de tipologías edificio largos como "1.45 × 0.50 ME04b-B Mesada recta
+    # c/zócalo h:5cm c/frente h:5cm * (×2)". Reduce levemente las columnas
+    # de números (~total se mantiene en 190mm).
+    w = [112, 18, 30, 30]
     rh = 5
     total_w = sum(w)
     row_n = [0]
@@ -1261,7 +1265,11 @@ def _generate_pdf(pdf_path: Path, data: dict) -> None:
     pdf.ln(3)
 
     # Table header
-    w = [92, 22, 38, 38]
+    # PR #14 — ampliar columna Descripción (92→112mm) para que entren labels
+    # de tipologías edificio largos como "1.45 × 0.50 ME04b-B Mesada recta
+    # c/zócalo h:5cm c/frente h:5cm * (×2)". Reduce levemente las columnas
+    # de números (~total se mantiene en 190mm).
+    w = [112, 18, 30, 30]
     pdf.set_font("Helvetica", "B", 9)
     pdf.cell(w[0], 6, "Descripcion")
     pdf.cell(w[1], 6, "Cantidad", align="R")

--- a/api/app/modules/agent/tools/validation_tool.py
+++ b/api/app/modules/agent/tools/validation_tool.py
@@ -235,7 +235,14 @@ def _check_piece_m2(qdata: dict) -> tuple[list[str], list[str]]:
 
 
 def _check_mo_item_totals(qdata: dict) -> tuple[list[str], list[str]]:
-    """Verify each MO item: total ≈ quantity × unit_price."""
+    """Verify each MO item: total ≈ quantity × unit_price.
+
+    Tolerancia dinámica: con qty alto el redondeo de unit_price se acumula
+    (qty=19 puede divergir ~10 ARS sin que haya bug). Ignoramos diferencias
+    pequeñas en términos absolutos Y proporcionales — solo flaguamos cuando
+    la diferencia es >$50 o >0.1% del total. El warning es informativo
+    (no afecta al PDF/Excel del cliente).
+    """
     errors, warnings = [], []
     for mo in qdata.get("mo_items", []):
         qty = mo.get("quantity", 0)
@@ -247,9 +254,16 @@ def _check_mo_item_totals(qdata: dict) -> tuple[list[str], list[str]]:
             continue
 
         expected = round(qty * up)
-        if abs(total - expected) > 2:
+        diff = abs(total - expected)
+        # Tolerancia: max($50, 0.1% del total) — absorbe rounding cosmético.
+        tolerance = max(50, abs(total) * 0.001)
+        if diff > tolerance:
+            # Mensaje en español, orientado al operador, sin jerga técnica.
             warnings.append(
-                f"MO '{desc}': total={total} pero qty={qty} × price={up} = {expected}"
+                f"Diferencia menor de redondeo en '{desc}': "
+                f"${diff:,.0f} sobre ${abs(total):,.0f}. "
+                f"No afecta al presupuesto del cliente."
+                .replace(",", ".")
             )
 
     return errors, warnings

--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -850,6 +850,16 @@ def calculate_quote(input_data: dict) -> dict:
             if pd.get("override"):
                 label = f"{label} *"
                 has_m2_override = True
+            # PR #14 — multiplicador embebido en el label cuando la pieza
+            # tiene cantidad > 1 (caso DINALE: ME04-B × 4, ME04b-B × 2).
+            # Antes el grouping deduplicaba por label idéntico y agregaba
+            # "(×N)" solo si había duplicados textuales. Cuando el operador
+            # pasa una sola pieza con quantity=N, el label tiene que reflejar
+            # esa cantidad explícitamente para que el cliente no confunda 1
+            # tipología con 1 unidad.
+            _qty = pd.get("quantity", 1)
+            if _qty and _qty > 1:
+                label = f"{label} (×{_qty})"
             raw_labels.append(label)
     # Group duplicates: "0.60 × 0.38 Mesada" × 6 → "0.60 × 0.38 Mesada (×6)"
     piece_labels = []

--- a/api/tests/test_list_pieces.py
+++ b/api/tests/test_list_pieces.py
@@ -255,6 +255,39 @@ class TestFrentinDoesNotDoubleCountMaterial:
         assert len(faldon) == 1, f"Expected 1 FALDON label, got: {labels}"
         assert "2.90ML" in faldon[0], f"Expected 'X.XXML FALDON', got: {faldon[0]}"
 
+    def test_sectors_label_includes_quantity_multiplier(self):
+        """PR #14 (B3) — labels en sectors deben incluir (×N) cuando
+        quantity > 1. Caso DINALE: ME04-B con 4 unidades, ME04b-B con 2.
+        Antes solo se agrupaban duplicados textuales, no piezas con qty
+        explícito."""
+        from app.modules.quote_engine.calculator import calculate_quote
+        result = calculate_quote({
+            "client_name": "DINALE", "material": "GRANITO GRIS MARA EXTRA 2 ESP",
+            "pieces": [
+                {"description": "ME01-B Mesada recta c/zócalo h:10cm",
+                 "largo": 2.15, "prof": 0.60, "m2_override": 1.625},
+                {"description": "ME04-B Mesada recta c/zócalo h:50cm",
+                 "largo": 2.30, "prof": 0.60, "quantity": 4, "m2_override": 12.520},
+                {"description": "ME04b-B Mesada recta",
+                 "largo": 1.45, "prof": 0.50, "quantity": 2, "m2_override": 1.840},
+            ],
+            "localidad": "rosario", "plazo": "4 meses",
+            "is_edificio": True, "colocacion": False,
+            "pileta": "empotrada_cliente",
+        })
+        assert result.get("ok"), result
+        sectors = result.get("sectors", [])
+        labels = sectors[0]["pieces"]
+        # ME01-B (qty=1) — sin multiplicador
+        me01 = [l for l in labels if "ME01-B" in l]
+        assert me01 and "(×" not in me01[0], f"qty=1 no debe llevar (×N): {me01}"
+        # ME04-B (qty=4) — con multiplicador
+        me04 = [l for l in labels if "ME04-B" in l]
+        assert me04 and "(×4)" in me04[0], f"qty=4 debe mostrar (×4): {me04}"
+        # ME04b-B (qty=2) — con multiplicador
+        me04b = [l for l in labels if "ME04b-B" in l]
+        assert me04b and "(×2)" in me04b[0], f"qty=2 debe mostrar (×2): {me04b}"
+
     def test_total_mo_distinct_from_grand_total(self):
         """PR #11 — TOTAL MO != GRAND TOTAL. Antes el render usaba total_ars
         (que es el grand total para ARS) en la fila 'TOTAL MO', dando la

--- a/api/tests/test_validation.py
+++ b/api/tests/test_validation.py
@@ -378,9 +378,39 @@ class TestMOTotals:
 
     def test_total_mismatch_warns(self):
         qdata = _valid_qdata()
-        qdata["mo_items"][0]["total"] = 1  # Wrong
+        qdata["mo_items"][0]["total"] = 1  # Wrong (way off)
         errors, warnings = _check_mo_item_totals(qdata)
         assert len(warnings) == 1
+
+    def test_small_rounding_diff_no_warn(self):
+        """PR #14 (B1) — diff de $5 sobre $1.178.850 (caso DINALE qty=19)
+        cae dentro de la tolerancia y NO debe warning."""
+        qdata = _valid_qdata()
+        qdata["mo_items"] = [{
+            "description": "Agujero y pegado pileta",
+            "quantity": 19, "unit_price": 62045, "total": 1178850,
+        }]
+        # 19 × 62045 = 1178855, diff = 5 ARS → bajo tolerancia ($50 abs)
+        errors, warnings = _check_mo_item_totals(qdata)
+        assert warnings == [], f"Diff de $5 no debe warning: {warnings}"
+
+    def test_warning_message_is_friendly_spanish(self):
+        """PR #14 (B1) — el mensaje debe estar en español natural,
+        sin jerga técnica (qty=, price=, etc.)."""
+        qdata = _valid_qdata()
+        qdata["mo_items"] = [{
+            "description": "Colocación", "quantity": 1, "unit_price": 100000,
+            "total": 50000,  # Off by 50k — definitely warns
+        }]
+        errors, warnings = _check_mo_item_totals(qdata)
+        assert len(warnings) == 1
+        msg = warnings[0]
+        # Debe estar en español natural
+        assert "Diferencia menor de redondeo" in msg
+        assert "No afecta al presupuesto" in msg
+        # NO debe contener jerga técnica
+        assert "qty=" not in msg
+        assert "price=" not in msg
 
 
 # ── TestColocacion ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Tres fixes en un PR para terminar de pulir el PDF DINALE.

**B2** — columna Descripción del PDF aumentada de 92→112mm para que entren los labels edificio largos. Antes se veían cortados ('Mesada recta *' sin h:Xcm).

**B3** — labels en sectors ahora muestran (×N) cuando la pieza tiene quantity > 1 explícito. ME04-B × 4, ME04b-B × 2, etc.

**B1** — warning de rounding del validator reescrito en español natural sin jerga técnica. Tolerancia subida a max($50, 0.1% total) — diff de $5 con qty=19 ya no aparece.

Tests cubren los 3.