### PR TITLE
fix(client-match): prefix/substring fallback para agrupar clientes 'hermanos'

### DIFF
--- a/api/app/modules/agent/tools/client_match.py
+++ b/api/app/modules/agent/tools/client_match.py
@@ -89,7 +89,17 @@ def are_fuzzy_same_client(a: str | None, b: str | None) -> bool:
 
     Decision rule:
       1. If both normalize to equal strings → same (fast path).
-      2. Else, their core-token sets must share at least one token of len>=4.
+      2. **Prefix/substring fallback**: one normalized name contiene a la
+         otra como substring alineado a palabras. Cubre:
+           - "DINALE" ⊂ "DINALE S.A."
+           - "Estudio 72" ⊂ "Estudio 72 — Fideicomiso Ventus"
+           - "Fideicomiso Ventus" ⊂ "Estudio 72 — Fideicomiso Ventus"
+         (Caso Estudio 72 15/04/2026: los tokens core de "Estudio 72" son
+         vacíos — "estudio" es stopword y "72" tiene len<3 — por eso
+         rows de "Estudio 72" no clusterizaban con "Estudio 72 —
+         Fideicomiso Ventus". El substring lo resuelve sin relajar
+         stopwords/longitud.)
+      3. Else, sus core-token sets deben compartir al menos un token len>=4.
 
     This is intentionally a bit permissive. A false positive the operator
     can always dismiss; a false negative (blocking a valid group) is more
@@ -101,6 +111,17 @@ def are_fuzzy_same_client(a: str | None, b: str | None) -> bool:
     nb = normalize_client_name(b)
     if na and na == nb:
         return True
+    # Prefix/substring fallback (word-boundary-aware).
+    if na and nb:
+        shorter, longer = (na, nb) if len(na) <= len(nb) else (nb, na)
+        # Require >=3 chars to avoid matching noise like "sa" ⊂ "casa xyz".
+        if len(shorter) >= 3:
+            # Build word-bounded pattern: shorter must appear between word
+            # boundaries inside longer. Using re.search with \b anchors.
+            import re as _re_sub
+            pat = r"(?:^|\s|[-–—_/])" + _re_sub.escape(shorter) + r"(?:$|\s|[-–—_/])"
+            if _re_sub.search(pat, longer):
+                return True
     ca = client_core_tokens(a)
     cb = client_core_tokens(b)
     shared = ca & cb

--- a/api/tests/test_client_match.py
+++ b/api/tests/test_client_match.py
@@ -88,6 +88,41 @@ def test_fuzzy_same_both_none_is_true():
     assert are_fuzzy_same_client(None, None) is True
 
 
+# ── PR #16 — prefix/substring fallback ──────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        # Caso Estudio 72 15/04/2026 — core tokens vacíos pero un nombre
+        # contiene al otro. Debe considerarse mismo cliente.
+        ("Estudio 72", "Estudio 72 — Fideicomiso Ventus"),
+        ("Estudio 72 — Fideicomiso Ventus", "Estudio 72"),
+        # DINALE y otros apocopados comunes.
+        ("DINALE", "DINALE S.A."),
+        ("DINALE S.A.", "DINALE"),
+        # Separadores distintos (guion, em-dash, slash).
+        ("Cliente Foo", "Cliente Foo - Obra Bar"),
+        ("Cliente Foo", "Cliente Foo / Obra Bar"),
+    ],
+)
+def test_fuzzy_same_prefix_substring(a, b):
+    assert are_fuzzy_same_client(a, b) is True
+
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        # "sa" ⊂ "Sacasa Constructora" pero NO debe matchear — el short
+        # tiene 2 chars, el gate requiere >=3.
+        ("SA", "Sacasa Constructora"),
+        # Substrings NO alineados a palabras NO deben matchear.
+        ("Carlos", "Arqcarlos Perez"),  # "carlos" aparece pero sin boundary
+    ],
+)
+def test_fuzzy_same_prefix_does_not_over_match(a, b):
+    assert are_fuzzy_same_client(a, b) is False
+
+
 # ── grouping ─────────────────────────────────────────────────────────────
 
 class _Q:

--- a/web/src/lib/clientMatch.ts
+++ b/web/src/lib/clientMatch.ts
@@ -46,6 +46,10 @@ export function clientCoreTokens(
   );
 }
 
+function _escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export function areFuzzySameClient(
   a: string | null | undefined,
   b: string | null | undefined
@@ -54,6 +58,19 @@ export function areFuzzySameClient(
   const na = normalizeClientName(a);
   const nb = normalizeClientName(b);
   if (na && na === nb) return true;
+  // Prefix/substring fallback (word-boundary-aware). Caso Estudio 72:
+  // "estudio 72" ⊂ "estudio 72 — fideicomiso ventus". Los core tokens
+  // son vacíos (estudio=stopword, 72 len<3), así que sin este fallback
+  // el checkbox no permitía agrupar quotes del mismo cliente.
+  if (na && nb) {
+    const [shorter, longer] = na.length <= nb.length ? [na, nb] : [nb, na];
+    if (shorter.length >= 3) {
+      const pat = new RegExp(
+        `(?:^|\\s|[-–—_/])${_escapeRegex(shorter)}(?:$|\\s|[-–—_/])`,
+      );
+      if (pat.test(longer)) return true;
+    }
+  }
   const ca = clientCoreTokens(a);
   const cb = clientCoreTokens(b);
   let found = false;


### PR DESCRIPTION
Bug Estudio 72 15/04/2026: el dashboard no dejaba seleccionar los 4 presupuestos del mismo cliente porque 2 tenían client_name='Estudio 72' y 2 'Estudio 72 — Fideicomiso Ventus'.

El fuzzy matcher los consideraba clientes distintos:
- 'Estudio 72' core tokens = {} (estudio=stopword, 72 len<3)
- 'Estudio 72 — Fideicomiso Ventus' = {fideicomiso, ventus}
- shared = {} → False

Fix: antes del chequeo de tokens, evaluar substring alineado a palabras. Si uno contiene al otro entre boundaries, mismo cliente.

Cubre también 'DINALE' ⊂ 'DINALE S.A.'. Evita sobre-match con gate len>=3 + word boundary requirement.

Aplicado en paralelo en backend (client_match.py) y frontend (clientMatch.ts).