### PR TITLE
feat(resumen): client_name canónico = el más corto del grupo

### DIFF
--- a/api/app/modules/agent/tools/resumen_obra_tool.py
+++ b/api/app/modules/agent/tools/resumen_obra_tool.py
@@ -175,7 +175,14 @@ def _build_resumen_data(
     quotes: list[Quote], notes: str
 ) -> dict[str, Any]:
     """Shape the dict expected by _generate_resumen_obra_pdf from N quotes."""
-    client_name = next((q.client_name for q in quotes if q.client_name), "")
+    # PR #17 — nombre canónico del cliente: usar el MÁS CORTO del grupo.
+    # Cuando el dashboard agrupa variantes como "Estudio 72" y
+    # "Estudio 72 — Fideicomiso Ventus" (mismo cliente, nombre largo con
+    # proyecto embebido), el PDF del resumen usa la forma "núcleo" para
+    # que el cliente lo vea consistente. Si hay empate de longitud, cae
+    # al que aparece primero (determinístico por orden de entrada).
+    _candidates = [q.client_name.strip() for q in quotes if (q.client_name or "").strip()]
+    client_name = min(_candidates, key=len) if _candidates else ""
     project = next((q.project for q in quotes if q.project), "")
 
     material_rows: list[dict] = []

--- a/api/tests/test_resumen_canonical_name.py
+++ b/api/tests/test_resumen_canonical_name.py
@@ -1,0 +1,55 @@
+"""PR #17 — nombre canónico del cliente en resumen consolidado.
+
+Cuando el dashboard agrupa variantes fuzzy (ej: 'Estudio 72' y
+'Estudio 72 — Fideicomiso Ventus'), el PDF del resumen debe usar la
+forma más corta (núcleo del cliente).
+"""
+import pytest
+
+from app.models.quote import Quote
+from app.modules.agent.tools.resumen_obra_tool import _build_resumen_data
+
+
+def _make(cid: str, name: str) -> Quote:
+    q = Quote.__new__(Quote)
+    q.id = cid
+    q.client_name = name
+    q.project = "Fideicomiso Ventus"
+    q.quote_breakdown = {"mo_items": []}
+    # Fields _collect_material_row might touch
+    q.material = "GRANITO CEARA"
+    q.total_ars = 0
+    q.total_usd = 0
+    return q
+
+
+def test_canonical_picks_shortest_client_name():
+    """Caso Estudio 72: mezcla de 'Estudio 72' y 'Estudio 72 — Fideicomiso Ventus'
+    → PDF usa 'Estudio 72' (más corto)."""
+    quotes = [
+        _make("q1", "Estudio 72 — Fideicomiso Ventus"),
+        _make("q2", "Estudio 72"),
+        _make("q3", "Estudio 72 — Fideicomiso Ventus"),
+    ]
+    data = _build_resumen_data(quotes, notes="")
+    assert data["client_name"] == "Estudio 72"
+
+
+def test_canonical_all_same_name():
+    """Si todas las quotes tienen el mismo nombre, se respeta ese."""
+    quotes = [_make("q1", "DINALE S.A."), _make("q2", "DINALE S.A.")]
+    data = _build_resumen_data(quotes, notes="")
+    assert data["client_name"] == "DINALE S.A."
+
+
+def test_canonical_skips_empty_names():
+    """Quotes sin client_name NO deben contar como candidato."""
+    quotes = [_make("q1", ""), _make("q2", "DINALE")]
+    data = _build_resumen_data(quotes, notes="")
+    assert data["client_name"] == "DINALE"
+
+
+def test_canonical_all_empty_returns_empty():
+    quotes = [_make("q1", ""), _make("q2", "")]
+    data = _build_resumen_data(quotes, notes="")
+    assert data["client_name"] == ""

--- a/api/tests/test_resumen_canonical_name.py
+++ b/api/tests/test_resumen_canonical_name.py
@@ -6,21 +6,24 @@ forma más corta (núcleo del cliente).
 """
 import pytest
 
-from app.models.quote import Quote
 from app.modules.agent.tools.resumen_obra_tool import _build_resumen_data
 
 
-def _make(cid: str, name: str) -> Quote:
-    q = Quote.__new__(Quote)
-    q.id = cid
-    q.client_name = name
-    q.project = "Fideicomiso Ventus"
-    q.quote_breakdown = {"mo_items": []}
-    # Fields _collect_material_row might touch
-    q.material = "GRANITO CEARA"
-    q.total_ars = 0
-    q.total_usd = 0
-    return q
+class _Q:
+    """Duck-typed stub — evita instanciar el modelo SQLAlchemy."""
+
+    def __init__(self, cid: str, name: str) -> None:
+        self.id = cid
+        self.client_name = name
+        self.project = "Fideicomiso Ventus"
+        self.quote_breakdown = {"mo_items": []}
+        self.material = "GRANITO CEARA"
+        self.total_ars = 0
+        self.total_usd = 0
+
+
+def _make(cid: str, name: str):
+    return _Q(cid, name)
 
 
 def test_canonical_picks_shortest_client_name():


### PR DESCRIPTION
Opción A acordada con usuario. Cuando se consolidan variantes como 'Estudio 72' y 'Estudio 72 — Fideicomiso Ventus', el PDF del resumen ahora usa 'Estudio 72' (el núcleo más corto) en vez del primero arbitrario.

Si hay empate de longitud cae al primero por min() estable.