### PR TITLE
fix(dashboard): badge OBRA también para edificios single-material

### DIFF
--- a/api/app/core/database.py
+++ b/api/app/core/database.py
@@ -68,6 +68,12 @@ async def init_db():
             "ALTER TABLE quotes ADD COLUMN IF NOT EXISTS drive_excel_url VARCHAR(500)",
             "ALTER TABLE quotes ADD COLUMN IF NOT EXISTS resumen_obra JSON",
             "ALTER TABLE quotes ADD COLUMN IF NOT EXISTS email_draft JSON",
+            # PR #19 — backfill is_building para quotes que tenían is_edificio=true
+            # solo en el JSON breakdown. Idempotente (UPDATE WHERE).
+            "UPDATE quotes SET is_building = TRUE "
+            "WHERE (is_building IS NULL OR is_building = FALSE) "
+            "AND quote_breakdown IS NOT NULL "
+            "AND (quote_breakdown->>'is_edificio')::text = 'true'",
         ]:
             try:
                 await conn.execute(__import__("sqlalchemy").text(col_sql))

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -4110,14 +4110,22 @@ class AgentService:
                     history = list(old_quote.change_history or []) if old_quote else []
                     history.append(change_entry)
 
+                    # PR #19 — propagar is_edificio del calc_result a la
+                    # columna is_building del Quote para que el dashboard
+                    # muestre el badge OBRA en edificios single-material
+                    # (DINALE, Estudio 72 individual, etc.). Antes solo se
+                    # marcaba en el flow building_parent multi-material.
+                    _values = {
+                        "quote_breakdown": calc_result,
+                        "total_ars": calc_result.get("total_ars"),
+                        "total_usd": calc_result.get("total_usd"),
+                        "material": calc_result.get("material_name"),
+                        "change_history": history,
+                    }
+                    if calc_result.get("is_edificio"):
+                        _values["is_building"] = True
                     await db.execute(
-                        update(Quote).where(Quote.id == save_to_qid).values(
-                            quote_breakdown=calc_result,
-                            total_ars=calc_result.get("total_ars"),
-                            total_usd=calc_result.get("total_usd"),
-                            material=calc_result.get("material_name"),
-                            change_history=history,
-                        )
+                        update(Quote).where(Quote.id == save_to_qid).values(**_values)
                     )
                     await db.commit()
                     logging.info(f"Saved breakdown for {save_to_qid} after calculate_quote | ARS: {change_entry['total_ars_before']} → {change_entry['total_ars_after']}")

--- a/api/app/modules/agent/schemas.py
+++ b/api/app/modules/agent/schemas.py
@@ -25,6 +25,10 @@ class QuoteListResponse(BaseModel):
     drive_excel_url: Optional[str] = None
     parent_quote_id: Optional[str] = None
     quote_kind: Optional[str] = "standard"
+    # PR #19 — flag para mostrar badge OBRA en dashboard. Antes solo se
+    # mostraba para quote_kind='building_parent' (edificios multi-material),
+    # dejando los edificios single-material sin marca visible.
+    is_building: Optional[bool] = False
     comparison_group_id: Optional[str] = None
     source: Optional[str] = "operator"
     is_read: bool = True

--- a/api/tests/test_is_building_exposure.py
+++ b/api/tests/test_is_building_exposure.py
@@ -1,0 +1,46 @@
+"""PR #19 — exponer is_building en list/detail responses para badge OBRA."""
+import pytest
+from sqlalchemy import update
+from app.models.quote import Quote
+
+
+@pytest.mark.asyncio
+async def test_list_response_includes_is_building(client, db_session):
+    """GET /api/quotes debe incluir is_building en cada item."""
+    # Create a quote and mark it as building
+    resp = await client.post("/api/quotes")
+    qid = resp.json()["id"]
+    await db_session.execute(
+        update(Quote).where(Quote.id == qid).values(
+            client_name="Test Edificio",
+            project="Obra X",
+            is_building=True,
+        )
+    )
+    await db_session.commit()
+
+    items = (await client.get("/api/quotes")).json()
+    target = next((q for q in items if q["id"] == qid), None)
+    assert target is not None
+    assert "is_building" in target
+    assert target["is_building"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_response_residential_is_building_false(client, db_session):
+    """Residencial → is_building False (no badge OBRA)."""
+    resp = await client.post("/api/quotes")
+    qid = resp.json()["id"]
+    await db_session.execute(
+        update(Quote).where(Quote.id == qid).values(
+            client_name="Casa Pérez",
+            project="Cocina",
+            is_building=False,
+        )
+    )
+    await db_session.commit()
+
+    items = (await client.get("/api/quotes")).json()
+    target = next((q for q in items if q["id"] == qid), None)
+    assert target is not None
+    assert target.get("is_building") is False

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -539,10 +539,10 @@ export default function DashboardPage() {
                       </td>
                       {/* Material */}
                       <td className={clsx("px-[18px] py-[13px] text-xs max-w-[250px] truncate", isUnread ? "text-t1 font-medium" : "text-t2")}>
-                        {q.quote_kind === "building_parent" ? (
+                        {q.quote_kind === "building_parent" || q.is_building ? (
                           <span className="flex items-center gap-1.5">
                             <span className="text-[9px] font-semibold px-1.5 py-px rounded bg-purple-500/15 text-purple-400">OBRA</span>
-                            {q.material || q.project || "Edificio"}
+                            <span className="truncate">{q.material || q.project || "Edificio"}</span>
                           </span>
                         ) : (
                           q.material || "\u2014"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -33,6 +33,7 @@ export interface Quote {
   drive_excel_url: string | null;
   parent_quote_id: string | null;
   quote_kind: "standard" | "building_parent" | "building_child_material" | "variant_option" | null;
+  is_building?: boolean | null;
   comparison_group_id: string | null;
   source: string | null;
   is_read: boolean;


### PR DESCRIPTION
Bug: el badge OBRA solo aparecía para quote_kind='building_parent' (multi-material). Edificios single-material como DINALE o las quotes individuales de Estudio 72 no lo mostraban.

Fix:
- Backend: setear Quote.is_building=True cuando calculate_quote retorna is_edificio=True
- Schema: exponer is_building en QuoteListResponse
- Frontend: mostrar badge cuando quote_kind='building_parent' OR is_building=true
- Backfill: UPDATE para marcar quotes existentes con is_edificio=true en breakdown