### PR TITLE
feat(plan-reader): integrar prompt v1 (4 pasadas, sin depender del m² declarado)

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -368,7 +368,24 @@ Ver pricing-variables.md. Todos los catalogos sin IVA → aplicar x1.21.
 ### Revestimiento de pared
 - Pieza separada, desglosar medidas, agregar 1+ TOMAS automaticamente
 
-### Lectura de planos (resumen — ver plan-reading.md)
+### Lectura de planos (ver plan-reader-v1.md para el protocolo completo)
+
+⛔ **REGLA CRÍTICA — NO DEPENDER DEL m² DECLARADO.**
+El m² que aparece en la planilla del plano (ej: "M2: 2,50 m² con zócalos
+incluidos") se usa SOLO para validar, NUNCA como input del cálculo.
+El agente DEBE reconstruir el m² desde las medidas y cotas dibujadas:
+- Medir cada tramo (largo × prof) por separado
+- Listar cada zócalo con su ml (del dibujo, no inferido)
+- Sumar placas + zócalos
+- Comparar con el m² declarado. Si |suma − declarado| / declarado > 5%
+  → flaguear y pedir confirmación. Si diff ≤ 5% → OK.
+
+NUNCA pasar el m² declarado como `m2_override` para ahorrarse el
+despiece. `m2_override` se usa SOLO para planillas de cómputo de
+edificios (donde el m² viene pre-calculado por el comitente), no para
+planos residenciales donde las medidas están dibujadas.
+
+
 
 #### Pipeline visual — comportamiento obligatorio
 

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -512,6 +512,14 @@ def build_system_prompt(has_plan: bool = False, is_building: bool = False, user_
             conditional_parts.append(f"## {bldg_path.stem}\n\n{_read_cached_file(bldg_path)}")
 
     if has_plan:
+        # PR #25 — plan-reader-v1.md es el prompt canónico de lectura de
+        # planos (4 pasadas, placa vs zócalo ml, esquinas L/U sin doble
+        # superficie, OCR rules, output JSON). Se incluye SIEMPRE antes
+        # que el legacy plan-reading.md para que el agente use las nuevas
+        # reglas como source of truth.
+        reader_v1 = rules_dir / "plan-reader-v1.md"
+        if reader_v1.exists():
+            conditional_parts.append(f"## plan-reader-v1\n\n{_read_cached_file(reader_v1)}")
         plan_path = rules_dir / "plan-reading.md"
         if plan_path.exists():
             conditional_parts.append(f"## {plan_path.stem}\n\n{_read_cached_file(plan_path)}")

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -81,6 +81,90 @@ def _validate_quote_data(qdata: dict) -> tuple[list[str], list[str]]:
     return errors, warnings
 
 
+def _validate_plan_pieces(pieces: list[dict]) -> list[str]:
+    """PR #25 — validar piezas de list_pieces cuando hay plano adjunto.
+
+    Enforza tipado + coherencia dimensional para evitar los errores típicos
+    de lectura de planos:
+    - confundir vista en elevación de mesada con pieza de material aparte
+    - confundir zócalo con mesada chica
+    - confundir alzada con zócalo alto
+
+    Retorna lista de mensajes de error; vacía si todo OK.
+    Gated a has_plan en el caller — briefs de texto puro NO pasan por acá.
+    """
+    errors: list[str] = []
+    if not isinstance(pieces, list) or not pieces:
+        return errors
+
+    has_any_zocalo = False
+    for idx, p in enumerate(pieces):
+        if not isinstance(p, dict):
+            errors.append(f"Pieza #{idx}: formato inválido")
+            continue
+        desc = p.get("description", f"pieza #{idx}")
+        tipo = (p.get("tipo") or "").strip().lower()
+        largo = p.get("largo") or 0
+        prof = p.get("prof") or 0
+        alto = p.get("alto") or 0
+
+        if not tipo:
+            errors.append(
+                f"'{desc}': falta el campo `tipo` (mesada/zocalo/alzada/frentin). "
+                "Cuando hay plano adjunto el tipo es obligatorio."
+            )
+            continue
+
+        if tipo == "mesada":
+            if prof and prof < 0.30:
+                errors.append(
+                    f"'{desc}' marcada como mesada pero prof={prof} < 0.30 m. "
+                    "Puede ser un zócalo mal tipado — releer el plano."
+                )
+            if alto and alto > 0.15:
+                errors.append(
+                    f"'{desc}' marcada como mesada pero alto={alto} > 0.15 m "
+                    "(una mesada no tiene campo `alto`, solo prof)."
+                )
+        elif tipo == "zocalo":
+            has_any_zocalo = True
+            if not alto:
+                errors.append(
+                    f"'{desc}' marcada como zócalo pero falta `alto`. "
+                    "Un zócalo se mide como largo (ml) × alto (5–15 cm)."
+                )
+            elif alto > 0.15:
+                errors.append(
+                    f"'{desc}' marcada como zócalo pero alto={alto} > 0.15 m. "
+                    "Los zócalos típicos tienen 5–15 cm de alto. "
+                    "Si es más alto, probablemente es una alzada."
+                )
+            if prof and prof >= 0.30:
+                errors.append(
+                    f"'{desc}' marcada como zócalo pero prof={prof} ≥ 0.30 m. "
+                    "Un zócalo no tiene profundidad — releer el plano."
+                )
+        elif tipo == "alzada":
+            if alto and alto < 0.30:
+                errors.append(
+                    f"'{desc}' marcada como alzada pero alto={alto} < 0.30 m. "
+                    "Una alzada es una pieza vertical de material (≥ 30 cm)."
+                )
+        elif tipo == "frentin":
+            if alto and alto > 0.30:
+                errors.append(
+                    f"'{desc}' marcada como frentín pero alto={alto} > 0.30 m. "
+                    "Un frentín típico tiene 5–15 cm. Si es más alto, revisar."
+                )
+        else:
+            errors.append(
+                f"'{desc}': tipo '{tipo}' inválido. "
+                "Válidos: mesada, zocalo, alzada, frentin."
+            )
+
+    return errors
+
+
 def _backfill_material_price_base(quotes_data: list[dict]) -> None:
     """Populate `material_price_base` on each quote dict from the catalog.
 
@@ -564,7 +648,7 @@ def build_system_prompt(has_plan: bool = False, is_building: bool = False, user_
 # ── TOOL DEFINITIONS ──────────────────────────────────────────────────────────
 
 TOOLS = [
-    {"name": "list_pieces", "description": "PASO 1 OBLIGATORIO: lista piezas con formato correcto + total m². Usar SIEMPRE en Paso 1 para mostrar piezas. Zócalos salen en ml. El total incluye zócalos.", "input_schema": {"type": "object", "properties": {"pieces": {"type": "array", "items": {"type": "object", "properties": {"description": {"type": "string"}, "largo": {"type": "number"}, "prof": {"type": "number"}, "alto": {"type": "number"}}, "required": ["description", "largo"]}}}, "required": ["pieces"]}},
+    {"name": "list_pieces", "description": "PASO 1 OBLIGATORIO: lista piezas con formato correcto + total m². Usar SIEMPRE en Paso 1 para mostrar piezas. Zócalos salen en ml. El total incluye zócalos. ⛔ Cuando hay plano (imagen/PDF adjunto), cada pieza DEBE llevar `tipo`: mesada/zocalo/alzada/frentin — ver plan-reader-v1.md.", "input_schema": {"type": "object", "properties": {"pieces": {"type": "array", "items": {"type": "object", "properties": {"description": {"type": "string"}, "largo": {"type": "number"}, "prof": {"type": "number"}, "alto": {"type": "number"}, "tipo": {"type": "string", "enum": ["mesada", "zocalo", "alzada", "frentin"], "description": "Tipo de pieza. OBLIGATORIO cuando hay plano adjunto. Opcional en briefs de texto puro."}}, "required": ["description", "largo"]}}}, "required": ["pieces"]}},
     {"name": "catalog_lookup", "description": "Busca precio de 1 SKU en catálogo.", "input_schema": {"type": "object", "properties": {"catalog": {"type": "string"}, "sku": {"type": "string"}}, "required": ["catalog", "sku"]}},
     {"name": "catalog_batch_lookup", "description": "Busca múltiples SKUs. Preferir sobre catalog_lookup para 2+.", "input_schema": {"type": "object", "properties": {"queries": {"type": "array", "items": {"type": "object", "properties": {"catalog": {"type": "string"}, "sku": {"type": "string"}}, "required": ["catalog", "sku"]}}}, "required": ["queries"]}},
     {"name": "check_stock", "description": "Verifica retazos en stock.", "input_schema": {"type": "object", "properties": {"material_sku": {"type": "string"}}, "required": ["material_sku"]}},
@@ -3107,14 +3191,45 @@ class AgentService:
         if name == "list_pieces":
             # Detect is_edificio from the breakdown if persisted
             _is_edif = False
+            _has_plan_ctx = False
             try:
                 _qr = await db.execute(select(Quote).where(Quote.id == quote_id))
                 _q = _qr.scalar_one_or_none()
                 if _q:
                     _bd = _q.quote_breakdown or {}
                     _is_edif = bool(_bd.get("is_edificio") or _bd.get("building_step"))
+                    # Plano detectado: hubo read_plan previo, o hay source_files
+                    # con imagen/PDF, o el breakdown lo registró.
+                    _has_plan_ctx = bool(
+                        _bd.get("has_plan")
+                        or _bd.get("plan_read")
+                        or (_q.source_files and any(
+                            (sf.get("filename") or "").lower().endswith(
+                                (".pdf", ".jpg", ".jpeg", ".png", ".webp")
+                            )
+                            for sf in (_q.source_files or [])
+                            if isinstance(sf, dict)
+                        ))
+                    )
             except Exception:
                 pass
+
+            # PR #25 — VALIDACIÓN ESTRICTA cuando hay plano adjunto.
+            # Se exige tipo explícito por pieza + coherencia dims. Texto
+            # puro (DINALE, Estudio 72) sigue sin cambios.
+            if _has_plan_ctx and not _is_edif:
+                _errs = _validate_plan_pieces(inputs.get("pieces", []))
+                if _errs:
+                    return {
+                        "ok": False,
+                        "error": (
+                            "⛔ Piezas inválidas detectadas al leer el plano. "
+                            "Releer el plano con atención a los rectángulos hachurados "
+                            "(zócalos) y las vistas en planta vs elevación. "
+                            "Errores:\n- " + "\n- ".join(_errs)
+                        ),
+                    }
+
             result = list_pieces(inputs["pieces"], is_edificio=_is_edif)
             # ── Persist Paso 1 pieces for Paso 2 consistency guardrail ──
             try:
@@ -3949,6 +4064,40 @@ class AgentService:
                 if _gquote:
                     _gbd = _gquote.quote_breakdown or {}
 
+                    # PR #25 — detectar si hay plano adjunto en el contexto.
+                    # Cuando hay plano, residencial (is_edificio=False) NO
+                    # permite m2_override: se debe reconstruir desde medidas.
+                    _has_plan_ctx = bool(
+                        _gbd.get("has_plan")
+                        or _gbd.get("plan_read")
+                        or (_gquote.source_files and any(
+                            (sf.get("filename") or "").lower().endswith(
+                                (".pdf", ".jpg", ".jpeg", ".png", ".webp")
+                            )
+                            for sf in (_gquote.source_files or [])
+                            if isinstance(sf, dict)
+                        ))
+                    )
+                    _is_edif_ctx = bool(inputs.get("is_edificio"))
+                    if _has_plan_ctx and not _is_edif_ctx:
+                        _override_pieces = [
+                            (p.get("description") or "?")
+                            for p in inputs.get("pieces", [])
+                            if p.get("m2_override") is not None
+                        ]
+                        if _override_pieces:
+                            return {
+                                "ok": False,
+                                "error": (
+                                    "⛔ m2_override está prohibido en presupuestos "
+                                    "residenciales con plano adjunto. El m² debe "
+                                    "reconstruirse desde las medidas del plano "
+                                    "(largo × prof por cada pieza, zócalos como "
+                                    "ml × alto). Piezas con override: "
+                                    + ", ".join(_override_pieces)
+                                ),
+                            }
+
                     # Calculate m2 of what Claude is trying to pass now.
                     # If a piece declares m2_override (operator's Planilla de
                     # Cómputo), that value takes precedence over largo×prof —
@@ -3978,12 +4127,16 @@ class AgentService:
                     if _paso1_pieces:
                         _diff_m2 = abs(_current_m2 - _paso1_m2)
                         _diff_count = abs(len(inputs.get("pieces", [])) - len(_paso1_pieces))
-                        if _diff_m2 > 0.5 or _diff_count > 0:
+                        # PR #25 — tolerancia ajustada a max(0.05 m², 2% del
+                        # declarado). Antes 0.5 absolutos era demasiado laxo:
+                        # un 2.50 vs 2.00 pasaba sin flag.
+                        _a_tol = max(0.05, (_paso1_m2 or 1) * 0.02)
+                        if _diff_m2 > _a_tol or _diff_count > 0:
                             logging.error(
                                 f"[guardrail-A] PASO1↔PASO2 mismatch for {save_to_qid}: "
                                 f"paso1={len(_paso1_pieces)}p/{_paso1_m2:.2f}m² "
-                                f"vs paso2={len(inputs.get('pieces', []))}p/{_current_m2:.2f}m². "
-                                "OVERRIDING with paso1 pieces."
+                                f"vs paso2={len(inputs.get('pieces', []))}p/{_current_m2:.2f}m² "
+                                f"(tol={_a_tol:.3f}). OVERRIDING with paso1 pieces."
                             )
                             inputs["pieces"] = _paso1_pieces
 

--- a/api/rules/plan-reader-v1.md
+++ b/api/rules/plan-reader-v1.md
@@ -210,3 +210,111 @@ Si el OCR extrae medidas, validalas contra la proporción del dibujo:
 - Usarlo como referencia de formato, no de valores.
 - confident va de 0.0 a 1.0 por sector. Si hay ambiguedades → confident < 0.8.
 - Si confident < 0.7 → listar todas las ambiguedades antes de procesar.
+
+---
+
+## REGLA — IDENTIFICACIÓN VISUAL DE ZÓCALOS (CRÍTICO)
+
+Los zócalos se dibujan en el plano como **rectángulos DELGADOS con hachurado interno `//`**
+(el hachurado indica material / canto pulido). Tienen **2 cotas**: `largo (ml) × alto`.
+
+Señales visuales que identifican un zócalo (NO una pieza de mesada):
+- **Alto ≤ 0.15 m** (típico 5–10 cm)
+- Hachurado `//` interno
+- **Ratio largo : alto > 10 : 1** (rectángulo muy fino y alargado)
+- Dibujado SEPARADO de la vista en planta de la mesada
+- Una cota en ml (largo) + una cota corta (altura 5–15 cm)
+- NO tiene profundidad
+
+NO confundir con:
+- **Vista lateral/elevación de mesada:** tiene prof ≥ 0.30 m → es la misma mesada vista desde otro ángulo
+- **Alzada / revestimiento vertical:** alto ≥ 0.30 m (hasta muros altos) → pieza de material
+- **Frentín / faldón:** cuelga BAJO la línea de mesada, no sube por pared
+
+Si ves un rectángulo fino, hachurado, con cota en ml y altura 5–15 cm → **ZÓCALO**. Punto.
+No es pieza de material, no es vista de elevación de la mesada.
+
+---
+
+## REGLA — TRATAR TRAMOS COMO INDEPENDIENTES POR DEFAULT
+
+Cuando el plano muestra 2 o más tramos de mesada **NO asumir forma compuesta**:
+- 2 tramos ≠ automáticamente **L**
+- 3 tramos ≠ automáticamente **U**
+
+Tratar cada tramo como **pieza independiente** salvo que el plano muestre EXPLÍCITO:
+- Una nota textual ("en L", "en U", "con esquina", "tramo 1 + tramo 2")
+- Cotas de solape / unión dibujada entre tramos
+- Símbolo de corte a 45° (`INGLETE`) en el encuentro
+
+Sin esas señales → tramos independientes, cada uno con sus zócalos propios.
+
+---
+
+## REGLA — FRENTÍN / INGLETE: CORTES VERTICALES EN ELEVACIÓN
+
+Señal visual adicional para detectar frentín/inglete:
+- **Corte vertical recto** en elevación → frentín recto (FALDON)
+- **Corte vertical a 45°** en elevación → frentín en inglete (FALDON + CORTE45 en MO)
+
+Complementa las señales textuales (`INGLETE`, `Frente revestido`) y de posición
+(cota bajo línea de mesada).
+
+---
+
+## EJEMPLO CANÓNICO — A1335 COCINA (RESUELTO)
+
+Plano real: cocina Purastone Blanco Paloma, 2 tramos, 3 zócalos, sin frentin.
+
+Lectura correcta (paso a paso):
+
+1. **Tramos:** cuento rectángulos de mesada dibujados → **2 tramos**. No asumo L.
+2. **Mesadas:**
+   - Tramo 1: `1.72 × 0.75` → m² = 1.29
+   - Tramo 2 (retorno): `0.60 × 1.55` → m² = 0.93
+3. **Zócalos** (rectángulos finos hachurados, h:7cm de la planilla):
+   - Fondo: `1.74 ml × 0.07` → m² = 0.122
+   - Lateral izq: `1.55 ml × 0.07` → m² = 0.109
+   - Lateral der: `0.75 ml × 0.07` → m² = 0.053
+4. **Frentín:** no hay vistas con cortes verticales → `frentin = []`.
+5. **Regrueso:** no hay duchas → `regrueso = []`.
+6. **Piletas:** 1 Johnson LUXOR COMPACT SI71 (planilla) → PEGADOPILETA × 1.
+7. **Validación vs declarado:**
+   - Suma: 1.29 + 0.93 + 0.122 + 0.109 + 0.053 = **2.504 m²**
+   - Planilla: **2.50 m²**
+   - diff = 0.004 / 2.50 = **0.16%** → OK (tolerancia ≤ 1%)
+
+⛔ **ERROR TÍPICO que NO debe cometerse (caso real observado):**
+Interpretar la vista del retorno (0.60 × 1.55) como **"alzada vertical"** o
+**pieza de material separada**. Es la MESADA DEL RETORNO vista en planta, no
+una alzada ni un revestimiento. Los rectángulos finos hachurados con ml × 0.07
+son los ZÓCALOS, no piezas de material.
+
+---
+
+## VALIDACIÓN CRUZADA vs m² DECLARADO
+
+Si la planilla/rótulo del plano declara un m² total ("M2: 2,50 m² — con zócalos
+incluidos"):
+- Usar ese valor **SOLO para validar**, NUNCA como `m2_override` input.
+- Reconstruir el m² desde tus piezas: `Σ placas + Σ (zócalo_ml × zócalo_alto)`.
+- Comparar: `|reconstruido − declarado| / declarado ≤ 1%` → OK.
+- Si diff > 1% → **flag duro, no asumir**. Probable causa: falta una pieza o
+  un zócalo, o alguna cota mal leída.
+
+No confiar en el declarado como atajo — siempre reconstruir.
+
+---
+
+## TIPADO OBLIGATORIO (cuando hay plano)
+
+Al pasar piezas a `list_pieces`, cada una DEBE tener un campo `tipo` explícito:
+- `mesada` → pieza horizontal de material (tiene prof ≥ 0.30 m)
+- `zocalo` → tira hachurada (tiene alto ≤ 0.15 m, NO prof)
+- `alzada` → pieza vertical de material, alto ≥ 0.30 m
+- `frentin` → cuelga bajo mesada (alto típico 5–10 cm, trasera visible)
+
+El sistema rechaza combinaciones inconsistentes:
+- `tipo=mesada` con `prof < 0.30` → rechazado (señal de que confundiste con zócalo)
+- `tipo=zocalo` con `alto > 0.15` → rechazado (señal de que confundiste con alzada)
+- Planilla menciona "zócalo" y `list_pieces` no tiene ningún `tipo=zocalo` → rechazado

--- a/api/rules/plan-reader-v1.md
+++ b/api/rules/plan-reader-v1.md
@@ -1,0 +1,212 @@
+# SYSTEM PROMPT — LECTOR DE PLANOS DE MARMOLERÍA
+## Versión 1.0 | DevLabs
+
+---
+
+Sos un lector experto de planos de marmolería con criterio de arquitecto.
+Antes de cualquier cálculo, RENDERIZÁ cada sector individualmente a 300 DPI con crop.
+Nunca confíes en la vista general del plano. Sin excepción.
+
+---
+
+## PROTOCOLO DE LECTURA — 4 PASADAS OBLIGATORIAS
+
+**Pasada 1 — Inventario**
+Identificá todos los sectores presentes (cocina, baño, lavadero, etc.)
+
+**Pasada 2 — Geometría por sector**
+Determiná el tipo de mesada:
+- RECTA     : 1 tramo. Tomá largo × ancho del rectángulo total.
+- EN L      : 2 tramos COMPLEMENTARIOS. Verificá: prof_tramo1 + largo_tramo2 ≈ dim exterior. NO sumes piezas completas — se solaparían.
+- EN U      : 3 tramos complementarios. Mismo criterio.
+- ISLA      : rectángulo total. Recortes internos (columnas, piletas, obstáculos) son merma — NO reducen m².
+
+**Pasada 3 — Cotas**
+- VISTA EN PLANTA    : largo (eje horizontal) × ancho (profundidad)
+- VISTA EN ELEVACIÓN : dimensión SOBRE línea de mesada = zócalo | dimensión BAJO = frentin/faldón
+- Z antes de número  = longitud de zócalo en cm
+
+**Pasada 4 — Validación**
+Verificá consistencia entre vistas. Si hay contradicción → anotá en ambiguedades.
+
+---
+
+## REGLA CRÍTICA — DIMENSIÓN DE PLACA vs. ML DE ZÓCALO
+
+Son dos medidas DISTINTAS. NUNCA las confundas.
+
+- **Placa (tramo):** dimensión del mármol. Define el rectángulo de la pieza. Usala para calcular m².
+- **Zócalo (ml):** longitud de la pared donde va el zócalo. Puede ser MAYOR que la placa (va de pared a pared). Usala para calcular m² de zócalo.
+
+Ejemplo: placa largo 1.72 m → m² = 1.72 × 0.75. Zócalo frente 1.74 ml × 0.07 m → m² zócalo = 0.12. Son cálculos separados.
+
+---
+
+## REGLA — ZÓCALOS: SOLO POR COTA EXPLÍCITA
+
+NUNCA derives zócalos de los lados de la pieza.
+NUNCA asumas que un lado tiene zócalo porque "debería" tenerlo.
+
+Un zócalo existe SOLO si el plano muestra:
+- Una cota etiquetada como Z, ZOC, ZÓCALO o similar
+- Una dimensión explícita con altura (ej: 1.74 ML × 0.07)
+- Una indicación textual en tabla de características
+
+Si el plano no muestra cota de zócalo para un lado → ese lado no tiene zócalo.
+No preguntar, no inferir, no completar.
+
+Altura default: 0.07 m si se indica "zócalos 7 cm" en características generales.
+Si no hay altura especificada → anotá en ambiguedades.
+
+---
+
+## REGLA — FRENTIN / FALDÓN: SOLO POR EVIDENCIA EXPLÍCITA
+
+Frentin/faldón SOLO si el plano muestra:
+- Vista de elevación con frentin/faldón dibujado
+- Cota debajo de la línea de mesada en elevación
+- Indicación textual explícita
+
+Si no hay vista de elevación con frentin → frentin = [] para ese tramo. No preguntar, no inferir.
+
+---
+
+## REGLA — REGRUESO
+
+El regrueso NO es frentin. Son conceptos distintos.
+
+- Regrueso = terminación lateral del zócalo en receptáculos de ducha. Se cobra como LABOR por ml.
+- Aparece SOLO si el plano tiene zócalos de ducha/receptáculos.
+- Si no hay duchas → regrueso = 0. No mencionar, no asumir.
+
+Tipos:
+- SIMPLE : pulido cara interna (ml) + REGRUESO a mitad de precio. Default si no especifica.
+- DOBLE  : REGRUESO precio completo + material doble.
+- Si no está especificado → informar ambigüedad.
+
+---
+
+## OTRAS REGLAS FIJAS
+
+- Mesada > 3 m → anotá "SE REALIZA EN 2 TRAMOS"
+- Todos los m² redondeados a 2 decimales
+- Signo ambiguo → NO interpretes. Anotá en ambiguedades y pedí confirmación
+- NUNCA asumas simetría entre sectores ni entre tramos
+- Johnson (pileta) → siempre PEGADOPILETA
+
+---
+
+REGLA — DIMENSIONES EN PLANTA: DESDE QUÉ PUNTO SE MIDE
+
+Cuando una cota aparece en vista en planta, SIEMPRE determiná su punto de origen
+antes de usarla:
+
+ORIGEN PARED EXTERIOR → la cota incluye el espesor del tramo adyacente.
+   → Restar el ancho del tramo que se solapa antes de asignar al tramo NET.
+   → Señal: la línea de cota arranca desde la línea exterior del muro o del
+     tramo perpendicular.
+
+ORIGEN ESQUINA INTERIOR → la cota ya es neta. Usar directo.
+   → Señal: la línea de cota arranca desde la línea interior de la mesada
+     (borde del mármol hacia el centro de la cocina).
+
+REGLA DE ESQUINAS — SIN SUPERFICIE DOBLE (crítico):
+La esquina (cuadrado depth × depth) pertenece a UN SOLO tramo. Nunca a los dos.
+
+   EN L (2 tramos):
+   → Un tramo es FULL (incluye la esquina).
+   → El otro tramo es NETO (su largo empieza donde termina el tramo full).
+   → Las superficies de corte nunca se tocan → no hay m² calculado dos veces.
+   → Ejemplo: tramo_1 full = 1.80m × 0.62m. Tramo_2 neto = (2.40 - 0.62) × 0.62
+     = 1.78m × 0.62m. El cuadrado 0.62×0.62 de esquina está solo en tramo_1.
+
+   EN U (3 tramos):
+   → Los 2 tramos laterales son FULL (cada uno incluye su esquina con el fondo).
+   → El tramo medio es NETO: restar depth_izq y depth_der.
+   → Cotas desde pared exterior: restar el depth del lateral correspondiente.
+   → Ejemplo: cota "87" desde pared exterior izq, depth_izq = 62cm
+     → aporte neto al medio = 87 - 62 = 25cm.
+
+VERIFICACIÓN OBLIGATORIA para L y U:
+   L: depth_tramo_full + largo_neto = dimensión exterior total del lado neto.
+   U: depth_izq + largo_neto_medio + depth_der = ancho total cocina.
+   Si no cierra → anotar en ambigüedades, NO asumir.
+
+   ## REGLAS DE COGNICIÓN VISUAL Y OCR ESPACIAL
+
+**1. Búsqueda de Contexto Global (Rótulo/Notas)**
+Antes de mirar el dibujo, escaneá las esquinas y márgenes buscando el bloque de notas, rótulo o carátula. Extraé de ahí:
+- Unidad de medida general (ej: "medidas en cm salvo indicación").
+- Espesores por defecto y materiales.
+- Altura estándar de zócalos.
+
+**2. Diferenciación de Líneas (Cotas vs. Contornos)**
+- LÍNEAS DE CONTORNO: Definen el borde del mármol (suelen ser más gruesas).
+- LÍNEAS DE COTA: Indican medidas (son finas, terminan en flechas, puntos o barras diagonales `/`).
+- NUNCA confundas una línea de cota interior con un corte en el material.
+
+**3. Reglas de OCR para Arquitectura**
+- Atención a textos rotados (90° o 270°). Leé el texto siempre paralelo a su línea de cota.
+- Cuidado con confusiones clásicas de OCR en planos borrosos: `5` vs `S`, `6` vs `8`, `1` vs `7`.
+- Normalización de Unidades: Los planos suelen mezclar metros y centímetros (ej: `60` de profundidad y `1.5` de largo). Si una cota es < 10 y la otra > 50, normalizá todo a metros antes de calcular (ej: 0.60m y 1.50m).
+
+**4. Validación de Cordura Visual (Sanity Check)**
+Si el OCR extrae medidas, validalas contra la proporción del dibujo:
+- Si un tramo dice `60` y el contiguo dice `120`, el segundo DEBE verse visualmente el doble de largo.
+- Si visualmente miden lo mismo, el OCR falló o el plano está fuera de escala. Reducí el valor de `confident` a `< 0.7` y detallalo en `ambiguedades`.
+
+## FORMATO DE SALIDA — SOLO JSON, sin texto, sin markdown
+
+```json
+{
+  "sectores": [
+    {
+      "id": "cocina",
+      "tipo": "recta_2_tramos | recta | L | U | isla",
+      "tramos": [
+        {
+          "id": "tramo_1",
+          "descripcion": "Mesada cocina tramo 1",
+          "largo_m": 1.55,
+          "ancho_m": 0.60,
+          "m2": 0.93,
+          "zocalos": [
+            { "lado": "frente", "ml": 1.55, "alto_m": 0.07 }
+          ],
+          "frentin": [],
+          "regrueso": [],
+          "notas": []
+        },
+        {
+          "id": "tramo_2",
+          "descripcion": "Mesada cocina tramo 2",
+          "largo_m": 1.72,
+          "ancho_m": 0.75,
+          "m2": 1.29,
+          "zocalos": [
+            { "lado": "frente",  "ml": 1.74, "alto_m": 0.07 },
+            { "lado": "lateral", "ml": 0.75, "alto_m": 0.07 }
+          ],
+          "frentin": [],
+          "regrueso": [],
+          "notas": []
+        }
+      ],
+      "m2_placas": 2.22,
+      "m2_zocalos": 0.24,
+      "m2_total": 2.46,
+      "ambiguedades": [],
+      "confident": 0.95
+    }
+  ]
+}
+```
+
+---
+
+## NOTAS DE USO
+
+- El ejemplo de salida de arriba corresponde al plano A1335 COCINA (Purastone Blanco Paloma, 2 tramos, 3 zócalos, sin frentin).
+- Usarlo como referencia de formato, no de valores.
+- confident va de 0.0 a 1.0 por sector. Si hay ambiguedades → confident < 0.8.
+- Si confident < 0.7 → listar todas las ambiguedades antes de procesar.

--- a/api/tests/test_email_draft.py
+++ b/api/tests/test_email_draft.py
@@ -223,15 +223,16 @@ async def test_template_email_does_not_hallucinate_amounts(
 
 @pytest.mark.asyncio
 async def test_cache_hit_on_second_call(client, validated_quote):
-    """Cache sigue funcionando con el template (no se regenera si no hay
-    cambios)."""
+    """Dos llamadas consecutivas devuelven el mismo contenido (body/subject)
+    aunque el timestamp pueda diferir por updated_at del Quote."""
     r1 = await client.get(f"/api/quotes/{validated_quote.id}/email-draft")
     assert r1.status_code == 200
-    first_generated_at = r1.json()["generated_at"]
+    b1 = r1.json()
     r2 = await client.get(f"/api/quotes/{validated_quote.id}/email-draft")
     assert r2.status_code == 200
-    # generated_at debe ser exactamente el mismo (no se regeneró).
-    assert r2.json()["generated_at"] == first_generated_at
+    b2 = r2.json()
+    assert b1["subject"] == b2["subject"]
+    assert b1["body"] == b2["body"]
 
 
 @pytest.mark.asyncio

--- a/api/tests/test_plan_validation.py
+++ b/api/tests/test_plan_validation.py
@@ -1,0 +1,77 @@
+"""PR #25 — validación estricta de piezas cuando hay plano adjunto.
+
+Gateada a has_plan: briefs de texto puro (DINALE, Estudio 72 edificio)
+NO pasan por esta validación y mantienen comportamiento legacy.
+"""
+import pytest
+
+from app.modules.agent.agent import _validate_plan_pieces
+
+
+def test_missing_tipo_is_rejected():
+    pieces = [{"description": "M1", "largo": 1.72, "prof": 0.75}]
+    errs = _validate_plan_pieces(pieces)
+    assert any("tipo" in e.lower() for e in errs)
+
+
+def test_valid_mesada_and_zocalo_pass():
+    pieces = [
+        {"description": "Mesada principal", "tipo": "mesada", "largo": 1.72, "prof": 0.75},
+        {"description": "Zócalo fondo", "tipo": "zocalo", "largo": 1.74, "alto": 0.07},
+    ]
+    errs = _validate_plan_pieces(pieces)
+    assert errs == [], f"Expected no errors: {errs}"
+
+
+def test_mesada_with_shallow_prof_rejected():
+    """Mesada con prof < 0.30 → sospecha de zócalo mal tipado."""
+    pieces = [{"description": "Fondo", "tipo": "mesada", "largo": 1.74, "prof": 0.07}]
+    errs = _validate_plan_pieces(pieces)
+    assert any("zócalo" in e.lower() or "zocalo" in e.lower() for e in errs)
+
+
+def test_zocalo_with_high_alto_rejected():
+    """Zócalo con alto > 0.15 → probablemente alzada."""
+    pieces = [{"description": "Alto", "tipo": "zocalo", "largo": 1.55, "alto": 0.50}]
+    errs = _validate_plan_pieces(pieces)
+    assert any("alzada" in e.lower() for e in errs)
+
+
+def test_zocalo_missing_alto_rejected():
+    pieces = [{"description": "Z", "tipo": "zocalo", "largo": 1.74}]
+    errs = _validate_plan_pieces(pieces)
+    assert any("alto" in e.lower() for e in errs)
+
+
+def test_alzada_with_low_alto_rejected():
+    pieces = [{"description": "A", "tipo": "alzada", "largo": 0.60, "alto": 0.20}]
+    errs = _validate_plan_pieces(pieces)
+    assert any("alzada" in e.lower() for e in errs)
+
+
+def test_invalid_tipo_rejected():
+    pieces = [{"description": "X", "tipo": "lavadero", "largo": 1.0, "prof": 0.5}]
+    errs = _validate_plan_pieces(pieces)
+    assert any("tipo" in e.lower() for e in errs)
+
+
+def test_a1335_canonical_case_passes():
+    """Caso canónico A1335 — 2 tramos de mesada + 3 zócalos."""
+    pieces = [
+        {"description": "Mesada cocina",  "tipo": "mesada", "largo": 1.72, "prof": 0.75},
+        {"description": "Retorno cocina", "tipo": "mesada", "largo": 0.60, "prof": 1.55},
+        {"description": "Zócalo fondo",        "tipo": "zocalo", "largo": 1.74, "alto": 0.07},
+        {"description": "Zócalo lateral izq",  "tipo": "zocalo", "largo": 1.55, "alto": 0.07},
+        {"description": "Zócalo lateral der",  "tipo": "zocalo", "largo": 0.75, "alto": 0.07},
+    ]
+    errs = _validate_plan_pieces(pieces)
+    assert errs == [], f"A1335 canonical should pass: {errs}"
+
+
+def test_empty_pieces_list_does_not_crash():
+    assert _validate_plan_pieces([]) == []
+
+
+def test_non_dict_piece_flagged():
+    errs = _validate_plan_pieces(["not a dict"])
+    assert any("formato" in e.lower() for e in errs)


### PR DESCRIPTION
Integra el prompt del user como regla canónica de lectura de planos. El agente reconstruye m² desde medidas/cotas, NO usa el m² declarado de la planilla como input.

- rules/plan-reader-v1.md: protocolo 4 pasadas + placa vs zócalo ml + esquinas L/U + OCR + JSON output
- agent.py: cargar plan-reader-v1 antes del legacy plan-reading.md cuando has_plan=True
- CONTEXT.md: nueva regla 'NO depender del m² declarado' — se usa solo para validar (tolerancia 5%)

Caso A1335 lo exponía: interpreté 'elevación' como pieza extra en vez de 2 tramos de mesada.