### PR TITLE
feat(plan-reader): convención lado + swap dims + ocultar ml=0

### DIFF
--- a/api/app/modules/quote_engine/dual_reader.py
+++ b/api/app/modules/quote_engine/dual_reader.py
@@ -266,6 +266,45 @@ def reconcile(opus: dict, sonnet: dict) -> dict:
                     "status": status,
                 }
 
+            # PR #28 — convención: largo ≥ ancho. Si Opus y Sonnet están
+            # "swapped" (uno dice 0.6×1.55 y el otro 1.55×0.6), preferir la
+            # variante con largo ≥ ancho. Evita que la UI muestre el
+            # retorno al revés cuando los modelos invierten ejes.
+            ov_l, sv_l = ot.get("largo_m", 0) or 0, st.get("largo_m", 0) or 0
+            ov_a, sv_a = ot.get("ancho_m", 0) or 0, st.get("ancho_m", 0) or 0
+            _swapped = (
+                abs(ov_l - sv_a) < 0.02 and abs(ov_a - sv_l) < 0.02
+                and ov_l > 0 and sv_l > 0
+                and (ov_l != sv_l)
+            )
+            if _swapped:
+                # Prefer the variant with largo >= ancho
+                opus_ok = ov_l >= ov_a
+                sonnet_ok = sv_l >= sv_a
+                _pick_largo, _pick_ancho = None, None
+                if opus_ok and not sonnet_ok:
+                    _pick_largo, _pick_ancho = ov_l, ov_a
+                elif sonnet_ok and not opus_ok:
+                    _pick_largo, _pick_ancho = sv_l, sv_a
+                elif opus_ok and sonnet_ok:
+                    _pick_largo, _pick_ancho = max(ov_l, sv_l), min(ov_a, sv_a)
+                if _pick_largo is not None:
+                    logger.info(
+                        f"[dual-read] tramo {tid}: dims swapped (opus={ov_l}×{ov_a} "
+                        f"vs sonnet={sv_l}×{sv_a}) → normalizando a "
+                        f"{_pick_largo}×{_pick_ancho} (largo≥ancho)"
+                    )
+                    fields["largo_m"]["valor"] = _pick_largo
+                    fields["largo_m"]["status"] = "OK"
+                    fields["ancho_m"]["valor"] = _pick_ancho
+                    fields["ancho_m"]["status"] = "OK"
+                    # Clear the conflict flag we added earlier for this tramo
+                    _marker_l = f"{sid}.{tid}.largo_m"
+                    _marker_a = f"{sid}.{tid}.ancho_m"
+                    conflict_fields = [
+                        c for c in conflict_fields if c not in (_marker_l, _marker_a)
+                    ]
+
             # Compare zócalos
             o_zocs = ot.get("zocalos", [])
             s_zocs = st.get("zocalos", [])

--- a/api/rules/plan-reader-v1.md
+++ b/api/rules/plan-reader-v1.md
@@ -299,9 +299,19 @@ si tiene zócalo o no. No dejes ningún lado sin decisión.
 
 Los 4 lados de una mesada rectangular en planta:
 - **frontal** (borde hacia el usuario)
-- **trasero / fondo** (contra pared del fondo)
+- **trasero** (contra pared del fondo)
 - **lateral_izq**
 - **lateral_der**
+
+⛔ **Nombrar cada zócalo por UN ÚNICO lado** — nunca usar sinónimos
+simultáneos. Usar SOLO los 4 valores literales de arriba:
+`frontal | trasero | lateral_izq | lateral_der`.
+NO usar `frente`, `fondo`, `lateral` genérico, `derecho`, `izquierdo`.
+
+⛔ **Un zócalo de fondo es `trasero`, NUNCA `frontal` ni `frente`.**
+Los frentes de mesada (borde visible hacia el usuario) normalmente NO
+llevan zócalo — ese lado queda libre. Si ves un rectángulo hachurado
+con cota grande, está contra la pared del fondo → `trasero`.
 
 Para cada lado, buscar en el plano un rectángulo fino hachurado `//` cuyo
 largo **coincida o supere** el largo del lado. Decisión binaria:

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -184,7 +184,15 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
               <FieldRow label="Largo" field={tramo.largo_m} onEdit={(v) => updateField(si, ti, "largo_m", v)} />
               <FieldRow label="Ancho" field={tramo.ancho_m} onEdit={(v) => updateField(si, ti, "ancho_m", v)} />
               <FieldRow label="m²" field={tramo.m2} onEdit={(v) => updateField(si, ti, "m2", v)} />
-              {tramo.zocalos.map((z, zi) => (
+              {tramo.zocalos.map((z, zi) => {
+                // PR #28 — ocultar zócalos con ml=0 (lados sin zócalo). El
+                // prompt obliga a enumerar los 4 lados con ml=0 cuando no
+                // hay, pero en la UI eso es ruido. Mantener render solo si
+                // hay ml>0 o si el status es conflictivo (requiere revisión).
+                const hasMl = (z.ml ?? 0) > 0;
+                const needsReview = z.status === "CONFLICTO" || z.status === "DUDOSO";
+                if (!hasMl && !needsReview) return null;
+                return (
                 <div key={zi} className="flex items-center gap-2 py-1 px-2 text-[13px]">
                   <span className="w-5 text-center">{STATUS_ICONS[z.status] || ""}</span>
                   <span className="text-t3 w-24 shrink-0">Zóc. {z.lado}</span>
@@ -202,7 +210,8 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
                     </span>
                   )}
                 </div>
-              ))}
+                );
+              })}
             </div>
           ))}
           {sector.ambiguedades.length > 0 && (


### PR DESCRIPTION
3 fixes tras A1335:

A. Prompt obliga frontal/trasero/lateral_izq/lateral_der literales, sin sinónimos. Evita duplicar zócalo como 'frente' y 'trasero' (mismo 1.74 con 2 etiquetas).

B. Resolver dual: si Opus y Sonnet reportan largo/ancho swapped, preferir la variante con largo ≥ ancho. Evita que el retorno salga 0.6×1.55 en vez de 1.55×0.6.

C. UI DualReadResult: ocultar filas de zócalo con ml=0 (se siguen mostrando si el status es conflict/dudoso).