### PR TITLE
fix(ui): checkboxes y controles nativos con color del sistema

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -28,6 +28,9 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 html, body { height: 100%; overflow: hidden; }
 
+/* Native form controls follow dark theme + accent color */
+:root { color-scheme: dark; accent-color: var(--acc); }
+
 /* Mobile-specific */
 @media (max-width: 767px) {
   html { font-size: 14px; }


### PR DESCRIPTION
## Summary
- Agrega `color-scheme: dark` y `accent-color: var(--acc)` en `:root` para que los checkboxes nativos se rendereen en dark mode y usen el azul del sistema en vez del blanco default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)