### PR TITLE
feat(dual-read): rediseño ledger full-width con total destacado

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -28,6 +28,9 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 html, body { height: 100%; overflow: hidden; }
 
+/* Native form controls follow dark theme + accent color */
+:root { color-scheme: dark; accent-color: var(--acc); }
+
 /* Mobile-specific */
 @media (max-width: 767px) {
   html { font-size: 14px; }

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -52,76 +52,93 @@ interface Props {
   onRetry?: (newData: DualReadData) => void;
 }
 
-const STATUS_ICONS: Record<string, string> = {
-  CONFIRMADO: "\u2705",
-  ALERTA: "\u26A0\uFE0F",
-  CONFLICTO: "\u274C",
-  DUDOSO: "\uD83D\uDFE0",
-  SOLO_SONNET: "\uD83D\uDD35",
-  SOLO_OPUS: "\uD83D\uDFE3",
+type IconStyle = { cls: string; char: string };
+const STATUS_STYLE: Record<string, IconStyle> = {
+  CONFIRMADO:   { cls: "bg-grn-bg text-grn",                        char: "✓" },
+  ALERTA:       { cls: "bg-amb-bg text-amb",                        char: "!" },
+  CONFLICTO:    { cls: "bg-[rgba(255,69,58,0.15)] text-err",        char: "✕" },
+  DUDOSO:       { cls: "bg-[rgba(191,85,236,0.15)] text-[#bf55ec]", char: "?" },
+  SOLO_SONNET:  { cls: "bg-[rgba(79,143,255,0.15)] text-acc",       char: "S" },
+  SOLO_OPUS:    { cls: "bg-[rgba(191,85,236,0.15)] text-[#bf55ec]", char: "O" },
 };
 
-const STATUS_COLORS: Record<string, string> = {
-  CONFIRMADO: "text-green-400",
-  ALERTA: "text-yellow-400",
-  CONFLICTO: "text-red-400",
-  DUDOSO: "text-orange-400",
-  SOLO_SONNET: "text-blue-400",
-  SOLO_OPUS: "text-purple-400",
-};
-
-function FieldRow({ label, field, onEdit }: {
-  label: string;
-  field: FieldValue;
-  onEdit?: (val: number) => void;
-}) {
-  const icon = STATUS_ICONS[field.status] || "";
-  const color = STATUS_COLORS[field.status] || "text-t2";
-  const editable = field.status === "CONFLICTO" || field.status === "DUDOSO";
-
+function StatusIcon({ status }: { status: string }) {
+  const s = STATUS_STYLE[status] || STATUS_STYLE.CONFIRMADO;
   return (
-    <div className="flex items-center gap-2 py-1 px-2 text-[13px]">
-      <span className="w-5 text-center">{icon}</span>
-      <span className="text-t3 w-24 shrink-0">{label}</span>
-      {editable ? (
-        <div className="flex gap-2 items-center">
-          {field.opus != null && (
-            <button
-              className="px-2 py-0.5 rounded text-xs border border-purple-400/30 text-purple-400 hover:bg-purple-400/10"
-              onClick={() => onEdit?.(field.opus!)}
-            >
-              Opus: {field.opus}
-            </button>
-          )}
-          {field.sonnet != null && (
-            <button
-              className="px-2 py-0.5 rounded text-xs border border-blue-400/30 text-blue-400 hover:bg-blue-400/10"
-              onClick={() => onEdit?.(field.sonnet!)}
-            >
-              Sonnet: {field.sonnet}
-            </button>
-          )}
-          <input
-            type="number"
-            step="0.01"
-            defaultValue={field.valor}
-            className="w-20 px-1.5 py-0.5 bg-s1 border border-b2 rounded text-xs text-t1"
-            onChange={(e) => onEdit?.(parseFloat(e.target.value) || 0)}
-          />
-        </div>
-      ) : (
-        <span className={`${color} font-medium`}>
-          {field.valor}m
-          {field.status === "ALERTA" && " (promedio)"}
-        </span>
+    <span
+      className={`inline-grid place-items-center w-[18px] h-[18px] rounded-[5px] text-[10px] font-bold ${s.cls}`}
+      title={status}
+      aria-label={status}
+    >
+      {s.char}
+    </span>
+  );
+}
+
+function EditableNumber({
+  field,
+  onEdit,
+}: {
+  field: FieldValue;
+  onEdit: (v: number) => void;
+}) {
+  const editable = field.status === "CONFLICTO" || field.status === "DUDOSO";
+  if (!editable) return <>{field.valor.toFixed(2)}</>;
+  return (
+    <div className="inline-flex items-center gap-1.5 justify-end flex-wrap">
+      {field.opus != null && (
+        <button
+          className="px-1.5 py-0.5 rounded text-[10px] border border-purple-400/30 text-purple-400 hover:bg-purple-400/10"
+          onClick={() => onEdit(field.opus!)}
+          title="Usar valor Opus"
+        >
+          O:{field.opus}
+        </button>
       )}
+      {field.sonnet != null && (
+        <button
+          className="px-1.5 py-0.5 rounded text-[10px] border border-blue-400/30 text-blue-400 hover:bg-blue-400/10"
+          onClick={() => onEdit(field.sonnet!)}
+          title="Usar valor Sonnet"
+        >
+          S:{field.sonnet}
+        </button>
+      )}
+      <input
+        type="number"
+        step="0.01"
+        defaultValue={field.valor}
+        className="w-16 px-1.5 py-0.5 bg-s1 border border-b2 rounded text-[11px] text-t1 text-right font-mono"
+        onChange={(e) => onEdit(parseFloat(e.target.value) || 0)}
+      />
     </div>
+  );
+}
+
+function EditableZocalo({
+  z,
+  onEdit,
+}: {
+  z: Zocalo;
+  onEdit: (v: number) => void;
+}) {
+  const editable = z.status === "CONFLICTO" || z.status === "DUDOSO";
+  if (!editable) return <>{z.ml.toFixed(2)}</>;
+  return (
+    <input
+      type="number"
+      step="0.01"
+      defaultValue={z.ml}
+      className="w-16 px-1.5 py-0.5 bg-s1 border border-b2 rounded text-[11px] text-t1 text-right font-mono"
+      onChange={(e) => onEdit(parseFloat(e.target.value) || 0)}
+    />
   );
 }
 
 export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Props) {
   const [retrying, setRetrying] = useState(false);
   const [retryError, setRetryError] = useState<string | null>(null);
+  const [editedData, setEditedData] = useState<DualReadData>(data);
 
   const handleRetry = async () => {
     setRetrying(true);
@@ -144,11 +161,8 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
     }
   };
 
-
-  const [editedData, setEditedData] = useState<DualReadData>(data);
-
   const updateField = (sectorIdx: number, tramoIdx: number, field: string, val: number) => {
-    setEditedData(prev => {
+    setEditedData((prev) => {
       const next = JSON.parse(JSON.stringify(prev));
       const tramo = next.sectores[sectorIdx].tramos[tramoIdx];
       if (field.startsWith("zocalo_")) {
@@ -161,98 +175,182 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
     });
   };
 
+  // Totals
+  let mesadasM2 = 0;
+  let zocalosM2 = 0;
+  let piecesCount = 0;
+  let zocalosCount = 0;
+  editedData.sectores.forEach((s) =>
+    s.tramos.forEach((t) => {
+      mesadasM2 += t.m2.valor || 0;
+      piecesCount += 1;
+      t.zocalos.forEach((z) => {
+        zocalosM2 += (z.ml || 0) * (z.alto_m || 0);
+        zocalosCount += 1;
+      });
+    })
+  );
+  const totalM2 = mesadasM2 + zocalosM2;
+
+  const allAmbiguedades = editedData.sectores.flatMap((s) => s.ambiguedades);
+  const title =
+    data.source === "DUAL" ? "Doble lectura del plano" : `Lectura ${data.source.replace("SOLO_", "")}`;
+  const firstSectorHead = editedData.sectores[0]
+    ? `${editedData.sectores[0].id} — ${editedData.sectores[0].tipo}`
+    : "";
+
   return (
-    <div className="rounded-[10px] border border-b1 bg-s2 p-3 my-2 max-w-lg">
-      <div className="text-[13px] font-semibold text-t1 mb-2">
-        {data.source === "DUAL" ? "Doble lectura del plano" : `Lectura ${data.source.replace("SOLO_", "")}`}
+    <div className="my-2 w-full rounded-2xl border border-b1 bg-s1 overflow-hidden shadow-[0_20px_40px_-20px_rgba(0,0,0,0.5)]">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-5 py-4 bg-gradient-to-b from-s3 to-s2 border-b border-b1">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-acc bg-acc-bg border border-acc/30 px-2 py-1 rounded-md">
+          {data.source === "DUAL" ? "Doble lectura" : data.source.replace("SOLO_", "Solo ")}
+        </span>
+        <h3 className="text-[15px] font-semibold text-t1 tracking-tight">{firstSectorHead || title}</h3>
+        <span className="ml-auto text-[12px] text-t3 font-mono">
+          {piecesCount} {piecesCount === 1 ? "pieza" : "piezas"} · {zocalosCount}{" "}
+          {zocalosCount === 1 ? "zócalo" : "zócalos"}
+        </span>
       </div>
 
       {data.m2_warning && (
-        <div className="text-[12px] text-yellow-400 bg-yellow-400/10 rounded px-2 py-1 mb-2">
+        <div className="mx-5 mt-4 text-[12px] text-amb bg-amb-bg rounded-lg px-3 py-2 border border-amb/25">
           {data.m2_warning}
         </div>
       )}
 
-      {editedData.sectores.map((sector, si) => (
-        <div key={sector.id} className="mb-3">
-          <div className="text-[12px] text-t3 uppercase tracking-wide mb-1">
-            {sector.id} — {sector.tipo}
+      {/* Body: pieces + totals */}
+      <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px]">
+        {/* Pieces */}
+        <div className="py-2 overflow-x-auto">
+          {/* Column headers */}
+          <div className="grid grid-cols-[22px_1fr_80px_80px_80px] gap-3 px-5 py-2.5 text-[10px] font-semibold uppercase tracking-[0.1em] text-t3 bg-s2 border-b border-b1">
+            <span></span>
+            <span>Pieza</span>
+            <span className="text-right">Largo</span>
+            <span className="text-right">Ancho</span>
+            <span className="text-right">m²</span>
           </div>
-          {sector.tramos.map((tramo, ti) => (
-            <div key={tramo.id} className="ml-2 border-l border-b1 pl-2 mb-2">
-              <div className="text-[12px] text-t2 font-medium mb-1">{tramo.descripcion || tramo.id}</div>
-              <FieldRow label="Largo" field={tramo.largo_m} onEdit={(v) => updateField(si, ti, "largo_m", v)} />
-              <FieldRow label="Ancho" field={tramo.ancho_m} onEdit={(v) => updateField(si, ti, "ancho_m", v)} />
-              <FieldRow label="m²" field={tramo.m2} onEdit={(v) => updateField(si, ti, "m2", v)} />
-              {tramo.zocalos.map((z, zi) => (
-                <div key={zi} className="flex items-center gap-2 py-1 px-2 text-[13px]">
-                  <span className="w-5 text-center">{STATUS_ICONS[z.status] || ""}</span>
-                  <span className="text-t3 w-24 shrink-0">Zóc. {z.lado}</span>
-                  {z.status === "CONFLICTO" || z.status === "DUDOSO" ? (
-                    <input
-                      type="number"
-                      step="0.01"
-                      defaultValue={z.ml}
-                      className="w-20 px-1.5 py-0.5 bg-s1 border border-b2 rounded text-xs text-t1"
-                      onChange={(e) => updateField(si, ti, `zocalo_${zi}`, parseFloat(e.target.value) || 0)}
-                    />
-                  ) : (
-                    <span className={STATUS_COLORS[z.status] || "text-t2"}>
-                      {z.ml}ml × {z.alto_m}m
-                    </span>
-                  )}
+
+          {editedData.sectores.map((sector, si) => (
+            <div key={sector.id}>
+              {editedData.sectores.length > 1 && (
+                <div className="px-5 pt-3.5 pb-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-t3">
+                  {sector.id} — {sector.tipo}
                 </div>
+              )}
+
+              {sector.tramos.map((tramo, ti) => (
+                <React.Fragment key={tramo.id}>
+                  {/* Mesada row */}
+                  <div className="grid grid-cols-[22px_1fr_80px_80px_80px] items-center gap-3 px-5 py-2.5 text-[13px] font-mono tabular-nums border-t border-b1">
+                    <StatusIcon status={tramo.largo_m.status} />
+                    <div className="font-sans">
+                      <div className="text-t1">{tramo.descripcion || tramo.id}</div>
+                      <div className="text-[11px] text-t3 mt-0.5">mesada rectangular</div>
+                    </div>
+                    <div className="text-t2 text-right">
+                      <EditableNumber field={tramo.largo_m} onEdit={(v) => updateField(si, ti, "largo_m", v)} />
+                      <span className="text-t4 ml-0.5">m</span>
+                    </div>
+                    <div className="text-t2 text-right">
+                      <EditableNumber field={tramo.ancho_m} onEdit={(v) => updateField(si, ti, "ancho_m", v)} />
+                      <span className="text-t4 ml-0.5">m</span>
+                    </div>
+                    <div className="text-t1 font-medium text-right">
+                      <EditableNumber field={tramo.m2} onEdit={(v) => updateField(si, ti, "m2", v)} />
+                    </div>
+                  </div>
+
+                  {/* Zócalos rows */}
+                  {tramo.zocalos.map((z, zi) => (
+                    <div
+                      key={zi}
+                      className="grid grid-cols-[22px_1fr_80px_80px_80px] items-center gap-3 px-5 py-2 text-[13px] font-mono tabular-nums border-t border-b1"
+                    >
+                      <StatusIcon status={z.status} />
+                      <div className="font-sans text-t2 pl-4 relative">
+                        <span className="absolute left-0 top-1/2 w-2.5 h-px bg-b2" />
+                        Zóc. {z.lado}
+                      </div>
+                      <div className="text-t2 text-right">
+                        <EditableZocalo z={z} onEdit={(v) => updateField(si, ti, `zocalo_${zi}`, v)} />
+                        <span className="text-t4 ml-0.5">ml</span>
+                      </div>
+                      <div className="text-t2 text-right">
+                        {z.alto_m.toFixed(2)}
+                        <span className="text-t4 ml-0.5">m</span>
+                      </div>
+                      <div className="text-t1 font-medium text-right">
+                        {(z.ml * z.alto_m).toFixed(2)}
+                      </div>
+                    </div>
+                  ))}
+                </React.Fragment>
               ))}
             </div>
           ))}
-          {sector.ambiguedades.length > 0 && (
-            <div className="text-[11px] text-orange-400 mt-1 ml-2">
-              {sector.ambiguedades.map((a, i) => <div key={i}>⚠️ {a}</div>)}
-            </div>
-          )}
         </div>
-      ))}
 
-      {(() => {
-        let mesadas = 0;
-        let zocalos = 0;
-        editedData.sectores.forEach(s => s.tramos.forEach(t => {
-          mesadas += t.m2.valor || 0;
-          t.zocalos.forEach(z => { zocalos += (z.ml || 0) * (z.alto_m || 0); });
-        }));
-        const total = mesadas + zocalos;
-        return (
-          <div className="mt-3 pt-2 border-t border-b1 flex items-baseline justify-between px-2">
-            <div>
-              <div className="text-[12px] text-t3 uppercase tracking-wide">Total</div>
-              <div className="text-[10px] text-t4 mt-0.5">
-                mesadas {mesadas.toFixed(2)} + zócalos {zocalos.toFixed(2)}
-              </div>
-            </div>
-            <div className="text-[15px] font-semibold text-t1 font-mono">
-              {total.toFixed(2)} m²
-            </div>
+        {/* Totals */}
+        <div className="border-t lg:border-t-0 lg:border-l border-b1 bg-gradient-to-b from-s2 to-s1 p-5">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-t3">Total a cortar</div>
+          <div className="mt-1.5 text-[44px] leading-none font-semibold tracking-[-1px] font-mono tabular-nums text-t1">
+            {totalM2.toFixed(2)}
+            <span className="text-[16px] text-t2 font-medium ml-1 tracking-tight font-sans">m²</span>
           </div>
-        );
-      })()}
+          <div className="mt-4 grid grid-cols-[1fr_auto] gap-x-4 gap-y-1.5 text-[12px] font-mono tabular-nums">
+            <span className="text-t3 font-sans">Mesadas</span>
+            <span className="text-t1 text-right">{mesadasM2.toFixed(2)} m²</span>
+            <span className="text-t3 font-sans">Zócalos</span>
+            <span className="text-t1 text-right">{zocalosM2.toFixed(2)} m²</span>
+            <span className="col-span-2 h-px bg-b1 my-1" />
+            <span className="text-t3 font-sans">Piezas</span>
+            <span className="text-t1 text-right">{piecesCount + zocalosCount}</span>
+          </div>
+        </div>
+      </div>
 
-      {data.source !== "DUAL" && !data._retry && (
-        <button
-          className="w-full mt-2 py-2 rounded-lg text-[12px] font-medium bg-orange-600/20 hover:bg-orange-600/30 border border-orange-600/40 text-orange-200 transition disabled:opacity-50"
-          onClick={handleRetry}
-          disabled={retrying}
-        >
-          {retrying ? "Consultando a Opus..." : "⚠️ Las medidas no coinciden — verificar con Opus"}
-        </button>
+      {/* Alerts */}
+      {allAmbiguedades.length > 0 && (
+        <div className="mx-5 mb-4 p-3.5 bg-amb-bg border border-amb/25 rounded-xl">
+          <h4 className="text-[11px] font-semibold uppercase tracking-[0.06em] text-amb mb-2">
+            Revisar antes de confirmar
+          </h4>
+          <ul className="flex flex-col gap-1.5">
+            {allAmbiguedades.map((a, i) => (
+              <li key={i} className="text-t2 text-[12px] leading-[1.5] pl-3.5 relative">
+                <span className="absolute left-0 top-[9px] w-1 h-1 rounded-full bg-amb" />
+                {a}
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
-      {retryError && <div className="text-[11px] text-red-400 mt-1">{retryError}</div>}
 
-      <button
-        className="w-full mt-2 py-2 rounded-lg text-[13px] font-medium bg-green-600 hover:bg-green-500 text-white transition"
-        onClick={() => onConfirm(editedData)}
-      >
-        Confirmar medidas
-      </button>
+      {/* Retry if needed */}
+      {data.source !== "DUAL" && !data._retry && (
+        <div className="px-5 pb-3">
+          <button
+            className="w-full py-2.5 rounded-lg text-[12px] font-medium bg-orange-600/20 hover:bg-orange-600/30 border border-orange-600/40 text-orange-200 transition disabled:opacity-50"
+            onClick={handleRetry}
+            disabled={retrying}
+          >
+            {retrying ? "Consultando a Opus..." : "⚠️ Las medidas no coinciden — verificar con Opus"}
+          </button>
+          {retryError && <div className="text-[11px] text-err mt-1">{retryError}</div>}
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex gap-2 px-5 py-4 border-t border-b1 bg-s2">
+        <button
+          className="flex-1 py-2.5 px-4 rounded-xl text-[13px] font-semibold bg-acc hover:bg-acc-hover text-white transition"
+          onClick={() => onConfirm(editedData)}
+        >
+          Confirmar medidas · {totalM2.toFixed(2)} m²
+        </button>
+      </div>
     </div>
   );
 }

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -213,6 +213,29 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
         </div>
       ))}
 
+      {(() => {
+        let mesadas = 0;
+        let zocalos = 0;
+        editedData.sectores.forEach(s => s.tramos.forEach(t => {
+          mesadas += t.m2.valor || 0;
+          t.zocalos.forEach(z => { zocalos += (z.ml || 0) * (z.alto_m || 0); });
+        }));
+        const total = mesadas + zocalos;
+        return (
+          <div className="mt-3 pt-2 border-t border-b1 flex items-baseline justify-between px-2">
+            <div>
+              <div className="text-[12px] text-t3 uppercase tracking-wide">Total</div>
+              <div className="text-[10px] text-t4 mt-0.5">
+                mesadas {mesadas.toFixed(2)} + zócalos {zocalos.toFixed(2)}
+              </div>
+            </div>
+            <div className="text-[15px] font-semibold text-t1 font-mono">
+              {total.toFixed(2)} m²
+            </div>
+          </div>
+        );
+      })()}
+
       {data.source !== "DUAL" && !data._retry && (
         <button
           className="w-full mt-2 py-2 rounded-lg text-[12px] font-medium bg-orange-600/20 hover:bg-orange-600/30 border border-orange-600/40 text-orange-200 transition disabled:opacity-50"


### PR DESCRIPTION
## Summary
- Nuevo layout full-width tipo ledger/spreadsheet para la card de doble lectura del plano.
- Panel de total a la derecha en desktop, debajo en mobile/tablet.
- Total a cortar como hero (tipografía grande, tabular numerals), con desglose de mesadas + zócalos + piezas.
- CTA de confirmar incluye el total para validación rápida contra el m² del proyectista.
- Mantiene toda la funcionalidad previa: edición de campos en CONFLICTO/DUDOSO, retry con Opus, warnings por sector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)