### PR TITLE
feat(plan-reader): extraer leyenda/tabla de características del plano

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1898,24 +1898,33 @@ class AgentService:
                                 })
                                 logging.info(f"[planilla] Sending cropped drawing only ({_drawing_img.width}x{_drawing_img.height}, {len(_draw_bytes)} bytes)")
 
-                                # ── COTAS: extract dimensional text positionally from PDF ──
+                                # ── COTAS + SPECS: extract dimensional text + leyenda from PDF ──
                                 _cotas_text = None
                                 try:
                                     from app.modules.quote_engine.cotas_extractor import (
-                                        extract_cotas_from_drawing, format_cotas_for_prompt
+                                        extract_cotas_from_drawing,
+                                        extract_specs_from_table,
+                                        format_cotas_and_specs,
                                     )
                                     _cotas = extract_cotas_from_drawing(
                                         page,
                                         table_x0=_planilla_data.table_x0,
                                         dpi=_plan_dpi,
                                     )
-                                    if _cotas:
-                                        _cotas_text = format_cotas_for_prompt(_cotas)
-                                        logging.info(f"[cotas] Injecting {len(_cotas)} pre-extracted cotas into dual read")
+                                    _specs = extract_specs_from_table(
+                                        page,
+                                        table_x0=_planilla_data.table_x0,
+                                    )
+                                    if _cotas or _specs:
+                                        _cotas_text = format_cotas_and_specs(_cotas, _specs)
+                                        logging.info(
+                                            f"[cotas+specs] Injecting {len(_cotas)} cotas + "
+                                            f"{len(_specs)} specs into dual read"
+                                        )
                                     else:
-                                        logging.info("[cotas] No cotas extractable from PDF text → fallback to vision-only")
+                                        logging.info("[cotas+specs] Nothing extractable from PDF text → fallback to vision-only")
                                 except Exception as e:
-                                    logging.warning(f"[cotas] Extraction failed, falling back to vision-only: {e}")
+                                    logging.warning(f"[cotas+specs] Extraction failed, falling back to vision-only: {e}")
 
                                 # ── DUAL READ: send crop to Sonnet (+ Opus if unsure) ──
                                 try:

--- a/api/app/modules/quote_engine/cotas_extractor.py
+++ b/api/app/modules/quote_engine/cotas_extractor.py
@@ -326,3 +326,135 @@ def format_cotas_for_prompt(cotas: list[Cota]) -> str:
             f"{prefix_str}{rot_str}"
         )
     return "\n".join(lines)
+
+
+# ═══════════════════════════════════════════════════════
+# Specs extraction — leyendas / tablas de características
+# ═══════════════════════════════════════════════════════
+#
+# El plano normalmente tiene, al costado del dibujo o debajo, una tabla de
+# características con texto tipo "ZOCALOS: 7 cm de altura", "PILETA: Johnson
+# LUXOR COMPACT SI71", "MATERIAL: Purastone Blanco Paloma", etc.
+#
+# `extract_cotas_from_drawing` ignora todo esto porque filtra por decimales
+# y excluye el área de la tabla (x0 >= table_x0). Resultado: los modelos de
+# visión NO reciben los datos explícitos del plano y terminan reportando
+# como "ambigüedad" cosas que están escritas literalmente al lado del dibujo.
+#
+# Esta extractor capta TODO el texto legible (sin filtro numérico) de áreas
+# candidatas a leyenda y lo formatea para inyectar en el prompt.
+
+# Keys conocidas — líneas con alguna de estas se consideran "spec útil"
+_SPEC_KEYS = (
+    "zocalo", "zócalo", "zocalos", "zócalos",
+    "pileta", "bacha",
+    "material", "mármol", "marmol", "granito", "silestone", "dekton",
+    "neolith", "purastone", "puraprima", "laminatto", "quartz",
+    "espesor", "20mm", "30mm", "2cm", "3cm",
+    "frentin", "faldón", "faldon",
+    "regrueso",
+    "pulido", "pulida", "canto",
+    "color", "terminación", "terminacion",
+    "altura", "cm de altura",
+)
+
+
+def _is_spec_line(text: str) -> bool:
+    """True si la línea parece contener una especificación útil (no un número suelto)."""
+    t = text.lower().strip()
+    if not t or len(t) < 3:
+        return False
+    # Solo un número → es una cota, no spec
+    if COTA_REGEX.match(t):
+        return False
+    return any(k in t for k in _SPEC_KEYS)
+
+
+def _group_words_into_lines(words: list[dict], y_tolerance: float = 3.0) -> list[str]:
+    """Agrupa words por línea (misma `top` ± tolerancia) y ordena x0."""
+    if not words:
+        return []
+    sorted_ws = sorted(words, key=lambda w: (w.get("top", 0), w.get("x0", 0)))
+    lines: list[list[dict]] = []
+    for w in sorted_ws:
+        if lines and abs(w.get("top", 0) - lines[-1][-1].get("top", 0)) < y_tolerance:
+            lines[-1].append(w)
+        else:
+            lines.append([w])
+    return [
+        " ".join(str(w.get("text", "")).strip() for w in ln if w.get("text"))
+        for ln in lines
+    ]
+
+
+def extract_specs_from_table(page, table_x0: float) -> list[str]:
+    """Extraé líneas de la tabla de características / leyenda del plano.
+
+    Captura texto a la DERECHA de table_x0 (típicamente la tabla de
+    especificaciones) y también el margen inferior del área del dibujo
+    (notas "ZOCALOS 7 cm", etc.). Filtra por keywords conocidas para
+    descartar ruido (nombre del estudio, logo, escalas, etc.).
+    """
+    if not page:
+        return []
+    try:
+        raw_words = page.extract_words(use_text_flow=True) or []
+    except Exception as e:
+        logger.warning(f"[specs] extract_words failed: {e}")
+        return []
+
+    # Tabla lateral: x0 >= table_x0. Además, capturamos cualquier texto del
+    # dibujo que matchee keywords (notas al pie tipo "ZOCALOS 7 cm altura").
+    page_h = float(getattr(page, "height", 0) or 0)
+    footer_cutoff = page_h * 0.95 if page_h else float("inf")
+    caratula_cutoff = page_h * 0.05 if page_h else 0
+
+    table_words = [
+        w for w in raw_words
+        if w.get("x0", 0) >= table_x0 and caratula_cutoff < w.get("top", 0) < footer_cutoff
+    ]
+    drawing_words_with_spec_kw = [
+        w for w in raw_words
+        if w.get("x0", 0) < table_x0
+        and any(k in str(w.get("text", "")).lower() for k in _SPEC_KEYS)
+    ]
+
+    lines = _group_words_into_lines(table_words + drawing_words_with_spec_kw)
+    specs = [ln for ln in lines if _is_spec_line(ln)]
+    # Dedup preservando orden
+    seen: set[str] = set()
+    out: list[str] = []
+    for s in specs:
+        key = s.lower().strip()
+        if key not in seen:
+            seen.add(key)
+            out.append(s.strip())
+    logger.info(f"[specs] Extracted {len(out)} spec lines from table/legend: {out}")
+    return out
+
+
+def format_specs_for_prompt(specs: list[str]) -> str:
+    """Formatea las especificaciones como bloque para inyectar en el prompt."""
+    if not specs:
+        return ""
+    lines = [
+        "ESPECIFICACIONES EXPLÍCITAS DEL PLANO (texto literal — NO las marques como ambigüedad):",
+        "Si alguna de estas líneas cubre un dato (altura de zócalo, modelo de pileta, material,",
+        "espesor, etc.), usá ese valor directo y NO reportes 'no especificado' en ambiguedades.",
+        "",
+    ]
+    for s in specs:
+        lines.append(f"- {s}")
+    return "\n".join(lines)
+
+
+def format_cotas_and_specs(cotas: list[Cota], specs: list[str]) -> str:
+    """Combine cotas + specs en un único bloque de contexto."""
+    parts = []
+    cotas_block = format_cotas_for_prompt(cotas)
+    if cotas_block:
+        parts.append(cotas_block)
+    specs_block = format_specs_for_prompt(specs)
+    if specs_block:
+        parts.append(specs_block)
+    return "\n\n".join(parts)

--- a/api/app/modules/quote_engine/dual_reader.py
+++ b/api/app/modules/quote_engine/dual_reader.py
@@ -164,6 +164,162 @@ async def _call_vision(
 # Reconciliation
 # ═══════════════════════════════════════════════════════
 
+# ═══════════════════════════════════════════════════════
+# Ambigüedades — dedup, filtro de obsoletas, categorización
+# ═══════════════════════════════════════════════════════
+#
+# Los modelos Opus y Sonnet a veces escriben el mismo warning con palabras
+# distintas (ej. "altura de zócalo asumida 0.07m" vs "se asume 0.07 m por
+# convención estándar (7 cm)"). Un `set()` no las dedupea porque las strings
+# difieren. Además, a veces un modelo levanta una ambigüedad que el otro
+# modelo resolvió, y después de reconciliar queda como warning "huérfano"
+# que contradice el resultado final (ej. "solo 1 zócalo" cuando Opus
+# encontró los otros dos).
+#
+# Solución: agrupar por "bucket" temático basado en keywords, filtrar las
+# que contradicen el reconciliado, y categorizar como DEFAULT / INFO /
+# REVISION para que la UI pueda darles jerarquía.
+
+_AMBIG_BUCKETS: list[tuple[str, list[list[str]]]] = [
+    # (bucket_id, list of keyword groups — all keywords in a group must match)
+    ("altura_zocalo_default", [
+        ["altura", "zócal", "asum"],
+        ["altura", "zocal", "asum"],
+        ["altura", "zócal", "default"],
+        ["altura", "zocal", "default"],
+        ["altura", "zócal", "convenci"],
+        ["altura", "zocal", "convenci"],
+        ["altura", "zócal", "7 cm"],
+        ["altura", "zocal", "7 cm"],
+        ["altura", "zócal", "7cm"],
+        ["altura", "zocal", "7cm"],
+    ]),
+    ("pileta_sin_modelo", [
+        ["pileta", "modelo"],
+        ["pileta", "marca"],
+    ]),
+    ("forma_l_sin_indicacion", [
+        ["forma", "l", "no"],
+        ["unión", "tramos"],
+        ["union", "tramos"],
+        ["inglete"],
+        ["solape"],
+        ["tramos", "independientes"],
+    ]),
+    ("conteo_zocalos", [
+        ["solo", "zócal", "identific"],
+        ["solo", "zocal", "identific"],
+        ["no muestra", "zócal"],
+        ["no muestra", "zocal"],
+    ]),
+]
+
+
+def _normalize_text(s: str) -> str:
+    """Lowercase, collapse whitespace, strip accents lightly."""
+    t = s.lower().strip()
+    t = re.sub(r"\s+", " ", t)
+    return t
+
+
+def _bucket_of(warning: str) -> str:
+    """Return bucket id if matches any known group, else the normalized text itself."""
+    t = _normalize_text(warning)
+    for bucket_id, groups in _AMBIG_BUCKETS:
+        for group in groups:
+            if all(kw in t for kw in group):
+                return bucket_id
+    # Fallback: fingerprint from content words (ignore numbers + stopwords)
+    stopwords = {
+        "de","el","la","los","las","en","por","un","una","no","se","con",
+        "al","del","para","que","y","o","a","es","esta","está","pese","ni",
+        "su","sus","lo","le","ya","ha","se","hay","sin","solo","explícito",
+    }
+    clean = re.sub(r"\d+[.,]?\d*\s*(m|cm|ml|mm)?", " ", t)
+    clean = re.sub(r"[^\w\sáéíóúñ]", " ", clean)
+    words = sorted({w for w in clean.split() if len(w) > 3 and w not in stopwords})
+    return "fp:" + " ".join(words)
+
+
+def _is_obsolete(warning: str, rec_tramos: list[dict]) -> bool:
+    """True if the warning contradicts the reconciled sector state."""
+    t = _normalize_text(warning)
+
+    # "solo se identifica N zócalo(s)" vs actual reconciled count
+    m = re.search(r"solo se identific\w*\s*(\d+)\s*z[oó]cal", t)
+    if m:
+        reported = int(m.group(1))
+        actual = sum(
+            1
+            for tr in rec_tramos
+            for z in tr.get("zocalos", [])
+            if (z.get("ml") or 0) > 0
+        )
+        if actual > reported:
+            return True
+
+    # "tramo X no muestra zócalos..." but that tramo now has zócalos
+    m = re.search(r"tramo[_\s]*([a-z0-9_]+).*(no muestra|sin z[oó]cal)", t)
+    if m:
+        key = m.group(1).strip("_ ")
+        for tr in rec_tramos:
+            tid = (tr.get("id") or "").lower()
+            desc = (tr.get("descripcion") or "").lower()
+            if key and (key in tid or key in desc):
+                has = any((z.get("ml") or 0) > 0 for z in tr.get("zocalos", []))
+                if has:
+                    return True
+    return False
+
+
+def _categorize(warning: str) -> str:
+    """Classify warning as DEFAULT (info-only), INFO (falta dato externo), REVISION (necesita vista al plano)."""
+    t = _normalize_text(warning)
+    if any(k in t for k in ("asum", "default", "convenci")) and ("altura" in t or "7 cm" in t or "7cm" in t):
+        return "DEFAULT"
+    if "pileta" in t and any(k in t for k in ("modelo", "marca", "no indicad")):
+        return "INFO"
+    if any(
+        k in t
+        for k in (
+            "solo se identific",
+            "no muestra",
+            "no hay texto",
+            "no hay indicación",
+            "no hay indicacion",
+            "pese a",
+            "dudos",
+            "conflict",
+            "tramos independientes",
+            "inglete",
+            "solape",
+        )
+    ):
+        return "REVISION"
+    return "REVISION"
+
+
+_CATEGORY_ORDER = {"REVISION": 0, "INFO": 1, "DEFAULT": 2}
+
+
+def _clean_ambiguedades(raw: list[str], rec_tramos: list[dict]) -> list[dict]:
+    """Dedup (by bucket), filter obsoletas, categorize, sort by priority."""
+    seen: set[str] = set()
+    out: list[dict] = []
+    for w in raw:
+        if not isinstance(w, str) or not w.strip():
+            continue
+        if _is_obsolete(w, rec_tramos):
+            continue
+        key = _bucket_of(w)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append({"tipo": _categorize(w), "texto": w.strip()})
+    out.sort(key=lambda d: _CATEGORY_ORDER.get(d["tipo"], 99))
+    return out
+
+
 def _compare_float(a: float, b: float) -> tuple[str, float]:
     """Compare two float values, return (status, reconciled_value)."""
     if a == b:
@@ -333,7 +489,10 @@ def reconcile(opus: dict, sonnet: dict) -> dict:
             "tipo": os.get("tipo", ss.get("tipo", "")),
             "tramos": rec_tramos,
             "m2_total": {"opus": o_m2, "sonnet": s_m2, "valor": m2_val or o_m2, "status": m2_status},
-            "ambiguedades": list(set(os.get("ambiguedades", []) + ss.get("ambiguedades", []))),
+            "ambiguedades": _clean_ambiguedades(
+                list(os.get("ambiguedades", [])) + list(ss.get("ambiguedades", [])),
+                rec_tramos,
+            ),
         })
 
     return {
@@ -371,7 +530,7 @@ def _build_single_result(data: dict, source: str) -> dict:
             "tipo": s.get("tipo", ""),
             "tramos": tramos,
             "m2_total": {"valor": s.get("m2_total", 0), "status": source},
-            "ambiguedades": s.get("ambiguedades", []),
+            "ambiguedades": _clean_ambiguedades(list(s.get("ambiguedades", [])), tramos),
         })
     return {
         "sectores": sectores,

--- a/api/rules/plan-reader-v1.md
+++ b/api/rules/plan-reader-v1.md
@@ -58,6 +58,17 @@ No preguntar, no inferir, no completar.
 Altura default: 0.07 m si se indica "zócalos 7 cm" en características generales.
 Si no hay altura especificada → anotá en ambiguedades.
 
+⚠️ IMPORTANTE — ESPECIFICACIONES EXPLÍCITAS:
+Si el prompt incluye un bloque "ESPECIFICACIONES EXPLÍCITAS DEL PLANO", ese
+texto viene extraído literal de la leyenda/tabla de características. Usalo
+directo:
+  - "ZOCALOS: 7 cm" → alto_m = 0.07 (confirmado, NO anotes ambigüedad)
+  - "PILETA: Johnson LUXOR COMPACT SI71" → modelo definido (NO anotes
+    "modelo no indicado")
+  - "MATERIAL: Purastone Blanco Paloma" → material definido
+NO marques como ambigüedad ningún dato que esté cubierto por el bloque
+ESPECIFICACIONES.
+
 ---
 
 ## REGLA — FRENTIN / FALDÓN: SOLO POR EVIDENCIA EXPLÍCITA

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -28,6 +28,9 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 html, body { height: 100%; overflow: hidden; }
 
+/* Native form controls follow dark theme + accent color */
+:root { color-scheme: dark; accent-color: var(--acc); }
+
 /* Mobile-specific */
 @media (max-width: 767px) {
   html { font-size: 14px; }

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -28,12 +28,15 @@ interface Tramo {
   regrueso: unknown[];
 }
 
+type AmbiguedadTipo = "DEFAULT" | "INFO" | "REVISION";
+type Ambiguedad = string | { tipo: AmbiguedadTipo; texto: string };
+
 interface Sector {
   id: string;
   tipo: string;
   tramos: Tramo[];
   m2_total: FieldValue;
-  ambiguedades: string[];
+  ambiguedades: Ambiguedad[];
 }
 
 interface DualReadData {
@@ -333,22 +336,44 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
         </div>
       </div>
 
-      {/* Alerts */}
-      {allAmbiguedades.length > 0 && (
-        <div className="mx-5 mb-4 p-3.5 bg-amb-bg border border-amb/25 rounded-xl">
-          <h4 className="text-[11px] font-semibold uppercase tracking-[0.06em] text-amb mb-2">
-            Revisar antes de confirmar
-          </h4>
-          <ul className="flex flex-col gap-1.5">
-            {allAmbiguedades.map((a, i) => (
-              <li key={i} className="text-t2 text-[12px] leading-[1.5] pl-3.5 relative">
-                <span className="absolute left-0 top-[9px] w-1 h-1 rounded-full bg-amb" />
-                {a}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+      {/* Alerts categorizadas */}
+      {allAmbiguedades.length > 0 && (() => {
+        const norm = allAmbiguedades.map((a) =>
+          typeof a === "string" ? { tipo: "REVISION" as AmbiguedadTipo, texto: a } : a
+        );
+        const groups: Record<AmbiguedadTipo, string[]> = { REVISION: [], INFO: [], DEFAULT: [] };
+        norm.forEach((a) => {
+          const t = (a.tipo || "REVISION") as AmbiguedadTipo;
+          (groups[t] || groups.REVISION).push(a.texto);
+        });
+        const META: Record<AmbiguedadTipo, { label: string; color: string; bg: string; border: string; dot: string }> = {
+          REVISION: { label: "Revisar en plano",   color: "text-amb", bg: "bg-amb-bg",                      border: "border-amb/25",                      dot: "bg-amb" },
+          INFO:     { label: "Falta dato",         color: "text-acc", bg: "bg-acc-bg",                      border: "border-acc/25",                      dot: "bg-acc" },
+          DEFAULT:  { label: "Valores por default", color: "text-t2", bg: "bg-[rgba(255,255,255,0.03)]",    border: "border-b1",                          dot: "bg-t3" },
+        };
+        const order: AmbiguedadTipo[] = ["REVISION", "INFO", "DEFAULT"];
+        return (
+          <div className="mx-5 mb-4 flex flex-col gap-2">
+            {order.map((t) =>
+              groups[t].length === 0 ? null : (
+                <div key={t} className={`p-3.5 ${META[t].bg} border ${META[t].border} rounded-xl`}>
+                  <h4 className={`text-[11px] font-semibold uppercase tracking-[0.06em] ${META[t].color} mb-2`}>
+                    {META[t].label}
+                  </h4>
+                  <ul className="flex flex-col gap-1.5">
+                    {groups[t].map((text, i) => (
+                      <li key={i} className="text-t2 text-[12px] leading-[1.5] pl-3.5 relative">
+                        <span className={`absolute left-0 top-[9px] w-1 h-1 rounded-full ${META[t].dot}`} />
+                        {text}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )
+            )}
+          </div>
+        );
+      })()}
 
       {/* Retry if needed */}
       {data.source !== "DUAL" && !data._retry && (

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -58,8 +58,17 @@ const STATUS_STYLE: Record<string, IconStyle> = {
   ALERTA:       { cls: "bg-amb-bg text-amb",                        char: "!" },
   CONFLICTO:    { cls: "bg-[rgba(255,69,58,0.15)] text-err",        char: "✕" },
   DUDOSO:       { cls: "bg-[rgba(191,85,236,0.15)] text-[#bf55ec]", char: "?" },
-  SOLO_SONNET:  { cls: "bg-[rgba(79,143,255,0.15)] text-acc",       char: "S" },
-  SOLO_OPUS:    { cls: "bg-[rgba(191,85,236,0.15)] text-[#bf55ec]", char: "O" },
+  SOLO_SONNET:  { cls: "bg-grn-bg text-grn",                        char: "✓" },
+  SOLO_OPUS:    { cls: "bg-grn-bg text-grn",                        char: "✓" },
+};
+
+const STATUS_TITLE: Record<string, string> = {
+  CONFIRMADO: "Ambos lectores coincidieron",
+  ALERTA: "Diferencia menor — se tomó el promedio",
+  CONFLICTO: "Conflicto entre lectores — requiere revisión",
+  DUDOSO: "Valor dudoso — requiere revisión",
+  SOLO_SONNET: "Solo Sonnet detectó este valor",
+  SOLO_OPUS: "Solo Opus detectó este valor",
 };
 
 function StatusIcon({ status }: { status: string }) {
@@ -67,8 +76,8 @@ function StatusIcon({ status }: { status: string }) {
   return (
     <span
       className={`inline-grid place-items-center w-[18px] h-[18px] rounded-[5px] text-[10px] font-bold ${s.cls}`}
-      title={status}
-      aria-label={status}
+      title={STATUS_TITLE[status] || status}
+      aria-label={STATUS_TITLE[status] || status}
     >
       {s.char}
     </span>
@@ -197,8 +206,13 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
   const allAmbiguedades = editedData.sectores.flatMap((s) => s.ambiguedades);
   const title =
     data.source === "DUAL" ? "Doble lectura del plano" : `Lectura ${data.source.replace("SOLO_", "")}`;
+  const prettify = (s: string) =>
+    s
+      .replace(/_/g, " ")
+      .toLowerCase()
+      .replace(/\b\w/g, (c) => c.toUpperCase());
   const firstSectorHead = editedData.sectores[0]
-    ? `${editedData.sectores[0].id} — ${editedData.sectores[0].tipo}`
+    ? `${prettify(editedData.sectores[0].id)} — ${prettify(editedData.sectores[0].tipo)}`
     : "";
 
   return (
@@ -210,7 +224,7 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
         </span>
         <h3 className="text-[15px] font-semibold text-t1 tracking-tight">{firstSectorHead || title}</h3>
         <span className="ml-auto text-[12px] text-t3 font-mono">
-          {piecesCount} {piecesCount === 1 ? "pieza" : "piezas"} · {zocalosCount}{" "}
+          {piecesCount} {piecesCount === 1 ? "mesada" : "mesadas"} · {zocalosCount}{" "}
           {zocalosCount === 1 ? "zócalo" : "zócalos"}
         </span>
       </div>
@@ -307,13 +321,14 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
             <span className="text-[16px] text-t2 font-medium ml-1 tracking-tight font-sans">m²</span>
           </div>
           <div className="mt-4 grid grid-cols-[1fr_auto] gap-x-4 gap-y-1.5 text-[12px] font-mono tabular-nums">
-            <span className="text-t3 font-sans">Mesadas</span>
+            <span className="text-t3 font-sans">
+              Mesadas <span className="text-t4">({piecesCount})</span>
+            </span>
             <span className="text-t1 text-right">{mesadasM2.toFixed(2)} m²</span>
-            <span className="text-t3 font-sans">Zócalos</span>
+            <span className="text-t3 font-sans">
+              Zócalos <span className="text-t4">({zocalosCount})</span>
+            </span>
             <span className="text-t1 text-right">{zocalosM2.toFixed(2)} m²</span>
-            <span className="col-span-2 h-px bg-b1 my-1" />
-            <span className="text-t3 font-sans">Piezas</span>
-            <span className="text-t1 text-right">{piecesCount + zocalosCount}</span>
           </div>
         </div>
       </div>

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -52,76 +52,93 @@ interface Props {
   onRetry?: (newData: DualReadData) => void;
 }
 
-const STATUS_ICONS: Record<string, string> = {
-  CONFIRMADO: "\u2705",
-  ALERTA: "\u26A0\uFE0F",
-  CONFLICTO: "\u274C",
-  DUDOSO: "\uD83D\uDFE0",
-  SOLO_SONNET: "\uD83D\uDD35",
-  SOLO_OPUS: "\uD83D\uDFE3",
+type IconStyle = { cls: string; char: string };
+const STATUS_STYLE: Record<string, IconStyle> = {
+  CONFIRMADO:   { cls: "bg-grn-bg text-grn",                        char: "✓" },
+  ALERTA:       { cls: "bg-amb-bg text-amb",                        char: "!" },
+  CONFLICTO:    { cls: "bg-[rgba(255,69,58,0.15)] text-err",        char: "✕" },
+  DUDOSO:       { cls: "bg-[rgba(191,85,236,0.15)] text-[#bf55ec]", char: "?" },
+  SOLO_SONNET:  { cls: "bg-[rgba(79,143,255,0.15)] text-acc",       char: "S" },
+  SOLO_OPUS:    { cls: "bg-[rgba(191,85,236,0.15)] text-[#bf55ec]", char: "O" },
 };
 
-const STATUS_COLORS: Record<string, string> = {
-  CONFIRMADO: "text-green-400",
-  ALERTA: "text-yellow-400",
-  CONFLICTO: "text-red-400",
-  DUDOSO: "text-orange-400",
-  SOLO_SONNET: "text-blue-400",
-  SOLO_OPUS: "text-purple-400",
-};
-
-function FieldRow({ label, field, onEdit }: {
-  label: string;
-  field: FieldValue;
-  onEdit?: (val: number) => void;
-}) {
-  const icon = STATUS_ICONS[field.status] || "";
-  const color = STATUS_COLORS[field.status] || "text-t2";
-  const editable = field.status === "CONFLICTO" || field.status === "DUDOSO";
-
+function StatusIcon({ status }: { status: string }) {
+  const s = STATUS_STYLE[status] || STATUS_STYLE.CONFIRMADO;
   return (
-    <div className="flex items-center gap-2 py-1 px-2 text-[13px]">
-      <span className="w-5 text-center">{icon}</span>
-      <span className="text-t3 w-24 shrink-0">{label}</span>
-      {editable ? (
-        <div className="flex gap-2 items-center">
-          {field.opus != null && (
-            <button
-              className="px-2 py-0.5 rounded text-xs border border-purple-400/30 text-purple-400 hover:bg-purple-400/10"
-              onClick={() => onEdit?.(field.opus!)}
-            >
-              Opus: {field.opus}
-            </button>
-          )}
-          {field.sonnet != null && (
-            <button
-              className="px-2 py-0.5 rounded text-xs border border-blue-400/30 text-blue-400 hover:bg-blue-400/10"
-              onClick={() => onEdit?.(field.sonnet!)}
-            >
-              Sonnet: {field.sonnet}
-            </button>
-          )}
-          <input
-            type="number"
-            step="0.01"
-            defaultValue={field.valor}
-            className="w-20 px-1.5 py-0.5 bg-s1 border border-b2 rounded text-xs text-t1"
-            onChange={(e) => onEdit?.(parseFloat(e.target.value) || 0)}
-          />
-        </div>
-      ) : (
-        <span className={`${color} font-medium`}>
-          {field.valor}m
-          {field.status === "ALERTA" && " (promedio)"}
-        </span>
+    <span
+      className={`inline-grid place-items-center w-[18px] h-[18px] rounded-[5px] text-[10px] font-bold ${s.cls}`}
+      title={status}
+      aria-label={status}
+    >
+      {s.char}
+    </span>
+  );
+}
+
+function EditableNumber({
+  field,
+  onEdit,
+}: {
+  field: FieldValue;
+  onEdit: (v: number) => void;
+}) {
+  const editable = field.status === "CONFLICTO" || field.status === "DUDOSO";
+  if (!editable) return <>{field.valor.toFixed(2)}</>;
+  return (
+    <div className="inline-flex items-center gap-1.5 justify-end flex-wrap">
+      {field.opus != null && (
+        <button
+          className="px-1.5 py-0.5 rounded text-[10px] border border-purple-400/30 text-purple-400 hover:bg-purple-400/10"
+          onClick={() => onEdit(field.opus!)}
+          title="Usar valor Opus"
+        >
+          O:{field.opus}
+        </button>
       )}
+      {field.sonnet != null && (
+        <button
+          className="px-1.5 py-0.5 rounded text-[10px] border border-blue-400/30 text-blue-400 hover:bg-blue-400/10"
+          onClick={() => onEdit(field.sonnet!)}
+          title="Usar valor Sonnet"
+        >
+          S:{field.sonnet}
+        </button>
+      )}
+      <input
+        type="number"
+        step="0.01"
+        defaultValue={field.valor}
+        className="w-16 px-1.5 py-0.5 bg-s1 border border-b2 rounded text-[11px] text-t1 text-right font-mono"
+        onChange={(e) => onEdit(parseFloat(e.target.value) || 0)}
+      />
     </div>
+  );
+}
+
+function EditableZocalo({
+  z,
+  onEdit,
+}: {
+  z: Zocalo;
+  onEdit: (v: number) => void;
+}) {
+  const editable = z.status === "CONFLICTO" || z.status === "DUDOSO";
+  if (!editable) return <>{z.ml.toFixed(2)}</>;
+  return (
+    <input
+      type="number"
+      step="0.01"
+      defaultValue={z.ml}
+      className="w-16 px-1.5 py-0.5 bg-s1 border border-b2 rounded text-[11px] text-t1 text-right font-mono"
+      onChange={(e) => onEdit(parseFloat(e.target.value) || 0)}
+    />
   );
 }
 
 export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Props) {
   const [retrying, setRetrying] = useState(false);
   const [retryError, setRetryError] = useState<string | null>(null);
+  const [editedData, setEditedData] = useState<DualReadData>(data);
 
   const handleRetry = async () => {
     setRetrying(true);
@@ -144,11 +161,8 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
     }
   };
 
-
-  const [editedData, setEditedData] = useState<DualReadData>(data);
-
   const updateField = (sectorIdx: number, tramoIdx: number, field: string, val: number) => {
-    setEditedData(prev => {
+    setEditedData((prev) => {
       const next = JSON.parse(JSON.stringify(prev));
       const tramo = next.sectores[sectorIdx].tramos[tramoIdx];
       if (field.startsWith("zocalo_")) {
@@ -161,98 +175,182 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
     });
   };
 
+  // Totals
+  let mesadasM2 = 0;
+  let zocalosM2 = 0;
+  let piecesCount = 0;
+  let zocalosCount = 0;
+  editedData.sectores.forEach((s) =>
+    s.tramos.forEach((t) => {
+      mesadasM2 += t.m2.valor || 0;
+      piecesCount += 1;
+      t.zocalos.forEach((z) => {
+        zocalosM2 += (z.ml || 0) * (z.alto_m || 0);
+        zocalosCount += 1;
+      });
+    })
+  );
+  const totalM2 = mesadasM2 + zocalosM2;
+
+  const allAmbiguedades = editedData.sectores.flatMap((s) => s.ambiguedades);
+  const title =
+    data.source === "DUAL" ? "Doble lectura del plano" : `Lectura ${data.source.replace("SOLO_", "")}`;
+  const firstSectorHead = editedData.sectores[0]
+    ? `${editedData.sectores[0].id} — ${editedData.sectores[0].tipo}`
+    : "";
+
   return (
-    <div className="rounded-[10px] border border-b1 bg-s2 p-3 my-2 max-w-lg">
-      <div className="text-[13px] font-semibold text-t1 mb-2">
-        {data.source === "DUAL" ? "Doble lectura del plano" : `Lectura ${data.source.replace("SOLO_", "")}`}
+    <div className="my-2 w-full rounded-2xl border border-b1 bg-s1 overflow-hidden shadow-[0_20px_40px_-20px_rgba(0,0,0,0.5)]">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-5 py-4 bg-gradient-to-b from-s3 to-s2 border-b border-b1">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-acc bg-acc-bg border border-acc/30 px-2 py-1 rounded-md">
+          {data.source === "DUAL" ? "Doble lectura" : data.source.replace("SOLO_", "Solo ")}
+        </span>
+        <h3 className="text-[15px] font-semibold text-t1 tracking-tight">{firstSectorHead || title}</h3>
+        <span className="ml-auto text-[12px] text-t3 font-mono">
+          {piecesCount} {piecesCount === 1 ? "pieza" : "piezas"} · {zocalosCount}{" "}
+          {zocalosCount === 1 ? "zócalo" : "zócalos"}
+        </span>
       </div>
 
       {data.m2_warning && (
-        <div className="text-[12px] text-yellow-400 bg-yellow-400/10 rounded px-2 py-1 mb-2">
+        <div className="mx-5 mt-4 text-[12px] text-amb bg-amb-bg rounded-lg px-3 py-2 border border-amb/25">
           {data.m2_warning}
         </div>
       )}
 
-      {editedData.sectores.map((sector, si) => (
-        <div key={sector.id} className="mb-3">
-          <div className="text-[12px] text-t3 uppercase tracking-wide mb-1">
-            {sector.id} — {sector.tipo}
+      {/* Body: pieces + totals */}
+      <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px]">
+        {/* Pieces */}
+        <div className="py-2 overflow-x-auto">
+          {/* Column headers */}
+          <div className="grid grid-cols-[22px_1fr_80px_80px_80px] gap-3 px-5 py-2.5 text-[10px] font-semibold uppercase tracking-[0.1em] text-t3 bg-s2 border-b border-b1">
+            <span></span>
+            <span>Pieza</span>
+            <span className="text-right">Largo</span>
+            <span className="text-right">Ancho</span>
+            <span className="text-right">m²</span>
           </div>
-          {sector.tramos.map((tramo, ti) => (
-            <div key={tramo.id} className="ml-2 border-l border-b1 pl-2 mb-2">
-              <div className="text-[12px] text-t2 font-medium mb-1">{tramo.descripcion || tramo.id}</div>
-              <FieldRow label="Largo" field={tramo.largo_m} onEdit={(v) => updateField(si, ti, "largo_m", v)} />
-              <FieldRow label="Ancho" field={tramo.ancho_m} onEdit={(v) => updateField(si, ti, "ancho_m", v)} />
-              <FieldRow label="m²" field={tramo.m2} onEdit={(v) => updateField(si, ti, "m2", v)} />
-              {tramo.zocalos.map((z, zi) => (
-                <div key={zi} className="flex items-center gap-2 py-1 px-2 text-[13px]">
-                  <span className="w-5 text-center">{STATUS_ICONS[z.status] || ""}</span>
-                  <span className="text-t3 w-24 shrink-0">Zóc. {z.lado}</span>
-                  {z.status === "CONFLICTO" || z.status === "DUDOSO" ? (
-                    <input
-                      type="number"
-                      step="0.01"
-                      defaultValue={z.ml}
-                      className="w-20 px-1.5 py-0.5 bg-s1 border border-b2 rounded text-xs text-t1"
-                      onChange={(e) => updateField(si, ti, `zocalo_${zi}`, parseFloat(e.target.value) || 0)}
-                    />
-                  ) : (
-                    <span className={STATUS_COLORS[z.status] || "text-t2"}>
-                      {z.ml}ml × {z.alto_m}m
-                    </span>
-                  )}
+
+          {editedData.sectores.map((sector, si) => (
+            <div key={sector.id}>
+              {editedData.sectores.length > 1 && (
+                <div className="px-5 pt-3.5 pb-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-t3">
+                  {sector.id} — {sector.tipo}
                 </div>
+              )}
+
+              {sector.tramos.map((tramo, ti) => (
+                <React.Fragment key={tramo.id}>
+                  {/* Mesada row */}
+                  <div className="grid grid-cols-[22px_1fr_80px_80px_80px] items-center gap-3 px-5 py-2.5 text-[13px] font-mono tabular-nums border-t border-b1">
+                    <StatusIcon status={tramo.largo_m.status} />
+                    <div className="font-sans">
+                      <div className="text-t1">{tramo.descripcion || tramo.id}</div>
+                      <div className="text-[11px] text-t3 mt-0.5">mesada rectangular</div>
+                    </div>
+                    <div className="text-t2 text-right">
+                      <EditableNumber field={tramo.largo_m} onEdit={(v) => updateField(si, ti, "largo_m", v)} />
+                      <span className="text-t4 ml-0.5">m</span>
+                    </div>
+                    <div className="text-t2 text-right">
+                      <EditableNumber field={tramo.ancho_m} onEdit={(v) => updateField(si, ti, "ancho_m", v)} />
+                      <span className="text-t4 ml-0.5">m</span>
+                    </div>
+                    <div className="text-t1 font-medium text-right">
+                      <EditableNumber field={tramo.m2} onEdit={(v) => updateField(si, ti, "m2", v)} />
+                    </div>
+                  </div>
+
+                  {/* Zócalos rows */}
+                  {tramo.zocalos.map((z, zi) => (
+                    <div
+                      key={zi}
+                      className="grid grid-cols-[22px_1fr_80px_80px_80px] items-center gap-3 px-5 py-2 text-[13px] font-mono tabular-nums border-t border-b1"
+                    >
+                      <StatusIcon status={z.status} />
+                      <div className="font-sans text-t2 pl-4 relative">
+                        <span className="absolute left-0 top-1/2 w-2.5 h-px bg-b2" />
+                        Zóc. {z.lado}
+                      </div>
+                      <div className="text-t2 text-right">
+                        <EditableZocalo z={z} onEdit={(v) => updateField(si, ti, `zocalo_${zi}`, v)} />
+                        <span className="text-t4 ml-0.5">ml</span>
+                      </div>
+                      <div className="text-t2 text-right">
+                        {z.alto_m.toFixed(2)}
+                        <span className="text-t4 ml-0.5">m</span>
+                      </div>
+                      <div className="text-t1 font-medium text-right">
+                        {(z.ml * z.alto_m).toFixed(2)}
+                      </div>
+                    </div>
+                  ))}
+                </React.Fragment>
               ))}
             </div>
           ))}
-          {sector.ambiguedades.length > 0 && (
-            <div className="text-[11px] text-orange-400 mt-1 ml-2">
-              {sector.ambiguedades.map((a, i) => <div key={i}>⚠️ {a}</div>)}
-            </div>
-          )}
         </div>
-      ))}
 
-      {(() => {
-        let mesadas = 0;
-        let zocalos = 0;
-        editedData.sectores.forEach(s => s.tramos.forEach(t => {
-          mesadas += t.m2.valor || 0;
-          t.zocalos.forEach(z => { zocalos += (z.ml || 0) * (z.alto_m || 0); });
-        }));
-        const total = mesadas + zocalos;
-        return (
-          <div className="mt-3 pt-2 border-t border-b1 flex items-baseline justify-between px-2">
-            <div>
-              <div className="text-[12px] text-t3 uppercase tracking-wide">Total</div>
-              <div className="text-[10px] text-t4 mt-0.5">
-                mesadas {mesadas.toFixed(2)} + zócalos {zocalos.toFixed(2)}
-              </div>
-            </div>
-            <div className="text-[15px] font-semibold text-t1 font-mono">
-              {total.toFixed(2)} m²
-            </div>
+        {/* Totals */}
+        <div className="border-t lg:border-t-0 lg:border-l border-b1 bg-gradient-to-b from-s2 to-s1 p-5">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-t3">Total a cortar</div>
+          <div className="mt-1.5 text-[44px] leading-none font-semibold tracking-[-1px] font-mono tabular-nums text-t1">
+            {totalM2.toFixed(2)}
+            <span className="text-[16px] text-t2 font-medium ml-1 tracking-tight font-sans">m²</span>
           </div>
-        );
-      })()}
+          <div className="mt-4 grid grid-cols-[1fr_auto] gap-x-4 gap-y-1.5 text-[12px] font-mono tabular-nums">
+            <span className="text-t3 font-sans">Mesadas</span>
+            <span className="text-t1 text-right">{mesadasM2.toFixed(2)} m²</span>
+            <span className="text-t3 font-sans">Zócalos</span>
+            <span className="text-t1 text-right">{zocalosM2.toFixed(2)} m²</span>
+            <span className="col-span-2 h-px bg-b1 my-1" />
+            <span className="text-t3 font-sans">Piezas</span>
+            <span className="text-t1 text-right">{piecesCount + zocalosCount}</span>
+          </div>
+        </div>
+      </div>
 
-      {data.source !== "DUAL" && !data._retry && (
-        <button
-          className="w-full mt-2 py-2 rounded-lg text-[12px] font-medium bg-orange-600/20 hover:bg-orange-600/30 border border-orange-600/40 text-orange-200 transition disabled:opacity-50"
-          onClick={handleRetry}
-          disabled={retrying}
-        >
-          {retrying ? "Consultando a Opus..." : "⚠️ Las medidas no coinciden — verificar con Opus"}
-        </button>
+      {/* Alerts */}
+      {allAmbiguedades.length > 0 && (
+        <div className="mx-5 mb-4 p-3.5 bg-amb-bg border border-amb/25 rounded-xl">
+          <h4 className="text-[11px] font-semibold uppercase tracking-[0.06em] text-amb mb-2">
+            Revisar antes de confirmar
+          </h4>
+          <ul className="flex flex-col gap-1.5">
+            {allAmbiguedades.map((a, i) => (
+              <li key={i} className="text-t2 text-[12px] leading-[1.5] pl-3.5 relative">
+                <span className="absolute left-0 top-[9px] w-1 h-1 rounded-full bg-amb" />
+                {a}
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
-      {retryError && <div className="text-[11px] text-red-400 mt-1">{retryError}</div>}
 
-      <button
-        className="w-full mt-2 py-2 rounded-lg text-[13px] font-medium bg-green-600 hover:bg-green-500 text-white transition"
-        onClick={() => onConfirm(editedData)}
-      >
-        Confirmar medidas
-      </button>
+      {/* Retry if needed */}
+      {data.source !== "DUAL" && !data._retry && (
+        <div className="px-5 pb-3">
+          <button
+            className="w-full py-2.5 rounded-lg text-[12px] font-medium bg-orange-600/20 hover:bg-orange-600/30 border border-orange-600/40 text-orange-200 transition disabled:opacity-50"
+            onClick={handleRetry}
+            disabled={retrying}
+          >
+            {retrying ? "Consultando a Opus..." : "⚠️ Las medidas no coinciden — verificar con Opus"}
+          </button>
+          {retryError && <div className="text-[11px] text-err mt-1">{retryError}</div>}
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex gap-2 px-5 py-4 border-t border-b1 bg-s2">
+        <button
+          className="flex-1 py-2.5 px-4 rounded-xl text-[13px] font-semibold bg-acc hover:bg-acc-hover text-white transition"
+          onClick={() => onConfirm(editedData)}
+        >
+          Confirmar medidas · {totalM2.toFixed(2)} m²
+        </button>
+      </div>
     </div>
   );
 }

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -213,6 +213,29 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
         </div>
       ))}
 
+      {(() => {
+        let mesadas = 0;
+        let zocalos = 0;
+        editedData.sectores.forEach(s => s.tramos.forEach(t => {
+          mesadas += t.m2.valor || 0;
+          t.zocalos.forEach(z => { zocalos += (z.ml || 0) * (z.alto_m || 0); });
+        }));
+        const total = mesadas + zocalos;
+        return (
+          <div className="mt-3 pt-2 border-t border-b1 flex items-baseline justify-between px-2">
+            <div>
+              <div className="text-[12px] text-t3 uppercase tracking-wide">Total</div>
+              <div className="text-[10px] text-t4 mt-0.5">
+                mesadas {mesadas.toFixed(2)} + zócalos {zocalos.toFixed(2)}
+              </div>
+            </div>
+            <div className="text-[15px] font-semibold text-t1 font-mono">
+              {total.toFixed(2)} m²
+            </div>
+          </div>
+        );
+      })()}
+
       {data.source !== "DUAL" && !data._retry && (
         <button
           className="w-full mt-2 py-2 rounded-lg text-[12px] font-medium bg-orange-600/20 hover:bg-orange-600/30 border border-orange-600/40 text-orange-200 transition disabled:opacity-50"


### PR DESCRIPTION
## Problema
Plano con leyenda explícita *"ZOCALOS: 7 cm"* y *"PILETA: Johnson LUXOR COMPACT SI71"*, pero la doble lectura igual reportaba *"altura no especificada"* y *"modelo no indicado"*.

Causa: \`cotas_extractor\` solo capturaba decimales del área del dibujo (\`x0 < table_x0\`), y filtraba activamente el área de la tabla lateral donde vive la leyenda.

## Solución
- \`extract_specs_from_table(page, table_x0)\`: nueva función que captura texto de la tabla lateral + notas con keywords conocidas (zócalo, pileta, material, espesor, altura, etc.).
- \`format_specs_for_prompt(specs)\`: bloque "ESPECIFICACIONES EXPLÍCITAS DEL PLANO" que se inyecta en el prompt del dual_reader.
- \`agent.py\`: junta cotas + specs en un solo contexto vía \`format_cotas_and_specs()\`.
- \`plan-reader-v1.md\`: instrucción explícita de NO marcar como ambigüedad ningún dato ya cubierto por el bloque de specs.

## Tests
41 tests pasan (dual_reader + cotas_extractor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)