### PR TITLE
fix(agent): no re-ejecutar dual_read en turnos siguientes

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1927,7 +1927,29 @@ class AgentService:
                                     logging.warning(f"[cotas+specs] Extraction failed, falling back to vision-only: {e}")
 
                                 # ── DUAL READ: send crop to Sonnet (+ Opus if unsure) ──
+                                # Skip si ya corrió OK para este quote. El archivo persiste
+                                # entre mensajes pero dual_read es costoso y determinístico:
+                                # no tiene sentido re-ejecutarlo en cada turno. Si el operador
+                                # quiere re-leer, usa "verificar con Opus" de la card.
                                 try:
+                                    _dr_check_q = await db.execute(select(Quote).where(Quote.id == quote_id))
+                                    _dr_check_quote = _dr_check_q.scalar_one_or_none()
+                                    _existing_dr = (
+                                        (_dr_check_quote.quote_breakdown or {}).get("dual_read_result")
+                                        if _dr_check_quote else None
+                                    )
+                                except Exception:
+                                    _existing_dr = None
+
+                                _skip_dual = bool(_existing_dr) and not _existing_dr.get("error")
+                                if _skip_dual:
+                                    logging.info(
+                                        f"[dual-read] skip (already ran) for quote {quote_id}"
+                                    )
+
+                                try:
+                                    if _skip_dual:
+                                        raise RuntimeError("__dual_read_skip__")
                                     from app.modules.quote_engine.dual_reader import dual_read_crop
                                     _dual_enabled = ai_cfg.get("dual_read_enabled", True) if 'ai_cfg' in dir() else get_ai_config().get("dual_read_enabled", True)
                                     yield {"type": "action", "content": "📐 Leyendo medidas del plano..."}
@@ -1972,7 +1994,10 @@ class AgentService:
                                         logging.warning(f"[dual-read] Error: {_dual_result.get('error')}")
                                         # Error → fall through to normal Claude flow
                                 except Exception as e:
-                                    logging.error(f"[dual-read] Exception: {e}", exc_info=True)
+                                    if str(e) == "__dual_read_skip__":
+                                        pass  # no-op — skip intencional
+                                    else:
+                                        logging.error(f"[dual-read] Exception: {e}", exc_info=True)
                                     # Non-fatal — fall through to normal Claude flow
 
                         except Exception as e:

--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -1432,50 +1432,6 @@ async def chat(
     plan_filename = validated_files[0][1] if validated_files else None
     extra_files = validated_files[1:] if len(validated_files) > 1 else []
 
-    # ── GATE: cliente + proyecto bloqueantes antes de procesar plano ─────────
-    # Si el operador adjunta archivos pero el quote aún no tiene cliente y/o
-    # proyecto, NO arrancamos el agente. Cortamos acá con una pregunta
-    # directa. El agente se salteaba esta regla cuando venía un plano.
-    _needs_client = not (quote.client_name or "").strip()
-    _needs_project = not (quote.project or "").strip()
-    if validated_files and (_needs_client or _needs_project):
-        if _needs_client and _needs_project:
-            _gate_msg = (
-                "Antes de procesar el plano necesito **cliente** y **proyecto** "
-                "(p. ej. *Cliente: Pérez — Obra: Casa Laprida 1245*). ¿Me los pasás?"
-            )
-        elif _needs_client:
-            _gate_msg = "Antes de procesar el plano: ¿**nombre del cliente**?"
-        else:
-            _gate_msg = "Antes de procesar el plano: ¿**nombre del proyecto / obra**?"
-
-        # Persistimos el turno para que quede en el historial del chat
-        _files_note = ", ".join(vf[1] for vf in validated_files)
-        _user_entry = {
-            "role": "user",
-            "content": (message or "") + (f"\n\n[archivos adjuntos: {_files_note}]" if _files_note else ""),
-        }
-        _assistant_entry = {"role": "assistant", "content": _gate_msg}
-        _updated = list(quote.messages or []) + [_user_entry, _assistant_entry]
-        await db.execute(
-            update(Quote).where(Quote.id == quote_id).values(messages=_updated)
-        )
-        await db.commit()
-
-        async def _gate_stream():
-            yield f"data: {json.dumps({'type': 'text', 'content': _gate_msg})}\n\n"
-            yield f"data: {json.dumps({'type': 'done', 'content': ''})}\n\n"
-
-        return StreamingResponse(
-            _gate_stream(),
-            media_type="text/event-stream",
-            headers={
-                "Cache-Control": "no-cache",
-                "X-Accel-Buffering": "no",
-                "Connection": "keep-alive",
-            },
-        )
-
     async def event_stream():
         full_response = ""
         try:


### PR DESCRIPTION
Con el PDF persistiendo entre mensajes (PR #199), dual_read se ejecutaba y emitía la card en cada turno → cards duplicadas. Fix: check de `quote_breakdown.dual_read_result` antes; si ya corrió, skip.