### PR TITLE
fix: restaurar PDF + persistir historia en turno de confirmación

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -882,9 +882,11 @@ class AgentService:
                     "Seguí con el flujo: si falta cliente o proyecto, pedilos; "
                     "si ya están, avanzá al Paso 2 (búsqueda de precios y cálculo)."
                 )
-                # Limpiar plan_bytes para que no se re-procese el plano en este turno
-                plan_bytes = None
-                plan_filename = None
+                # NOTA: NO limpiamos plan_bytes — Claude necesita el plano +
+                # planilla (material, pileta, ubicación) para el Paso 2. Sin
+                # eso alucina (ej: reporta Silestone cuando el plano es
+                # Purastone). La skip-lógica de dual_read previene re-emisión
+                # de card porque verified_context ya quedó guardado arriba.
             except Exception as e:
                 logging.error(f"[dual-read] Confirmation handler failed: {e}", exc_info=True)
                 # Continuar con el mensaje original — Claude intentará responder
@@ -1990,6 +1992,19 @@ class AgentService:
                                     logging.info(
                                         f"[dual-read] re-emit saved result for quote {quote_id}"
                                     )
+                                    # Persistir el turno del usuario para que el siguiente
+                                    # turno tenga historia (Claude necesita ver el upload
+                                    # previo para dar contexto en Paso 2).
+                                    try:
+                                        _um_q = await db.execute(select(Quote).where(Quote.id == quote_id))
+                                        _um_quote = _um_q.scalar_one_or_none()
+                                        if _um_quote:
+                                            _user_entry = {"role": "user", "content": [{"type": "text", "text": (user_message or "").strip() or f"(adjuntó plano: {plan_filename})"}]}
+                                            _asst_entry = {"role": "assistant", "content": "__DUAL_READ_CARD_SHOWN__"}
+                                            await db.execute(update(Quote).where(Quote.id == quote_id).values(messages=list(_um_quote.messages or []) + [_user_entry, _asst_entry]))
+                                            await db.commit()
+                                    except Exception as _e:
+                                        logging.warning(f"[dual-read] Failed to persist turn: {_e}")
                                     yield {"type": "dual_read_result", "content": json.dumps(_existing_dr, ensure_ascii=False)}
                                     yield {"type": "done", "content": ""}
                                     return
@@ -2036,6 +2051,19 @@ class AgentService:
                                         except Exception as e:
                                             logging.warning(f"[dual-read] Failed to save result: {e}")
                                         logging.info(f"[dual-read] Result sent: source={_dual_result.get('source')}, review={_dual_result.get('requires_human_review')}")
+                                        # Persistir el turno para tener historia en el siguiente
+                                        # turno (confirmación). Sin esto, Claude en Paso 2 pierde
+                                        # el contexto del upload original.
+                                        try:
+                                            _um_q2 = await db.execute(select(Quote).where(Quote.id == quote_id))
+                                            _um_quote2 = _um_q2.scalar_one_or_none()
+                                            if _um_quote2:
+                                                _user_entry2 = {"role": "user", "content": [{"type": "text", "text": (user_message or "").strip() or f"(adjuntó plano: {plan_filename})"}]}
+                                                _asst_entry2 = {"role": "assistant", "content": "__DUAL_READ_CARD_SHOWN__"}
+                                                await db.execute(update(Quote).where(Quote.id == quote_id).values(messages=list(_um_quote2.messages or []) + [_user_entry2, _asst_entry2]))
+                                                await db.commit()
+                                        except Exception as _e2:
+                                            logging.warning(f"[dual-read] Failed to persist turn: {_e2}")
                                         # ── STOP: agent terminates turn, waits for operator confirmation ──
                                         yield {"type": "done", "content": ""}
                                         return

--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -1364,16 +1364,13 @@ async def chat(
     # siguientes. Recuperamos el más reciente desde source_files si este
     # mensaje no adjuntó nada nuevo.
     #
-    # EXCEPCIÓN: no restaurar para triggers de sistema ([DUAL_READ_CONFIRMED],
-    # [SYSTEM_TRIGGER:*]). Esos mensajes se procesan en handlers específicos
-    # de stream_chat y NO deben entrar al flow de plan_bytes (si entran,
-    # el check de dual_read corre ANTES del handler y re-emite la card
-    # en vez de dejarlo ejecutar).
-    _is_system_message = (
-        message.startswith("[DUAL_READ_CONFIRMED]")
-        or message.startswith("[SYSTEM_TRIGGER:")
-    )
-    if not validated_files and quote.source_files and not _is_system_message:
+    # EXCEPCIÓN: [SYSTEM_TRIGGER:*] tienen handlers propios que no necesitan
+    # el plano. [DUAL_READ_CONFIRMED] SÍ necesita restauración — Claude en
+    # Paso 2 necesita el plano + planilla (material, pileta, ubicación) o
+    # alucina el material. La skip-lógica del dual_read check previene la
+    # re-emisión de la card.
+    _is_system_trigger_only = message.startswith("[SYSTEM_TRIGGER:")
+    if not validated_files and quote.source_files and not _is_system_trigger_only:
         from app.core.static import OUTPUT_DIR as _OUT_RE
         # Tomamos el archivo más reciente (último en la lista)
         for _sf in reversed(quote.source_files):


### PR DESCRIPTION
Causa raíz del Paso 2 alucinado ('Silestone' en vez de Purastone): en el turno de confirmar, Claude recibía system prompt con medidas verificadas pero SIN contexto del material/pileta/etc porque (a) el PDF no se restauraba, (b) la historia del turno 1 no se había guardado. Fix combinado en router + agent.