### PR TITLE
fix(calc): 3 issues del presu Lucia Dalla Bona (catálogo + redondeo + colocación split)

### DIFF
--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -3,9 +3,44 @@
 import math
 import logging
 from datetime import datetime
+from decimal import Decimal, ROUND_HALF_UP
 
 from app.modules.agent.tools.catalog_tool import catalog_lookup
 from app.core.company_config import get as cfg
+
+
+def _round_half_up(value: float, decimals: int = 2) -> float:
+    """Redondeo half-up (1.575 → 1.58, no 1.57 como hace Python por float).
+
+    Usa Decimal sobre la representación string para evitar el bug clásico
+    de Python: round(1.575, 2) == 1.57 porque el float 1.575 es internamente
+    1.5749999...
+    """
+    if value is None:
+        return 0.0
+    quant = Decimal("1").scaleb(-decimals)  # ej: 0.01 para decimals=2
+    return float(Decimal(str(value)).quantize(quant, rounding=ROUND_HALF_UP))
+
+
+_AMBIENTE_KEYWORDS = {
+    "cocina": "Cocina",
+    "lavadero": "Lavadero",
+    "baño": "Baño",
+    "bano": "Baño",
+    "vanitory": "Vanitory",
+    "isla": "Isla",
+    "barra": "Barra",
+    "bar": "Barra",
+}
+
+
+def _detect_ambiente(desc: str) -> str | None:
+    """Detecta el ambiente de una pieza por keyword en la descripción."""
+    d = (desc or "").lower()
+    for kw, name in _AMBIENTE_KEYWORDS.items():
+        if kw in d:
+            return name
+    return None
 
 # Material classifications — read from config.json, fallback to defaults
 def _set(path: str, default: list) -> set:
@@ -310,7 +345,10 @@ def calculate_m2(pieces: list) -> tuple[float, list[dict]]:
             "description": p.get("description", ""),
             "largo": largo,
             "dim2": dim2,
-            "m2": round(raw_m2, 4) if not is_frentin_piece else 0,
+            # Half-up rounding para evitar 1.575 → 1.57 (bug de float).
+            # Se guarda a 4 decimales para preservar precisión interna y se
+            # redondea a 2 al display, ambos con half-up.
+            "m2": _round_half_up(raw_m2, 4) if not is_frentin_piece else 0,
             "quantity": qty_in,        # preserve explicit qty
             "override": used_override, # renderer uses this to add '*' mark
             "_is_frentin": is_frentin_piece,
@@ -371,7 +409,7 @@ def list_pieces(pieces: list, is_edificio: bool = False) -> dict:
             if pd["largo"] >= 3.0 and not is_edificio:
                 label += " (SE REALIZA EN 2 TRAMOS)"
 
-        m2_display = round(pd["m2"] * qty, 2)
+        m2_display = _round_half_up(pd["m2"] * qty, 2)
         entry = {"label": label, "m2": m2_display}
         if qty > 1:
             entry["qty"] = qty
@@ -655,12 +693,47 @@ def calculate_quote(input_data: dict) -> dict:
             "total": round(price * anafe_qty),
         })
 
-    # Colocación
+    # Colocación — split por ambiente cuando se detectan varios.
+    # Si las piezas tienen keywords "cocina", "lavadero", "baño", etc., emitimos
+    # una línea de colocación por ambiente. Cada uno respeta el mínimo de 1m².
+    # Si todas las piezas son del mismo ambiente (o no se detecta ninguno),
+    # se mantiene la línea única "Colocación" como antes.
     if colocacion:
         sku = "COLOCACIONDEKTON/NEOLITH" if is_sint else "COLOCACION"
         price, base = _get_mo_price(sku)
-        qty = max(total_m2, cfg("colocacion.min_quantity", 1.0))
-        mo_items.append({"description": "Colocación", "quantity": round(qty, 2), "unit_price": price, "base_price": base, "total": round(price * qty)})
+        min_qty = cfg("colocacion.min_quantity", 1.0)
+
+        # Agrupar m² por ambiente leyendo descriptions de las piezas finales
+        ambientes_m2: dict[str, float] = {}
+        for pd in piece_details:
+            if pd.get("_is_frentin"):
+                continue
+            amb = _detect_ambiente(pd.get("description", ""))
+            if amb is None:
+                continue
+            qty_p = pd.get("quantity", 1) or 1
+            ambientes_m2[amb] = ambientes_m2.get(amb, 0) + (pd.get("m2", 0) * qty_p)
+
+        # Decidir: split solo si hay >= 2 ambientes detectados; si no, línea única.
+        if len(ambientes_m2) >= 2:
+            for amb, m2_amb in ambientes_m2.items():
+                qty = max(m2_amb, min_qty)
+                mo_items.append({
+                    "description": f"Colocación {amb.lower()}",
+                    "quantity": _round_half_up(qty, 2),
+                    "unit_price": price,
+                    "base_price": base,
+                    "total": round(price * qty),
+                })
+        else:
+            qty = max(total_m2, min_qty)
+            mo_items.append({
+                "description": "Colocación",
+                "quantity": _round_half_up(qty, 2),
+                "unit_price": price,
+                "base_price": base,
+                "total": round(price * qty),
+            })
 
     # Frentín/faldón — MO is charged per METRO LINEAL, not per piece
     # frentin_ml = total metros lineales of faldón/frentín pieces

--- a/api/catalog/materials-granito-importado.json
+++ b/api/catalog/materials-granito-importado.json
@@ -113,7 +113,7 @@
   },
   {
     "sku": "GRANITODALLAS",
-    "name": "GRANITO DALLAS",
+    "name": "GRANITO BLANCO DALLAS",
     "material_type": "granito",
     "category": "piedra_natural",
     "thickness_mm": 20,


### PR DESCRIPTION
## 3 fixes en un PR

### 1. Catálogo: \"GRANITO DALLAS\" → \"GRANITO BLANCO DALLAS\"
El cliente/operador lo conoce como Blanco Dallas; el catálogo tenía el nombre truncado. Ahora aparece completo en Paso 2, PDF, Excel.

### 2. Redondeo half-up con Decimal
Bug de float: \`round(1.575, 2) == 1.57\` (el float es internamente 1.5749…). Resultado: \`2.25 × 0.70 = 1.575\` daba 1.57 en vez de 1.58 → total difería 1cm² del cálculo manual.

Fix: helper \`_round_half_up\` con \`Decimal(str(v)).quantize(0.01, ROUND_HALF_UP)\`.
- 1.575 → 1.58 ✓
- 1.574 → 1.57 ✓
- 0.875 → 0.88 ✓

Aplicado en \`piece_details[\"m2\"]\` y \`m2_display\`.

### 3. Split de Colocación por ambiente
Cuando las piezas tienen keywords (cocina, lavadero, baño, vanitory, isla, barra), la línea de Colocación se divide:
- \"Colocación cocina\" — m² del ambiente
- \"Colocación lavadero\" — m² del otro
- Cada ambiente respeta mínimo 1m²

Si solo hay un ambiente o no se detecta, sigue como línea única.

## Test
Mismas 23 fallas pre-existentes del entorno (sin asyncpg/thefuzz), 0 regress nuevo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)