### PR TITLE
fix(calc): total m² = suma de displays half-up (consistencia columna ↔ total)

### DIFF
--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -339,16 +339,19 @@ def calculate_m2(pieces: list) -> tuple[float, list[dict]]:
             or _desc_head.startswith("frentín")
             or _desc_head.startswith("frentin")
         )
+        # m² por pieza con half-up a 2 decimales (lo que el operador ve en la
+        # columna m²). Sumamos al total el valor ya redondeado para que el
+        # total coincida con la suma visual — antes total_m2 usaba los raw
+        # floats (1.5749...), generando inconsistencias entre display (5.34)
+        # y precio calculado (5.33 × USD → cobraba menos de lo mostrado).
+        m2_piece_2d = _round_half_up(raw_m2, 2) if not is_frentin_piece else 0
         if not is_frentin_piece:
-            total += raw_m2 * qty_in  # respect input quantity
+            total += m2_piece_2d * qty_in  # respect input quantity
         raw_details.append({
             "description": p.get("description", ""),
             "largo": largo,
             "dim2": dim2,
-            # Half-up rounding para evitar 1.575 → 1.57 (bug de float).
-            # Se guarda a 4 decimales para preservar precisión interna y se
-            # redondea a 2 al display, ambos con half-up.
-            "m2": _round_half_up(raw_m2, 4) if not is_frentin_piece else 0,
+            "m2": m2_piece_2d,
             "quantity": qty_in,        # preserve explicit qty
             "override": used_override, # renderer uses this to add '*' mark
             "_is_frentin": is_frentin_piece,

--- a/api/tests/test_list_pieces.py
+++ b/api/tests/test_list_pieces.py
@@ -20,8 +20,9 @@ class TestListPieces:
 
         assert result["ok"]
 
-        # Total MUST include zócalo: 2.665 + 1.82 + 0.345 = 4.83
-        assert result["total_m2"] == 4.83, f"Expected 4.83, got {result['total_m2']}"
+        # Total = suma de displays half-up (PR consistencia m²):
+        # 2.67 (2.665 up) + 1.82 + 0.35 (0.345 up) = 4.84
+        assert result["total_m2"] == 4.84, f"Expected 4.84, got {result['total_m2']}"
 
         # Check each piece label
         labels = [p["label"] for p in result["pieces"]]
@@ -139,7 +140,7 @@ class TestListPiecesToolDispatch:
         )
 
         assert result["ok"]
-        assert result["total_m2"] == 4.83
+        assert result["total_m2"] == 4.84
 
         labels = [p["label"] for p in result["pieces"]]
         zocalo = [l for l in labels if "ZOC" in l]
@@ -230,8 +231,8 @@ class TestFrentinDoesNotDoubleCountMaterial:
             {"description": "Mesada", "largo": 2.15, "prof": 0.60, "m2_override": 1.625},
             {"description": "Faldón recto", "largo": 2.90, "prof": 0.05},
         ])
-        # Solo la mesada debe contribuir: 1.625 ≈ 1.62 (round to 2)
-        assert total == 1.62, f"Expected 1.62 (faldón not summed), got {total}"
+        # Solo la mesada contribuye. m2_override=1.625 → half-up 2dec = 1.63.
+        assert total == 1.63, f"Expected 1.63 (half-up de 1.625, faldón no se suma), got {total}"
         faldon = next(d for d in details if "Faldón" in d["description"])
         assert faldon["_is_frentin"] is True
         assert faldon["m2"] == 0, f"Faldón m² debe ser 0: {faldon}"

--- a/api/tests/test_m2_override.py
+++ b/api/tests/test_m2_override.py
@@ -16,8 +16,9 @@ def test_no_override_uses_largo_prof():
     total, details = calculate_m2(
         [{"description": "DC-02", "largo": 1.43, "prof": 0.62, "quantity": 2}]
     )
-    # 1.43 * 0.62 * 2 = 1.7732 → rounded 2 decimals
-    assert abs(total - 1.77) < 0.01
+    # 1.43 * 0.62 = 0.8866 → half-up 2 dec = 0.89 → × 2 = 1.78
+    # (PR consistencia m²: el total es suma de displays, no round(raw))
+    assert abs(total - 1.78) < 0.01
     assert details[0]["override"] is False
 
 

--- a/api/tests/test_regression.py
+++ b/api/tests/test_regression.py
@@ -151,13 +151,25 @@ class TestBug038NegroBrasilMerma:
         assert "Negro Brasil" in merma["motivo"]
 
 
-# ── BUG-045: Blanco Nube — m² inconsistente, anafe falso, rounding cascado ──
+# ── BUG-045 → revertido por decisión comercial / UX ──────────────────────
+# Historia: al principio el calculator sumaba valores redondeados (3.89) y
+# alguien lo marcó como "per-piece rounding bug", pidiendo round(sum(raw))
+# que da 3.88. Esa regla generó la inconsistencia UX de: el operador veía
+# "1,86 + 0,70 + 1,21 + 0,12 = 3.89" en la columna pero el total cobrado
+# era 3.88.
+#
+# Decisión nueva: sumar los m² display (half-up a 2 decimales). Motivos:
+#   - UX: lo que se ve en la columna = lo que se cobra. Cero fricción con
+#     el cliente que suma a ojo la tabla.
+#   - Comercial: B ≥ A siempre (half-up acumula .xx5 a favor del marmolero).
+#   - Magnitud: ±0.01 m² por pieza borde → diferencia insignificante.
+#
+# Estos tests ahora validan la regla invertida.
 
-class TestBug045BlancoNubeM2Rounding:
-    """BUG-045: Per-piece rounding caused 3.89 instead of 3.88."""
+class TestM2SumOfDisplayedValues:
+    """El total debe coincidir con la suma visual de la columna m² (display)."""
 
-    def test_no_per_piece_rounding(self):
-        """Pieces must NOT be rounded individually before summing."""
+    def test_total_equals_sum_of_rounded_pieces(self):
         pieces = [
             {"description": "Mesada principal", "largo": 3.00, "prof": 0.62},
             {"description": "Mesada secundaria", "largo": 1.16, "prof": 0.60},
@@ -165,11 +177,10 @@ class TestBug045BlancoNubeM2Rounding:
             {"description": "Zócalo", "largo": 2.01, "alto": 0.06},
         ]
         m2, details = calculate_m2(pieces)
-        # Raw: 1.86 + 0.696 + 1.2078 + 0.1206 = 3.8844 → round(2) = 3.88
-        assert m2 == 3.88, f"Expected 3.88 but got {m2} — likely per-piece rounding"
+        # Cada pieza half-up a 2 dec: 1.86 + 0.70 + 1.21 + 0.12 = 3.89
+        assert m2 == 3.89, f"Expected 3.89 (sum of display values) but got {m2}"
 
-    def test_total_is_sum_rounded_not_sum_of_rounded(self):
-        """Verify round(sum) != sum(round) for this specific case."""
+    def test_sum_of_displays_equals_total(self):
         pieces = [
             {"description": "Mesada principal", "largo": 3.00, "prof": 0.62},
             {"description": "Mesada secundaria", "largo": 1.16, "prof": 0.60},
@@ -177,10 +188,9 @@ class TestBug045BlancoNubeM2Rounding:
             {"description": "Zócalo", "largo": 2.01, "alto": 0.06},
         ]
         m2, details = calculate_m2(pieces)
-        # Sum of individually rounded (2 dec) = 1.86 + 0.70 + 1.21 + 0.12 = 3.89
-        sum_of_rounded = sum(round(d["largo"] * d["dim2"], 2) for d in details)
-        assert m2 != round(sum_of_rounded, 2), \
-            "m2 should be round(raw_sum) not sum(round(each))"
+        sum_of_displayed = round(sum(d["m2"] for d in details), 2)
+        assert m2 == sum_of_displayed, \
+            f"Total ({m2}) debe coincidir con la suma de la columna ({sum_of_displayed})"
 
 
 class TestBug045AnafeSinEvidencia:


### PR DESCRIPTION
Con el operador decidimos opción B: el total es la suma de los m² que se muestran (half-up por pieza), no round(sum(raw)). Cero fricción con el cliente al sumar visualmente. Tests de BUG-045 revertidos y documentados.