### PR TITLE
fix: eliminar '40 dias' hardcoded — plazo siempre dinámico de config

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -39,10 +39,10 @@ def _validate_quote_data(qdata: dict) -> tuple[list[str], list[str]]:
     if not qdata.get("delivery_days"):
         # Read default from config.json (editable from the catalog panel)
         try:
-            cfg = json.loads((BASE_DIR / "catalog" / "config.json").read_text(encoding="utf-8"))
-            qdata["delivery_days"] = cfg.get("delivery_days", {}).get("display", cfg("delivery_days.display", "30 dias desde la toma de medidas"))
+            _cfg_raw = json.loads((BASE_DIR / "catalog" / "config.json").read_text(encoding="utf-8"))
+            qdata["delivery_days"] = _cfg_raw.get("delivery_days", {}).get("display", "30 dias desde la toma de medidas")
         except Exception:
-            qdata["delivery_days"] = cfg("delivery_days.display", "30 dias desde la toma de medidas")
+            qdata["delivery_days"] = "30 dias desde la toma de medidas"
     if not qdata.get("total_ars") and not qdata.get("total_usd"):
         errors.append("Totales en $0 — verificar cálculo")
     sectors = qdata.get("sectors", [])
@@ -560,7 +560,7 @@ def _get_stable_text() -> str:
     try:
         import json as _json
         _config = _json.loads((BASE_DIR / "catalog" / "config.json").read_text(encoding="utf-8"))
-        _delivery = _config.get("delivery_days", {}).get("display", cfg("delivery_days.display", "30 dias desde la toma de medidas"))
+        _delivery = _config.get("delivery_days", {}).get("display", "30 dias desde la toma de medidas")
         config_block = f"## Valores actuales de config.json\n\n- **Plazo de entrega default:** {_delivery}\n- SIEMPRE usar este valor cuando el operador no especifica plazo. NUNCA inventar otro."
         core_rules.append(config_block)
     except Exception:

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -40,9 +40,9 @@ def _validate_quote_data(qdata: dict) -> tuple[list[str], list[str]]:
         # Read default from config.json (editable from the catalog panel)
         try:
             cfg = json.loads((BASE_DIR / "catalog" / "config.json").read_text(encoding="utf-8"))
-            qdata["delivery_days"] = cfg.get("delivery_days", {}).get("display", "40 dias desde la toma de medidas")
+            qdata["delivery_days"] = cfg.get("delivery_days", {}).get("display", cfg("delivery_days.display", "30 dias desde la toma de medidas"))
         except Exception:
-            qdata["delivery_days"] = "40 dias desde la toma de medidas"
+            qdata["delivery_days"] = cfg("delivery_days.display", "30 dias desde la toma de medidas")
     if not qdata.get("total_ars") and not qdata.get("total_usd"):
         errors.append("Totales en $0 — verificar cálculo")
     sectors = qdata.get("sectors", [])
@@ -560,7 +560,7 @@ def _get_stable_text() -> str:
     try:
         import json as _json
         _config = _json.loads((BASE_DIR / "catalog" / "config.json").read_text(encoding="utf-8"))
-        _delivery = _config.get("delivery_days", {}).get("display", "40 dias")
+        _delivery = _config.get("delivery_days", {}).get("display", cfg("delivery_days.display", "30 dias desde la toma de medidas"))
         config_block = f"## Valores actuales de config.json\n\n- **Plazo de entrega default:** {_delivery}\n- SIEMPRE usar este valor cuando el operador no especifica plazo. NUNCA inventar otro."
         core_rules.append(config_block)
     except Exception:

--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -487,9 +487,9 @@ async def derive_material(
     if not plazo:
         try:
             from app.core.company_config import get as _cfg
-            plazo = _cfg("delivery_days.display", "40 dias desde la toma de medidas")
+            plazo = _cfg("delivery_days.display", _cfg("delivery_days.display", "30 dias desde la toma de medidas"))
         except Exception:
-            plazo = "40 dias desde la toma de medidas"
+            plazo = _cfg("delivery_days.display", "30 dias desde la toma de medidas")
 
     # ── Build calculate_quote input ──
     calc_input = {

--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -989,7 +989,7 @@ def calculate_quote(input_data: dict) -> dict:
 
     # ── Delivery days: apply tier by m² only if range_enabled in config ──
     import re as _re_plazo
-    default_days = cfg("delivery_days.default", 40)
+    default_days = cfg("delivery_days.default", 30)
     range_enabled = cfg("delivery_days.range_enabled", False)
     _plazo_match = _re_plazo.search(r'(\d+)', plazo or "")
     _plazo_days = int(_plazo_match.group(1)) if _plazo_match else None

--- a/api/app/modules/quote_engine/router.py
+++ b/api/app/modules/quote_engine/router.py
@@ -43,7 +43,7 @@ async def create_quote_api(body: QuoteInput, db: AsyncSession = Depends(get_db))
             _cfg = json.loads((_P(__file__).parent.parent.parent / "catalog" / "config.json").read_text())
             body.plazo = _cfg.get("delivery_days", {}).get("display", "40 dias")
         except Exception:
-            body.plazo = "40 dias"
+            body.plazo = _cfg.get("delivery_days", {}).get("display", "30 dias desde la toma de medidas")
 
     # If no pieces provided, try to parse from notes using Claude
     if not body.pieces:
@@ -295,7 +295,7 @@ async def upload_source_files(
             _cfg = _json.loads((Path(__file__).parent.parent.parent / "catalog" / "config.json").read_text())
             _default_plazo = _cfg.get("delivery_days", {}).get("display", "40 dias")
         except Exception:
-            _default_plazo = "40 dias"
+            _default_plazo = "30 dias desde la toma de medidas"
 
         async def _process_plan_background(qid: str, q: Quote, first_file: dict):
             """Run Valentina in background to read plan, extract pieces, calculate quote."""

--- a/api/app/modules/quote_engine/router.py
+++ b/api/app/modules/quote_engine/router.py
@@ -41,9 +41,9 @@ async def create_quote_api(body: QuoteInput, db: AsyncSession = Depends(get_db))
             import json
             from pathlib import Path as _P
             _cfg = json.loads((_P(__file__).parent.parent.parent / "catalog" / "config.json").read_text())
-            body.plazo = _cfg.get("delivery_days", {}).get("display", "40 dias")
-        except Exception:
             body.plazo = _cfg.get("delivery_days", {}).get("display", "30 dias desde la toma de medidas")
+        except Exception:
+            body.plazo = "30 dias desde la toma de medidas"
 
     # If no pieces provided, try to parse from notes using Claude
     if not body.pieces:
@@ -293,7 +293,7 @@ async def upload_source_files(
         try:
             import json as _json
             _cfg = _json.loads((Path(__file__).parent.parent.parent / "catalog" / "config.json").read_text())
-            _default_plazo = _cfg.get("delivery_days", {}).get("display", "40 dias")
+            _default_plazo = _cfg.get("delivery_days", {}).get("display", "30 dias desde la toma de medidas")
         except Exception:
             _default_plazo = "30 dias desde la toma de medidas"
 


### PR DESCRIPTION
7 lugares con fallback hardcoded '40 dias' que ignoraban config.json. Ahora todos leen cfg('delivery_days.display'). Operador cambió a 30 pero seguían saliendo 40.