### PR TITLE
feat: regenerar PDF/Excel desde detalle sin re-correr Valentina

### DIFF
--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -430,6 +430,125 @@ async def validate_quote(
     }
 
 
+# ── REGENERATE — re-emit PDF/Excel from existing breakdown, no recalc ────────
+#
+# Caso de uso: corregiste un bug en el template (grand total duplicado, SKU
+# mal, formato Excel) y querés refrescar los archivos de un presupuesto
+# YA validado, SIN re-correr Valentina y SIN tocar ningún dato del negocio.
+#
+# Diferencias con /validate (que sí podría usarse pero cambia estado):
+#   - NO toca status (un quote validated/sent sigue como estaba).
+#   - NO toca client_name, project, totales, quote_breakdown.
+#   - Solo actualiza las URLs de archivos (pdf_url, excel_url, drive_url,
+#     drive_file_id) y appendea un entry a change_history para auditoría.
+
+@router.post("/quotes/{quote_id}/regenerate")
+async def regenerate_quote_docs(
+    quote_id: str,
+    db: AsyncSession = Depends(get_db),
+):
+    """Re-generate PDF/Excel from existing breakdown. No recalc, no status change."""
+    result = await db.execute(select(Quote).where(Quote.id == quote_id))
+    quote = result.scalar_one_or_none()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Presupuesto no encontrado")
+
+    bd = quote.quote_breakdown
+    if not bd:
+        raise HTTPException(
+            status_code=400,
+            detail="El presupuesto no tiene desglose calculado — no hay datos para regenerar",
+        )
+
+    from app.modules.agent.tools.document_tool import generate_documents
+    from app.modules.agent.tools.drive_tool import upload_to_drive, delete_drive_file
+
+    # Same fallback pattern as /validate (line 370+): breakdown is source of
+    # truth, fill only fields that legacy quotes might not have.
+    doc_data = dict(bd)
+    doc_data.setdefault("client_name", quote.client_name)
+    doc_data.setdefault("project", quote.project)
+    doc_data.setdefault("material_name", quote.material)
+    doc_data.setdefault("total_ars", quote.total_ars)
+    doc_data.setdefault("total_usd", quote.total_usd)
+    doc_data.setdefault("discount_pct", 0)
+    doc_data.setdefault("sectors", [])
+    doc_data.setdefault("mo_items", [])
+
+    doc_result = await generate_documents(quote_id, doc_data)
+    if not doc_result.get("ok"):
+        raise HTTPException(
+            status_code=500,
+            detail=f"Falló la generación de documentos: {doc_result.get('error')}",
+        )
+
+    pdf_url = doc_result.get("pdf_url")
+    excel_url = doc_result.get("excel_url")
+
+    # Drive: replace old file with new one (same strategy as /validate).
+    existing_drive_file_id = quote.drive_file_id
+    existing_drive_url = quote.drive_url
+    new_drive_url = None
+    new_drive_file_id = None
+    if existing_drive_file_id:
+        try:
+            await delete_drive_file(existing_drive_file_id)
+        except Exception as e:
+            logging.warning(f"[regenerate] delete_drive_file failed for {quote_id}: {e}")
+    try:
+        drive_result = await upload_to_drive(
+            quote_id,
+            doc_data["client_name"],
+            doc_data["material_name"],
+            doc_data.get("date"),
+        )
+        if drive_result.get("ok"):
+            new_drive_url = drive_result.get("drive_url")
+            new_drive_file_id = drive_result.get("drive_file_id")
+    except Exception as e:
+        logging.warning(f"[regenerate] upload_to_drive failed for {quote_id}: {e}")
+
+    final_drive_url = new_drive_url or existing_drive_url
+    final_drive_file_id = new_drive_file_id or existing_drive_file_id
+
+    # Audit log: append to change_history (column ya existe, formato igual
+    # que el que usa calculate_quote save al final del loop).
+    regenerated_at = datetime.now().isoformat()
+    change_entry = {
+        "timestamp": regenerated_at,
+        "action": "regenerate_docs",
+        "pdf_url_before": quote.pdf_url,
+        "excel_url_before": quote.excel_url,
+        "pdf_url_after": pdf_url,
+        "excel_url_after": excel_url,
+    }
+    history = list(quote.change_history or [])
+    history.append(change_entry)
+
+    update_values = {
+        "pdf_url": pdf_url,
+        "excel_url": excel_url,
+        "change_history": history,
+    }
+    if new_drive_url:
+        update_values["drive_url"] = new_drive_url
+        update_values["drive_file_id"] = new_drive_file_id
+
+    await db.execute(
+        update(Quote).where(Quote.id == quote_id).values(**update_values)
+    )
+    await db.commit()
+
+    logging.info(f"[regenerate] Quote {quote_id} docs regenerated (status unchanged)")
+    return {
+        "ok": True,
+        "pdf_url": pdf_url,
+        "excel_url": excel_url,
+        "drive_url": final_drive_url,
+        "regenerated_at": regenerated_at,
+    }
+
+
 # ── DERIVE MATERIAL — create new quote with different material ───────────────
 
 @router.post("/quotes/{quote_id}/derive-material")

--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -10,6 +10,7 @@ import { selectZone } from "@/lib/api";
 import { ResumenObraCard } from "@/components/quote/ResumenObraCard";
 import { EmailDraftCard } from "@/components/quote/EmailDraftCard";
 import { CondicionesCard } from "@/components/quote/CondicionesCard";
+import RegenerateButton from "@/components/quote/RegenerateButton";
 import clsx from "clsx";
 import { A, I, O, N, DOT, SUP2, DASH, ITEM, WARN, CIRCLE, ARROW, XMARK, CLOUD, WAVE, PAGE, PICTURE, CLIP, RULER, TAG, FOLDER, CHART } from "@/lib/chars";
 
@@ -351,6 +352,15 @@ export default function QuotePage() {
           {quote?.drive_pdf_url && <FileLink href={quote.drive_pdf_url} label="PDF Drive" cls="border-acc/20 text-acc" />}
           {quote?.drive_excel_url && <FileLink href={quote.drive_excel_url} label="Excel Drive" cls="border-emerald-400/20 text-emerald-400" />}
           {!quote?.drive_pdf_url && quote?.pdf_url && <FileLink href={quote.pdf_url} label="PDF" cls="border-red-400/20 text-red-400" />}
+          {/* Regenerar: solo si hay docs ya generados Y hay breakdown para reutilizar */}
+          <RegenerateButton
+            quoteId={quoteId}
+            enabled={!!quote && !!bd && (!!quote.pdf_url || !!quote.drive_pdf_url)}
+            onRegenerated={async () => {
+              const updated = await fetchQuote(quoteId);
+              setQuote(updated);
+            }}
+          />
         </div>
       </div>
 

--- a/web/src/components/quote/RegenerateButton.tsx
+++ b/web/src/components/quote/RegenerateButton.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import clsx from "clsx";
+import { regenerateQuoteDocs } from "@/lib/api";
+
+interface Props {
+  /** Id del presupuesto a regenerar. */
+  quoteId: string;
+  /** Si false, no se muestra el botón (ej. no hay breakdown todavía). */
+  enabled: boolean;
+  /** Callback que el parent usa para refetch del quote y refrescar los links. */
+  onRegenerated: () => void | Promise<void>;
+}
+
+/**
+ * Botón "Regenerar archivos" con modal de confirmación.
+ *
+ * Llama a POST /quotes/{id}/regenerate que re-emite PDF/Excel usando los
+ * datos ya guardados en DB. NO re-corre Valentina, NO recalcula, NO cambia
+ * status — solo aplica el template actual sobre el breakdown existente.
+ */
+export default function RegenerateButton({ quoteId, enabled, onRegenerated }: Props) {
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  // Escape cierra el modal
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape" && !busy) setOpen(false);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, busy]);
+
+  // Auto-hide del toast a los 3s
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(null), 3000);
+    return () => clearTimeout(t);
+  }, [toast]);
+
+  const handleConfirm = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await regenerateQuoteDocs(quoteId);
+      await onRegenerated();
+      setOpen(false);
+      setToast("Archivos regenerados");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Error al regenerar");
+    } finally {
+      setBusy(false);
+    }
+  }, [quoteId, onRegenerated]);
+
+  if (!enabled) return null;
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className={clsx(
+          "flex items-center gap-[5px] px-3 py-1.5 rounded-md text-[11px] font-medium no-underline border bg-transparent hover:bg-white/[0.04] transition cursor-pointer",
+          "border-white/10 text-t2 hover:text-t1",
+        )}
+        title="Regenerar PDF y Excel con el template actual"
+      >
+        ↻ Regenerar
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+          onClick={() => !busy && setOpen(false)}
+        >
+          <div
+            className="w-full max-w-md rounded-2xl border border-b1 bg-s2 p-6 shadow-[0_20px_40px_-20px_rgba(0,0,0,0.5)]"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-[15px] font-semibold text-t1 mb-2">Regenerar archivos</h3>
+            <p className="text-[13px] text-t2 leading-relaxed mb-4">
+              ¿Regenerar <strong className="text-t1">PDF y Excel</strong> con el template actual?
+              Los archivos anteriores serán reemplazados.
+            </p>
+            <div className="text-[12px] text-t3 bg-s1 border border-b1 rounded-lg px-3 py-2 mb-5 leading-relaxed">
+              No se recalculan precios, m² ni MO. No se cambia el estado del
+              presupuesto. Solo se refrescan los archivos.
+            </div>
+
+            {error && (
+              <div className="text-[12px] text-err bg-[rgba(255,69,58,0.1)] border border-err/30 rounded-lg px-3 py-2 mb-3">
+                {error}
+              </div>
+            )}
+
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={() => setOpen(false)}
+                disabled={busy}
+                className="px-4 py-2 rounded-lg text-[13px] font-medium border border-b2 text-t2 hover:text-t1 hover:border-b3 transition disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={handleConfirm}
+                disabled={busy}
+                className="px-4 py-2 rounded-lg text-[13px] font-semibold bg-acc hover:bg-acc-hover text-white transition disabled:opacity-60 disabled:cursor-not-allowed flex items-center gap-2"
+              >
+                {busy ? (
+                  <>
+                    <span className="inline-block w-3 h-3 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+                    Regenerando…
+                  </>
+                ) : (
+                  "Regenerar"
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {toast && (
+        <div className="fixed bottom-6 right-6 z-50 px-4 py-3 rounded-lg bg-grn text-white text-[13px] font-medium shadow-[0_10px_30px_-10px_rgba(48,209,88,0.5)] animate-[fadeIn_0.2s_ease]">
+          ✓ {toast}
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -379,6 +379,27 @@ export async function validateQuote(id: string): Promise<{ ok: boolean; pdf_url?
   return res.json();
 }
 
+/**
+ * Regenera PDF y Excel del presupuesto usando los datos ya guardados en DB.
+ * NO re-corre Valentina, NO recalcula precios ni m², NO cambia el status.
+ * Solo aplica el template actual sobre el breakdown persistido.
+ */
+export async function regenerateQuoteDocs(id: string): Promise<{
+  ok: boolean;
+  pdf_url: string;
+  excel_url: string;
+  drive_url: string | null;
+  regenerated_at: string;
+}> {
+  const res = await fetch(`${API_BASE}/api/quotes/${id}/regenerate`, { method: "POST", credentials: "include" });
+  handleAuthError(res);
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || "Error al regenerar archivos");
+  }
+  return res.json();
+}
+
 // ── Usage ────────────────────────────────────────────────────────────────────
 
 export async function fetchUsageDashboard() {


### PR DESCRIPTION
## Caso de uso
Template bug (grand total duplicado, formato columna, fix de merma/sobrante, etc.) → hay que refrescar los archivos de presupuestos ya validados **sin recalcular nada**.

## Cambios
- **Backend**: \`POST /quotes/{id}/regenerate\` — reusa \`generate_documents\` + \`upload_to_drive\` como \`/validate\`, pero **NO toca status, totales ni quote_breakdown**. Appendea a \`change_history\` para auditoría.
- **Frontend**: botón \"↻ Regenerar\" junto a los links de PDF/Excel en \`/quote/[id]\`. Modal de confirmación + spinner + toast de éxito.

## Verificación manual
1. Abrir quote validado con docs.
2. Click en \"↻ Regenerar\" → modal → Confirmar.
3. Verificar DB: status/totales/breakdown iguales; solo \`pdf_url\`, \`excel_url\`, \`drive_url\`, \`drive_file_id\` actualizados; \`change_history\` con entry nuevo \`action: regenerate_docs\`.
4. Descargar PDF/Excel → refleja el template actual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)