### PR TITLE
fix(regenerate): importar datetime dentro del endpoint

### DIFF
--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -460,6 +460,7 @@ async def regenerate_quote_docs(
             detail="El presupuesto no tiene desglose calculado — no hay datos para regenerar",
         )
 
+    from datetime import datetime
     from app.modules.agent.tools.document_tool import generate_documents
     from app.modules.agent.tools.drive_tool import upload_to_drive, delete_drive_file
 


### PR DESCRIPTION
NameError en runtime del endpoint /regenerate del PR #225. datetime se importa localmente en otros endpoints pero yo no lo hice en el nuevo. Fix trivial.