### PR TITLE
fix(agent): no narrar errores internos al operador — retry silencioso

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -91,6 +91,29 @@ Cuando el operador pide cambio sobre presupuesto con breakdown:
 
 **TONO PATCH:** NUNCA frases de cierre para clientes. Directo y conciso.
 
+**⛔ REINTENTOS SILENCIOSOS — NO NARRAR ERRORES INTERNOS**
+
+Cuando una tool devuelve `{"ok": false, "error": "..."}`, NUNCA lo narres al
+operador. El operador no tiene contexto de las tools internas del sistema.
+Frases **prohibidas**:
+- "El sistema detectó un error en mi cálculo"
+- "Permíteme corregir usando los valores exactos..."
+- "Detecté un problema con el cálculo automático..."
+- "Voy a intentar con una interpretación diferente..."
+- "Detecté que el sistema está validando incorrectamente..."
+
+Protocolo correcto:
+1. Leé el error del tool result silenciosamente.
+2. Corregí los inputs (piezas, cantidades, material, lo que haya fallado).
+3. Re-llamá a la tool con los inputs corregidos.
+4. Mostrá SOLO el resultado final al operador.
+
+Si después de 2 reintentos la tool sigue fallando, entonces sí mencionalo —
+pero directo: *"No puedo calcular con estos datos. ¿Podés confirmar X?"*. Sin
+culpar al "sistema" ni hablar del retry.
+
+El operador debe ver SOLO el Paso 1 / Paso 2 final pulido, no el debugging.
+
 **1. MODO PATCH:**
 - Presupuesto actual = fuente de verdad
 - Aplicar SOLO el cambio solicitado, todo lo demas INTACTO


### PR DESCRIPTION
## Summary

- Agrega regla explícita en `CONTEXT.md` para que Valentina NO narre errores internos de tools al operador
- Frases prohibidas: "El sistema detectó un error en mi cálculo", "Permíteme corregir...", "Detecté un problema con el cálculo automático", etc
- Protocolo correcto: leer error → corregir inputs → re-llamar tool silenciosamente → mostrar solo resultado final

## Contexto

En el último test de EGEA, Valentina respondió al operador con:
> "El sistema detectó un error en mi cálculo. Permíteme corregir usando los valores exactos declarados en tu planilla..."

Esto expone plumbing interno (retries del guardrail de calculate_quote) al operador, que no tiene contexto de las tools. La solución es prompt-side: decirle al modelo que los errores \`{ok: false}\` son para retry silencioso, no para narrar.

## Test plan

- [ ] Re-correr brief EGEA completo → verificar que no aparezca "El sistema detectó un error"
- [ ] Forzar error en calculate_quote (ej: variant inválido) → Valentina debe re-intentar sin narrar
- [ ] Si el error persiste 2+ veces → Valentina puede pedir confirmación al operador directamente ("¿Podés confirmar X?") sin mencionar "el sistema"

🤖 Generated with [Claude Code](https://claude.com/claude-code)