### PR TITLE
fix(edificio): eliminar deriva de $1-3 entre display MO y total_ars

### DIFF
--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -899,9 +899,15 @@ def calculate_quote(input_data: dict) -> dict:
     if is_edificio:
         for item in mo_items:
             if "flete" not in item["description"].lower():
-                original_total = item["total"]
-                item["total"] = round(original_total / 1.05)
+                # Redondear unit_price primero, luego recomputar total =
+                # round(unit × qty). Antes se redondeaban unit y total por
+                # separado (round(unit/1.05) vs round(total/1.05)), y con
+                # edificio + mo_discount_pct esto generaba una deriva de
+                # 1-3 pesos entre el "unit × qty" que muestra el PDF y el
+                # total_ars que suma el grand total. Esta versión garantiza
+                # que unit × qty == total siempre.
                 item["unit_price"] = round(item["unit_price"] / 1.05)
+                item["total"] = round(item["unit_price"] * item["quantity"])
                 item["edificio_discount"] = True
         logging.info(f"Edificio MO ÷1.05 applied (except flete)")
 


### PR DESCRIPTION
## Summary

- Arregla deriva de 1-3 pesos entre la columna \"Precio total\" que muestra el PDF (unit × qty) y el \"Total PESOS\" (grand_total_ars) en presupuestos de edificio con `mo_discount_pct`.
- El bloque edificio ÷1.05 redondeaba `unit_price` y `total` por separado; ahora redondea unit primero y **recomputa** total = round(unit × qty).

## Contexto (EGEA)

El PDF de EGEA del 16/04 mostraba:
- Agujero pegado pileta: 11 × \$62.045 = **\$682.495** (display)
- Total PESOS: **\$4.612.042**

Sumando a mano daba **\$4.612.045** ($3 de diferencia). Causa:

```
Pileta original (c/IVA):   65.147 × 11 = 716.617
/1.05 por separado:
  item["unit_price"]       = round(65.147 / 1.05)      = 62.045
  item["total"] (stored)   = round(716.617 / 1.05)     = 682.492 ← grand total usa este
  display (unit × qty)     = round(62.045 × 11)        = 682.495 ← PDF muestra este

Delta: 3 pesos.
```

Aplicado a EGEA + mo_discount 5%, propagaba al grand total mostrado en el box de \"PRESUPUESTO TOTAL\".

## Fix

```python
# Antes:
item["total"] = round(original_total / 1.05)
item["unit_price"] = round(item["unit_price"] / 1.05)

# Después:
item["unit_price"] = round(item["unit_price"] / 1.05)
item["total"] = round(item["unit_price"] * item["quantity"])
```

Ahora stored == display siempre. Cero deriva.

## Test plan

- [x] `pytest tests/test_fase1_regresion.py tests/test_tomas_qty.py tests/test_validation.py` → 70/70 pasan
- [ ] Re-generar PDF EGEA desde /regenerate → verificar Total PESOS = suma exacta de las filas MO
- [ ] Caso sin mo_discount (solo /1.05) → el PDF debe cuadrar también
- [ ] Caso no-edificio (sin ÷1.05) → sin cambios (no tocamos esa rama)

🤖 Generated with [Claude Code](https://claude.com/claude-code)