### PR TITLE
fix(variant-negated): suprimir warning cuando brief tiene el nombre canónico

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -4429,24 +4429,41 @@ class AgentService:
                     (r'\b(?:no|sin)\s+pulido\b', "pulido"),
                 ]
                 _matched_name_lower = (calc_result.get("material_name") or "").lower()
-                for _pat, _kw in _neg_patterns:
-                    if _re_neg.search(_pat, _neg_text) and _kw in _matched_name_lower:
-                        _w = (
-                            f"⚠️ VARIANT NEGADA: el operador escribió "
-                            f"'{_kw}' en el brief negándola, pero el catálogo "
-                            f"solo tiene '{calc_result['material_name']}' como "
-                            "opción. Se cotiza con esa variante — confirmar "
-                            "con operador antes de generar PDF."
-                        )
-                        existing = calc_result.setdefault("warnings", [])
-                        if _w not in existing:
-                            existing.append(_w)
-                        logging.warning(
-                            f"[variant-negated-agent] '{_kw}' negado por brief "
-                            f"pero match es '{calc_result['material_name']}' "
-                            f"para {save_to_qid}"
-                        )
-                        break
+                # PR #46 — suprimir falsos positivos: si el brief contiene el
+                # nombre canónico completo del material literalmente (ej:
+                # "GRANITO GRIS MARA EXTRA 2 ESP"), el operador lo pidió
+                # explícito y no hay variant negada que confirmar. Una
+                # negación accidental ("no dejar extra 2 mm de tolerancia")
+                # no debe disparar el warning en ese caso.
+                _explicit_request = bool(
+                    _matched_name_lower
+                    and _matched_name_lower in _neg_text
+                )
+                if not _explicit_request:
+                    for _pat, _kw in _neg_patterns:
+                        if _re_neg.search(_pat, _neg_text) and _kw in _matched_name_lower:
+                            _w = (
+                                f"⚠️ VARIANT NEGADA: el operador escribió "
+                                f"'{_kw}' en el brief negándola, pero el catálogo "
+                                f"solo tiene '{calc_result['material_name']}' como "
+                                "opción. Se cotiza con esa variante — confirmar "
+                                "con operador antes de generar PDF."
+                            )
+                            existing = calc_result.setdefault("warnings", [])
+                            if _w not in existing:
+                                existing.append(_w)
+                            logging.warning(
+                                f"[variant-negated-agent] '{_kw}' negado por brief "
+                                f"pero match es '{calc_result['material_name']}' "
+                                f"para {save_to_qid}"
+                            )
+                            break
+                else:
+                    logging.info(
+                        f"[variant-negated-agent] SUPPRESSED: brief contiene "
+                        f"'{_matched_name_lower}' literal → operador lo pidió "
+                        f"explícito, no es variant negada."
+                    )
 
             # ── Post-calculate deterministic validation ──
             if calc_result.get("ok"):


### PR DESCRIPTION
## Summary

- Suprime el warning \`⚠️ VARIANT NEGADA\` en agent.py cuando el brief contiene el nombre canónico completo del material literalmente — en ese caso el operador lo pidió explícito y no hay nada que confirmar.

## Contexto (EGEA 16.04.2026)

Valentina mostraba esto al operador:

> ⚠️ VARIANT NEGADA: el operador escribió 'extra 2' en el brief negándola, pero el catálogo solo tiene 'GRANITO GRIS MARA EXTRA 2 ESP' como opción. Se cotiza con esa variante — confirmar con operador antes de generar PDF.

Pero el operador escribió **literal** \`GRANITO GRIS MARA EXTRA 2 ESP\` en el brief — nunca negó nada. El falso positivo venía de un \`no\` accidental en alguna oración del brief que disparaba el regex \`\bno\\s+extra\\s*2\\b\` (ej: \"no dejar extra 2 mm de tolerancia\").

## Fix

Antes de iterar los patrones de negación, chequear si el \`_neg_text\` (brief + historial) contiene el nombre canónico completo del material. Si sí → skip todo el loop de warnings.

```python
_explicit_request = bool(
    _matched_name_lower and _matched_name_lower in _neg_text
)
if not _explicit_request:
    for _pat, _kw in _neg_patterns:
        ...
```

### Casos que siguen disparando (true positives)

- Brief DINALE: \`\"Granito Gris Mara — 25mm (SKU estándar, NO Extra 2)\"\` → brief NO contiene \"granito gris mara extra 2 esp\" literal → warning OK ✓
- Brief: \`\"mara sin extra 2, quiero fiamatado\"\` → brief NO contiene nombre canónico → warning OK ✓

### Casos que dejan de disparar (false positives)

- Brief EGEA: \`\"GRANITO GRIS MARA EXTRA 2 ESP\"\` (+ cualquier \"no\" accidental en otra oración) → warning SUPPRESSED ✓

## Test plan

- [x] \`pytest tests/test_quote_engine.py\` → 37/37 pasan (incluye el test DINALE \`test_mara_variant_negated_surfaces_warning\` que va por calculator.py path, no agent.py)
- [x] Mismos 16 fails pre-existentes en main (evaluation + edificio_render) no relacionados a este PR
- [ ] Re-correr EGEA con brief original → verificar que NO aparezca el warning
- [ ] Correr flujo DINALE (brief con \"NO Extra 2\" explícito sin nombre canónico en el mismo texto) → warning SIGUE apareciendo

🤖 Generated with [Claude Code](https://claude.com/claude-code)