### PR TITLE
fix(label): strip dimensiones duplicadas en description + regla CONTEXT.md

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -114,6 +114,28 @@ culpar al "sistema" ni hablar del retry.
 
 El operador debe ver SOLO el Paso 1 / Paso 2 final pulido, no el debugging.
 
+**⛔ DESCRIPTION DE PIEZAS — NO DUPLICAR DIMENSIONES**
+
+Cuando armes el input de `calculate_quote`, en `pieces[].description` NUNCA
+repitas las dimensiones que ya vas a pasar como `largo` / `prof`. El label del
+PDF lo construye el calculador prefijando `"<largo> × <prof>"` al description.
+Si duplicás, el PDF queda con dimensiones repetidas.
+
+✅ CORRECTO:
+```
+{"description": "ME01-B Mesada recta c/zócalo h:10cm", "largo": 2.15, "prof": 0.60}
+→ PDF: "2.15 × 0.60 ME01-B Mesada recta c/zócalo h:10cm"
+```
+
+❌ INCORRECTO (duplica):
+```
+{"description": "ME01-B Mesada recta - 2.15m × 0.60m c/zócalo h:10cm", "largo": 2.15, "prof": 0.60}
+→ PDF: "2.15 × 0.60 ME01-B Mesada recta - 2.15m × 0.60m c/zócalo h:10cm"
+```
+
+El description es para la identidad de la pieza (tipología + material + detalle
+del zócalo/frente), NO para las medidas. Las medidas van en `largo` / `prof`.
+
 **1. MODO PATCH:**
 - Presupuesto actual = fuente de verdad
 - Aplicar SOLO el cambio solicitado, todo lo demas INTACTO

--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -959,7 +959,19 @@ def calculate_quote(input_data: dict) -> dict:
                 label = f'{pd["largo"]:.2f}ML X {pd["dim2"]:.2f} ZOC'
             else:
                 dim2_label = f'{pd["largo"]:.2f} × {pd["dim2"]:.2f}'
-                label = f'{dim2_label} {pd["description"]}'
+                # PR #48 — strip defensivo: si Valentina metió las dimensiones
+                # dentro del description (ej: "ME01-B Mesada recta - 2.15m ×
+                # 0.60m c/zócalo h:10cm"), se duplican cuando el builder
+                # antepone dim2_label. Limpiamos patrones "- N.Nm × N.Nm" /
+                # "- N.N m x N.N m" ubicados dentro del description.
+                import re as _re_dim
+                _clean_desc = _re_dim.sub(
+                    r'\s*[-–—]\s*\d+[.,]?\d*\s*m\s*[×xX]\s*\d+[.,]?\d*\s*m\s*',
+                    ' ',
+                    pd["description"] or "",
+                )
+                _clean_desc = _re_dim.sub(r'\s{2,}', ' ', _clean_desc).strip()
+                label = f'{dim2_label} {_clean_desc}'
                 # "SE REALIZA EN 2 TRAMOS" only for residential — edificios
                 # already list many pieces by tipología, legend adds noise.
                 if pd["largo"] >= 3.0 and not is_edificio:


### PR DESCRIPTION
## Summary

- Limpia los labels de piezas cuando Valentina mete las dimensiones dentro de \`pieces[].description\`. Antes quedaban duplicadas: \`\"2.15 × 0.60 ME01-B Mesada recta - 2.15m × 0.60m c/zócalo h:10cm\"\`.
- Dos arreglos: strip defensivo en \`calculator.py\` + regla explícita en \`CONTEXT.md\` para que Valentina no duplique.

## Contexto (EGEA 16.04.2026 re-run)

El PDF nuevo tenía los totales correctos ($4.612.045 ✓) pero las piezas mostraban:

```
2.15 × 0.60 ME01-B Mesada recta - 2.15m × 0.60m c/zócalo h:10cm *
```

Nota el \`- 2.15m × 0.60m\` duplicado. El prefijo \"2.15 × 0.60\" lo pone el builder; si Valentina además lo mete dentro del description, quedan dobles.

## Fix

### 1. Strip en \`calculator.py\`

```python
_clean_desc = re.sub(
    r'\s*[-–—]\s*\d+[.,]?\d*\s*m\s*[×xX]\s*\d+[.,]?\d*\s*m\s*',
    ' ',
    pd[\"description\"] or \"\",
)
_clean_desc = re.sub(r'\s{2,}', ' ', _clean_desc).strip()
label = f'{dim2_label} {_clean_desc}'
```

Regex matchea \`\" - 2.15m × 0.60m \"\`, \`\" — 1.12m x 0.60m \"\`, comas decimales, etc.

### 2. Regla en \`CONTEXT.md\`

> **⛔ DESCRIPTION DE PIEZAS — NO DUPLICAR DIMENSIONES**
> Cuando armes el input de \`calculate_quote\`, en \`pieces[].description\` NUNCA repitas las dimensiones que ya vas a pasar como \`largo\` / \`prof\`.

Con ejemplos ✅ / ❌.

## Casos validados

| Input description | Label resultante |
|---|---|
| \`ME01-B Mesada recta - 2.15m × 0.60m c/zócalo h:10cm\` | \`2.15 × 0.60 ME01-B Mesada recta c/zócalo h:10cm\` ✓ |
| \`ME02-B Mesada recta — 1.12m x 0.60m c/zócalo h:10cm\` | \`1.12 × 0.60 ME02-B Mesada recta c/zócalo h:10cm\` ✓ |
| \`Mesada recta c/zócalo h:10cm\` (sin duplicación) | \`2.15 × 0.60 Mesada recta c/zócalo h:10cm\` (intacto) ✓ |
| \`Mesada principal\` | \`2.15 × 0.60 Mesada principal\` (intacto) ✓ |

## Test plan

- [x] \`pytest\` suite relevante → 107/107 pasan
- [x] Regex validado con 6 casos edge (dash/en-dash/em-dash, x/×/X, comas decimales)
- [ ] Re-correr EGEA después del deploy → labels limpios sin duplicación

🤖 Generated with [Claude Code](https://claude.com/claude-code)