### PR TITLE
fix(regenerate): strip dims duplicadas también en el renderer

### DIFF
--- a/api/app/modules/agent/tools/document_tool.py
+++ b/api/app/modules/agent/tools/document_tool.py
@@ -208,9 +208,46 @@ def _normalize_delivery(raw: str) -> str:
     return raw
 
 
+def _strip_duplicate_dims_in_labels(quote_data: dict) -> None:
+    """PR #48 — limpia dimensiones duplicadas en piece labels al vuelo.
+
+    El builder de labels en calculator.py antepone "<largo> × <prof>" al
+    description de cada pieza. Si Valentina (o un breakdown legacy guardado
+    pre-fix) ya metió las dimensiones dentro del description (ej:
+    "ME01-B Mesada recta - 2.15m × 0.60m c/zócalo h:10cm"), quedan dobles
+    en el PDF.
+
+    Este strip corre en el renderer para que /regenerate también limpie
+    presupuestos legacy sin re-ejecutar calculate_quote.
+
+    Muta `quote_data["sectors"][*]["pieces"]` en su lugar.
+    """
+    import re as _re_strip
+    _pat = _re_strip.compile(
+        r'\s*[-–—]\s*\d+[.,]?\d*\s*m\s*[×xX]\s*\d+[.,]?\d*\s*m\s*',
+        _re_strip.IGNORECASE,
+    )
+    for sector in quote_data.get("sectors") or []:
+        pieces = sector.get("pieces") or []
+        cleaned = []
+        for p in pieces:
+            if isinstance(p, str):
+                _c = _pat.sub(' ', p)
+                _c = _re_strip.sub(r'\s{2,}', ' ', _c).strip()
+                cleaned.append(_c)
+            else:
+                cleaned.append(p)
+        sector["pieces"] = cleaned
+
+
 async def generate_documents(quote_id: str, quote_data: dict) -> dict:
     """Generate PDF and Excel for a quote."""
     try:
+        # PR #48 — strip defensivo de dimensiones duplicadas en piece labels.
+        # Aplica acá (entry point de render) para que /regenerate también
+        # limpie breakdowns legacy que tienen labels duplicados guardados.
+        _strip_duplicate_dims_in_labels(quote_data)
+
         # PR #40 — reemplazar delivery_days vago (A confirmar, A convenir,
         # N/A, vacío, -) con el default del config.json. Se aplica acá en
         # vez de solo en _validate_quote_data para que el flujo /regenerate


### PR DESCRIPTION
## Summary

- Complemento del PR #237. El strip previo estaba solo en \`calculator.py\` — cubre presupuestos **nuevos** pero no \`/regenerate\` (que usa \`quote_breakdown\` de la DB sin re-calcular).
- Agrega función \`_strip_duplicate_dims_in_labels()\` al entry de \`generate_documents\` que limpia labels in-place antes del render.

## Por qué

El user tiene el presupuesto EGEA ya guardado con labels duplicados:
\`\"2.15 × 0.60 ME01-B Mesada recta - 2.15m × 0.60m c/zócalo h:10cm *\"\`

Si lo regenera, \`/regenerate\` no pasa por \`calculate_quote\` — toma los sectors directamente de \`quote.quote_breakdown\`. El strip en calculator.py no se dispara. → PDF seguía sucio.

Solución: strip también en el renderer (\`document_tool.py::generate_documents\`). Así cualquier path que pase por ahí (flow normal + regenerate + legacy) emite labels limpios.

## Casos validados (script ad-hoc)

| Input | Output |
|---|---|
| \`2.15 × 0.60 ME01-B Mesada recta - 2.15m × 0.60m c/zócalo h:10cm *\` | \`2.15 × 0.60 ME01-B Mesada recta c/zócalo h:10cm *\` ✓ |
| \`2.30 × 0.60 ME04-B ... * (×4)\` | dims duplicadas fuera, \`(×4)\` preserved ✓ |
| \`Mesada principal\` (simple) | intacto ✓ |
| \`1.50ML X 0.05 ZOC\` (zócalo ML) | intacto ✓ |

## Test plan

- [x] \`pytest\` 70/70
- [x] 8 casos edge en script ad-hoc
- [ ] Regenerar EGEA del 16.04.2026 después del deploy → PDF con labels limpios

🤖 Generated with [Claude Code](https://claude.com/claude-code)