### PR TITLE
feat(plan-reader): alto zócalo desde cota suelta + prioridad de lectura

### DIFF
--- a/api/rules/plan-reader-v1.md
+++ b/api/rules/plan-reader-v1.md
@@ -256,6 +256,29 @@ NO confundir con:
 Si ves un rectángulo fino, hachurado, con cota en ml y altura 5–15 cm → **ZÓCALO**. Punto.
 No es pieza de material, no es vista de elevación de la mesada.
 
+### Señal alternativa: cota suelta en borde sin hachurado
+
+Algunos planos de planta NO dibujan el zócalo como rectángulo hachurado
+separado — sólo marcan su **alto** como una cota suelta en el borde (vertical
+en los laterales y/o arriba del rectángulo de mesada).
+
+Patrón típico:
+```
+     0.10 m  ← alto zócalo trasero
+   ┌────────────────────────┐
+0.10 m │                        │ 0.10 m   ← altos zócalos laterales
+   │      MESADA 0.60 m     │
+   └────────────────────────┘
+```
+
+Regla de lectura: **cualquier cota numérica suelta entre 0.05 y 0.50 m**
+ubicada en el borde del rectángulo de mesada (y que NO coincida con la
+profundidad de la misma) se interpreta como **alto de zócalo** para el lado
+donde aparece. Usarla en vez del default de 5 cm.
+
+Si el plano tiene además la leyenda explícita `ZÓCALOS H=10cm`, esa leyenda
+manda y aplica a todos los lados con zócalo.
+
 ---
 
 ## REGLA — TRATAR TRAMOS COMO INDEPENDIENTES POR DEFAULT

--- a/api/rules/plan-reading.md
+++ b/api/rules/plan-reading.md
@@ -146,7 +146,18 @@ Simbolo hornallas/tomas en planta → ANAFE/TOMAS. Anotar cantidad.
 | 89 Z / 118 Z | Largo zocalo cm | Usar esa medida |
 
 > Z → lleva zocalo. Sin excepciones.
-> Alto zocalo: si no hay cota → **5cm (0.05m)** por defecto. NUNCA preguntar.
+>
+> **Alto zócalo — prioridad de lectura (usar el primer valor disponible):**
+> 1. Leyenda explícita tipo `ZÓCALOS H=10cm`, `Z=10`, `H zócalo = 10 cm`.
+> 2. Cota suelta en el **borde lateral** de la planta (vertical), valor
+>    entre 0.05 y 0.50 m, que no esté etiquetada como "prof" ni como otra
+>    cosa y no coincida con la profundidad de mesada.
+> 3. Leyenda/rotulado del plano (bloque de notas general).
+> 4. Default = **5 cm (0.05 m)** solo si no hay NINGÚN valor leíble.
+>
+> ⛔ Si en el plano hay cotas verticales en los bordes (ej: `0.10 m`
+> arriba y/o abajo del rectángulo de mesada) y NO coinciden con la prof,
+> interpretarlas como **alto de zócalo** — no como segundas profundidades.
 
 ### Profundidad de mesada
 - Sin cota → 0.60m estandar


### PR DESCRIPTION
## Summary

PR 2 de la serie post-audit plano recta con zócalos en nicho 3 paredes.

Gap: en planos de planta que no dibujan el zócalo como rectángulo hachurado separado, el alto se marca solo como cota suelta en los bordes (ej: \`0.10\` vertical en lateral izq/der). Las reglas previas exigían hachurado + etiqueta \`Z\` → Valentina ignoraba esas cotas y caía al default 5cm.

Fixes P1:

### 1. \`plan-reading.md\` — Prioridad de lectura

Reemplazar \"default 5cm NUNCA preguntar\" por 4 niveles:
1. Leyenda explícita (\`ZÓCALOS H=10cm\`)
2. Cota suelta en borde entre 0.05 y 0.50m
3. Rotulado general
4. Default 5cm (solo si no hay NINGÚN valor)

### 2. \`plan-reader-v1.md §IDENTIFICACIÓN VISUAL DE ZÓCALOS\`

Nueva subsección \"Señal alternativa: cota suelta en borde sin hachurado\" con diagrama ASCII y regla: cota 0.05-0.50m en borde que no sea prof → alto de zócalo.

## Test plan

- [x] \`pytest\` 55/55
- [ ] Plano 1 post-deploy: Valentina usa 10cm para zócalos, no 5cm default

🤖 Generated with [Claude Code](https://claude.com/claude-code)