### PR TITLE
feat(plan-reader): anafe/pileta del plano como MO obligatoria en briefs solo-plano

### DIFF
--- a/api/rules/plan-reading.md
+++ b/api/rules/plan-reading.md
@@ -134,6 +134,16 @@ Hatching/rayado = pared → NO canto expuesto → NO frentin. Lados sin tachar =
 ## Deteccion de anafe/tomas
 Simbolo hornallas/tomas en planta → ANAFE/TOMAS. Anotar cantidad.
 
+**Brief solo-plano (sin lista MO explícita del operador):** si el plano muestra
+anafe/hornallas empotradas → MO obligatoria `anafe=True` + `anafe_qty=N`. Si
+muestra pileta empotrada → `pileta="empotrada_cliente"` (o `empotrada_johnson`
+si es Johnson). No olvidar ninguno de los dos aunque el brief no los repita en
+texto — el plano ES el brief.
+
+⚠️ Esto aplica **solo cuando no hay MO exhaustiva listada** (ver CONTEXT.md
+§"MANO DE OBRA LISTADA ES EXHAUSTIVA"). Si el operador listó la MO ítem por
+ítem, esa lista manda y Valentina NO agrega anafe/pileta que no figuren ahí.
+
 ---
 
 ## Anotaciones en planos


### PR DESCRIPTION
## Summary

PR 3 de la serie post-audit plano \"recta con zócalos en nicho 3 paredes\".

### Gap

No había regla explícita que obligara a Valentina a generar MO de anafe/pileta cuando el brief es **solo-plano** (sin lista de MO del operador). El único ejemplo canónico previo (A1335) menciona PEGADOPILETA pero no anafe → Valentina olvidaba el anafe aun teniéndolo dibujado.

### Fix

\`rules/plan-reading.md\` §Detección de anafe/tomas: agregar regla para briefs solo-plano:

- Plano con anafe empotrado → \`anafe=True\` + \`anafe_qty=N\`
- Plano con pileta empotrada → \`pileta=\"empotrada_cliente\"\` / \`empotrada_johnson\`
- No olvidar aunque el brief de texto no los repita — el plano ES el brief.

### Interacción con regla existente

\`CONTEXT.md §MANO DE OBRA LISTADA ES EXHAUSTIVA\` sigue teniendo prioridad: si el operador listó la MO ítem por ítem, la lista manda. Esta nueva regla aplica solo cuando NO hay lista MO explícita.

### Nota sobre item 6 del audit

El warning en \`_validate_plan_pieces\` por zocalo con alto=0.05 (default) fue descartado: requeriría acceso al brief desde el validator que está aislado por diseño. El fix de #240 (prioridad de lectura del alto) ya reduce el riesgo en la capa correcta.

## Test plan

- [x] \`pytest\` 55/55
- [ ] Plano 1 post-deploy: Valentina genera MO \`anafe + pileta\` automáticamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)