### PR TITLE
feat(plan-reader): preguntar por zócalos cuando son ambiguos en el plano

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -257,6 +257,26 @@ en el header del PDF/Excel y es lo primero que ve el cliente.
 
 ---
 
+## ⛔ REGLA — ZÓCALOS AMBIGUOS EN PLANO: PREGUNTAR, NO ADIVINAR
+
+Cuando el brief es **solo plano** (sin despiece textual ni lista MO) y el
+plano **NO muestra zócalos explícitamente** (sin hachurado, sin leyenda Z/H=,
+sin cotas 0.05-0.50m en bordes) pero la mesada toca pared → Valentina
+**DEBE preguntar** al operador antes de Paso 2:
+
+> *"El plano no muestra zócalos explícitamente. ¿Lleva zócalos? Si sí, alto
+> (default común: 5cm) y contra qué paredes (fondo, lat izq, lat der)."*
+
+Bloqueante — no llamar `calculate_quote` hasta tener respuesta. Ver regla
+completa en `rules/plan-reading.md §REGLA — ZÓCALOS AMBIGUOS`.
+
+Excepciones (NO preguntar, calcular directo):
+- Brief dice "sin zócalos" / "no lleva zócalos" explícito
+- Brief lista despiece completo sin zócalos (respetar literal)
+- Mesada isla (no toca pared) → zócalos = []
+
+---
+
 ## ⛔ REGLA — MANO DE OBRA LISTADA ES EXHAUSTIVA
 
 Cuando el operador escribe un brief con la sección **MANO DE OBRA** listando

--- a/api/rules/plan-reading.md
+++ b/api/rules/plan-reading.md
@@ -169,6 +169,39 @@ texto — el plano ES el brief.
 > arriba y/o abajo del rectángulo de mesada) y NO coinciden con la prof,
 > interpretarlas como **alto de zócalo** — no como segundas profundidades.
 
+---
+
+## ⛔ REGLA — ZÓCALOS AMBIGUOS: PREGUNTAR AL OPERADOR
+
+Cuando el plano **NO muestra zócalos explícitamente** (ninguno de estos
+marcadores presente):
+- Rectángulos finos hachurados `//` con ratio ≥10:1
+- Leyenda `Z`, `ZOC`, `ZÓCALOS`, `H=Xcm`
+- Cotas de alto (0.05–0.50 m) en bordes del rectángulo de mesada
+
+Y simultáneamente:
+- La mesada toca al menos una pared (caso típico residencial)
+- El brief de texto **NO** dice "sin zócalos" / "no lleva zócalos" explícito
+
+→ Valentina **DEBE preguntar al operador** antes de seguir con Paso 2:
+
+> *"El plano no muestra zócalos explícitamente. ¿Esta mesada lleva zócalos?
+> Si sí, ¿de qué alto? (default común: 5 cm). Especificame también contra
+> qué paredes: fondo / lateral izq / lateral der."*
+
+⛔ **PROHIBIDO** calcular silenciosamente con:
+- **0 zócalos** (omitir por completo) cuando la presencia es ambigua
+- **5 cm default** cuando la existencia misma no está confirmada
+
+La pregunta es bloqueante — esperar respuesta del operador antes de `calculate_quote`.
+
+### Excepciones (NO preguntar, calcular directo)
+
+- Brief dice explícitamente `"sin zócalos"` / `"no lleva zócalos"` → `zócalos = []`
+- Brief lista el despiece completo sin zócalos → respetar esa lista literal
+- Mesada **isla** (no toca pared en ningún lado) → `zócalos = []`
+- Brief dice `"zócalos según plano"` y el plano SÍ los muestra → usar los del plano
+
 ### Profundidad de mesada
 - Sin cota → 0.60m estandar
 - Cota no obvia → evaluar si es tramo adicional o detalle estructural


### PR DESCRIPTION
## Summary

PR 4 de la serie post-audit. Dispara sobre el plano 2 (misma cocina que plano 1 pero **sin zócalos dibujados**).

### Gap

Muchos planos residenciales no dibujan zócalos aunque el diseño final sí los lleve. Hoy Valentina los omite silenciosamente (\`zócalos=[]\`) o aplica default 5cm — el presupuesto sale sub-cotizado sin que el operador lo note.

### Fix

Regla nueva en \`rules/plan-reading.md\`: si el plano toca pared pero **NO** tiene ninguno de estos marcadores:

- Rectángulos finos hachurados \`//\`
- Leyenda \`Z\`, \`ZOC\`, \`ZÓCALOS\`, \`H=Xcm\`
- Cotas de alto (0.05–0.50 m) en bordes

Y el brief de texto **no** dice \"sin zócalos\" explícito →

> Valentina DEBE preguntar:
> *\"El plano no muestra zócalos explícitamente. ¿Lleva zócalos? Si sí, alto (default común: 5cm) y contra qué paredes (fondo, lat izq, lat der).\"*

⛔ Bloqueante: no llamar \`calculate_quote\` hasta tener respuesta.

### Excepciones (NO preguntar)

- Brief dice \"sin zócalos\" / \"no lleva zócalos\"
- Brief lista despiece completo sin zócalos
- Mesada isla (no toca pared en ningún lado)
- Brief dice \"zócalos según plano\" y el plano los muestra

### Archivos

- \`rules/plan-reading.md\` — regla completa con triggers, acción y excepciones
- \`CONTEXT.md\` — versión corta apuntando a la regla completa

## Test plan

- [x] \`pytest\` 55/55
- [ ] Plano 2 (recta sin zócalos dibujados) post-deploy: Valentina debe preguntar antes de Paso 2
- [ ] Plano 1 (recta con zócalos dibujados): no pregunta, usa los que ve

🤖 Generated with [Claude Code](https://claude.com/claude-code)