### PR TITLE
feat(validator): hard gate contra zócalos con alto=0.05 default silencioso

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -95,6 +95,11 @@ def _validate_plan_pieces(pieces: list[dict]) -> list[str]:
     - confundir zócalo con mesada chica
     - confundir alzada con zócalo alto
 
+    PR #54: hard gate adicional contra drift del modelo — si Valentina agrega
+    zócalos con alto=0.05 exacto (default silencioso sin leer plano ni
+    preguntar al operador), bloquear con error explícito. Ver rules/
+    plan-reading.md §REGLA — ZÓCALOS AMBIGUOS.
+
     Retorna lista de mensajes de error; vacía si todo OK.
     Gated a has_plan en el caller — briefs de texto puro NO pasan por acá.
     """
@@ -103,6 +108,7 @@ def _validate_plan_pieces(pieces: list[dict]) -> list[str]:
         return errors
 
     has_any_zocalo = False
+    zocalo_altos: list[float] = []
     for idx, p in enumerate(pieces):
         if not isinstance(p, dict):
             errors.append(f"Pieza #{idx}: formato inválido")
@@ -133,6 +139,8 @@ def _validate_plan_pieces(pieces: list[dict]) -> list[str]:
                 )
         elif tipo == "zocalo":
             has_any_zocalo = True
+            if alto:
+                zocalo_altos.append(float(alto))
             if not alto:
                 errors.append(
                     f"'{desc}' marcada como zócalo pero falta `alto`. "
@@ -169,6 +177,30 @@ def _validate_plan_pieces(pieces: list[dict]) -> list[str]:
                 f"'{desc}': tipo '{tipo}' inválido. "
                 "Válidos: mesada, zocalo, alzada, frentin."
             )
+
+    # PR #54 — Hard gate contra drift del prompt: si TODOS los zócalos tienen
+    # alto=0.05 exacto (default silencioso), asumimos que Valentina no leyó
+    # el alto del plano ni preguntó al operador. Bloquear y forzar
+    # re-lectura/pregunta.
+    #
+    # El default 5cm solo es legítimo cuando:
+    #   - el plano no muestra NINGÚN alto y
+    #   - el operador lo confirmó explícitamente
+    # Como el validator no puede saber si preguntó, adoptamos la regla
+    # conservadora: "alto=0.05 exacto en ≥1 zócalo y plano adjunto" ⇒ error.
+    # Para los casos legítimos, Valentina puede pasar un alto ligeramente
+    # distinto (ej: 0.050 con 3+ decimales es el valor real, no el default)
+    # o actualizar tras confirmación del operador.
+    if zocalo_altos and all(round(a, 4) == 0.05 for a in zocalo_altos):
+        errors.append(
+            "⛔ ZÓCALOS CON ALTO=0.05 (DEFAULT). El plano no mostró el alto "
+            "explícito (leyenda H=Xcm, cota 0.05-0.50m en borde, o rotulado) "
+            "y no registrás haber preguntado al operador. Antes de seguir: "
+            "(1) releer el plano buscando H=Xcm / cotas de alto en bordes; "
+            "(2) si no hay, PREGUNTAR al operador '¿Lleva zócalos? Alto y "
+            "contra qué paredes'. Una vez confirmado, re-emitir con ese valor. "
+            "Ver rules/plan-reading.md §REGLA — ZÓCALOS AMBIGUOS."
+        )
 
     return errors
 

--- a/api/tests/test_plan_validation.py
+++ b/api/tests/test_plan_validation.py
@@ -83,3 +83,52 @@ def test_empty_pieces_list_does_not_crash():
 def test_non_dict_piece_flagged():
     errs = _validate_plan_pieces(["not a dict"])
     assert any("formato" in e.lower() for e in errs)
+
+
+# ── PR #54 — Hard gate contra drift: zócalos con alto=0.05 default ──
+
+def test_all_zocalos_with_default_alto_rejected():
+    """Si TODOS los zócalos tienen alto=0.05 exacto → default silencioso.
+    Bloquear y forzar pregunta al operador antes de calcular."""
+    pieces = [
+        {"description": "Mesada", "tipo": "mesada", "largo": 3.10, "prof": 0.60},
+        {"description": "Zócalo trasero", "tipo": "zocalo", "largo": 3.10, "alto": 0.05},
+        {"description": "Zócalo lat izq", "tipo": "zocalo", "largo": 0.60, "alto": 0.05},
+        {"description": "Zócalo lat der", "tipo": "zocalo", "largo": 0.60, "alto": 0.05},
+    ]
+    errs = _validate_plan_pieces(pieces)
+    assert any("default" in e.lower() for e in errs), (
+        f"Default 5cm silencioso en todos los zócalos debe bloquear: {errs}"
+    )
+
+
+def test_zocalo_with_explicit_alto_10cm_passes():
+    """Zócalos con alto distinto del default (ej: 10cm del plano) → OK."""
+    pieces = [
+        {"description": "Mesada", "tipo": "mesada", "largo": 3.10, "prof": 0.60},
+        {"description": "Zócalo trasero", "tipo": "zocalo", "largo": 3.10, "alto": 0.10},
+        {"description": "Zócalo lat izq", "tipo": "zocalo", "largo": 0.60, "alto": 0.10},
+    ]
+    errs = _validate_plan_pieces(pieces)
+    assert errs == [], f"Altos explícitos del plano deben pasar: {errs}"
+
+
+def test_mixed_zocalo_altos_passes():
+    """Si algunos zócalos tienen default 0.05 y otros no → hay al menos uno
+    explícito, pasa. (El default completo es lo sospechoso)."""
+    pieces = [
+        {"description": "Mesada", "tipo": "mesada", "largo": 2.0, "prof": 0.60},
+        {"description": "Zócalo trasero", "tipo": "zocalo", "largo": 2.0, "alto": 0.10},
+        {"description": "Zócalo lat", "tipo": "zocalo", "largo": 0.60, "alto": 0.05},
+    ]
+    errs = _validate_plan_pieces(pieces)
+    assert errs == [], f"Altos mixtos deben pasar: {errs}"
+
+
+def test_no_zocalos_passes():
+    """Sin zócalos → no aplica el gate."""
+    pieces = [
+        {"description": "Mesada", "tipo": "mesada", "largo": 3.10, "prof": 0.60},
+    ]
+    errs = _validate_plan_pieces(pieces)
+    assert errs == [], f"Sin zócalos no aplica el gate: {errs}"


### PR DESCRIPTION
## Summary

PR 5 de la serie plano. Cierra el drift del prompt detectado en plano 2.

### Caso observado (plano 2 post-deploy)

Valentina tenía las reglas P0 (#239, #240, #242) que le exigen preguntar al operador cuando el alto del zócalo es ambiguo, pero las ignoró — calculó con 5cm default silenciosamente:

\`\`\`
3.10ML X 0.05 ZOC
0.60ML X 0.05 ZOC
0.60ML X 0.05 ZOC
\`\`\`

Las reglas del prompt son necesarias pero no suficientes contra drift del modelo.

### Fix deterministic en \`_validate_plan_pieces\`

Si **todos** los zócalos declarados tienen \`alto=0.05\` exacto (default silencioso) y hay plano adjunto → bloquear el \`list_pieces\` con error explícito que instruye releer el plano o preguntar al operador.

\`\`\`python
if zocalo_altos and all(round(a, 4) == 0.05 for a in zocalo_altos):
    errors.append(\"⛔ ZÓCALOS CON ALTO=0.05 (DEFAULT)...\")
\`\`\`

El gate solo aplica cuando \`has_plan=True\` (briefs de texto puro quedan fuera).

### Casos cubiertos (4 tests nuevos)

| Caso | Resultado |
|---|---|
| Todos los zócalos alto=0.05 | **BLOQUEA** ✓ |
| Alto explícito (0.10 del plano) | pasa ✓ |
| Altos mixtos (uno default, otro explícito) | pasa ✓ |
| Sin zócalos | no aplica ✓ |

### Sobre el bug de Dual Read card

Este PR no lo toca — es un problema arquitectural separado. El \`dual_read\` solo dispara cuando hay \`_planilla_data\` parseado (tabla de planilla de cómputo). Para imágenes sueltas o PDFs sin tabla, \`_planilla_data=None\` → dual_read no corre → card no aparece. Tema del PR 6 pendiente.

## Test plan

- [x] \`pytest test_plan_validation.py\` 15/15
- [x] \`pytest\` suite relevante 70/70
- [ ] Re-subir plano 2 post-deploy → Valentina debe preguntar ANTES de calcular, o el \`list_pieces\` se rechaza

🤖 Generated with [Claude Code](https://claude.com/claude-code)