### PR TITLE
feat(config): alto zócalo default centralizado en catalog/config.json

### DIFF
--- a/api/app/modules/quote_engine/dual_reader.py
+++ b/api/app/modules/quote_engine/dual_reader.py
@@ -21,6 +21,14 @@ from typing import Optional
 import anthropic
 
 from app.core.config import settings
+from app.core.company_config import get as _cfg
+
+
+def _default_zocalo_alto() -> float:
+    """PR #57 — leer alto zócalo default desde catalog/config.json en vez
+    de hardcodear. Permite que el operador lo edite desde el panel de
+    Configuración web sin redeploy."""
+    return _cfg("measurements.default_zocalo_height", 0.07)
 
 logger = logging.getLogger(__name__)
 
@@ -388,6 +396,7 @@ def _compare_zocalos(a_list: list, b_list: list) -> list[dict]:
     for lado in sorted(all_lados):
         za = a_by_lado.get(lado)
         zb = b_by_lado.get(lado)
+        _alto_default = _default_zocalo_alto()
         if za and zb:
             status, ml = _compare_float(za.get("ml", 0), zb.get("ml", 0))
             result.append({
@@ -395,19 +404,19 @@ def _compare_zocalos(a_list: list, b_list: list) -> list[dict]:
                 "opus_ml": za.get("ml", 0),
                 "sonnet_ml": zb.get("ml", 0),
                 "ml": ml if ml is not None else za.get("ml", 0),
-                "alto_m": za.get("alto_m", 0.07),
+                "alto_m": za.get("alto_m", _alto_default),
                 "status": status,
             })
         elif za:
             result.append({
                 "lado": lado, "opus_ml": za.get("ml", 0), "sonnet_ml": None,
-                "ml": za.get("ml", 0), "alto_m": za.get("alto_m", 0.07),
+                "ml": za.get("ml", 0), "alto_m": za.get("alto_m", _alto_default),
                 "status": "SOLO_OPUS",
             })
         elif zb:
             result.append({
                 "lado": lado, "opus_ml": None, "sonnet_ml": zb.get("ml", 0),
-                "ml": zb.get("ml", 0), "alto_m": zb.get("alto_m", 0.07),
+                "ml": zb.get("ml", 0), "alto_m": zb.get("alto_m", _alto_default),
                 "status": "SOLO_SONNET",
             })
     return result
@@ -746,7 +755,7 @@ def build_verified_context(confirmed_data: dict) -> str:
             lines.append(f"  {desc}: {largo_v}m × {ancho_v}m = {m2_v} m²")
             for z in tramo.get("zocalos", []):
                 ml = z.get("ml", 0)
-                alto = z.get("alto_m", 0.07)
+                alto = z.get("alto_m", _default_zocalo_alto())
                 lado = z.get("lado", "?")
                 lines.append(f"  Zócalo {lado}: {ml}ml × {alto}m")
         lines.append("")

--- a/api/catalog/config.json
+++ b/api/catalog/config.json
@@ -74,7 +74,7 @@
   },
   "measurements": {
     "default_depth": 0.6,
-    "default_zocalo_height": 0.05,
+    "default_zocalo_height": 0.07,
     "tall_zocalo_threshold": 0.1
   },
   "colocacion": {

--- a/api/rules/plan-reading.md
+++ b/api/rules/plan-reading.md
@@ -163,7 +163,9 @@ texto — el plano ES el brief.
 >    entre 0.05 y 0.50 m, que no esté etiquetada como "prof" ni como otra
 >    cosa y no coincida con la profundidad de mesada.
 > 3. Leyenda/rotulado del plano (bloque de notas general).
-> 4. Default = **5 cm (0.05 m)** solo si no hay NINGÚN valor leíble.
+> 4. Default = valor de `catalog/config.json → measurements.default_zocalo_height`
+>    (actualmente **7 cm / 0.07 m**, editable desde el panel de Configuración
+>    del operador) solo si no hay NINGÚN valor leíble.
 >
 > ⛔ Si en el plano hay cotas verticales en los bordes (ej: `0.10 m`
 > arriba y/o abajo del rectángulo de mesada) y NO coinciden con la prof,


### PR DESCRIPTION
## Summary

3 fuentes distintas de verdad para el alto default del zócalo cuando el plano no lo declara:

| Fuente | Valor antes |
|---|---|
| \`rules/plan-reading.md\` | 5cm |
| \`dual_reader.py\` (hardcoded 4 lugares) | 7cm |
| \`catalog/config.json → measurements.default_zocalo_height\` | 5cm (solo usado por text_parser) |

Consolido en **config.json = 0.07** (acordado con operador como estándar industrial) y hago que todos los subsystems lean de ahí.

## Cambios

1. \`catalog/config.json\` — \`default_zocalo_height\` 0.05 → **0.07**
2. \`dual_reader.py\` — nuevo \`_default_zocalo_alto()\` que lee via \`app.core.company_config.get\`. Reemplaza los 4 hardcodeos de 0.07.
3. \`rules/plan-reading.md\` — la regla de fallback apunta al config, indica editable desde UI.
4. UI settings — sin cambios de código (el campo \"Alto zócalo (m)\" ya existía en \`settings/page.tsx\` y lee/persiste este mismo path).

## Impacto

- Operador edita el default desde la UI sin redeploy.
- Cero divergencia entre subsystems (rule, vision QA, text parser).
- Compatible con \`text_parser.py\` (ya usaba este path).

## Test plan

- [x] \`pytest\` 109/109 (plan_validation + quote_engine + fase1_regresion + validation)
- [ ] Settings: abrir \`/settings\`, campo \"Alto zócalo (m)\" muestra 0.07
- [ ] Cambiar a 0.05 y guardar → next plano sin alto declarado en Dual Read aparece con 0.05
- [ ] Volver a 0.07

🤖 Generated with [Claude Code](https://claude.com/claude-code)