### PR TITLE
fix(plan-reader): remover hardcodeos de alto default en prompt de visión

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -265,7 +265,8 @@ sin cotas 0.05-0.50m en bordes) pero la mesada toca pared → Valentina
 **DEBE preguntar** al operador antes de Paso 2:
 
 > *"El plano no muestra zócalos explícitamente. ¿Lleva zócalos? Si sí, alto
-> (default común: 5cm) y contra qué paredes (fondo, lat izq, lat der)."*
+> (default del sistema: ver `measurements.default_zocalo_height` del
+> panel de Configuración) y contra qué paredes (fondo, lat izq, lat der)."*
 
 Bloqueante — no llamar `calculate_quote` hasta tener respuesta. Ver regla
 completa en `rules/plan-reading.md §REGLA — ZÓCALOS AMBIGUOS`.
@@ -437,8 +438,9 @@ Ver pricing-variables.md. Todos los catalogos sin IVA → aplicar x1.21.
 ### Zocalos
 - Leer cada mesada individualmente — NO asumir simetria
 - ml = dimension REAL de cada lado
-- Alto default = 5cm (sin preguntar). Si plano tiene cota → usar cota
-- PDF/Excel: una linea `ZOCALO X.XX ml x 0.05 m`
+- Alto default: ver `catalog/config.json → measurements.default_zocalo_height`
+  (editable desde panel Configuración). Si plano tiene cota → usar cota.
+- PDF/Excel: una linea `ZOCALO X.XX ml x <alto> m`
 - Alto > 10cm → agregar 1 TOMAS automaticamente
 - Pieza ≤ 0,10m en plano = zocalo, NUNCA omitir
 
@@ -617,7 +619,7 @@ Si el sistema te devuelve un resultado con tipologías validadas y necesita conf
 - Tipologías identificadas (nombre + cantidad de unidades)
 - Notas literales del plano ("VERIFICAR MEDIDAS EN OBRA", "PRELIMINAR")
 - Material indicado (ya resuelto por alias si aplica)
-- Zócalos (alto indicado en plano o default 7.5cm si se menciona)
+- Zócalos (alto indicado en plano o default del config si se menciona)
 - Artefactos visibles (piletas sa-01..sa-04, griferías gr-01..gr-02)
 
 **B. Supuestos, Interpretación de Despiece y Notas del Plano**

--- a/api/rules/plan-reader-v1.md
+++ b/api/rules/plan-reader-v1.md
@@ -55,8 +55,12 @@ Un zócalo existe SOLO si el plano muestra:
 Si el plano no muestra cota de zócalo para un lado → ese lado no tiene zócalo.
 No preguntar, no inferir, no completar.
 
-Altura default: 0.07 m si se indica "zócalos 7 cm" en características generales.
-Si no hay altura especificada → anotá en ambiguedades.
+Altura default del sistema: leer desde `catalog/config.json →
+measurements.default_zocalo_height` (valor actual 0.07 m, editable por el
+operador desde el panel de Configuración). Usar ESE valor cuando el plano
+indica "zócalos" en características generales sin especificar alto.
+Si no hay altura especificada y tampoco default configurado → anotá en
+`ambiguedades` y preguntá.
 
 ⚠️ IMPORTANTE — ESPECIFICACIONES EXPLÍCITAS:
 Si el prompt incluye un bloque "ESPECIFICACIONES EXPLÍCITAS DEL PLANO", ese
@@ -274,7 +278,7 @@ Patrón típico:
 Regla de lectura: **cualquier cota numérica suelta entre 0.05 y 0.50 m**
 ubicada en el borde del rectángulo de mesada (y que NO coincida con la
 profundidad de la misma) se interpreta como **alto de zócalo** para el lado
-donde aparece. Usarla en vez del default de 5 cm.
+donde aparece. Usarla en vez del default del sistema.
 
 Si el plano tiene además la leyenda explícita `ZÓCALOS H=10cm`, esa leyenda
 manda y aplica a todos los lados con zócalo.


### PR DESCRIPTION
## Root cause

Usuario: \"seteé 0.07 en config pero el Dual Read muestra 0.05\".

El prompt que se pasa a Opus/Sonnet (\`plan-reader-v1.md\`) y el CONTEXT de Valentina tenían hardcodeos de \"5cm\" / \"0.05\" como default del alto de zócalo. Los modelos miraban esos números y devolvían \`alto_m=0.05\` en su JSON, que ganaba sobre el default del config en \`reconcile_zocalos\` (el config solo aplica cuando el modelo NO devuelve valor).

## Cambios

### \`rules/plan-reader-v1.md\`
- Línea 58: \"Altura default: 0.07 m\" → apunta a \`catalog/config.json → measurements.default_zocalo_height\`
- Línea 277: \"default de 5 cm\" → \"default del sistema\"

### \`CONTEXT.md\`
- Línea 268: pregunta al operador \"default común: 5cm\" → apunta al config
- Línea 440: \"Alto default = 5cm\" → apunta al config
- Línea 441: \"PDF/Excel ZOCALO ... x 0.05 m\" → placeholder \`<alto>\`
- Línea 620: \"default 7.5cm\" (¡otro valor inconsistente!) → \"default del config\"

## Preservado

Ejemplos canónicos (A1335 con 0.07, nicho con 0.10, ME05 con 0.05) quedan intactos — son valores específicos del caso, no defaults del sistema.

## Test plan

- [x] \`pytest\` 70/70
- [ ] Post-deploy: subir plano sin cota de alto → Dual Read card muestra **0.07** (valor config actual), no 0.05

🤖 Generated with [Claude Code](https://claude.com/claude-code)