### PR TITLE
feat(plan-reader): prof default 0.60 con warning + zócalo default largo mesada

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -305,6 +305,26 @@ Excepciones (NO preguntar, calcular directo):
 - Brief dice "sin zócalos" / "no lleva zócalos" explícito
 - Brief lista despiece completo sin zócalos (respetar literal)
 - Mesada isla (no toca pared) → zócalos = []
+- **Brief dice "con zócalos" / "lleva zócalos" genérico** → NO preguntar
+  paredes. Regla D'Angelo: zócalo default contra **la pared del largo** de la
+  mesada. Recta = 1 z. trasero (largo). L = 2 z. traseros (uno por tramo).
+  U = 3 z. (trasero + 2 laterales). Alto = default config. Ver regla completa
+  en `rules/plan-reading.md §DEFAULT "con zócalos"`.
+
+---
+
+## ⛔ REGLA — PROFUNDIDAD NO ESPECIFICADA EN PLANO
+
+Cuando el plano es **vista isométrica/3D** o solo muestra largos (típico
+en renders de cocina), sin cota de profundidad:
+- **Asumir `prof = 0.60 m`** (estándar residencial).
+- **AGREGAR WARNING VISIBLE** al operador en Paso 1:
+
+> *⚠️ ASUMIDO: prof mesada = 0.60 m (estándar residencial). El plano no
+> muestra cota de profundidad. Confirmar con el cliente si es otra medida.*
+
+⛔ NUNCA asumir 0.60 silenciosamente — el operador debe ver el warning
+para poder corregir antes del cálculo.
 
 ---
 

--- a/api/rules/plan-reader-v1.md
+++ b/api/rules/plan-reader-v1.md
@@ -29,6 +29,15 @@ Determiná el tipo de mesada:
 **Pasada 4 — Validación**
 Verificá consistencia entre vistas. Si hay contradicción → anotá en ambiguedades.
 
+**Pasada 5 — Profundidad no leíble**
+Si el plano es vista isométrica/3D o no muestra cota de profundidad (típico
+en renders de cocina que solo marcan largos como "1280 mm", "1610 mm"):
+- **Asumir prof = 0.60 m** (estándar residencial).
+- Agregar a `ambiguedades` con tipo `DEFAULT`:
+  *"ASUMIDO: prof mesada = 0.60 m (estándar residencial). El plano no muestra
+  cota de profundidad. Confirmar con cliente."*
+NUNCA asumir prof silenciosamente sin ambigüedad explícita.
+
 ---
 
 ## REGLA CRÍTICA — DIMENSIÓN DE PLACA vs. ML DE ZÓCALO

--- a/api/rules/plan-reading.md
+++ b/api/rules/plan-reading.md
@@ -12,6 +12,24 @@
 - Rasterizar y revisar mesada por mesada antes de asignar lados
 - **CADA lado que toca pared lleva zocalo** — verificar cada lado individualmente
 - En mesadas en L: el lado donde los dos tramos se unen **NUNCA lleva zocalo** (es la union, no toca pared)
+
+### ⛔ DEFAULT cuando el operador dice "con zócalos" genérico (sin especificar paredes)
+
+Cuando el brief dice **"con zócalos"** / **"lleva zócalos"** sin aclarar paredes:
+- **Regla de negocio (D'Angelo):** zócalo va **contra la pared del LARGO de
+  la mesada** (el lado más largo, típicamente el trasero contra la pared del
+  fondo). NO preguntar — asumir esa pared.
+- Para **mesada recta**: 1 zócalo trasero de largo igual al largo de la mesada.
+- Para **mesada en L**: 1 zócalo trasero por tramo (2 en total), cada uno
+  del largo de su tramo.
+- Para **mesada en U**: 3 zócalos (trasero fondo + laterales izq/der), del
+  largo respectivo de cada tramo.
+- Alto: default del config (`measurements.default_zocalo_height`, actualmente 0.07m).
+- **NO agregar zócalos laterales** (contra paredes perpendiculares al largo)
+  salvo que el plano los muestre explícito o el operador los pida.
+
+Si el brief es ambiguo en OTRA dirección (ej: "sin zócalos" / "lleva zócalos
+laterales" / cotas de zócalo en el plano) → seguir esa instrucción específica.
 - ⛔ Ejemplo cocina en L: tramo 1 (1.72×0.75) + tramo 2 (0.60×1.55):
   - Zocalo fondo tramo 1 (inferior): **1.74ml** (cota del plano)
   - Zocalo fondo tramo 2: **1.55ml** (va por la pared del fondo del tramo 2)
@@ -255,6 +273,17 @@ Multiplicar m2 x cantidad. Numero suelto en PDF puede ser ruido — verificar co
 
 ### Profundidad edificio
 Sin cota explicita → 0.60m. Dos cotas horizontales = 2 largos de tramo, NO profundidad.
+
+### Profundidad no especificada en plano (residencial)
+Sin cota de profundidad en el plano (común en vistas isométricas/3D o cuando
+solo se ven los largos) → **asumir 0.60 m** Y **AGREGAR WARNING VISIBLE** al
+operador en Paso 1 del tipo:
+
+> *⚠️ ASUMIDO: prof mesada = 0.60 m (estándar residencial). El plano no
+> muestra cota de profundidad. Confirmar con el cliente si es otra medida.*
+
+⛔ NUNCA asumir 0.60 silenciosamente — el operador debe ver el warning
+explícito para poder corregir antes del cálculo.
 
 ### Agrupacion piezas iguales
 Mismas medidas → agrupar: `LARGO X PROF X CANT UNID`. Diferencia 1cm → lineas separadas.


### PR DESCRIPTION
## Preventivos para plano 2 (mesada en L, vista isométrica)

Plano nuevo (cliente Natalia, Rosario) es render 3D con cotas de LARGO solamente (1280mm + 1610mm). No hay cota de profundidad. Enunciado dice \"con zócalos\" genérico.

## Reglas nuevas (acordadas con operador)

### 1. Profundidad no especificada → 0.60m con warning explícito

Si el plano es vista isométrica/3D o solo muestra largos sin prof:
- Asumir **prof = 0.60m** (estándar residencial)
- **OBLIGATORIO** emitir warning: *\"⚠️ ASUMIDO prof = 0.60 m. Confirmar con cliente.\"*
- Prohibido asumir silenciosamente

Aplicado en 3 lugares:
- \`rules/plan-reading.md\` §Profundidad residencial
- \`rules/plan-reader-v1.md\` §Pasada 5 (dual_reader)
- \`CONTEXT.md\` §REGLA — PROFUNDIDAD NO ESPECIFICADA

### 2. \"con zócalos\" genérico → contra la pared del largo (D'Angelo)

Regla de negocio: zócalo default va contra la pared del **LARGO** de la mesada (trasero).

| Forma | Zócalos default |
|---|---|
| Recta | 1 z. trasero (largo) |
| L | 2 z. traseros (uno por tramo) |
| U | 3 z. (trasero + 2 laterales) |

Alto = \`measurements.default_zocalo_height\` del config (0.07m actual, editable).

No preguntar paredes cuando el brief dice \"con zócalos\" sin más detalle. Solo preguntar si el brief es ambiguo en OTRA dirección (ej: laterales explícitos, sin zócalos).

## Test plan

- [x] \`pytest\` 76/76
- [ ] Manual: plano 2 (Natalia, mesada L) → Paso 1 debe tener:
  - Warning de prof 0.60m asumido
  - 2 zócalos traseros generados automáticamente (sin preguntar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)