### PR TITLE
feat(dual-read): pasar enunciado como contexto + botón × en mesadas

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -383,6 +383,7 @@ async def _run_dual_read(
             planilla_m2=planilla_m2,
             dual_enabled=_dual_enabled,
             cotas_text=cotas_text,
+            brief_text=user_message,
         )
         if _dual_result.get("error"):
             logging.warning(f"[dual-read] Error: {_dual_result.get('error')}")

--- a/api/app/modules/quote_engine/dual_reader.py
+++ b/api/app/modules/quote_engine/dual_reader.py
@@ -82,16 +82,42 @@ async def _call_vision(
     model: str,
     timeout: float = OPUS_TIMEOUT_SECONDS,
     cotas_text: str | None = None,
+    brief_text: str | None = None,
 ) -> dict:
     """Call Claude Vision API with plan reader prompt. Returns parsed JSON.
 
     If cotas_text is provided, it's injected BEFORE the extraction instruction
     so the model uses those pre-extracted cotas instead of reading numbers
     from the image. The model still sees the image for geometric interpretation.
+
+    PR #68 — brief_text: texto que mandó el operador junto al plano (ej:
+    "con zócalos", "granito negro boreal", "rosario", "natalia"). Se inyecta
+    como contexto para que los modelos de visión puedan desambiguar
+    decisiones (material, zócalos presentes, localidad, etc.) en vez de
+    flaguear falso positivos como "confirmar con cliente".
     """
     client = anthropic.AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY)
 
     user_text_blocks = []
+    if brief_text and brief_text.strip():
+        user_text_blocks.append({
+            "type": "text",
+            "text": (
+                "CONTEXTO DEL OPERADOR (texto que acompañó al plano):\n"
+                f"```\n{brief_text.strip()}\n```\n\n"
+                "Usá esta información para desambiguar lectura:\n"
+                "- Si menciona material (granito, silestone, etc.) → no flaguees "
+                "\"material no indicado\".\n"
+                "- Si dice \"con zócalos\" o \"lleva zócalos\" → considerá que sí los "
+                "tiene aunque el render no los dibuje explícito. NO flaguees "
+                "\"zócalos no visibles\" como razón para descartarlos.\n"
+                "- Si menciona localidad, cliente, obra → incluilo en los campos "
+                "`client_name` / `proyecto` / `localidad` del JSON si el schema los tiene.\n"
+                "- Si dice \"bacha comprada\" / \"cliente provee pileta\" → `pileta = "
+                "empotrada_cliente`, sin sku Johnson.\n"
+                "- Aclaraciones del operador MANDAN sobre lo que se vea en la imagen."
+            ),
+        })
     if cotas_text:
         user_text_blocks.append({
             "type": "text",
@@ -601,6 +627,7 @@ async def dual_read_crop(
     planilla_m2: Optional[float] = None,
     dual_enabled: bool = True,
     cotas_text: Optional[str] = None,
+    brief_text: Optional[str] = None,
 ) -> dict:
     """Read a crop with Sonnet first, Opus on demand. Reconcile results.
 
@@ -627,14 +654,14 @@ async def dual_read_crop(
         logger.info(f"[dual-read] Calling Sonnet for '{crop_label}' with {len(cotas_text)} chars of pre-extracted cotas...")
     else:
         logger.info(f"[dual-read] Calling Sonnet for '{crop_label}' (no cotas_text)...")
-    sonnet_result = await _call_vision(crop_bytes, sonnet_model, timeout=30, cotas_text=cotas_text)
+    sonnet_result = await _call_vision(crop_bytes, sonnet_model, timeout=30, cotas_text=cotas_text, brief_text=brief_text)
 
     if sonnet_result.get("error"):
         logger.error(f"[dual-read] Sonnet failed: {sonnet_result['error']}")
         if dual_enabled:
             # Fallback to Opus
             logger.info(f"[dual-read] Falling back to Opus...")
-            opus_result = await _call_vision(crop_bytes, opus_model, timeout=OPUS_TIMEOUT_SECONDS, cotas_text=cotas_text)
+            opus_result = await _call_vision(crop_bytes, opus_model, timeout=OPUS_TIMEOUT_SECONDS, cotas_text=cotas_text, brief_text=brief_text)
             if opus_result.get("error"):
                 return {"error": "Both models failed", "sonnet_error": sonnet_result["error"], "opus_error": opus_result["error"]}
             return _build_single_result(opus_result, "SOLO_OPUS")
@@ -670,7 +697,7 @@ async def dual_read_crop(
 
     # Step 3: Sonnet unsure → call Opus with timeout
     logger.info(f"[dual-read] Sonnet unsure ({min_confidence:.2f}) → calling Opus (timeout={OPUS_TIMEOUT_SECONDS}s)...")
-    opus_result = await _call_vision(crop_bytes, opus_model, timeout=OPUS_TIMEOUT_SECONDS, cotas_text=cotas_text)
+    opus_result = await _call_vision(crop_bytes, opus_model, timeout=OPUS_TIMEOUT_SECONDS, cotas_text=cotas_text, brief_text=brief_text)
 
     if opus_result.get("error"):
         # Opus failed/timed out → use Sonnet alone

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -221,6 +221,21 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
     });
   };
 
+  // PR #68 — remover una mesada (tramo) completa del despiece. Útil cuando
+  // el Dual Read duplicó tramos (Opus y Sonnet disagree) o detectó
+  // elementos ajenos (heladera, bajo mesada) como piezas.
+  const removeTramo = (sectorIdx: number, tramoIdx: number) => {
+    setEditedData((prev) => {
+      const next = JSON.parse(JSON.stringify(prev));
+      next.sectores[sectorIdx].tramos.splice(tramoIdx, 1);
+      // Si el sector queda vacío, removerlo también.
+      if (next.sectores[sectorIdx].tramos.length === 0) {
+        next.sectores.splice(sectorIdx, 1);
+      }
+      return next;
+    });
+  };
+
   // Totals
   let mesadasM2 = 0;
   let zocalosM2 = 0;
@@ -310,8 +325,20 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
                       <EditableNumber field={tramo.ancho_m} onEdit={(v) => updateField(si, ti, "ancho_m", v)} />
                       <span className="text-t4 ml-0.5">m</span>
                     </div>
-                    <div className="text-t1 font-medium text-right">
+                    <div className="text-t1 font-medium text-right flex items-center justify-end gap-2">
                       <EditableNumber field={tramo.m2} onEdit={(v) => updateField(si, ti, "m2", v)} />
+                      {/* PR #68 — botón × también en mesadas para remover duplicados
+                          / piezas ajenas (heladera, bajo mesada) que el dual_read
+                          detecta mal. */}
+                      <button
+                        type="button"
+                        onClick={() => removeTramo(si, ti)}
+                        title="Remover esta mesada"
+                        aria-label="Remover esta mesada"
+                        className="w-5 h-5 rounded-md grid place-items-center text-[11px] leading-none text-t4 hover:text-err hover:bg-[rgba(255,69,58,0.12)] border border-transparent hover:border-err/30 transition-colors cursor-pointer"
+                      >
+                        ×
+                      </button>
                     </div>
                   </div>
 


### PR DESCRIPTION
Fix crítico: el dual_read corría solo con la imagen, sin ver el enunciado del operador. Por eso flageaba falsos positivos ("material no indicado" cuando el brief decía "negro boreal", "zócalos no visibles" cuando decía "con zócalos"). Ahora se pasa el enunciado como `brief_text` a ambos modelos con instrucciones de cómo usarlo. Además, botón × en mesadas para que el operador pueda limpiar duplicados que los modelos a veces generan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)