### PR TITLE
fix(dual-read): UX una celda reconciliada + sector/tramo dedup

### DIFF
--- a/api/app/modules/quote_engine/dual_reader.py
+++ b/api/app/modules/quote_engine/dual_reader.py
@@ -453,6 +453,22 @@ def reconcile(opus: dict, sonnet: dict) -> dict:
     opus_sectores = opus.get("sectores", [])
     sonnet_sectores = sonnet.get("sectores", [])
 
+    # PR #69 — sector dedup: si Opus devuelve 1 sector y Sonnet devuelve 1
+    # sector pero con IDs distintos (caso común: Opus="cocina", Sonnet=
+    # "lavadero" para la misma mesada en L), son EL MISMO sector con
+    # labeling diferente. Mergear al id de Opus (usualmente más conservador)
+    # para que la reconciliación de tramos se haga entre los dos modelos
+    # en vez de mostrarlos como sectores duplicados separados.
+    if len(opus_sectores) == 1 and len(sonnet_sectores) == 1:
+        o_id = opus_sectores[0].get("id", "sector")
+        s_id = sonnet_sectores[0].get("id", "sector")
+        if o_id != s_id:
+            logger.info(
+                f"[dual-read] sector dedup: Opus id='{o_id}' vs Sonnet id='{s_id}' "
+                f"→ unificando ambos como '{o_id}'."
+            )
+            sonnet_sectores = [dict(sonnet_sectores[0], id=o_id)]
+
     # Match sectors by id
     opus_by_id = {s.get("id", f"s{i}"): s for i, s in enumerate(opus_sectores)}
     sonnet_by_id = {s.get("id", f"s{i}"): s for i, s in enumerate(sonnet_sectores)}
@@ -466,9 +482,33 @@ def reconcile(opus: dict, sonnet: dict) -> dict:
         os = opus_by_id.get(sid, {})
         ss = sonnet_by_id.get(sid, {})
 
+        # PR #69 — tramo dedup análogo al de sectores: si ambos modelos
+        # reportan la misma cantidad de tramos pero con IDs distintos
+        # (caso común: Opus="tramo_largo"+"retorno", Sonnet="principal"+
+        # "retorno"), tratarlos como los mismos tramos por posición.
+        _opus_tramos_raw = os.get("tramos", []) or []
+        _sonnet_tramos_raw = ss.get("tramos", []) or []
+        if (
+            len(_opus_tramos_raw) > 0
+            and len(_opus_tramos_raw) == len(_sonnet_tramos_raw)
+        ):
+            _sonnet_tramos_norm = []
+            for _idx, _st_raw in enumerate(_sonnet_tramos_raw):
+                _opus_id = _opus_tramos_raw[_idx].get("id") if _idx < len(_opus_tramos_raw) else None
+                _sonnet_id = _st_raw.get("id")
+                if _opus_id and _sonnet_id and _opus_id != _sonnet_id:
+                    logger.info(
+                        f"[dual-read] tramo dedup [{sid}]: Opus id='{_opus_id}' "
+                        f"vs Sonnet id='{_sonnet_id}' → unificando como '{_opus_id}'."
+                    )
+                    _sonnet_tramos_norm.append(dict(_st_raw, id=_opus_id))
+                else:
+                    _sonnet_tramos_norm.append(_st_raw)
+            _sonnet_tramos_raw = _sonnet_tramos_norm
+
         # Match tramos by id
-        o_tramos = {t.get("id", f"t{i}"): t for i, t in enumerate(os.get("tramos", []))}
-        s_tramos = {t.get("id", f"t{i}"): t for i, t in enumerate(ss.get("tramos", []))}
+        o_tramos = {t.get("id", f"t{i}"): t for i, t in enumerate(_opus_tramos_raw)}
+        s_tramos = {t.get("id", f"t{i}"): t for i, t in enumerate(_sonnet_tramos_raw)}
         all_tramo_ids = list(dict.fromkeys(list(o_tramos.keys()) + list(s_tramos.keys())))
 
         rec_tramos = []

--- a/api/tests/test_dual_reader.py
+++ b/api/tests/test_dual_reader.py
@@ -139,7 +139,7 @@ class TestFlowControl:
         unsure_result = _sample_result(confident=0.7)
 
         call_count = {"sonnet": 0, "opus": 0}
-        async def mock_vision(crop_bytes, model, timeout=15, cotas_text=None):
+        async def mock_vision(crop_bytes, model, timeout=15, cotas_text=None, brief_text=None):
             if "sonnet" in model.lower():
                 call_count["sonnet"] += 1
                 return unsure_result
@@ -157,7 +157,7 @@ class TestFlowControl:
     @pytest.mark.asyncio
     async def test_opus_timeout(self):
         """Opus timeout → returns SOLO_SONNET."""
-        async def mock_vision(crop_bytes, model, timeout=15, cotas_text=None):
+        async def mock_vision(crop_bytes, model, timeout=15, cotas_text=None, brief_text=None):
             if "sonnet" in model.lower():
                 return _sample_result(confident=0.7)
             else:
@@ -173,7 +173,7 @@ class TestFlowControl:
         """dual_read_enabled=false → ONLY Sonnet, no Opus, no reconciliation."""
         call_models = []
 
-        async def mock_vision(crop_bytes, model, timeout=15, cotas_text=None):
+        async def mock_vision(crop_bytes, model, timeout=15, cotas_text=None, brief_text=None):
             call_models.append(model)
             return _sample_result(confident=0.95)
 

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -119,34 +119,25 @@ function EditableNumber({
 }) {
   const editable = field.status === "CONFLICTO" || field.status === "DUDOSO";
   if (!editable) return <>{field.valor.toFixed(2)}</>;
+  // PR #69 — UX simplificado: una sola celda editable con el valor
+  // reconciliado. Tooltip revela Opus/Sonnet originales si el operador
+  // quiere transparencia. Antes se mostraban 3 cajitas (O:X, S:Y, input)
+  // por cada medida, generando ruido visual.
+  const tooltipParts: string[] = [];
+  if (field.opus != null) tooltipParts.push(`Opus: ${field.opus}`);
+  if (field.sonnet != null) tooltipParts.push(`Sonnet: ${field.sonnet}`);
+  const tooltip = tooltipParts.length
+    ? `Reconciliado — ${tooltipParts.join(" · ")}`
+    : "Valor reconciliado";
   return (
-    <div className="inline-flex items-center gap-1.5 justify-end flex-wrap">
-      {field.opus != null && (
-        <button
-          className="px-1.5 py-0.5 rounded text-[10px] border border-purple-400/30 text-purple-400 hover:bg-purple-400/10"
-          onClick={() => onEdit(field.opus!)}
-          title="Usar valor Opus"
-        >
-          O:{field.opus}
-        </button>
-      )}
-      {field.sonnet != null && (
-        <button
-          className="px-1.5 py-0.5 rounded text-[10px] border border-blue-400/30 text-blue-400 hover:bg-blue-400/10"
-          onClick={() => onEdit(field.sonnet!)}
-          title="Usar valor Sonnet"
-        >
-          S:{field.sonnet}
-        </button>
-      )}
-      <input
-        type="number"
-        step="0.01"
-        defaultValue={field.valor}
-        className="w-16 px-1.5 py-0.5 bg-s1 border border-b2 rounded text-[11px] text-t1 text-right font-mono"
-        onChange={(e) => onEdit(parseFloat(e.target.value) || 0)}
-      />
-    </div>
+    <input
+      type="number"
+      step="0.01"
+      defaultValue={field.valor}
+      title={tooltip}
+      className="w-16 px-1.5 py-0.5 bg-s1 border border-b2 rounded text-[11px] text-t1 text-right font-mono hover:border-b1/60 focus:border-acc/50 outline-none"
+      onChange={(e) => onEdit(parseFloat(e.target.value) || 0)}
+    />
   );
 }
 


### PR DESCRIPTION
Dos fixes:

**A) UX**: las cotas con status CONFLICTO/DUDOSO mostraban 3 cajas por celda (O:X, S:Y, input). Ahora es **1 sola celda** editable con tooltip que muestra Opus/Sonnet para transparencia.

**B) Dedup de sectores/tramos en reconcile()**: si Opus y Sonnet ven la misma forma pero con IDs distintos (ej Opus='cocina', Sonnet='lavadero'), se unifican al id de Opus. Esto evita que una L con 2 tramos aparezca como 4 mesadas en 2 sectores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)