### PR TITLE
feat(plan-reader): zócalos SOLO contra pared + render 3D = sector único

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -313,6 +313,37 @@ Excepciones (NO preguntar, calcular directo):
 
 ---
 
+## ⛔ REGLA — ZÓCALOS SOLO CONTRA PARED (nunca contra appliance)
+
+Un zócalo existe **exclusivamente contra un muro de mampostería**. NUNCA se
+coloca del lado donde hay:
+- Heladera, lavavajillas, lavarropa, anafe free-standing
+- Borde libre (la mesada termina sin pared atrás)
+- Unión entre tramos de una L/U (la unión no toca pared)
+
+Incluso cuando el operador dice "con zócalos" genérico, si el plano muestra
+un electrodoméstico contiguo a un extremo → ese extremo queda **sin zócalo**.
+
+Ver regla completa en `rules/plan-reading.md §REGLA DURA — Zócalos SOLO contra PARED`.
+
+---
+
+## ⛔ REGLA — RENDER 3D / ISOMÉTRICO
+
+Si el plano es un **render 3D / SketchUp-style** (no planta arquitectónica):
+- **1 solo sector** por cocina. NO dividir en "cocina" + "lavadero" / "cocina"
+  + "isla" aunque visualmente cambien los electrodomésticos. Es UNA mesada
+  continua con N tramos.
+- **Cotas consecutivas = tramos continuos** mientras no haya corner físico
+  visible. Ej: "423mm + 1280mm" sin corner = UN tramo de 1.703m, no dos.
+- **Tramos = segmentos separados por corners (L/U)**, no por cada appliance.
+- Ignorar electrodomésticos para el cálculo de mesada; lo que importa es el
+  largo total de cada tramo.
+
+Ver ejemplo canónico en `rules/plan-reader-v1.md §REGLA — RENDER 3D`.
+
+---
+
 ## ⛔ REGLA — PROFUNDIDAD NO ESPECIFICADA EN PLANO
 
 Cuando el plano es **vista isométrica/3D** o solo muestra largos (típico

--- a/api/rules/plan-reader-v1.md
+++ b/api/rules/plan-reader-v1.md
@@ -40,6 +40,78 @@ NUNCA asumir prof silenciosamente sin ambigüedad explícita.
 
 ---
 
+## ⛔ REGLA — RENDER 3D / ISOMÉTRICO vs. PLANTA
+
+Si el plano es un **render 3D / vista isométrica / SketchUp-style** (no es
+una planta arquitectónica cenital), aplicar estas reglas:
+
+**Señales de render 3D:**
+- Se ven electrodomésticos como objetos 3D (no símbolos 2D)
+- Perspectiva/proyección isométrica visible (líneas oblicuas)
+- Falta hatching de paredes
+- Cotas solo horizontales en el borde superior (largos), sin cotas de prof
+- No hay carátula técnica ni cuadro de rotulación
+
+**Reglas específicas:**
+
+1. **UN SOLO SECTOR por cocina.** El render muestra LA cocina entera. NO
+   dividir en "cocina" + "lavadero" por más que visualmente cambien los
+   electrodomésticos. Es UNA mesada continua con N tramos (típicamente
+   recta, L o U por el corner visible).
+
+2. **Tramos = segmentos entre cotas consecutivas**. Si hay cotas
+   "423mm + 1280mm + 1610mm" en el borde superior y hay UN corner
+   visible (mesada que dobla 90°):
+   - Los 2 primeros (423 + 1280 = 1.703m) son UN tramo continuo
+   - El último (1.610m) es el L-retorno después del corner
+   - **NO dividir por cada cota** — las cotas son mediciones parciales
+     de un tramo continuo, salvo que haya un quiebre físico entre ellas.
+
+3. **Ignorar electrodomésticos para el cálculo de mesada.** Lo que importa
+   es el LARGO TOTAL del tramo (suma de cotas parciales sobre ese tramo),
+   NO cuántos appliances ocupa. La stove + lavarropa no son "2 mesadas",
+   son UN tramo donde van apoyados.
+
+4. **Zócalos:** ver `plan-reading.md §REGLA DURA — Zócalos SOLO contra
+   PARED`. En renders 3D:
+   - Default "con zócalos" → zócalo trasero por tramo (contra la pared
+     del largo), con largo = suma de cotas del tramo.
+   - NO poner zócalo del lado donde hay una heladera/electrodoméstico
+     free-standing.
+   - NO poner zócalo en el lado de unión L/U.
+   - NO poner zócalo en bordes libres.
+
+5. **Frentín/faldón:** en render 3D no se ve la elevación. Si el operador
+   no lo menciona → no agregar. Si lo menciona → preguntar altura.
+
+**Ejemplo canónico — render 3D cocina en L (Natalia):**
+```
+Cotas superiores: 423mm + 1280mm + 1610mm
+Corner visible entre el 1280mm y el 1610mm (en el lavarropa).
+Heladera al extremo izquierdo (free-standing, fuera de mesada a su
+derecha). Lavadero al extremo derecho del L-retorno.
+```
+
+Lectura correcta:
+- 1 sector "cocina" (NO "cocina + lavadero").
+- 1 mesada en L con 2 tramos:
+  - Tramo 1 (horizontal, FULL con esquina): 1.703 × 0.60 m = 1.022 m²
+    (cajonero + horno + lavarropa).
+  - Tramo 2 (retorno vertical, NETO sin esquina): (1.610 - 0.60) × 0.60
+    = 1.010 × 0.60 = 0.606 m².
+- Zócalos: 2 traseros (contra la pared del fondo):
+  - Trasero tramo 1: 1.703 ml × 0.07 m.
+  - Trasero tramo 2: 1.610 ml × 0.07 m.
+- NO zócalo lateral contra heladera.
+- NO zócalo en la unión L.
+- NO zócalo en el borde libre derecho del retorno.
+
+⛔ **Error típico a evitar:** tratar "cocina" y "lavadero" como dos sectores
+separados. Son la misma mesada continua en L. El lavadero es parte de la
+cocina.
+
+---
+
 ## REGLA CRÍTICA — DIMENSIÓN DE PLACA vs. ML DE ZÓCALO
 
 Son dos medidas DISTINTAS. NUNCA las confundas.

--- a/api/rules/plan-reading.md
+++ b/api/rules/plan-reading.md
@@ -30,6 +30,33 @@ Cuando el brief dice **"con zócalos"** / **"lleva zócalos"** sin aclarar pared
 
 Si el brief es ambiguo en OTRA dirección (ej: "sin zócalos" / "lleva zócalos
 laterales" / cotas de zócalo en el plano) → seguir esa instrucción específica.
+
+### ⛔ REGLA DURA — Zócalos SOLO contra PARED
+
+Los zócalos existen **exclusivamente contra muros de mampostería**. NUNCA
+agregar un zócalo en un lado donde:
+
+- Hay un **electrodoméstico** (heladera, lavavajillas, lavarropa, anafe free-
+  standing) que ocupa ese lado. El zócalo no puede apoyarse contra un
+  appliance porque éste se retira/reemplaza.
+- El lado es un **borde libre** (la mesada termina sin pared atrás — ej:
+  borde frontal hacia el usuario, o extremo de una isla).
+- El lado es una **unión entre tramos** (donde dos mesadas se conectan —
+  ver regla de L/U: el lado de unión NO lleva zócalo).
+
+Cuando el plano muestra un appliance (heladera grande, lavarropa, estufa)
+contiguo a un extremo de la mesada → ese extremo NO lleva zócalo, aunque
+el operador haya dicho "con zócalos" genérico.
+
+Ejemplo plano 2 (render 3D cocina Natalia):
+- Tramo 1: mesada sobre cajonero + horno + lavarropa (1.703m total).
+- Tramo 2: L-retorno sobre lavadero (1.61m).
+- Heladera al extremo IZQUIERDO del tramo 1 (free-standing).
+- ✅ Zócalo trasero tramo 1 (1.703m) — contra pared.
+- ✅ Zócalo trasero tramo 2 (1.61m) — contra pared lateral.
+- ❌ NO zócalo lateral_izq del tramo 1 (ahí está la heladera, no pared).
+- ❌ NO zócalo lateral_der del tramo 2 (borde libre).
+- ❌ NO zócalo en el lado de unión L.
 - ⛔ Ejemplo cocina en L: tramo 1 (1.72×0.75) + tramo 2 (0.60×1.55):
   - Zocalo fondo tramo 1 (inferior): **1.74ml** (cota del plano)
   - Zocalo fondo tramo 2: **1.55ml** (va por la pared del fondo del tramo 2)


### PR DESCRIPTION
Dos reglas nuevas para el caso del plano 2 (render 3D isométrico de cocina en L):

**A) Zócalos SOLO contra pared** (`plan-reading.md`): nunca se ponen contra heladeras, lavavajillas, lavarropas, bordes libres ni uniones L/U. Incluso con 'con zócalos' genérico del operador, extremos con appliances quedan sin zócalo.

**C) Render 3D = 1 sector** (`plan-reader-v1.md`): detectar por señales visuales (objetos 3D, perspectiva, sin hatching). Cuando es render 3D: 1 solo sector por cocina (no dividir cocina+lavadero), cotas consecutivas sin corner = mismo tramo continuo.

Incluye ejemplo canónico completo del plano 2 (Natalia) con 2 tramos L + 2 zócalos traseros + 0 zócalos laterales/contra-appliance.

Queda pendiente Fix B (detector automático 3D vs planta) para PR futuro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)