### PR TITLE
feat(plan-reader): clasificación automática de view_type + badge en card (Fix B)

### DIFF
--- a/api/app/modules/quote_engine/dual_reader.py
+++ b/api/app/modules/quote_engine/dual_reader.py
@@ -612,11 +612,35 @@ def reconcile(opus: dict, sonnet: dict) -> dict:
             ),
         })
 
+    # PR #71 — propagar view_type del modelo con mayor confianza (o del
+    # que lo reportó). Si ambos coinciden → perfecto. Si difieren →
+    # mergeamos hacia la clasificación más restrictiva (render_3d gana
+    # sobre planta porque requiere reglas más conservadoras).
+    _o_vt = opus.get("view_type", "unknown")
+    _s_vt = sonnet.get("view_type", "unknown")
+    if _o_vt == _s_vt:
+        _merged_vt = _o_vt
+        _merged_reason = opus.get("view_type_reason") or sonnet.get("view_type_reason") or ""
+    elif _o_vt in ("unknown", "") and _s_vt not in ("unknown", ""):
+        _merged_vt = _s_vt
+        _merged_reason = sonnet.get("view_type_reason", "")
+    elif _s_vt in ("unknown", "") and _o_vt not in ("unknown", ""):
+        _merged_vt = _o_vt
+        _merged_reason = opus.get("view_type_reason", "")
+    else:
+        # Conflict — prefer render_3d / mixed / elevation over planta
+        _priority = {"render_3d": 3, "mixed": 2, "elevation": 2, "planta": 1, "unknown": 0}
+        _merged_vt = _o_vt if _priority.get(_o_vt, 0) >= _priority.get(_s_vt, 0) else _s_vt
+        _merged_reason = f"Opus: {_o_vt}; Sonnet: {_s_vt}. Se eligió {_merged_vt} por prioridad."
+        logger.info(f"[dual-read] view_type conflict: Opus={_o_vt} vs Sonnet={_s_vt} → merged={_merged_vt}")
+
     return {
         "sectores": reconciled_sectores,
         "requires_human_review": requires_review,
         "conflict_fields": conflict_fields,
         "source": "DUAL",
+        "view_type": _merged_vt,
+        "view_type_reason": _merged_reason,
     }
 
 
@@ -654,6 +678,9 @@ def _build_single_result(data: dict, source: str) -> dict:
         "requires_human_review": False,
         "conflict_fields": [],
         "source": source,
+        # PR #71 — clasificación de tipo de vista propagada del modelo.
+        "view_type": data.get("view_type", "unknown"),
+        "view_type_reason": data.get("view_type_reason", ""),
     }
 
 

--- a/api/rules/plan-reader-v1.md
+++ b/api/rules/plan-reader-v1.md
@@ -9,7 +9,48 @@ Nunca confíes en la vista general del plano. Sin excepción.
 
 ---
 
-## PROTOCOLO DE LECTURA — 4 PASADAS OBLIGATORIAS
+## PROTOCOLO DE LECTURA — PASADAS OBLIGATORIAS
+
+**Pasada 0 — Clasificar el tipo de vista (OBLIGATORIA PRIMERA)**
+
+Antes de cualquier otra lectura, determiná qué TIPO de plano es esto:
+
+- `"planta"` → Vista cenital 2D (arquitectónica). Señales:
+  * Contornos nítidos, sin perspectiva
+  * Hatching de paredes (`//` o puntos)
+  * Cotas ortogonales con flechas/barras diagonales
+  * Símbolos esquematizados (pileta como rectángulo con círculos,
+    anafe como 4 círculos en cuadrado)
+  * Carátula/rótulo técnico con escala
+
+- `"render_3d"` → Vista isométrica / perspectiva (SketchUp, Blender, etc).
+  Señales:
+  * Electrodomésticos dibujados como objetos 3D (heladera tridimensional)
+  * Líneas oblicuas (isometría o perspectiva)
+  * Superficies con sombreado/gradientes
+  * Sin hatching de paredes
+  * Cotas típicamente solo horizontales arriba
+
+- `"elevation"` → Vista frontal/lateral (corte). Señales:
+  * Muestra alturas (zócalo, frentín, alacenas)
+  * No muestra profundidad
+  * Proyección ortogonal pero NO cenital
+
+- `"mixed"` → Plano con múltiples vistas (planta + elevación + detalle).
+  Tratar cada vista según su tipo.
+
+- `"unknown"` → Si realmente no es claro. Usar reglas conservadoras de
+  planta y flaguear alta `requires_human_review`.
+
+⛔ **Anotá el `view_type` en el JSON output como campo top-level.**
+
+El `view_type` condiciona las pasadas siguientes:
+- `planta`: reglas originales (hatching, L/U por geometría, 4-lados zócalos)
+- `render_3d`: ver §REGLA — RENDER 3D más abajo (1 sector, tramos
+  continuos, zócalos solo contra pared)
+- `elevation`: medidas verticales = alturas (zócalo, frentín), NO
+  profundidades. Los largos son proyecciones, no dimensiones reales.
+- `mixed` / `unknown`: ser conservador, flaguear ambigüedades.
 
 **Pasada 1 — Inventario**
 Identificá todos los sectores presentes (cocina, baño, lavadero, etc.)
@@ -266,6 +307,8 @@ Si el OCR extrae medidas, validalas contra la proporción del dibujo:
 
 ```json
 {
+  "view_type": "planta | render_3d | elevation | mixed | unknown",
+  "view_type_reason": "Breve explicación de por qué clasificaste así (ej: 'objetos 3D isométricos, sin hatching')",
   "sectores": [
     {
       "id": "cocina",

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -45,8 +45,39 @@ interface DualReadData {
   conflict_fields: string[];
   source: string;
   m2_warning?: string | null;
+  view_type?: string;
+  view_type_reason?: string;
   _retry?: boolean;
 }
+
+// PR #71 — metadata del tipo de vista para el badge
+const VIEW_TYPE_META: Record<string, { label: string; cls: string; emoji: string }> = {
+  planta: {
+    label: "Planta 2D",
+    cls: "bg-emerald-500/10 text-emerald-400 border-emerald-400/30",
+    emoji: "📐",
+  },
+  render_3d: {
+    label: "Render 3D",
+    cls: "bg-amber-500/10 text-amber-400 border-amber-400/30",
+    emoji: "🎨",
+  },
+  elevation: {
+    label: "Elevación",
+    cls: "bg-sky-500/10 text-sky-400 border-sky-400/30",
+    emoji: "↕️",
+  },
+  mixed: {
+    label: "Vistas mixtas",
+    cls: "bg-purple-500/10 text-purple-400 border-purple-400/30",
+    emoji: "🗂️",
+  },
+  unknown: {
+    label: "Tipo indeterminado",
+    cls: "bg-gray-500/10 text-gray-400 border-gray-400/30",
+    emoji: "❓",
+  },
+};
 
 interface Props {
   data: DualReadData;
@@ -265,6 +296,22 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
         <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-acc bg-acc-bg border border-acc/30 px-2 py-1 rounded-md">
           {data.source === "DUAL" ? "Doble lectura" : data.source.replace("SOLO_", "Solo ")}
         </span>
+        {/* PR #71 — badge de tipo de vista (planta / render 3D / etc) */}
+        {(() => {
+          const vt = data.view_type || "unknown";
+          const meta = VIEW_TYPE_META[vt] || VIEW_TYPE_META.unknown;
+          const tooltip = data.view_type_reason
+            ? `${meta.label} — ${data.view_type_reason}`
+            : meta.label;
+          return (
+            <span
+              className={`text-[10px] font-semibold uppercase tracking-[0.1em] px-2 py-1 rounded-md border ${meta.cls}`}
+              title={tooltip}
+            >
+              {meta.emoji} {meta.label}
+            </span>
+          );
+        })()}
         <h3 className="text-[15px] font-semibold text-t1 tracking-tight">{firstSectorHead || title}</h3>
         <span className="ml-auto text-[12px] text-t3 font-mono">
           {piecesCount} {piecesCount === 1 ? "mesada" : "mesadas"} · {zocalosCount}{" "}


### PR DESCRIPTION
Cierra la trilogía de fixes post-plano 2 (Fix A+C en PR #259, Fix B acá).

## Problema

El sistema aplicaba reglas de planta arquitectónica a cualquier plano, incluso renders 3D isométricos. Resultado: misread sistemático.

## Fix

Clasificación explícita del tipo de vista como **Pasada 0** del protocolo de lectura. Los modelos Opus/Sonnet clasifican y emiten `view_type` en el JSON output. 5 clases: `planta` / `render_3d` / `elevation` / `mixed` / `unknown`.

El view_type condiciona las pasadas siguientes:
- **planta** → reglas originales (hatching, L/U geometría, 4 lados zócalos)
- **render_3d** → reglas nuevas (1 sector, tramos continuos, zócalos contra pared)
- **elevation** → alturas no profundidades
- **mixed/unknown** → conservador

## UI

Badge en el header del card con emoji + color + tooltip explicando razón. Operador ve de un vistazo si el sistema entendió bien el tipo de plano.

## Reconciliación

Si Opus y Sonnet coinciden → OK. Si uno dice unknown → se toma el del otro. Si conflictean → prioridad render_3d > mixed/elevation > planta > unknown (conservador).

## Test plan

- [x] pytest 97/97 passing
- [ ] Manual plano 1 → badge "📐 Planta 2D"
- [ ] Manual plano 2 → badge "🎨 Render 3D" + lectura correcta

🤖 Generated with [Claude Code](https://claude.com/claude-code)