### PR TITLE
feat(plan-reader): regla simple — zócalo ml = cota directa del plano

### DIFF
--- a/api/rules/plan-reader-v1.md
+++ b/api/rules/plan-reader-v1.md
@@ -125,31 +125,43 @@ una planta arquitectónica cenital), aplicar estas reglas:
 5. **Frentín/faldón:** en render 3D no se ve la elevación. Si el operador
    no lo menciona → no agregar. Si lo menciona → preguntar altura.
 
-**Ejemplo canónico — render 3D cocina en L (Natalia):**
+**Ejemplo canónico — render 3D cocina Natalia (3 cotas + cocina entera):**
 ```
-Cotas superiores: 423mm + 1280mm + 1610mm
-Corner visible entre el 1280mm y el 1610mm (en el lavarropa).
-Heladera al extremo izquierdo (free-standing, fuera de mesada a su
-derecha). Lavadero al extremo derecho del L-retorno.
+Cotas superiores: 423mm (cajonera) + 1280mm (lavarropa + L horizontal)
+                  + 1610mm (L retorno lavadero)
+Heladera free-standing al extremo izquierdo (fuera, sin mesada encima).
+Cocina entera (horno + anafe free-standing) entre cajonera y lavarropa
+  — visible por la puerta del horno; interrumpe mesada Y zócalo ahí.
+Bacha empotrada en el L retorno.
 ```
 
-Lectura correcta:
-- 1 sector "cocina" (NO "cocina + lavadero").
-- 1 mesada en L con 2 tramos:
-  - Tramo 1 (horizontal, FULL con esquina): 1.703 × 0.60 m = 1.022 m²
-    (cajonero + horno + lavarropa).
-  - Tramo 2 (retorno vertical, NETO sin esquina): (1.610 - 0.60) × 0.60
-    = 1.010 × 0.60 = 0.606 m².
-- Zócalos: 2 traseros (contra la pared del fondo):
-  - Trasero tramo 1: 1.703 ml × 0.07 m.
-  - Trasero tramo 2: 1.610 ml × 0.07 m.
-- NO zócalo lateral contra heladera.
-- NO zócalo en la unión L.
-- NO zócalo en el borde libre derecho del retorno.
+Lectura correcta (regla simple: cada cota = un pedazo):
 
-⛔ **Error típico a evitar:** tratar "cocina" y "lavadero" como dos sectores
-separados. Son la misma mesada continua en L. El lavadero es parte de la
-cocina.
+**Mesadas — 3 tramos:**
+| # | Descripción | Cálculo | m² |
+|---|-------------|---------|------|
+| 1 | Cajonera (tramo chico izq) | 0.423 × 0.60 | 0.254 |
+| 2 | L-retorno lavadero (FULL con esquina) | 1.61 × 0.60 | 0.966 |
+| 3 | L-horizontal centro (NETO sin esquina) | (1.28 − 0.60) × 0.60 = 0.68 × 0.60 | 0.408 |
+| **Total** | — | — | **1.628** |
+
+**Zócalos — 3 cotas = 3 zócalos** (regla: cota del plano = ml directo):
+| # | Pared | ml | m² (× 0.07) |
+|---|-------|----|----|
+| Z1 | Fondo cajonera | 0.423 | 0.030 |
+| Z2 | Fondo L horizontal | 1.280 | 0.090 |
+| Z3 | Lateral L retorno | 1.610 | 0.113 |
+| **Total** | — | **3.313** | **0.232** |
+
+**Total a cortar: 1.628 + 0.232 = 1.860 m²**
+
+⛔ **Errores típicos a evitar:**
+- Tratar "cocina" y "lavadero" como dos sectores separados. Es UN sector.
+- Subtraer ancho de estufa para calcular ml de zócalo. La cota del plano
+  manda; el operador ya decidió qué es pared y qué no al dibujar.
+- Dar ml = suma horizontal (ej: 423+1280 = 1703). Son cotas separadas,
+  cada una un zócalo distinto.
+- Poner zócalo contra heladera / borde libre / unión L.
 
 ---
 

--- a/api/rules/plan-reading.md
+++ b/api/rules/plan-reading.md
@@ -31,32 +31,45 @@ Cuando el brief dice **"con zócalos"** / **"lleva zócalos"** sin aclarar pared
 Si el brief es ambiguo en OTRA dirección (ej: "sin zócalos" / "lleva zócalos
 laterales" / cotas de zócalo en el plano) → seguir esa instrucción específica.
 
-### ⛔ REGLA DURA — Zócalos SOLO contra PARED
+### ⛔ REGLA SIMPLE — Zócalos desde las COTAS del plano
 
-Los zócalos existen **exclusivamente contra muros de mampostería**. NUNCA
-agregar un zócalo en un lado donde:
+Cuando el brief dice "con zócalos" / "lleva zócalos":
 
-- Hay un **electrodoméstico** (heladera, lavavajillas, lavarropa, anafe free-
-  standing) que ocupa ese lado. El zócalo no puede apoyarse contra un
-  appliance porque éste se retira/reemplaza.
-- El lado es un **borde libre** (la mesada termina sin pared atrás — ej:
-  borde frontal hacia el usuario, o extremo de una isla).
-- El lado es una **unión entre tramos** (donde dos mesadas se conectan —
-  ver regla de L/U: el lado de unión NO lleva zócalo).
+1. **TODO tramo de mesada que va contra pared lleva zócalo.** No repreguntar.
+2. **ml de zócalo = cota directa del plano** para ese tramo. No subtraer
+   segmentos de appliances, no restar esquinas, no hacer aritmética.
+3. Un zócalo por cada cota del plano que mide una pared con mesada contra.
+4. El alto: default config (`measurements.default_zocalo_height`).
 
-Cuando el plano muestra un appliance (heladera grande, lavarropa, estufa)
-contiguo a un extremo de la mesada → ese extremo NO lleva zócalo, aunque
-el operador haya dicho "con zócalos" genérico.
+**Exclusiones (NO llevar zócalo):**
+- **Cocina entera / estufa-horno free-standing**: donde hay una cocina
+  entera (horno + anafe, full-height floor-to-counter visible por la
+  puerta del horno), la mesada está interrumpida y no hay zócalo ahí.
+  El operador ya marcó en las cotas qué es mesada y qué no — confiar.
+- **Heladera free-standing**: si está standalone (sin mesada encima),
+  no toca mesada — no genera zócalo.
+- **Borde libre**: lado donde la mesada termina sin pared.
+- **Unión L/U**: el lado donde 2 tramos se juntan no toca pared, no
+  lleva zócalo.
 
-Ejemplo plano 2 (render 3D cocina Natalia):
-- Tramo 1: mesada sobre cajonero + horno + lavarropa (1.703m total).
-- Tramo 2: L-retorno sobre lavadero (1.61m).
-- Heladera al extremo IZQUIERDO del tramo 1 (free-standing).
-- ✅ Zócalo trasero tramo 1 (1.703m) — contra pared.
-- ✅ Zócalo trasero tramo 2 (1.61m) — contra pared lateral.
-- ❌ NO zócalo lateral_izq del tramo 1 (ahí está la heladera, no pared).
-- ❌ NO zócalo lateral_der del tramo 2 (borde libre).
-- ❌ NO zócalo en el lado de unión L.
+⛔ **No dividir el zócalo en segmentos por cada appliance.** Si el plano
+muestra cota 1.28m para un tramo con lavarropa empotrado, el zócalo es
+1.28 ml (no 0.68 ml después de restar el lavarropa). La cota del plano
+es la verdad.
+
+Ejemplo (render 3D cocina Natalia):
+
+Cotas del plano: 423mm + 1280mm + 1610mm (3 cotas = 3 zócalos).
+
+| # | Cota | Zócalo ml | m² (× 0.07) |
+|---|------|-----------|-------------|
+| Z1 | 0.423m (cajonera) | 0.423 | 0.030 |
+| Z2 | 1.280m (fondo L) | 1.280 | 0.090 |
+| Z3 | 1.610m (lateral L) | 1.610 | 0.113 |
+| **Total** | — | **3.313** | **0.232 m²** |
+
+No hay que preguntar "¿qué paredes llevan?" ni restar el ancho de la estufa.
+Las cotas están; cada cota = un zócalo.
 - ⛔ Ejemplo cocina en L: tramo 1 (1.72×0.75) + tramo 2 (0.60×1.55):
   - Zocalo fondo tramo 1 (inferior): **1.74ml** (cota del plano)
   - Zocalo fondo tramo 2: **1.55ml** (va por la pared del fondo del tramo 2)


### PR DESCRIPTION
Simplificación tras clarificación del operador.

Regla única ahora: **cada cota del plano es un zócalo de ese largo**. No subtraer appliances. No restar esquinas. No preguntar.

Exclusiones cortas (se aplican automáticamente al leer las cotas):
- Cocina entera / stove free-standing → no zócalo ahí
- Heladera standalone → no toca mesada
- Borde libre → no lleva
- Unión L/U → no lleva

Ejemplo canónico actualizado (plano 2 Natalia): 3 cotas → 3 zócalos (0.423 + 1.28 + 1.61 = 3.313 ml).

Reemplaza la lógica más compleja de PRs #259/#260 que causaba confusión.

🤖 Generated with [Claude Code](https://claude.com/claude-code)