### PR TITLE
fix(plan-reader): regla dura — zócalo REQUIERE cota propia del plano

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -313,6 +313,26 @@ Excepciones (NO preguntar, calcular directo):
 
 ---
 
+## ⛔ REGLA DURA — Zócalo REQUIERE cota propia del plano
+
+Un zócalo SOLO se reporta si hay una **cota del plano** (número dibujado)
+específicamente para ese lado. NUNCA inventar ml desde la profundidad de
+la mesada.
+
+❌ Error prohibido: mesada de `0.42 × 0.60` → reportar zócalo lateral_izq
+   de `0.60 ml` sacando el número desde la prof. Eso no es una cota real
+   del plano, es una prof inferida.
+
+✅ Correcto: 1 cota en el plano = 1 zócalo de ese largo. Sin cota → ml=0.
+
+Para renders 3D con N cotas horizontales → N zócalos traseros. Los
+laterales solo se reportan si hay una cota vertical específica para ellos.
+
+Ver ejemplo canónico en `rules/plan-reader-v1.md §REGLA DURA — Zócalo
+REQUIERE cota propia`.
+
+---
+
 ## ⛔ REGLA — ZÓCALOS SOLO CONTRA PARED (nunca contra appliance)
 
 Un zócalo existe **exclusivamente contra un muro de mampostería**. NUNCA se

--- a/api/rules/plan-reader-v1.md
+++ b/api/rules/plan-reader-v1.md
@@ -557,6 +557,35 @@ otros 2–3 lados de la mesada que toca pared también llevan zócalo — tenés
 que buscar sus cotas ACTIVAMENTE en el plano (suelen estar dibujadas en
 una sub-vista de elevación lateral cerca del tramo correspondiente).
 
+### ⛔ REGLA DURA — Zócalo REQUIERE cota propia del plano
+
+El zócalo de un lado SOLO se reporta si existe una **cota del plano que
+lo respalde** (número dibujado específicamente para ese lado). Nunca
+inventar el ml desde la profundidad de la mesada.
+
+❌ **Error prohibido:** en una cajonera de `0.42 × 0.60`, ver `prof=0.60`
+y decir "lateral_izq: 0.60 ml" inventando un zócalo lateral cuyo largo
+= prof de la mesada. Eso sería "zócalo deducido desde la prof", no desde
+una cota real → prohibido.
+
+✅ **Correcto:** solo reportar un zócalo cuando:
+1. Hay un rectángulo hachurado dibujado para ese lado, con su cota ml, **O**
+2. Hay una leyenda explícita (`Z trasero = Xm`), **O**
+3. El plano muestra una cota horizontal/vertical que mide ESA pared
+   específicamente (no una prof genérica que se usó para la mesada).
+
+Si el plano solo tiene cotas horizontales (3 cotas: "423 + 1280 + 1610"),
+hay **3 zócalos traseros**, uno por cota. Los lados laterales (izq/der)
+no llevan zócalo salvo que haya una cota vertical específica para ellos.
+
+**Ejemplo plano 2 Natalia (render 3D):**
+- Cotas del plano: `423mm + 1280mm + 1610mm` (3 cotas horizontales).
+- 3 zócalos traseros: `0.42` + `1.28` + `1.61` ml.
+- ❌ NO zócalo lateral_izq del tramo cajonera con `ml=0.60` (eso sale
+  de la prof, no de una cota real).
+- ❌ NO zócalo lateral_der del tramo L con `ml=0.60` (ídem).
+- Frontal: siempre `ml=0` (borde libre hacia el usuario).
+
 **Ejemplo A1335 aplicado — enumeración por lado:**
 
 Tramo 1 (Mesada cocina, 1.72 × 0.75, en planta principal):


### PR DESCRIPTION
Bug observado en plano 2 (render 3D Natalia): Valentina agregó 2 zócalos laterales spurios inventando su ml desde la profundidad de la mesada (0.60m) en vez de una cota real del plano.

Fix: regla dura explícita — un zócalo SOLO se reporta si hay:
1. Rectángulo hachurado con su cota en ml
2. Leyenda explícita (Z trasero = Xm)
3. Cota horizontal/vertical específica para esa pared (NO la prof de la mesada)

N cotas horizontales = N zócalos traseros. Laterales solo si hay cota vertical propia.

Esperado: plano 2 → 3 zócalos (no 5), total 1.86 m².

🤖 Generated with [Claude Code](https://claude.com/claude-code)