### PR TITLE
fix(dual-read-card): ocultar zócalos con ml=0 (ruido visual)

### DIFF
--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -380,11 +380,13 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
                     </div>
                   </div>
 
-                  {/* Zócalos rows — ocultar ml=0 salvo que requieran revisión */}
+                  {/* Zócalos rows — ocultar siempre los que tienen ml=0.
+                      PR #77: antes se mostraban los CONFLICTO/DUDOSO con ml=0
+                      (ruido visual sin valor — el operador no puede agregar
+                      ml por input funcional y ml=0 no suma al cálculo). */}
                   {tramo.zocalos.map((z, zi) => {
                     const hasMl = (z.ml ?? 0) > 0;
-                    const needsReview = z.status === "CONFLICTO" || z.status === "DUDOSO";
-                    if (!hasMl && !needsReview) return null;
+                    if (!hasMl) return null;
                     return (
                       <div
                         key={zi}


### PR DESCRIPTION
Las filas 'Zóc lateral_izq: 0 ml, 0.00m, 0.00 m²' eran ruido. Sonnet/Opus las sugerían con status CONFLICTO pero sin ml, y no hay forma funcional de 'activarlas' (input vacío sin +Agregar). ml=0 no suma al cálculo tampoco.

Antes: se mostraban los CONFLICTO/DUDOSO con ml=0.
Ahora: si ml=0 → ocultar. Los zócalos con ml>0 siguen editables + removibles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)