### PR TITLE
feat(flow): despiece confirmado inmutable + cambios revierten a Paso 1

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1249,12 +1249,23 @@ class AgentService:
                 _already_confirmed_cm = bool(
                     _cm_bd.get("verified_context") or _cm_bd.get("measurements_confirmed")
                 )
-                if (
-                    _existing_card
-                    and not _existing_card.get("error")
-                    and not _already_confirmed_cm
-                ):
-                    logging.info(f"[card-editor] Detected modification intent for {quote_id}")
+                if _existing_card and not _existing_card.get("error"):
+                    # PR #80 — Cualquier modificación del despiece (pre o
+                    # post-confirmación) aplica el patch. Si el quote ya
+                    # había pasado a Paso 2 (verified_context + material
+                    # guardados), lo REVERTIMOS a Paso 1: limpiamos state
+                    # post-confirmación para que el operador re-confirme
+                    # el nuevo despiece y Valentina regenere Paso 2.
+                    _has_paso2 = bool(
+                        _cm_bd.get("material_name")
+                        or _cm_bd.get("total_ars")
+                        or _cm_bd.get("mo_items")
+                    )
+                    _reverting_from_paso2 = _already_confirmed_cm or _has_paso2
+                    logging.info(
+                        f"[card-editor] Modification intent for {quote_id} "
+                        f"(reverting_from_paso2={_reverting_from_paso2})"
+                    )
                     yield {"type": "action", "content": "✏️ Aplicando cambios al card..."}
                     _ops = await extract_card_patch(user_message, _existing_card)
                     if not _ops:
@@ -1286,13 +1297,31 @@ class AgentService:
                     _patched_card, _applied, _errors = apply_card_patch(
                         dict(_existing_card), _ops
                     )
-                    # Guardar el card patcheado + re-emitir.
+                    # Guardar el card patcheado + limpiar Paso 2 state si
+                    # estamos revirtiendo.
                     try:
                         _cm_bd_new = dict(_cm_bd)
                         _cm_bd_new["dual_read_result"] = _patched_card
+                        if _reverting_from_paso2:
+                            # Limpiar todo el state post-confirmación para
+                            # que el flujo vuelva a Paso 1.
+                            for _stale in (
+                                "verified_context", "verified_measurements",
+                                "measurements_confirmed", "material_name",
+                                "material_m2", "material_price_unit",
+                                "material_currency", "discount_amount",
+                                "discount_pct", "total_ars", "total_usd",
+                                "mo_items", "sectors", "sinks", "piece_details",
+                                "mo_discount_amount", "mo_discount_pct",
+                                "total_mo_ars", "sobrante_m2", "sobrante_total",
+                                "paso1_pieces", "paso1_total_m2",
+                            ):
+                                _cm_bd_new.pop(_stale, None)
                         await db.execute(
                             update(Quote).where(Quote.id == quote_id).values(
-                                quote_breakdown=_cm_bd_new
+                                quote_breakdown=_cm_bd_new,
+                                total_ars=None if _reverting_from_paso2 else _cm_quote.total_ars,
+                                total_usd=None if _reverting_from_paso2 else _cm_quote.total_usd,
                             )
                         )
                         await db.commit()
@@ -1300,6 +1329,14 @@ class AgentService:
                         logging.warning(f"[card-editor] save patched card failed: {_e_s}")
 
                     _summary = format_patch_summary(_applied, _errors)
+                    if _reverting_from_paso2:
+                        _summary = (
+                            "🔄 Volvimos a Paso 1 porque cambiaste el despiece. "
+                            "El Paso 2 anterior fue descartado.\n\n"
+                            + _summary
+                            + "\n\nConfirmá las nuevas medidas en el card para "
+                            "generar el nuevo Paso 2."
+                        )
                     yield {"type": "text", "content": _summary}
                     yield {
                         "type": "dual_read_result",

--- a/api/app/modules/quote_engine/dual_reader.py
+++ b/api/app/modules/quote_engine/dual_reader.py
@@ -829,19 +829,28 @@ def _check_m2(result: dict, planilla_m2: Optional[float]) -> Optional[str]:
 def build_verified_context(confirmed_data: dict) -> str:
     """Build injection text from operator-confirmed measurements.
 
-    PR #59: detecta items "confirmados" que siguen en estado ambiguo
-    (zócalos con status CONFLICTO/DUDOSO y ml=0, ambiguedades sin resolver,
-    falta de datos como modelo de pileta). Los flagea al final del contexto
-    para que Valentina NO siga a Paso 2 sin preguntar al operador.
+    PR #80: el despiece confirmado es INMUTABLE desde el punto de vista
+    de Valentina. No se emiten warnings ni se piden aclaraciones sobre
+    piezas con status CONFLICTO o zócalos con ml=0 — se asume que el
+    operador intencionalmente confirmó esa configuración (ya sea
+    clickeando × para remover, editando inputs, o con + Agregar).
+
+    Si el operador detecta un error post-confirmación, el flujo es:
+    reabrir Paso 1 (ver card_editor handler en agent.py), editar, y
+    re-confirmar. El Paso 2 se regenera recién con el nuevo despiece.
+
+    Esta función antes (PR #59) surface-ba "pending_questions" para
+    zócalos CONFLICTO sin resolver → resultaba en ruido (Valentina
+    preguntaba de vuelta cosas que el operador ya había decidido). La
+    regla nueva es: confirmado es confirmado.
     """
     lines = [
         "[MEDIDAS VERIFICADAS POR DOBLE LECTURA + OPERADOR — FUENTE DE VERDAD]",
         "⛔ Estos valores son definitivos. NO leas la imagen. Usá estos valores exactos.",
+        "⛔ NO preguntar al operador sobre el despiece (ya confirmado). Si detecta",
+        "   un error y te lo menciona, el sistema automáticamente reabre Paso 1.",
         "",
     ]
-
-    # Items pendientes detectados durante el parse
-    pending_questions: list[str] = []
 
     for sector in confirmed_data.get("sectores", []):
         sid = sector.get("id", "sector")
@@ -856,45 +865,13 @@ def build_verified_context(confirmed_data: dict) -> str:
             ancho_v = ancho.get("valor", 0) if isinstance(ancho, dict) else ancho
             m2_v = m2.get("valor", 0) if isinstance(m2, dict) else m2
             lines.append(f"  {desc}: {largo_v}m × {ancho_v}m = {m2_v} m²")
-            zocalos_written = 0
-            zocalos_unresolved: list[str] = []
             for z in tramo.get("zocalos", []):
                 ml = z.get("ml", 0) or 0
                 alto = z.get("alto_m", _default_zocalo_alto())
                 lado = z.get("lado", "?")
-                z_status = (z.get("status") or "").upper()
                 if ml > 0:
                     lines.append(f"  Zócalo {lado}: {ml}ml × {alto}m")
-                    zocalos_written += 1
-                elif z_status in ("CONFLICTO", "DUDOSO"):
-                    # Estaba marcado ambiguo y el operador lo dejó en ml=0.
-                    # NO asumir "cero zócalos" — preguntar.
-                    zocalos_unresolved.append(f"{lado} (status={z_status})")
-            if zocalos_unresolved:
-                pending_questions.append(
-                    f"Zócalos en '{desc}': el dual_read propuso "
-                    f"{len(zocalos_unresolved)} zócalos sin confirmar "
-                    f"({', '.join(zocalos_unresolved)}) y el operador los "
-                    "confirmó con ml=0. ¿Quiso decir que NO lleva zócalos, "
-                    "o los olvidó? — PREGUNTAR antes de Paso 2."
-                )
-        # Ambigüedades del sector que no son solo "DEFAULT" — las de
-        # tipo REVISION siguen vivas aunque el operador haya confirmado
-        # las medidas.
-        for amb in sector.get("ambiguedades", []):
-            amb_text = amb if isinstance(amb, str) else amb.get("texto", "")
-            amb_tipo = "" if isinstance(amb, str) else (amb.get("tipo") or "").upper()
-            if amb_tipo == "REVISION" and amb_text:
-                pending_questions.append(f"Revisar: {amb_text}")
-        lines.append("")
-
-    if pending_questions:
-        lines.append("")
-        lines.append("⛔ PREGUNTAS PENDIENTES AL OPERADOR — NO IR A PASO 2")
-        lines.append("Items que el dual_read flageó como ambiguos y el operador")
-        lines.append("no aclaró en el card. PREGUNTALE explícito antes de calcular:")
-        for q in pending_questions:
-            lines.append(f"- {q}")
+                # ml=0 → ignorado (operador lo descartó intencionalmente)
         lines.append("")
 
     return "\n".join(lines)


### PR DESCRIPTION
Refactor del flujo Paso 1 / Paso 2 con límites claros. Basado en feedback del operador.

## Principio

- **Paso 1 confirmado = inmutable** para Valentina. Cero warnings o preguntas sobre el despiece ya confirmado.
- **Cambio post-confirmación** = sistema vuelve a Paso 1 automáticamente (descarta Paso 2, re-emite card patcheada, pide re-confirmación).

## Cambios

**1. `dual_reader.py::build_verified_context`**
Eliminado el bloque de 'PREGUNTAS PENDIENTES' sobre zócalos CONFLICTO con ml=0. Ese warning era útil antes de PRs #78/#79 (card editable) — ahora es ruido.

**2. `agent.py::card_editor handler`**
Extendido para aplicar patch pre o post-confirmación. Si post, limpia todo el state de Paso 2 (material, totales, MO items, sectors, etc.) y emite '🔄 Volvimos a Paso 1' antes de re-emitir el card.

## Flujo

1. Subir plano → card
2. Editar card (UI o chat) → confirmar
3. Paso 2 → PDF
4. Si error detectado: 'te falto un zócalo' → descarta Paso 2 → card vuelve a aparecer patcheada → re-confirmar → Paso 2 regenerado

**Tests:** pytest 120/120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)