### PR TITLE
fix: silent retry reforzado + pileta_qty=0 respetada por calculator

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -93,14 +93,22 @@ Cuando el operador pide cambio sobre presupuesto con breakdown:
 
 **⛔ REINTENTOS SILENCIOSOS — NO NARRAR ERRORES INTERNOS**
 
-Cuando una tool devuelve `{"ok": false, "error": "..."}`, NUNCA lo narres al
-operador. El operador no tiene contexto de las tools internas del sistema.
+Cuando una tool devuelve `{"ok": false, "error": "..."}` O cuando detectás
+que un cálculo previo quedó inconsistente con el estado actual, NUNCA lo
+narres al operador. El operador no tiene contexto de las tools internas
+del sistema ni del estado interno de Valentina.
+
 Frases **prohibidas**:
 - "El sistema detectó un error en mi cálculo"
 - "Permíteme corregir usando los valores exactos..."
 - "Detecté un problema con el cálculo automático..."
 - "Voy a intentar con una interpretación diferente..."
 - "Detecté que el sistema está validando incorrectamente..."
+- **"Detecté que el sistema mantuvo X aunque puse Y..."** (PR #82)
+- **"Voy a usar `patch_quote_mo` para remover..."** (no mencionar nombres de tools internas)
+- **"El sistema no removió X aunque le pasé Y"**
+- Cualquier referencia a campos del tool schema (`pileta_qty`, `anafe`,
+  `discount_pct`, etc.) — el operador no sabe que existen.
 
 Protocolo correcto:
 1. Leé el error del tool result silenciosamente.
@@ -110,9 +118,24 @@ Protocolo correcto:
 
 Si después de 2 reintentos la tool sigue fallando, entonces sí mencionalo —
 pero directo: *"No puedo calcular con estos datos. ¿Podés confirmar X?"*. Sin
-culpar al "sistema" ni hablar del retry.
+culpar al "sistema" ni hablar del retry ni nombrar tools internas.
 
 El operador debe ver SOLO el Paso 1 / Paso 2 final pulido, no el debugging.
+
+---
+
+**⛔ CÓMO REMOVER PILETA DEL CÁLCULO**
+
+Para remover la pileta de un presupuesto (ej: el operador dice "no hay
+pileta"), NO uses `pileta_qty=0`. El calculator genera el ítem igual
+porque el tipo de pileta (`pileta="empotrada_cliente"`) sigue seteado.
+
+Forma correcta: **NO pasar el parámetro `pileta` en absoluto** (dejarlo
+omitido/null). Eso le dice al calculator "sin pileta" sin ambigüedad.
+
+Regla análoga para `anafe`, `frentin`, etc: si no aplica → NO pasar el
+parámetro. `False` / `0` pueden generar ítem fantasma dependiendo del
+calculator.
 
 **⛔ DESCRIPTION DE PIEZAS — NO DUPLICAR DIMENSIONES**
 

--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -707,7 +707,11 @@ def calculate_quote(input_data: dict) -> dict:
     mo_items = []
 
     # Pileta (supports quantity for edificios)
-    if pileta:
+    # PR #82 — respetar `pileta_qty=0` como "sin pileta", aunque el
+    # operador/LLM haya pasado `pileta=empotrada_cliente`. Antes,
+    # max(1, 0)=1 forzaba el ítem igual → bug de "agujero pileta
+    # fantasma" cuando Valentina intentaba remover pasando qty=0.
+    if pileta and pileta_qty > 0:
         qty = max(1, pileta_qty)
         if pileta in ("empotrada_cliente", "empotrada_johnson"):
             sku = "PILETADEKTON/NEOLITH" if is_sint else "PEGADOPILETA"

--- a/api/tests/test_quote_engine.py
+++ b/api/tests/test_quote_engine.py
@@ -279,6 +279,27 @@ class TestCalculateQuote:
         assert result["total_ars"] > 0
         assert len(result["mo_items"]) >= 3  # pileta + anafe + colocación + flete
 
+    def test_pileta_qty_zero_skips_item(self):
+        """PR #82 — Si Valentina pasa pileta=X + pileta_qty=0 (intento de
+        remover), el calculator debe tratarlo como 'sin pileta'. Antes,
+        max(1, 0)=1 forzaba el ítem igual (bug fantasma)."""
+        result = calculate_quote({
+            "client_name": "Test",
+            "project": "Cocina",
+            "material": "Silestone Blanco Norte",
+            "pieces": [{"description": "Mesada", "largo": 2.0, "prof": 0.6}],
+            "localidad": "Rosario",
+            "colocacion": False,
+            "pileta": "empotrada_cliente",
+            "pileta_qty": 0,  # intento de remover
+            "plazo": "30 días",
+        })
+        assert result["ok"] is True
+        descriptions = [mo["description"].lower() for mo in result["mo_items"]]
+        assert not any("pileta" in d for d in descriptions), (
+            f"pileta_qty=0 debe omitir el ítem aunque pileta!=None. MO: {descriptions}"
+        )
+
     def test_quote_without_pileta_anafe(self):
         result = calculate_quote({
             "client_name": "Test",


### PR DESCRIPTION
Bug observado: Valentina narró en voz alta '_Detecté que el sistema mantuvo X aunque puse pileta_qty=0. Voy a usar patch_quote_mo..._' cuando intentaba remover la pileta.

**Bug 1 (silent retry):** la regla de PR #233 prohíbe narrar debugging interno. Agrego frases explícitas a la blacklist incluyendo nombres de tools internas y campos del schema.

**Bug 2 (calculator):** línea 710 `if pileta:` + `max(1, pileta_qty)` forzaba el ítem aunque qty=0. Fix: `if pileta and pileta_qty > 0:`. Test nuevo valida el caso.

Regla adicional en CONTEXT.md §CÓMO REMOVER PILETA: la forma correcta es NO pasar el parámetro `pileta` en absoluto (null), no qty=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)