### PR TITLE
feat(chat): copy-to-clipboard en despiece, Pasos 1/2 y snapshot pre-PDF

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -9,8 +9,8 @@
     },
     {
       "name": "web",
-      "runtimeExecutable": "/opt/homebrew/bin/npm",
-      "runtimeArgs": ["run", "dev"],
+      "runtimeExecutable": "/bin/sh",
+      "runtimeArgs": ["-c", "cd web && /opt/homebrew/bin/npm run dev"],
       "port": 3000
     }
   ]

--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useParams } from "next/navigation";
 import { fetchQuote, streamChat, markQuoteAsRead, validateQuote, type QuoteDetail } from "@/lib/api";
 import { useQuotes } from "@/lib/quotes-context";
 import MessageBubble from "@/components/chat/MessageBubble";
+import CopyButton from "@/components/chat/CopyButton";
 import ZoneSelector from "@/components/chat/ZoneSelector";
 import { selectZone } from "@/lib/api";
 import { ResumenObraCard } from "@/components/quote/ResumenObraCard";
@@ -510,20 +511,35 @@ export default function QuotePage() {
                     <MessageBubble message={msg} actionText={msg.isStreaming ? actionText : undefined} />
                   )}
                   {needsConfirm && (
-                    <div className="flex gap-2 mt-2 ml-[42px]">
-                      <button
-                        onClick={() => send("Confirmo")}
-                        className="px-4 py-2 rounded-lg text-[13px] font-medium bg-grn text-white border-none cursor-pointer hover:brightness-110 transition"
-                      >
-                        Confirmar
-                      </button>
-                      <button
-                        onClick={() => { const ta = document.querySelector("textarea"); if (ta) ta.focus(); }}
-                        className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent border border-b2 text-t2 cursor-pointer hover:text-t1 hover:border-b3 transition"
-                      >
-                        Corregir
-                      </button>
-                    </div>
+                    <>
+                      <div className="mt-2 ml-[42px]">
+                        <CopyButton
+                          text={(() => {
+                            const header = [
+                              `## SNAPSHOT — ${quote?.client_name || "Cliente"} / ${quote?.project || "Proyecto"}`,
+                              "",
+                            ].join("\n");
+                            return header + msg.content;
+                          })()}
+                          label="📋 Copiar todo"
+                          fullWidth
+                        />
+                      </div>
+                      <div className="flex gap-2 mt-2 ml-[42px]">
+                        <button
+                          onClick={() => send("Confirmo")}
+                          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-grn text-white border-none cursor-pointer hover:brightness-110 transition"
+                        >
+                          Confirmar
+                        </button>
+                        <button
+                          onClick={() => { const ta = document.querySelector("textarea"); if (ta) ta.focus(); }}
+                          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent border border-b2 text-t2 cursor-pointer hover:text-t1 hover:border-b3 transition"
+                        >
+                          Corregir
+                        </button>
+                      </div>
+                    </>
                   )}
                   {isLastReal && lastFailedMsg && !msg.isStreaming && !sending && msg.content.includes(WARN) && (
                     <div className="flex gap-2 mt-2 ml-[42px]">

--- a/web/src/components/chat/CopyButton.tsx
+++ b/web/src/components/chat/CopyButton.tsx
@@ -1,0 +1,88 @@
+"use client";
+import { useState } from "react";
+import clsx from "clsx";
+
+interface Props {
+  text: string;
+  label?: string;
+  iconOnly?: boolean;
+  fullWidth?: boolean;
+  className?: string;
+}
+
+export default function CopyButton({
+  text,
+  label = "Copiar",
+  iconOnly = false,
+  fullWidth = false,
+  className,
+}: Props) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    const done = () => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    };
+    try {
+      await navigator.clipboard.writeText(text);
+      done();
+    } catch {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      ta.style.position = "fixed";
+      ta.style.top = "0";
+      ta.style.left = "0";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.focus();
+      ta.select();
+      try {
+        document.execCommand("copy");
+        done();
+      } catch {
+        /* ignore */
+      }
+      document.body.removeChild(ta);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      title={iconOnly ? label : undefined}
+      aria-label={label}
+      className={clsx(
+        "relative z-20 inline-flex items-center gap-1.5 rounded-md text-[11px] font-medium transition-colors cursor-pointer",
+        "text-t3 bg-transparent border border-b2",
+        "hover:text-acc hover:bg-acc2 hover:border-acc/40",
+        iconOnly
+          ? "p-1.5 min-w-[44px] min-h-[44px] justify-center"
+          : "px-2.5 py-1.5",
+        fullWidth && "w-full justify-center min-h-[44px]",
+        className,
+      )}
+    >
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        className={clsx("shrink-0", fullWidth ? "w-3.5 h-3.5" : "w-3 h-3")}
+      >
+        <path d="M8 5h8a2 2 0 012 2v12a2 2 0 01-2 2H8a2 2 0 01-2-2V7a2 2 0 012-2z" />
+        <path d="M16 3H10a2 2 0 00-2 2" />
+      </svg>
+      {!iconOnly && <span>{label}</span>}
+      <span
+        className={clsx(
+          "absolute top-full mt-1.5 right-0 px-2.5 py-1 rounded-md bg-grn text-white text-[11px] font-semibold pointer-events-none transition-opacity duration-200 whitespace-nowrap z-20",
+          copied ? "opacity-100" : "opacity-0",
+        )}
+      >
+        Copiado ✓
+      </span>
+    </button>
+  );
+}

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useState } from "react";
+import CopyButton from "./CopyButton";
 
 interface FieldValue {
   opus?: number | null;
@@ -400,6 +401,34 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
       .replace(/_/g, " ")
       .toLowerCase()
       .replace(/\b\w/g, (c) => c.toUpperCase());
+
+  // Markdown formatter para copy-to-clipboard. Genera una tabla estructurada
+  // con piezas + zócalos + totales, lista para pegar en Claude Code.
+  const despieceMarkdown = (() => {
+    const lines: string[] = ["## Despiece", "", "| Pieza | Medida | m² |", "|---|---|---|"];
+    let total = 0;
+    editedData.sectores.forEach((sector) => {
+      if (editedData.sectores.length > 1) {
+        lines.push(`| **${prettify(sector.id)} — ${prettify(sector.tipo)}** |  |  |`);
+      }
+      sector.tramos.forEach((tramo) => {
+        const desc = tramo.descripcion || tramo.id;
+        const largo = tramo.largo_m.valor.toFixed(2);
+        const ancho = tramo.ancho_m.valor.toFixed(2);
+        const m2 = tramo.m2.valor || 0;
+        total += m2;
+        lines.push(`| ${desc} | ${largo} × ${ancho} | ${m2.toFixed(2)} |`);
+        tramo.zocalos.forEach((z) => {
+          if ((z.ml ?? 0) <= 0) return;
+          const zm2 = z.ml * (z.alto_m || 0);
+          total += zm2;
+          lines.push(`| Zóc. ${z.lado} | ${z.ml.toFixed(2)} ml × ${z.alto_m.toFixed(2)} | ${zm2.toFixed(2)} |`);
+        });
+      });
+    });
+    lines.push(`| **Total** | — | **${total.toFixed(2)}** |`);
+    return lines.join("\n");
+  })();
   const firstSectorHead = editedData.sectores[0]
     ? `${prettify(editedData.sectores[0].id)} — ${prettify(editedData.sectores[0].tipo)}`
     : "";
@@ -428,10 +457,21 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
           );
         })()}
         <h3 className="text-[15px] font-semibold text-t1 tracking-tight">{firstSectorHead || title}</h3>
-        <span className="ml-auto text-[12px] text-t3 font-mono">
+        <span className="ml-auto text-[12px] text-t3 font-mono hidden md:inline">
           {piecesCount} {piecesCount === 1 ? "mesada" : "mesadas"} · {zocalosCount}{" "}
           {zocalosCount === 1 ? "zócalo" : "zócalos"}
         </span>
+        <CopyButton
+          text={despieceMarkdown}
+          label="Copiar despiece"
+          className="md:ml-3 ml-auto hidden sm:inline-flex"
+        />
+        <CopyButton
+          text={despieceMarkdown}
+          label="Copiar despiece"
+          iconOnly
+          className="ml-auto sm:hidden"
+        />
       </div>
 
       {data.m2_warning && (

--- a/web/src/components/chat/MessageBubble.tsx
+++ b/web/src/components/chat/MessageBubble.tsx
@@ -1,6 +1,21 @@
 import { memo, useMemo } from "react";
 import clsx from "clsx";
 import type { UIMessage } from "@/app/quote/[id]/page";
+import CopyButton from "./CopyButton";
+
+// Heurística para etiquetar el botón copiar según el contenido: Paso 2 tiene
+// "Grand Total" / múltiples "$", Paso 1 tiene tabla de piezas sin precios.
+function copyLabel(content: string): string {
+  if (/grand total/i.test(content) || /total mo/i.test(content)) return "Copiar Paso 2";
+  if (/\|[^\n]*pieza/i.test(content) || /despiece/i.test(content)) return "Copiar Paso 1";
+  return "Copiar";
+}
+
+function hasCopyableContent(content: string): boolean {
+  // Tabla markdown detectable: al menos 2 líneas con pipes.
+  const pipeLines = content.split("\n").filter((l) => l.trim().startsWith("|") && l.trim().endsWith("|"));
+  return pipeLines.length >= 2;
+}
 
 interface Props { message: UIMessage; actionText?: string; }
 
@@ -87,8 +102,19 @@ const Block = memo(function Block({ block, isLast, isStreaming, actionText }: { 
     );
   }
 
+  const showCopy = !isStreaming && hasCopyableContent(block.content);
   return (
-    <div className={clsx("px-[18px] py-3.5 bg-s2 text-[15px] leading-[1.7] text-t2", !isLast && "border-b border-b1")}>
+    <div className={clsx("relative px-[18px] py-3.5 bg-s2 text-[15px] leading-[1.7] text-t2", !isLast && "border-b border-b1")}>
+      {showCopy && (
+        <>
+          <div className="absolute top-3 right-3 hidden sm:block z-10">
+            <CopyButton text={block.content} label={copyLabel(block.content)} />
+          </div>
+          <div className="absolute top-2 right-2 sm:hidden z-10">
+            <CopyButton text={block.content} label={copyLabel(block.content)} iconOnly />
+          </div>
+        </>
+      )}
       <FormattedText text={block.content} isStreaming={isStreaming} />
     </div>
   );


### PR DESCRIPTION
## Summary

Permite al operador copiar el contenido estructurado (markdown) desde el chat para pegarlo en Claude Code al debuggear. 4 CTAs según mockup aprobado:

- **Dual Read card** → `Copiar despiece` en header (markdown con piezas + zócalos + total)
- **Chat bubbles de Valentina** → `Copiar Paso 1` / `Copiar Paso 2` auto-detectado por heurística (tabla vs Grand Total)
- **Pre-PDF (confirmación)** → `📋 Copiar todo` full-width antes de Confirmar/Corregir con header `SNAPSHOT — Cliente / Proyecto` + último mensaje

## UX

- Toast verde `Copiado ✓` debajo del botón por 1.8s
- Hover azul (`--acc`) en los botones, mismo tono que el design system
- Mobile: botones icon-only 44×44px (touch target)
- Fallback `execCommand('copy')` si clipboard API falla (HTTP, browsers viejos)

## Nuevos archivos

- `web/src/components/chat/CopyButton.tsx` — componente compartido con toast, variantes `iconOnly` y `fullWidth`

## Modificados

- `web/src/components/chat/DualReadResult.tsx` — formatter markdown del despiece + botón en header (desktop full label, mobile icon-only)
- `web/src/components/chat/MessageBubble.tsx` — botón auto-visible en bubbles con tabla markdown, label detectado por contenido
- `web/src/app/quote/[id]/page.tsx` — botón `Copiar todo` cuando `needsConfirm` (pre-PDF)

## Test plan

- [ ] Abrir un quote con Dual Read → click en `Copiar despiece` → pegar en otra app → verificar markdown correcto
- [ ] Verificar botones `Copiar Paso 1` y `Copiar Paso 2` aparecen en bubbles con tabla
- [ ] Llegar al paso pre-PDF (Valentina pregunta "¿Confirmás?") → verificar botón `📋 Copiar todo` full-width con snapshot completo
- [ ] Redimensionar a mobile (<640px) → verificar que los botones son icon-only 44px
- [ ] Verificar toast `Copiado ✓` aparece 1.8s debajo del botón

🤖 Generated with [Claude Code](https://claude.com/claude-code)