### PR TITLE
style(chat): CTA Confirmar full-width celeste

### DIFF
--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -588,13 +588,13 @@ export default function QuotePage() {
                       <div className="flex gap-2 mt-2 ml-[42px]">
                         <button
                           onClick={() => send("Confirmo")}
-                          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-grn text-white border-none cursor-pointer hover:brightness-110 transition"
+                          className="flex-1 px-4 py-2.5 rounded-lg text-[13px] font-semibold bg-acc text-white border-none cursor-pointer hover:brightness-110 transition"
                         >
                           Confirmar
                         </button>
                         <button
                           onClick={() => { const ta = document.querySelector("textarea"); if (ta) ta.focus(); }}
-                          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent border border-b2 text-t2 cursor-pointer hover:text-t1 hover:border-b3 transition"
+                          className="px-4 py-2.5 rounded-lg text-[13px] font-medium bg-transparent border border-b2 text-t2 cursor-pointer hover:text-t1 hover:border-b3 transition"
                         >
                           Corregir
                         </button>


### PR DESCRIPTION
## Summary
- Confirmar: primary celeste (`bg-acc` = `#4f8fff`) + `flex-1` → ocupa todo el ancho disponible
- Corregir: queda como secundario bordeado al costado (mismo alto `py-2.5`)
- Matchea la jerarquía visual del patrón primary/secondary grande (como el "Pause session" del mock de referencia)

## Test plan
- [ ] Llegar a un presupuesto con Dual Read + Paso 1 + Paso 2 confirmados → aparece "¿Confirmás para generar PDF y Excel?"
- [ ] Verificar Confirmar celeste, full-width, hover con brillo
- [ ] Verificar Corregir al costado, bordeado, focus en textarea al clickear

🤖 Generated with [Claude Code](https://claude.com/claude-code)