### PR TITLE
feat(detail): edición manual de campos simples del presupuesto

### DIFF
--- a/api/tests/test_router.py
+++ b/api/tests/test_router.py
@@ -306,6 +306,74 @@ class TestPatchQuote:
         resp = await client.patch(f"/api/quotes/{qid}", json={})
         assert resp.status_code == 400
 
+    @pytest.mark.asyncio
+    async def test_patch_notes(self, client):
+        qid = (await client.post("/api/quotes")).json()["id"]
+        notes = "Medir in situ antes del corte.\nCliente prefiere filo recto."
+        resp = await client.patch(f"/api/quotes/{qid}", json={"notes": notes})
+        assert resp.status_code == 200
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        assert detail["notes"] == notes
+
+    @pytest.mark.asyncio
+    async def test_patch_project(self, client):
+        qid = (await client.post("/api/quotes")).json()["id"]
+        resp = await client.patch(f"/api/quotes/{qid}", json={"project": "Cocina 1er piso"})
+        assert resp.status_code == 200
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        assert detail["project"] == "Cocina 1er piso"
+
+    @pytest.mark.asyncio
+    async def test_patch_client_name_max_length_exceeded(self, client):
+        qid = (await client.post("/api/quotes")).json()["id"]
+        resp = await client.patch(
+            f"/api/quotes/{qid}",
+            json={"client_name": "x" * 501},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_patch_empty_string_replaces_value(self, client):
+        """Empty string is a valid write — operator can blank a field."""
+        qid = (await client.post("/api/quotes")).json()["id"]
+        await client.patch(f"/api/quotes/{qid}", json={"client_name": "Juan"})
+        await client.patch(f"/api/quotes/{qid}", json={"client_name": ""})
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        assert detail["client_name"] == ""
+
+    @pytest.mark.asyncio
+    async def test_patch_bool_false_writes(self, client):
+        """Booleans set to False must persist (exclude_none=True must still include False)."""
+        qid = (await client.post("/api/quotes")).json()["id"]
+        await client.patch(f"/api/quotes/{qid}", json={"colocacion": True, "anafe": True})
+        await client.patch(f"/api/quotes/{qid}", json={"colocacion": False, "anafe": False})
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        assert detail["colocacion"] is False
+        assert detail["anafe"] is False
+
+    @pytest.mark.asyncio
+    async def test_patch_all_editable_fields_together(self, client):
+        """Operator can PATCH the full editable set in one request."""
+        qid = (await client.post("/api/quotes")).json()["id"]
+        payload = {
+            "client_name": "Natalia",
+            "project": "Echesortu",
+            "material": "Granito Negro Boreal",
+            "client_phone": "341-5555555",
+            "client_email": "natalia@test.com",
+            "localidad": "Rosario",
+            "pileta": "empotrada_cliente",
+            "colocacion": True,
+            "anafe": False,
+            "notes": "Edificio de 2 plantas",
+        }
+        resp = await client.patch(f"/api/quotes/{qid}", json=payload)
+        assert resp.status_code == 200
+        assert set(resp.json()["updated"]) == set(payload.keys())
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        for k, v in payload.items():
+            assert detail[k] == v
+
 
 # ── X-API-Key auth fallback ─────────────────────────────────────────────────
 

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -77,6 +77,7 @@ body::after {
 @keyframes pulse { 0%,100%{opacity:.25;transform:scale(.7)} 50%{opacity:1;transform:scale(1)} }
 @keyframes fadeUp { from{opacity:0;transform:translateY(6px)} to{opacity:1;transform:translateY(0)} }
 @keyframes fadeIn { from{opacity:0;transform:translateY(6px)} to{opacity:1;transform:translateY(0)} }
+@keyframes spin { to { transform: rotate(360deg); } }
 
 .msg-anim { animation: fadeUp 0.25s ease; }
 

--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useRouter, useParams } from "next/navigation";
-import { fetchQuote, streamChat, markQuoteAsRead, validateQuote, type QuoteDetail } from "@/lib/api";
+import { fetchQuote, streamChat, markQuoteAsRead, validateQuote, updateQuote, type QuoteDetail, type QuoteEditablePatch } from "@/lib/api";
 import { useQuotes } from "@/lib/quotes-context";
 import MessageBubble from "@/components/chat/MessageBubble";
 import CopyButton from "@/components/chat/CopyButton";
@@ -12,6 +12,7 @@ import { ResumenObraCard } from "@/components/quote/ResumenObraCard";
 import { EmailDraftCard } from "@/components/quote/EmailDraftCard";
 import { CondicionesCard } from "@/components/quote/CondicionesCard";
 import RegenerateButton from "@/components/quote/RegenerateButton";
+import EditableField from "@/components/quote/EditableField";
 import clsx from "clsx";
 import { A, I, O, N, DOT, SUP2, DASH, ITEM, WARN, CIRCLE, ARROW, XMARK, CLOUD, WAVE, PAGE, PICTURE, CLIP, RULER, TAG, FOLDER, CHART } from "@/lib/chars";
 
@@ -385,6 +386,12 @@ export default function QuotePage() {
     }
   }, [quoteId, generating]);
 
+  const handleFieldUpdate = useCallback(async (patch: QuoteEditablePatch) => {
+    await updateQuote(quoteId, patch);
+    setQuote((prev) => (prev ? ({ ...prev, ...patch } as QuoteDetail) : prev));
+    refreshQuotes();
+  }, [quoteId, refreshQuotes]);
+
   const onKey = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); send(); }
   };
@@ -444,7 +451,7 @@ export default function QuotePage() {
       {/* Content */}
       {tab === "detail" ? (
         <div className="flex-1 overflow-y-auto px-4 md:px-7 py-4 md:py-6">
-          <DetailView quote={quote} breakdown={bd} onSwitchToChat={() => setTab("chat")} onGenerate={quote?.status === "pending" || quote?.status === "draft" ? handleGenerate : undefined} generating={generating} />
+          <DetailView quote={quote} breakdown={bd} onSwitchToChat={() => setTab("chat")} onGenerate={quote?.status === "pending" || quote?.status === "draft" ? handleGenerate : undefined} generating={generating} onFieldUpdate={handleFieldUpdate} />
           {/* Show modifications section only when quote has breakdown and is not sent */}
           {bd && quote?.status !== "sent" && (
             <Section title="Modificaciones" className="mt-5">
@@ -638,7 +645,14 @@ export default function QuotePage() {
 
 // ── DETAIL VIEW ─────────────────────────────────────────────────────────────
 
-function DetailView({ quote, breakdown, onSwitchToChat, onGenerate, generating }: { quote: QuoteDetail | null; breakdown: Record<string, any> | null; onSwitchToChat: () => void; onGenerate?: () => void; generating?: boolean }) {
+const PILETA_OPTIONS = [
+  { value: "",                  label: "(no especificado)" },
+  { value: "empotrada_cliente", label: "Empotrada (la trae el cliente)" },
+  { value: "empotrada_johnson", label: "Empotrada Johnson" },
+  { value: "apoyo",             label: "De apoyo" },
+];
+
+function DetailView({ quote, breakdown, onSwitchToChat, onGenerate, generating, onFieldUpdate }: { quote: QuoteDetail | null; breakdown: Record<string, any> | null; onSwitchToChat: () => void; onGenerate?: () => void; generating?: boolean; onFieldUpdate?: (patch: QuoteEditablePatch) => Promise<void> }) {
   if (!quote) return null;
 
   const pieces = breakdown?.sectors?.flatMap((s: any) => s.pieces || []) || [];
@@ -652,9 +666,21 @@ function DetailView({ quote, breakdown, onSwitchToChat, onGenerate, generating }
     <div className="flex flex-col gap-5">
       <Section title="Resumen">
         <div className="grid grid-cols-4 gap-4">
-          <MetaItem label="Cliente" value={quote.client_name || DASH} />
-          <MetaItem label="Proyecto" value={quote.project || DASH} />
-          <MetaItem label="Material" value={quote.material || DASH} />
+          {onFieldUpdate ? (
+            <EditableField label="Cliente" type="text" value={quote.client_name} placeholder="Nombre del cliente" onSave={(v) => onFieldUpdate({ client_name: v })} />
+          ) : (
+            <MetaItem label="Cliente" value={quote.client_name || DASH} />
+          )}
+          {onFieldUpdate ? (
+            <EditableField label="Proyecto" type="text" value={quote.project} placeholder="Nombre del proyecto/obra" onSave={(v) => onFieldUpdate({ project: v })} />
+          ) : (
+            <MetaItem label="Proyecto" value={quote.project || DASH} />
+          )}
+          {onFieldUpdate ? (
+            <EditableField label="Material" type="text" value={quote.material} placeholder="Material principal" onSave={(v) => onFieldUpdate({ material: v })} />
+          ) : (
+            <MetaItem label="Material" value={quote.material || DASH} />
+          )}
           <MetaItem label="Fecha" value={new Date(quote.created_at).toLocaleString("es-AR", { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" })} />
           <MetaItem label="Demora" value={breakdown?.delivery_days || DASH} />
           <MetaItem label="Origen" value={quote.source === "web" ? "Web (chatbot)" : "Operador"} />
@@ -666,7 +692,23 @@ function DetailView({ quote, breakdown, onSwitchToChat, onGenerate, generating }
         </div>
       </Section>
 
-      {quote.notes && (
+      {onFieldUpdate && (
+        <Section title="Datos del cliente y obra">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <EditableField label="Tel\u00e9fono" type="text" value={quote.client_phone} placeholder="Ej: 341-1234567" onSave={(v) => onFieldUpdate({ client_phone: v })} />
+            <EditableField label="Email" type="text" value={quote.client_email} placeholder="nombre@dominio.com" onSave={(v) => onFieldUpdate({ client_email: v })} />
+            <EditableField label="Localidad" type="text" value={quote.localidad} placeholder="Ej: Rosario" onSave={(v) => onFieldUpdate({ localidad: v })} />
+            <EditableField label="Pileta" type="select" value={quote.pileta || ""} options={PILETA_OPTIONS} onSave={(v) => onFieldUpdate({ pileta: v })} />
+            <EditableField label="Colocaci\u00f3n" type="toggle" value={quote.colocacion} onSave={(v) => onFieldUpdate({ colocacion: v })} />
+            <EditableField label="Anafe" type="toggle" value={quote.anafe} onSave={(v) => onFieldUpdate({ anafe: v })} />
+            <div className="md:col-span-2">
+              <EditableField label="Notas" type="textarea" value={quote.notes} placeholder="Notas internas del presupuesto" onSave={(v) => onFieldUpdate({ notes: v })} />
+            </div>
+          </div>
+        </Section>
+      )}
+
+      {!onFieldUpdate && quote.notes && (
         <Section title="Notas del cliente">
           <p className="text-[13px] text-t2 leading-[1.65] whitespace-pre-wrap">{quote.notes}</p>
         </Section>

--- a/web/src/components/quote/EditableField.tsx
+++ b/web/src/components/quote/EditableField.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type FieldType = "text" | "textarea" | "select" | "toggle";
+
+interface BaseProps {
+  label: string;
+  type: FieldType;
+  disabled?: boolean;
+  highlight?: boolean;
+  placeholder?: string;
+}
+
+interface TextProps extends BaseProps {
+  type: "text" | "textarea";
+  value: string | null | undefined;
+  onSave: (next: string) => Promise<void>;
+  options?: never;
+}
+
+interface SelectProps extends BaseProps {
+  type: "select";
+  value: string | null | undefined;
+  onSave: (next: string) => Promise<void>;
+  options: Array<{ value: string; label: string }>;
+}
+
+interface ToggleProps extends BaseProps {
+  type: "toggle";
+  value: boolean | null | undefined;
+  onSave: (next: boolean) => Promise<void>;
+  options?: never;
+}
+
+type Props = TextProps | SelectProps | ToggleProps;
+
+const LABEL_STYLE: React.CSSProperties = {
+  fontSize: 10,
+  color: "var(--t3)",
+  textTransform: "uppercase",
+  letterSpacing: "0.08em",
+  marginBottom: 3,
+  display: "flex",
+  alignItems: "center",
+  gap: 6,
+};
+const VALUE_STYLE: React.CSSProperties = {
+  fontSize: 14,
+  color: "var(--t2)",
+  minHeight: 20,
+  lineHeight: 1.4,
+};
+const EMPTY_STYLE: React.CSSProperties = { ...VALUE_STYLE, color: "var(--t3)", fontStyle: "italic" };
+const INPUT_STYLE: React.CSSProperties = {
+  width: "100%",
+  padding: "6px 8px",
+  fontSize: 14,
+  fontFamily: "inherit",
+  background: "var(--s2)",
+  color: "var(--t1)",
+  border: "1px solid var(--acc)",
+  borderRadius: 6,
+  outline: "none",
+};
+const BTN: React.CSSProperties = {
+  padding: "4px 10px",
+  fontSize: 11,
+  fontWeight: 500,
+  borderRadius: 6,
+  border: "1px solid var(--b2)",
+  background: "transparent",
+  color: "var(--t2)",
+  cursor: "pointer",
+  fontFamily: "inherit",
+};
+const BTN_PRIMARY: React.CSSProperties = {
+  ...BTN,
+  background: "var(--acc)",
+  borderColor: "var(--acc)",
+  color: "#fff",
+};
+
+export default function EditableField(props: Props) {
+  const { label, type, disabled, highlight, placeholder } = props;
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<string>(() => stringifyValue(props));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hover, setHover] = useState(false);
+  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | null>(null);
+
+  useEffect(() => {
+    if (!editing) setDraft(stringifyValue(props));
+  }, [props, editing]);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      if ("select" in inputRef.current) (inputRef.current as HTMLInputElement).select?.();
+    }
+  }, [editing]);
+
+  const startEdit = () => {
+    if (disabled || saving) return;
+    setError(null);
+    setDraft(stringifyValue(props));
+    setEditing(true);
+  };
+
+  const cancel = () => {
+    setEditing(false);
+    setError(null);
+    setDraft(stringifyValue(props));
+  };
+
+  const commit = async (rawNext: string | boolean) => {
+    setSaving(true);
+    setError(null);
+    try {
+      if (type === "toggle") {
+        await (props as ToggleProps).onSave(Boolean(rawNext));
+      } else {
+        await (props as TextProps | SelectProps).onSave(String(rawNext));
+      }
+      setEditing(false);
+    } catch (e: any) {
+      setError(e?.message || "No se pudo guardar");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // ── TOGGLE: no edit mode, instant save ────────────────────────────────────
+  if (type === "toggle") {
+    const checked = Boolean((props as ToggleProps).value);
+    return (
+      <div>
+        <div style={LABEL_STYLE}>{label}</div>
+        <label
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 8,
+            cursor: disabled || saving ? "not-allowed" : "pointer",
+            opacity: disabled || saving ? 0.6 : 1,
+          }}
+        >
+          <span
+            style={{
+              width: 32, height: 18, borderRadius: 9,
+              background: checked ? "var(--acc)" : "var(--b2)",
+              position: "relative", transition: "background 0.15s",
+              flexShrink: 0,
+            }}
+          >
+            <span
+              style={{
+                position: "absolute", top: 2, left: checked ? 16 : 2,
+                width: 14, height: 14, borderRadius: "50%",
+                background: "#fff", transition: "left 0.15s",
+              }}
+            />
+          </span>
+          <input
+            type="checkbox"
+            checked={checked}
+            disabled={disabled || saving}
+            onChange={(e) => commit(e.target.checked)}
+            style={{ position: "absolute", opacity: 0, pointerEvents: "none" }}
+          />
+          <span style={{ fontSize: 13, color: "var(--t2)" }}>{checked ? "Sí" : "No"}</span>
+          {saving && <Spinner />}
+        </label>
+        {error && <ErrorLine message={error} />}
+      </div>
+    );
+  }
+
+  // ── TEXT / TEXTAREA / SELECT: click-to-edit ───────────────────────────────
+  const rawValue = stringifyValue(props);
+  const hasValue = rawValue.trim().length > 0;
+
+  return (
+    <div
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+    >
+      <div style={LABEL_STYLE}>
+        <span>{label}</span>
+        {!editing && hover && !disabled && (
+          <button
+            type="button"
+            onClick={startEdit}
+            aria-label={`Editar ${label}`}
+            style={{
+              background: "transparent", border: "none", padding: 0,
+              color: "var(--acc)", cursor: "pointer", fontSize: 11, lineHeight: 1,
+            }}
+          >
+            ✏
+          </button>
+        )}
+      </div>
+
+      {editing ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {type === "textarea" ? (
+            <textarea
+              ref={(el) => { inputRef.current = el; }}
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") cancel();
+                // Ctrl/Cmd+Enter to save in textarea
+                if ((e.ctrlKey || e.metaKey) && e.key === "Enter") commit(draft);
+              }}
+              placeholder={placeholder}
+              rows={3}
+              disabled={saving}
+              style={{ ...INPUT_STYLE, resize: "vertical", minHeight: 60 }}
+            />
+          ) : type === "select" ? (
+            <select
+              ref={(el) => { inputRef.current = el; }}
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Escape") cancel(); }}
+              disabled={saving}
+              style={INPUT_STYLE}
+            >
+              {(props as SelectProps).options.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          ) : (
+            <input
+              ref={(el) => { inputRef.current = el; }}
+              type="text"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") cancel();
+                if (e.key === "Enter") commit(draft);
+              }}
+              placeholder={placeholder}
+              disabled={saving}
+              style={INPUT_STYLE}
+            />
+          )}
+          <div style={{ display: "flex", gap: 6 }}>
+            <button
+              type="button"
+              onClick={() => commit(draft)}
+              disabled={saving || draft === stringifyValue(props)}
+              style={{ ...BTN_PRIMARY, opacity: saving || draft === stringifyValue(props) ? 0.5 : 1 }}
+            >
+              {saving ? "Guardando..." : "Guardar"}
+            </button>
+            <button type="button" onClick={cancel} disabled={saving} style={BTN}>
+              Cancelar
+            </button>
+          </div>
+          {error && <ErrorLine message={error} />}
+        </div>
+      ) : (
+        <div
+          onClick={startEdit}
+          title={disabled ? undefined : "Clic para editar"}
+          style={{
+            ...(hasValue ? VALUE_STYLE : EMPTY_STYLE),
+            fontWeight: highlight ? 600 : 400,
+            color: highlight && hasValue ? "var(--t1)" : hasValue ? "var(--t2)" : "var(--t3)",
+            cursor: disabled ? "default" : "text",
+            whiteSpace: type === "textarea" ? "pre-wrap" : undefined,
+          }}
+        >
+          {hasValue ? rawValue : (placeholder || "—")}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function stringifyValue(props: Props): string {
+  if (props.type === "toggle") return props.value ? "true" : "false";
+  const v = props.value;
+  if (v == null) return "";
+  return String(v);
+}
+
+function Spinner() {
+  return (
+    <span
+      style={{
+        width: 10, height: 10, borderRadius: "50%",
+        border: "2px solid var(--b2)", borderTopColor: "var(--acc)",
+        animation: "spin 0.8s linear infinite", display: "inline-block",
+      }}
+    />
+  );
+}
+
+function ErrorLine({ message }: { message: string }) {
+  return <div style={{ fontSize: 11, color: "var(--red, #f87171)", marginTop: 4 }}>{message}</div>;
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -38,6 +38,12 @@ export interface Quote {
   source: string | null;
   is_read: boolean;
   notes: string | null;
+  client_phone: string | null;
+  client_email: string | null;
+  localidad: string | null;
+  colocacion: boolean | null;
+  pileta: string | null;
+  anafe: boolean | null;
   sink_type: { basin_count: "simple" | "doble"; mount_type: "arriba" | "abajo" } | null;
   resumen_obra?: ResumenObraRecord | null;
   condiciones_pdf?: {
@@ -178,6 +184,33 @@ export async function deleteQuote(id: string): Promise<void> {
 export async function markQuoteAsRead(id: string): Promise<void> {
   const res = await fetch(`${API_BASE}/api/quotes/${id}/read`, { method: "PATCH", credentials: "include" });
   if (!res.ok) throw new Error("Error al marcar como leído");
+}
+
+export type QuoteEditablePatch = Partial<{
+  client_name: string;
+  project: string;
+  material: string;
+  client_phone: string;
+  client_email: string;
+  localidad: string;
+  notes: string;
+  pileta: string;
+  colocacion: boolean;
+  anafe: boolean;
+}>;
+
+export async function updateQuote(id: string, patch: QuoteEditablePatch): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/quotes/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(patch),
+    credentials: "include",
+  });
+  handleAuthError(res);
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || "Error al actualizar presupuesto");
+  }
 }
 
 // ── Derive Material ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Nuevo componente `EditableField` reutilizable (text / textarea / select / toggle) con edición inline: click-to-edit, Enter/Esc, botones Guardar/Cancelar, loading mientras PATCHea y rollback en error.
- En **Resumen** ahora Cliente / Proyecto / Material son editables.
- Nueva sección **"Datos del cliente y obra"** con: Teléfono, Email, Localidad, Pileta (select con valores canónicos), Colocación y Anafe (toggles), Notas (textarea).
- Edición disponible en cualquier estado (draft/pending/validated/sent) — herramienta interna del operador.
- Cliente API `updateQuote()` que usa el `PATCH /quotes/:id` que ya existía.
- **La edición vía IA no se toca.** El chat sigue funcionando igual, sobre `quote_breakdown`.

## Tests
- pytest `TestPatchQuote` extendido con: `notes`, `project`, `max_length exceeded → 422`, empty-string clears, bool `False` persists, PATCH combinado de todo el set editable.

## Test plan manual
- [ ] Abrir presupuesto → pestaña Detalle → hover sobre Cliente → click lápiz → editar → Guardar (debería reflejarse en sidebar).
- [ ] Esc cancela. Enter guarda (Ctrl+Enter en textarea de Notas).
- [ ] Toggle Colocación / Anafe → guarda al instante.
- [ ] Select Pileta → cambiar opción → guarda.
- [ ] Verificar que el chat con Valentina sigue funcionando sin cambios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)