### PR TITLE
feat(detail): scope edición a Cliente/Proyecto/Notas + regen los respeta

### DIFF
--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -442,6 +442,29 @@ async def validate_quote(
 #   - Solo actualiza las URLs de archivos (pdf_url, excel_url, drive_url,
 #     drive_file_id) y appendea un entry a change_history para auditoría.
 
+def _build_regenerate_doc_data(quote: Quote, bd: dict) -> dict:
+    """Prep doc_data for /regenerate: start from the cached breakdown and
+    override the fields that the operator can edit manually (no recalc).
+
+    `setdefault` for the rest — legacy breakdowns that might be missing keys
+    get filled from the Quote columns; newer breakdowns keep their values.
+    """
+    doc_data = dict(bd)
+    # Editable-from-detail-view fields: the operator may have edited these via
+    # PATCH /quotes/:id after the breakdown was cached. Force-override so the
+    # regenerated PDF/Excel reflects the latest values.
+    doc_data["client_name"] = quote.client_name
+    doc_data["project"] = quote.project
+    doc_data["notes"] = quote.notes
+    doc_data.setdefault("material_name", quote.material)
+    doc_data.setdefault("total_ars", quote.total_ars)
+    doc_data.setdefault("total_usd", quote.total_usd)
+    doc_data.setdefault("discount_pct", 0)
+    doc_data.setdefault("sectors", [])
+    doc_data.setdefault("mo_items", [])
+    return doc_data
+
+
 @router.post("/quotes/{quote_id}/regenerate")
 async def regenerate_quote_docs(
     quote_id: str,
@@ -464,17 +487,7 @@ async def regenerate_quote_docs(
     from app.modules.agent.tools.document_tool import generate_documents
     from app.modules.agent.tools.drive_tool import upload_to_drive, delete_drive_file
 
-    # Same fallback pattern as /validate (line 370+): breakdown is source of
-    # truth, fill only fields that legacy quotes might not have.
-    doc_data = dict(bd)
-    doc_data.setdefault("client_name", quote.client_name)
-    doc_data.setdefault("project", quote.project)
-    doc_data.setdefault("material_name", quote.material)
-    doc_data.setdefault("total_ars", quote.total_ars)
-    doc_data.setdefault("total_usd", quote.total_usd)
-    doc_data.setdefault("discount_pct", 0)
-    doc_data.setdefault("sectors", [])
-    doc_data.setdefault("mo_items", [])
+    doc_data = _build_regenerate_doc_data(quote, bd)
 
     doc_result = await generate_documents(quote_id, doc_data)
     if not doc_result.get("ok"):

--- a/api/tests/test_router.py
+++ b/api/tests/test_router.py
@@ -375,6 +375,79 @@ class TestPatchQuote:
             assert detail[k] == v
 
 
+# ── /regenerate helper: ediciones manuales pisan breakdown cacheado ─────────
+
+class TestRegenerateDocDataBuild:
+    """_build_regenerate_doc_data should override client_name/project/notes
+    from the Quote column (manual edits via detail view) rather than trust
+    the stale copies inside the cached breakdown."""
+
+    def test_overrides_client_name_project_notes_from_quote(self):
+        from app.modules.agent.router import _build_regenerate_doc_data
+        from app.models.quote import Quote
+
+        quote = Quote(
+            id="q1",
+            client_name="Natalia (editada)",
+            project="Echesortu (editado)",
+            material="Granito Negro Boreal",
+            notes="Nota editada manualmente",
+            total_ars=100000,
+            total_usd=100,
+        )
+        stale_bd = {
+            "client_name": "Nombre viejo",
+            "project": "Proyecto viejo",
+            "notes": "Nota vieja",
+            "material_name": "Granito Negro Boreal",
+            "sectors": [{"label": "cocina", "pieces": ["mesada"]}],
+            "mo_items": [],
+            "total_ars": 100000,
+            "total_usd": 100,
+        }
+
+        data = _build_regenerate_doc_data(quote, stale_bd)
+
+        assert data["client_name"] == "Natalia (editada)"
+        assert data["project"] == "Echesortu (editado)"
+        assert data["notes"] == "Nota editada manualmente"
+        # El resto del breakdown queda intacto
+        assert data["sectors"] == stale_bd["sectors"]
+        assert data["material_name"] == "Granito Negro Boreal"
+        assert data["total_ars"] == 100000
+
+    def test_empty_notes_on_quote_clears_stale_notes(self):
+        """Si el operador borra notas manualmente (notes=None o ''),
+        no deben quedar las viejas del breakdown."""
+        from app.modules.agent.router import _build_regenerate_doc_data
+        from app.models.quote import Quote
+
+        quote = Quote(id="q1", client_name="X", project="Y", notes=None)
+        stale_bd = {"client_name": "A", "project": "B", "notes": "vieja"}
+
+        data = _build_regenerate_doc_data(quote, stale_bd)
+        assert data["notes"] is None
+
+    def test_setdefault_fills_legacy_breakdowns_missing_keys(self):
+        """Breakdowns viejos pueden no tener sectors/mo_items/totals — fallback."""
+        from app.modules.agent.router import _build_regenerate_doc_data
+        from app.models.quote import Quote
+
+        quote = Quote(
+            id="q1", client_name="X", project="Y",
+            material="Silestone", total_ars=50000, total_usd=50, notes=None,
+        )
+        legacy_bd = {}
+
+        data = _build_regenerate_doc_data(quote, legacy_bd)
+        assert data["material_name"] == "Silestone"
+        assert data["total_ars"] == 50000
+        assert data["total_usd"] == 50
+        assert data["discount_pct"] == 0
+        assert data["sectors"] == []
+        assert data["mo_items"] == []
+
+
 # ── X-API-Key auth fallback ─────────────────────────────────────────────────
 
 class TestApiKeyAuth:

--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -645,13 +645,6 @@ export default function QuotePage() {
 
 // ── DETAIL VIEW ─────────────────────────────────────────────────────────────
 
-const PILETA_OPTIONS = [
-  { value: "",                  label: "(no especificado)" },
-  { value: "empotrada_cliente", label: "Empotrada (la trae el cliente)" },
-  { value: "empotrada_johnson", label: "Empotrada Johnson" },
-  { value: "apoyo",             label: "De apoyo" },
-];
-
 function DetailView({ quote, breakdown, onSwitchToChat, onGenerate, generating, onFieldUpdate }: { quote: QuoteDetail | null; breakdown: Record<string, any> | null; onSwitchToChat: () => void; onGenerate?: () => void; generating?: boolean; onFieldUpdate?: (patch: QuoteEditablePatch) => Promise<void> }) {
   if (!quote) return null;
 
@@ -676,11 +669,7 @@ function DetailView({ quote, breakdown, onSwitchToChat, onGenerate, generating, 
           ) : (
             <MetaItem label="Proyecto" value={quote.project || DASH} />
           )}
-          {onFieldUpdate ? (
-            <EditableField label="Material" type="text" value={quote.material} placeholder="Material principal" onSave={(v) => onFieldUpdate({ material: v })} />
-          ) : (
-            <MetaItem label="Material" value={quote.material || DASH} />
-          )}
+          <MetaItem label="Material" value={quote.material || DASH} />
           <MetaItem label="Fecha" value={new Date(quote.created_at).toLocaleString("es-AR", { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" })} />
           <MetaItem label="Demora" value={breakdown?.delivery_days || DASH} />
           <MetaItem label="Origen" value={quote.source === "web" ? "Web (chatbot)" : "Operador"} />
@@ -692,26 +681,22 @@ function DetailView({ quote, breakdown, onSwitchToChat, onGenerate, generating, 
         </div>
       </Section>
 
-      {onFieldUpdate && (
-        <Section title="Datos del cliente y obra">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <EditableField label="Tel\u00e9fono" type="text" value={quote.client_phone} placeholder="Ej: 341-1234567" onSave={(v) => onFieldUpdate({ client_phone: v })} />
-            <EditableField label="Email" type="text" value={quote.client_email} placeholder="nombre@dominio.com" onSave={(v) => onFieldUpdate({ client_email: v })} />
-            <EditableField label="Localidad" type="text" value={quote.localidad} placeholder="Ej: Rosario" onSave={(v) => onFieldUpdate({ localidad: v })} />
-            <EditableField label="Pileta" type="select" value={quote.pileta || ""} options={PILETA_OPTIONS} onSave={(v) => onFieldUpdate({ pileta: v })} />
-            <EditableField label="Colocaci\u00f3n" type="toggle" value={quote.colocacion} onSave={(v) => onFieldUpdate({ colocacion: v })} />
-            <EditableField label="Anafe" type="toggle" value={quote.anafe} onSave={(v) => onFieldUpdate({ anafe: v })} />
-            <div className="md:col-span-2">
-              <EditableField label="Notas" type="textarea" value={quote.notes} placeholder="Notas internas del presupuesto" onSave={(v) => onFieldUpdate({ notes: v })} />
-            </div>
-          </div>
+      {onFieldUpdate ? (
+        <Section title="Notas">
+          <EditableField
+            label="Notas del presupuesto"
+            type="textarea"
+            value={quote.notes}
+            placeholder="Notas internas (aparecen en el PDF al regenerar)"
+            onSave={(v) => onFieldUpdate({ notes: v })}
+          />
         </Section>
-      )}
-
-      {!onFieldUpdate && quote.notes && (
-        <Section title="Notas del cliente">
-          <p className="text-[13px] text-t2 leading-[1.65] whitespace-pre-wrap">{quote.notes}</p>
-        </Section>
+      ) : (
+        quote.notes && (
+          <Section title="Notas del cliente">
+            <p className="text-[13px] text-t2 leading-[1.65] whitespace-pre-wrap">{quote.notes}</p>
+          </Section>
+        )
       )}
 
       {/* PR #24 — Condiciones de Contratación: solo edificios. Se genera

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -38,12 +38,6 @@ export interface Quote {
   source: string | null;
   is_read: boolean;
   notes: string | null;
-  client_phone: string | null;
-  client_email: string | null;
-  localidad: string | null;
-  colocacion: boolean | null;
-  pileta: string | null;
-  anafe: boolean | null;
   sink_type: { basin_count: "simple" | "doble"; mount_type: "arriba" | "abajo" } | null;
   resumen_obra?: ResumenObraRecord | null;
   condiciones_pdf?: {
@@ -189,14 +183,7 @@ export async function markQuoteAsRead(id: string): Promise<void> {
 export type QuoteEditablePatch = Partial<{
   client_name: string;
   project: string;
-  material: string;
-  client_phone: string;
-  client_email: string;
-  localidad: string;
   notes: string;
-  pileta: string;
-  colocacion: boolean;
-  anafe: boolean;
 }>;
 
 export async function updateQuote(id: string, patch: QuoteEditablePatch): Promise<void> {


### PR DESCRIPTION
## Summary
Después del PR anterior (#275) el scope de edición manual era demasiado amplio. Ahora:
- **Solo editables**: Cliente, Proyecto, Notas.
- **Material, Teléfono, Email, Localidad, Pileta, Colocación, Anafe**: **no editables manualmente** — se modifican vía chat con Valentina, que recalcula todo (material, flete, piletas, etc.).
- **Bug fix crítico en regenerate**: `doc_data.setdefault("client_name", quote.client_name)` no pisaba el valor si el breakdown ya lo tenía → editabas Cliente y el PDF regenerado salía con el nombre viejo. Ahora los 3 editables pisan explícitamente el breakdown.

## Frontend
- `QuoteEditablePatch` shrink a `{ client_name?, project?, notes? }`.
- `Quote` interface vuelve al estado previo (sin `client_phone`/`email`/`localidad`/`colocacion`/`pileta`/`anafe`).
- DetailView: quita EditableField de Material, elimina sección completa "Datos del cliente y obra", deja Notas como sección editable dedicada.

## Backend
- Nuevo helper `_build_regenerate_doc_data(quote, bd)` en `router.py`:
  - Override explícito de `client_name` / `project` / `notes` desde las columnas del Quote (editados en detalle).
  - `setdefault` para el resto (compatibilidad con breakdowns legacy).

## Tests
`TestRegenerateDocDataBuild` nuevo:
- `test_overrides_client_name_project_notes_from_quote` — ediciones pisan bd stale.
- `test_empty_notes_on_quote_clears_stale_notes` — borrar notas se refleja.
- `test_setdefault_fills_legacy_breakdowns_missing_keys` — fallback para breakdowns viejos.

## Test plan manual
- [ ] Regenerar un presupuesto viejo sin editar nada → PDF igual que antes (no regresión).
- [ ] Editar Cliente en detalle → Regenerar → PDF tiene el nombre nuevo.
- [ ] Editar Notas → Regenerar → PDF tiene las notas nuevas.
- [ ] Cambiar material vía chat con Valentina → recalcula todo (comportamiento previo intacto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)