### PR TITLE
rules: Valentina cuenta múltiples anafes (gas + eléctrico)

### DIFF
--- a/api/rules/plan-reading.md
+++ b/api/rules/plan-reading.md
@@ -198,6 +198,36 @@ anafe/hornallas **empotradas en mesada** → MO obligatoria `anafe=True` +
 (o `empotrada_johnson` si es Johnson). No olvidar ninguno de los dos aunque
 el brief no los repita en texto — el plano ES el brief.
 
+### ⛔ REGLA — MÚLTIPLES ANAFES EN LA MISMA COCINA
+
+En una cocina puede haber **más de un anafe empotrado** — típicamente uno a
+gas y otro eléctrico (o vitrocerámica), dibujados separados pero en la misma
+mesada. **Contarlos como unidades independientes.**
+
+**Cómo detectarlos:**
+- Cada anafe = 1 grupo de hornallas dibujado en un rectángulo/cuadrado propio
+  dentro de la mesada (típicamente 4-6 círculos en grilla).
+- Etiquetas visibles: `"anafe a gas"`, `"anafe eléctrico"`, `"vitrocerámica"`,
+  `"inducción"`, o figuras separadas una al lado de la otra / una arriba
+  de la otra sin contigüidad.
+- Si en el plano hay **2 rectángulos con hornallas separados por un gap o
+  por una línea → son 2 anafes, no uno más ancho**.
+
+**Regla de cotización:**
+- `anafe = True`
+- `anafe_qty = N` (cantidad total de anafes detectados en esta cocina)
+- El calculator ya agrega `N` agujeros en la MO (línea "Agujero anafe" × N).
+
+**Cuándo preguntar:**
+- Si detectás 2+ símbolos de anafe en el plano **y el brief no los menciona
+  explícitamente** → PREGUNTAR confirmando:
+  > "Veo 2 anafes en el plano (gas + eléctrico / vitrocerámica). ¿Los cotizo
+  > ambos como anafes empotrados en esta mesada?"
+- Si el brief dice "anafe" (singular) pero el plano muestra 2 → PREGUNTAR
+  igual, es discrepancia.
+- Si el brief dice "2 anafes" / "anafe gas + eléctrico" y el plano lo
+  confirma → **NO preguntar**, cotizar directo con `anafe_qty=2`.
+
 ### ⛔ EXCEPCIÓN — Cocina entera (horno + anafe free-standing)
 
 Si el plano muestra una **cocina entera free-standing** (horno con puerta

--- a/api/rules/plan-reading.md
+++ b/api/rules/plan-reading.md
@@ -198,35 +198,17 @@ anafe/hornallas **empotradas en mesada** → MO obligatoria `anafe=True` +
 (o `empotrada_johnson` si es Johnson). No olvidar ninguno de los dos aunque
 el brief no los repita en texto — el plano ES el brief.
 
-### ⛔ REGLA — MÚLTIPLES ANAFES EN LA MISMA COCINA
+### ⛔ MÚLTIPLES ANAFES EN LA MISMA COCINA
 
-En una cocina puede haber **más de un anafe empotrado** — típicamente uno a
-gas y otro eléctrico (o vitrocerámica), dibujados separados pero en la misma
-mesada. **Contarlos como unidades independientes.**
+Puede haber >1 anafe empotrado (ej: gas + eléctrico/vitrocerámica) en la
+misma mesada. Cada rectángulo con hornallas separado = 1 anafe (no un único
+anafe más ancho). Etiquetas típicas: "anafe a gas", "anafe eléctrico",
+"vitrocerámica", "inducción".
 
-**Cómo detectarlos:**
-- Cada anafe = 1 grupo de hornallas dibujado en un rectángulo/cuadrado propio
-  dentro de la mesada (típicamente 4-6 círculos en grilla).
-- Etiquetas visibles: `"anafe a gas"`, `"anafe eléctrico"`, `"vitrocerámica"`,
-  `"inducción"`, o figuras separadas una al lado de la otra / una arriba
-  de la otra sin contigüidad.
-- Si en el plano hay **2 rectángulos con hornallas separados por un gap o
-  por una línea → son 2 anafes, no uno más ancho**.
+Cotizar con `anafe=True` + `anafe_qty=N` (el calculator agrega N líneas).
 
-**Regla de cotización:**
-- `anafe = True`
-- `anafe_qty = N` (cantidad total de anafes detectados en esta cocina)
-- El calculator ya agrega `N` agujeros en la MO (línea "Agujero anafe" × N).
-
-**Cuándo preguntar:**
-- Si detectás 2+ símbolos de anafe en el plano **y el brief no los menciona
-  explícitamente** → PREGUNTAR confirmando:
-  > "Veo 2 anafes en el plano (gas + eléctrico / vitrocerámica). ¿Los cotizo
-  > ambos como anafes empotrados en esta mesada?"
-- Si el brief dice "anafe" (singular) pero el plano muestra 2 → PREGUNTAR
-  igual, es discrepancia.
-- Si el brief dice "2 anafes" / "anafe gas + eléctrico" y el plano lo
-  confirma → **NO preguntar**, cotizar directo con `anafe_qty=2`.
+Preguntar si: detectás 2+ símbolos y brief dice "anafe" singular o no lo
+aclara. NO preguntar si brief ya confirma la cantidad.
 
 ### ⛔ EXCEPCIÓN — Cocina entera (horno + anafe free-standing)
 

--- a/api/tests/test_five_fixes.py
+++ b/api/tests/test_five_fixes.py
@@ -315,6 +315,58 @@ class TestAlvaroTorresCase:
         assert "warnings" not in result or len(result.get("warnings", [])) == 0
 
 
+# ── Residential: multiple anafes (gas + eléctrico) in one kitchen ───────────
+
+class TestResidentialMultipleAnafes:
+    """Caso Bernardi: cocina con 2 anafes empotrados (gas + eléctrico) en
+    la misma mesada. Valentina debe pasar `anafe_qty=2` y el calculator
+    debe agregar 1 línea "Agujero anafe" con quantity=2."""
+
+    def test_anafe_qty_2_doubles_mo_quantity(self):
+        result = calculate_quote({
+            "client_name": "Érica Bernardi",
+            "project": "Cocina",
+            "material": "Puraprima Onix White",
+            "pieces": [
+                {"description": "Mesada lateral", "largo": 2.95, "prof": 0.60},
+                {"description": "Mesada bajo",    "largo": 2.05, "prof": 0.60},
+                {"description": "Isla",           "largo": 1.60, "prof": 0.60},
+            ],
+            "localidad": "rosario",
+            "colocacion": True,
+            "anafe": True,
+            "anafe_qty": 2,
+            "pileta": "empotrada_cliente",
+        })
+
+        assert result["ok"]
+        anafe_items = [m for m in result["mo_items"]
+                       if "anafe" in m["description"].lower()]
+        # Debe haber exactamente 1 línea de anafe con quantity=2 (no 2 líneas separadas)
+        assert len(anafe_items) == 1, (
+            f"Expected 1 anafe line with quantity=2, got {len(anafe_items)}: {anafe_items}"
+        )
+        assert anafe_items[0]["quantity"] == 2
+        assert anafe_items[0]["total"] == round(anafe_items[0]["unit_price"] * 2)
+
+    def test_anafe_qty_default_1_for_single_anafe(self):
+        """Sin anafe_qty explícito → default 1 (no debe duplicarse)."""
+        result = calculate_quote({
+            "client_name": "Test",
+            "project": "Cocina",
+            "material": "Silestone Blanco Norte",
+            "pieces": [{"description": "Mesada", "largo": 2.0, "prof": 0.60}],
+            "localidad": "rosario",
+            "colocacion": True,
+            "anafe": True,
+            "pileta": "empotrada_cliente",
+        })
+        anafe_items = [m for m in result["mo_items"]
+                       if "anafe" in m["description"].lower()]
+        assert len(anafe_items) == 1
+        assert anafe_items[0]["quantity"] == 1
+
+
 # ── Warnings visibility ─────────────────────────────────────────────────────
 
 class TestFleteWarnings:

--- a/api/tests/test_five_fixes.py
+++ b/api/tests/test_five_fixes.py
@@ -337,6 +337,7 @@ class TestResidentialMultipleAnafes:
             "anafe": True,
             "anafe_qty": 2,
             "pileta": "empotrada_cliente",
+            "plazo": "30 dias desde la toma de medidas",
         })
 
         assert result["ok"]
@@ -360,6 +361,7 @@ class TestResidentialMultipleAnafes:
             "colocacion": True,
             "anafe": True,
             "pileta": "empotrada_cliente",
+            "plazo": "30 dias desde la toma de medidas",
         })
         anafe_items = [m for m in result["mo_items"]
                        if "anafe" in m["description"].lower()]


### PR DESCRIPTION
## Problema
Caso **Bernardi** (brief: "material en Puraprima Onix White Mate, Cliente: Érica Bernardi" + plano con anafe a gas + anafe eléctrico en la misma cocina).

La regla de `plan-reading.md` solo daba pauta sobre un anafe. Valentina tiende a reportar `anafe: true` (singular) y el cotizador agrega 1 "Agujero anafe" cuando corresponden 2.

## Fix
- **Rule-side** (`plan-reading.md`): nueva sección "MÚLTIPLES ANAFES EN LA MISMA COCINA" con:
  - Cómo detectarlos visualmente (2 rectángulos con hornallas separados + etiquetas).
  - Cuándo preguntar vs cotizar directo (brief menciona "2 anafes" → directo; brief no menciona → confirmar).
  - Recordar usar `anafe_qty = N`.
- **Tests** (`test_five_fixes.py` → `TestResidentialMultipleAnafes`):
  - `anafe_qty=2` → exactamente 1 línea "Agujero anafe" con `quantity=2` y total correcto.
  - Default sin `anafe_qty` → `quantity=1` (regresión guard).

El calculator ya soporta `anafe_qty=N` (usado en edificios). Esta regla extiende el teaching a residencial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)