### PR TITLE
rules: Valentina distingue pileta simple vs doble

### DIFF
--- a/api/rules/plan-reading.md
+++ b/api/rules/plan-reading.md
@@ -179,16 +179,10 @@ Hatching/rayado = pared → NO canto expuesto → NO frentin. Lados sin tachar =
 
 ### ⛔ PILETA SIMPLE vs DOBLE
 
-Una bacha con 2 cavidades/óvalos dentro del mismo rectángulo/contorno =
-**pileta doble**. Una sola cavidad = **simple**. Pasar `sink_type.basin_count`
-("simple" / "doble") al calculator — afecta SKU y MO.
-
-Señales de doble en el plano: 2 óvalos contiguos, rectángulo con línea
-divisoria central, etiquetas "pileta doble", "doble bacha".
-
-Si el brief dice "doble" pero el plano muestra 1 cavidad (o viceversa) →
-PREGUNTAR qué cotizar. Si el plano no deja claro (dibujo genérico sin
-divisiones), PREGUNTAR "¿bacha simple o doble?".
+2 cavidades/óvalos dentro del mismo rectángulo = **doble**. 1 cavidad =
+**simple**. Pasar `sink_type.basin_count`. Señales de doble: 2 óvalos
+contiguos, línea divisoria central, texto "doble bacha". Si brief y plano
+no coinciden o el plano es ambiguo → PREGUNTAR "¿bacha simple o doble?".
 
 ### ⛔ Modelo de pileta — NUNCA inventar
 - **SIEMPRE** buscar el modelo exacto en `sinks.json` con `catalog_lookup("sinks", sku)`

--- a/api/rules/plan-reading.md
+++ b/api/rules/plan-reading.md
@@ -177,6 +177,19 @@ Hatching/rayado = pared → NO canto expuesto → NO frentin. Lados sin tachar =
 - "DESAGUE" sin modelo → apoyo (AGUJEROAPOYO) | Con modelo → empotrada (PEGADOPILETA)
 - 3 puntitos junto a ovalo → empotrada (PEGADOPILETA)
 
+### ⛔ PILETA SIMPLE vs DOBLE
+
+Una bacha con 2 cavidades/óvalos dentro del mismo rectángulo/contorno =
+**pileta doble**. Una sola cavidad = **simple**. Pasar `sink_type.basin_count`
+("simple" / "doble") al calculator — afecta SKU y MO.
+
+Señales de doble en el plano: 2 óvalos contiguos, rectángulo con línea
+divisoria central, etiquetas "pileta doble", "doble bacha".
+
+Si el brief dice "doble" pero el plano muestra 1 cavidad (o viceversa) →
+PREGUNTAR qué cotizar. Si el plano no deja claro (dibujo genérico sin
+divisiones), PREGUNTAR "¿bacha simple o doble?".
+
 ### ⛔ Modelo de pileta — NUNCA inventar
 - **SIEMPRE** buscar el modelo exacto en `sinks.json` con `catalog_lookup("sinks", sku)`
 - Si el plano/enunciado dice un nombre que no matchea exacto → hacer **fuzzy match**:

--- a/api/tests/test_sink_type.py
+++ b/api/tests/test_sink_type.py
@@ -39,6 +39,27 @@ class TestSinkTypePost:
         assert q["sink_type"]["mount_type"] == "abajo"
 
     @pytest.mark.asyncio
+    async def test_create_quote_with_sink_type_doble(self, client):
+        """basin_count=doble (caso Bernardi: pileta con 2 bachas) se persiste."""
+        from unittest.mock import patch
+        with patch("app.modules.quote_engine.router.upload_to_drive", return_value={"ok": True, "drive_url": "https://drive.test"}):
+            resp = await client.post("/api/v1/quote", json={
+                "client_name": "Érica Bernardi",
+                "project": "Cocina",
+                "material": "Silestone Blanco Norte",
+                "pieces": [{"description": "Mesada", "largo": 2.05, "prof": 0.60}],
+                "localidad": "Rosario",
+                "plazo": "30 dias",
+                "pileta": "empotrada_cliente",
+                "sink_type": {"basin_count": "doble", "mount_type": "abajo"},
+            })
+
+        assert resp.status_code == 200
+        qid = resp.json()["quotes"][0]["quote_id"]
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        assert detail["sink_type"]["basin_count"] == "doble"
+
+    @pytest.mark.asyncio
     async def test_create_quote_without_sink_type(self, client):
         """Omitting sink_type should not break anything."""
         from unittest.mock import patch


### PR DESCRIPTION
## Problema
Caso **Bernardi** (plano con pileta de 2 bachas): la regla de `plan-reading.md` solo diferencia apoyo vs empotrada, no simple vs doble. Sin teaching Valentina no pasa `sink_type.basin_count="doble"` y el PDF/Excel no refleja que es pileta doble.

## Fix
- **Rule-side** (`plan-reading.md`): nueva sección corta "PILETA SIMPLE vs DOBLE":
  - 2 cavidades en el mismo rectángulo/contorno → doble.
  - 1 cavidad → simple.
  - Señales: 2 óvalos contiguos, línea divisoria central.
  - Preguntar si hay discrepancia brief↔plano o el plano es ambiguo.
- **Test** (`test_sink_type.py` → `test_create_quote_with_sink_type_doble`): persiste `basin_count="doble"` (regression guard Bernardi).

El schema ya soporta `basin_count: Literal["simple", "doble"]`. El fix es teaching en las reglas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)