### PR TITLE
rules: distinguir render fotorrealista de planta técnica

### DIFF
--- a/api/rules/plan-reader-v1.md
+++ b/api/rules/plan-reader-v1.md
@@ -39,6 +39,11 @@ Antes de cualquier otra lectura, determiná qué TIPO de plano es esto:
 - `"mixed"` → Plano con múltiples vistas (planta + elevación + detalle).
   Tratar cada vista según su tipo.
 
+- `"render_fotorrealista"` → Imagen fotorrealista (Blender/V-Ray, texturas
+  y luces tipo foto, banquetas/vegetación, **sin cotas ni hatching**). NO
+  extraer medidas. Solo contexto de materiales/electrodomésticos. Si no
+  hay planta técnica aparte → PEDIRLA antes de calcular.
+
 - `"unknown"` → Si realmente no es claro. Usar reglas conservadoras de
   planta y flaguear alta `requires_human_review`.
 

--- a/api/rules/plan-reader-v1.md
+++ b/api/rules/plan-reader-v1.md
@@ -39,10 +39,9 @@ Antes de cualquier otra lectura, determiná qué TIPO de plano es esto:
 - `"mixed"` → Plano con múltiples vistas (planta + elevación + detalle).
   Tratar cada vista según su tipo.
 
-- `"render_fotorrealista"` → Imagen fotorrealista (Blender/V-Ray, texturas
-  y luces tipo foto, banquetas/vegetación, **sin cotas ni hatching**). NO
-  extraer medidas. Solo contexto de materiales/electrodomésticos. Si no
-  hay planta técnica aparte → PEDIRLA antes de calcular.
+- `"render_fotorrealista"` → Foto 3D (Blender/V-Ray, texturas y luces,
+  sin cotas). NO extraer medidas. Solo contexto. Si no hay planta técnica
+  → PEDIRLA antes de calcular.
 
 - `"unknown"` → Si realmente no es claro. Usar reglas conservadoras de
   planta y flaguear alta `requires_human_review`.

--- a/api/tests/test_render_vs_plan_rules.py
+++ b/api/tests/test_render_vs_plan_rules.py
@@ -1,0 +1,37 @@
+"""Regression: plan-reader-v1.md must teach Valentina the difference between
+photorealistic renders and technical plans.
+
+Caso Bernardi: el operador adjunta 1 PDF técnico + 2 renders fotorrealistas.
+Sin la regla, Valentina intenta extraer cotas de los renders → hallucinations.
+"""
+from pathlib import Path
+
+
+def _read_plan_reader() -> str:
+    return (Path(__file__).parent.parent / "rules" / "plan-reader-v1.md").read_text()
+
+
+def test_render_fotorrealista_view_type_documented():
+    """El enum de view_type debe incluir render_fotorrealista."""
+    assert "render_fotorrealista" in _read_plan_reader()
+
+
+def test_rule_forbids_measuring_photorealistic_renders():
+    """Regla debe prohibir extraer medidas de renders fotorrealistas."""
+    text = _read_plan_reader()
+    # Busca que haya una regla cerca de render_fotorrealista que diga NO extraer
+    idx = text.find("render_fotorrealista")
+    assert idx >= 0
+    window = text[idx:idx + 500]
+    assert "NO" in window and "medidas" in window.lower(), (
+        "Rule near render_fotorrealista should forbid extracting measurements"
+    )
+
+
+def test_rule_asks_for_technical_plan_when_only_renders():
+    """Si no hay planta técnica → debe pedirla al operador."""
+    text = _read_plan_reader()
+    idx = text.find("render_fotorrealista")
+    window = text[idx:idx + 500]
+    # La regla debe mencionar pedir el plano técnico
+    assert "planta" in window.lower() or "plano t" in window.lower()


### PR DESCRIPTION
## Problema
Caso **Bernardi**: el operador adjunta 1 PDF técnico (planta cenital con cotas) + 2 **renders fotorrealistas** (Blender/V-Ray, texturas, luces, banquetas — estilo Pinterest).

Hoy el sistema envía **todas** las imágenes a Claude con el mismo prompt de lectura técnica. Resultado: Claude intenta extraer cotas de los renders → inventa medidas o emite warnings de ambigüedad espurios.

El enum `view_type` en `plan-reader-v1.md` tenía `planta` / `render_3d` (SketchUp isométrico) / `elevation` / `unknown` — pero **no** cubría renders fotorrealistas de marketing.

## Fix
`plan-reader-v1.md`: nueva entrada en el enum `view_type`:

- `render_fotorrealista`: imagen con texturas/luces estilo foto, sin cotas ni hatching. NO extraer medidas. Solo contexto visual (materiales/electrodomésticos). Si no hay planta técnica aparte → pedirla antes de calcular.

## Tests
`test_render_vs_plan_rules.py`:
- La regla existe (`render_fotorrealista` en el archivo).
- La regla prohíbe extraer medidas.
- La regla pide el plano técnico cuando solo hay renders.

Regression guard para que no se borre sin darse cuenta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)