### PR TITLE
fix(chat): PDF prioriza sobre imágenes al elegir plan para dual_read

### DIFF
--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -123,6 +123,33 @@ async def _find_drive_url_in_files_v2(db: AsyncSession, quote_id: str, filename:
 
 # ── LIST QUOTES ──────────────────────────────────────────────────────────────
 
+def _pick_plan_and_extras(
+    validated_files: list[tuple[bytes, str]],
+) -> tuple[bytes | None, str | None, list[tuple[bytes, str]]]:
+    """Pick the technical plan from uploaded files.
+
+    Si hay al menos un PDF → ese es el plano principal (los PDFs son
+    técnicos por convención en este dominio). El resto pasa como contexto
+    visual. Si no hay PDFs, caemos al primer archivo (orden de upload).
+
+    Antes se usaba ``validated_files[0]`` — frágil cuando el operador
+    sube renders fotorrealistas antes del PDF técnico (caso Bernardi:
+    JPG, JPG, PDF) porque dual_read terminaba corriendo sobre el render.
+    """
+    if not validated_files:
+        return None, None, []
+    pdf_idx = next(
+        (i for i, (_b, name) in enumerate(validated_files)
+         if name.lower().endswith(".pdf")),
+        None,
+    )
+    if pdf_idx is None:
+        return validated_files[0][0], validated_files[0][1], validated_files[1:]
+    plan_bytes, plan_filename = validated_files[pdf_idx]
+    extras = [f for i, f in enumerate(validated_files) if i != pdf_idx]
+    return plan_bytes, plan_filename, extras
+
+
 def _extract_drive_urls(quote) -> dict:
     """Extract drive_pdf_url and drive_excel_url from files_v2 in breakdown."""
     bd = quote.quote_breakdown if quote.quote_breakdown else {}
@@ -1614,9 +1641,7 @@ async def chat(
         )
 
     # Pass ALL files to Claude (not just the first one)
-    plan_bytes = validated_files[0][0] if validated_files else None
-    plan_filename = validated_files[0][1] if validated_files else None
-    extra_files = validated_files[1:] if len(validated_files) > 1 else []
+    plan_bytes, plan_filename, extra_files = _pick_plan_and_extras(validated_files)
 
     async def event_stream():
         full_response = ""

--- a/api/tests/test_pick_plan_and_extras.py
+++ b/api/tests/test_pick_plan_and_extras.py
@@ -1,0 +1,72 @@
+"""Regression: PDFs deben tener prioridad sobre imágenes al elegir plan_bytes.
+
+Caso Bernardi: operador subió [render.jpg, render.jpg, plano.pdf]. Con la
+lógica anterior (validated_files[0]) el render terminaba como plan_bytes y
+dual_read leía un render fotorrealista como si fuera un plano técnico.
+"""
+from app.modules.agent.router import _pick_plan_and_extras
+
+
+def test_pdf_wins_over_images_regardless_of_order():
+    files = [
+        (b"render1", "WhatsApp Image (4).jpeg"),
+        (b"render2", "WhatsApp Image (3).jpeg"),
+        (b"plano_bytes", "Bernardi-Mesadas cocina.pdf"),
+    ]
+    plan_bytes, plan_name, extras = _pick_plan_and_extras(files)
+    assert plan_bytes == b"plano_bytes"
+    assert plan_name == "Bernardi-Mesadas cocina.pdf"
+    extra_names = [name for _b, name in extras]
+    assert extra_names == ["WhatsApp Image (4).jpeg", "WhatsApp Image (3).jpeg"]
+
+
+def test_pdf_first_still_works():
+    files = [
+        (b"plano", "plano.pdf"),
+        (b"render", "render.jpg"),
+    ]
+    plan_bytes, plan_name, extras = _pick_plan_and_extras(files)
+    assert plan_name == "plano.pdf"
+    assert len(extras) == 1
+    assert extras[0][1] == "render.jpg"
+
+
+def test_no_pdf_falls_back_to_first_file():
+    """Sin PDF → usar primer archivo (comportamiento legacy)."""
+    files = [
+        (b"img1", "foto.jpg"),
+        (b"img2", "foto2.png"),
+    ]
+    plan_bytes, plan_name, extras = _pick_plan_and_extras(files)
+    assert plan_name == "foto.jpg"
+    assert len(extras) == 1
+    assert extras[0][1] == "foto2.png"
+
+
+def test_multiple_pdfs_takes_the_first_pdf():
+    files = [
+        (b"render", "render.jpg"),
+        (b"plano1", "primer-plano.pdf"),
+        (b"plano2", "segundo-plano.pdf"),
+    ]
+    plan_bytes, plan_name, extras = _pick_plan_and_extras(files)
+    assert plan_name == "primer-plano.pdf"
+    # ambos no-elegidos caen como extras, preservando orden relativo
+    extra_names = [name for _b, name in extras]
+    assert extra_names == ["render.jpg", "segundo-plano.pdf"]
+
+
+def test_empty_input():
+    plan_bytes, plan_name, extras = _pick_plan_and_extras([])
+    assert plan_bytes is None
+    assert plan_name is None
+    assert extras == []
+
+
+def test_uppercase_pdf_extension_detected():
+    files = [
+        (b"render", "render.jpg"),
+        (b"plano", "PLANO.PDF"),
+    ]
+    plan_bytes, plan_name, _ = _pick_plan_and_extras(files)
+    assert plan_name == "PLANO.PDF"


### PR DESCRIPTION
## Root cause del caso Bernardi

El operador subió **3 archivos en este orden**: `render.jpg, render.jpg, Bernardi-Mesadas.pdf`. El backend usaba `validated_files[0]` como "plano principal" → **el render fotorrealista** terminaba pasado a `_run_dual_read()` como si fuera un plano técnico → medidas alucinadas (4.15m como mesada, "patas laterales de isla" inexistentes, 1 anafe en lugar de 2, pileta en isla en lugar del lateral).

El PDF técnico con las cotas reales caía como `extra_file` (solo contexto visual), cuando debería haber sido la fuente de verdad.

## Fix
Nuevo helper `_pick_plan_and_extras()` en `router.py`:
- Si hay al menos un PDF → ese es `plan_bytes`; el resto (imágenes / otros PDFs) → `extra_files`.
- Sin PDF → fallback al primer archivo (comportamiento legacy para uploads de solo imágenes).
- Preserva orden relativo de los archivos no elegidos.

## Tests
`test_pick_plan_and_extras.py` (6 casos):
- PDF al final + renders primero → PDF gana (caso Bernardi).
- PDF primero → sigue funcionando igual.
- Sin PDF → fallback al primero.
- Múltiples PDFs → primer PDF.
- Extensión mayúscula `.PDF`.
- Input vacío.

## Efecto esperado en Bernardi
Con este fix, al subir `[render.jpg, render.jpg, Bernardi.pdf]`:
- `plan_bytes` = PDF → dual_read corre sobre el plano técnico con cotas reales.
- `extra_files` = 2 renders → pasan como contexto (y la regla de PR #279 evita que Valentina intente extraer medidas de ellos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)