### PR TITLE
feat(chat): card editable también para input solo-texto con medidas

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1363,6 +1363,88 @@ class AgentService:
             logging.warning(f"[card-editor] handler exception (non-fatal): {e}", exc_info=True)
             # Fall through al flujo normal de Claude.
 
+        # ── Text-only brief → emit card editable ──
+        # Si no hay archivos adjuntos pero el operador mandó texto con medidas,
+        # parseamos el texto y emitimos la MISMA card que dual_read. Así el
+        # despiece editable es SIEMPRE el puente obligatorio antes del cálculo,
+        # independientemente de si el input fue visual (plano) o textual.
+        #
+        # Condiciones:
+        # - No hay plan_bytes ni extra_files (input 100% texto)
+        # - No es un trigger de sistema ([DUAL_READ_CONFIRMED], [SYSTEM_TRIGGER])
+        # - No hay card previa ya emitida ni medidas confirmadas (dedup)
+        # - El parser devuelve ≥1 mesada válida
+        _is_system_trigger = user_message and user_message.strip().startswith("[")
+        if (
+            not _just_confirmed_dual_read
+            and not plan_bytes
+            and not (extra_files or [])
+            and user_message
+            and not _is_system_trigger
+        ):
+            try:
+                _tp_q = await db.execute(select(Quote).where(Quote.id == quote_id))
+                _tp_quote = _tp_q.scalar_one_or_none()
+                _tp_bd = (_tp_quote.quote_breakdown or {}) if _tp_quote else {}
+                _tp_has_card = bool(_tp_bd.get("dual_read_result"))
+                _tp_confirmed = bool(
+                    _tp_bd.get("verified_context") or _tp_bd.get("measurements_confirmed")
+                )
+            except Exception:
+                _tp_quote = None
+                _tp_bd = {}
+                _tp_has_card = False
+                _tp_confirmed = False
+
+            if _tp_quote is not None and not _tp_has_card and not _tp_confirmed:
+                try:
+                    from app.modules.quote_engine.text_parser import parse_brief_to_card
+                    _info_hint = _extract_quote_info(user_message)
+                    yield {"type": "action", "content": "📐 Leyendo medidas del texto..."}
+                    _text_card = await parse_brief_to_card(
+                        user_message,
+                        _info_hint.get("material", "") or "",
+                        _info_hint.get("project", "") or "",
+                    )
+                except Exception as _e_tp:
+                    logging.warning(f"[text-parse] parse_brief_to_card failed: {_e_tp}")
+                    _text_card = None
+
+                if _text_card:
+                    # Guardar card + metadata extraída + turno en historial
+                    try:
+                        _persist_bd = dict(_tp_bd)
+                        _persist_bd["dual_read_result"] = _text_card
+                        _update_values = {"quote_breakdown": _persist_bd}
+                        if _info_hint.get("client_name") and not _tp_quote.client_name:
+                            _update_values["client_name"] = _info_hint["client_name"]
+                        if _info_hint.get("project") and not _tp_quote.project:
+                            _update_values["project"] = _info_hint["project"]
+                        if _info_hint.get("material") and not _tp_quote.material:
+                            _update_values["material"] = _info_hint["material"]
+                        _update_values["messages"] = list(_tp_quote.messages or []) + [
+                            {"role": "user", "content": [{"type": "text", "text": user_message}]},
+                            {"role": "assistant", "content": "__DUAL_READ_CARD_SHOWN__"},
+                        ]
+                        await db.execute(
+                            update(Quote).where(Quote.id == quote_id).values(**_update_values)
+                        )
+                        await db.commit()
+                    except Exception as _e_pp:
+                        logging.warning(f"[text-parse] persist failed: {_e_pp}")
+                    logging.info(
+                        f"[text-parse] emitted card with {len(_text_card['sectores'][0]['tramos'])} "
+                        f"tramos for {quote_id}"
+                    )
+                    yield {
+                        "type": "dual_read_result",
+                        "content": json.dumps(_text_card, ensure_ascii=False),
+                    }
+                    yield {"type": "done", "content": ""}
+                    return
+                # Si parsing devolvió None → sigue al flujo normal; el LLM
+                # verá el mensaje y pedirá medidas con formato en su respuesta.
+
         # Build system prompt per request with contextual loading
         has_plan = plan_bytes is not None and plan_filename is not None
 

--- a/api/app/modules/quote_engine/text_parser.py
+++ b/api/app/modules/quote_engine/text_parser.py
@@ -101,3 +101,117 @@ async def parse_measurements(notes: str, material: str, project: str = "") -> di
     except Exception as e:
         logger.error(f"Parser error: {e}")
         return None
+
+
+def _field(valor: float) -> dict:
+    """FieldValue shape usado por el componente DualReadResult."""
+    return {"opus": None, "sonnet": None, "valor": valor, "status": "CONFIRMADO"}
+
+
+def parsed_pieces_to_card(parsed: dict) -> dict | None:
+    """Adapter: transforma el output de `parse_measurements()` a la misma
+    shape que emite `_run_dual_read()` para que el frontend renderice la
+    card editable igual que para un plano.
+
+    - **Recalcula `m2`** siempre como `round(largo * ancho, 2)` (no confía
+      en el parser para consistencia largo/ancho/m2).
+    - Separa piezas de mesada (tienen `prof`) de zócalos (tienen `alto`).
+      Los zócalos se asignan al último tramo de mesada previo.
+    - Cada tramo queda `_manual=True` para que todos los fields sean
+      editables desde la UI (el operador no confirma a ciegas).
+    - `source="TEXT"` al top-level separa origen (texto) de reconciliación
+      (que aquí no aplica — es fuente única). `_retry=True` oculta el
+      botón "reintentar con Opus" (no hay plano para releer).
+
+    Devuelve `None` si `parsed` no tiene al menos una mesada con `largo>0`
+    (sin medidas válidas no tiene sentido emitir card — el flujo clásico
+    pedirá medidas).
+    """
+    if not parsed or not isinstance(parsed.get("pieces"), list):
+        return None
+
+    tramos: list[dict] = []
+    pending_zocalos: list[dict] = []
+    for p in parsed["pieces"]:
+        largo = p.get("largo")
+        if not isinstance(largo, (int, float)) or largo <= 0:
+            continue
+        prof = p.get("prof")
+        alto = p.get("alto")
+
+        if prof is not None and isinstance(prof, (int, float)) and prof > 0:
+            # Es una mesada
+            m2 = round(largo * prof, 2)
+            tramo = {
+                "id": f"t{len(tramos) + 1}",
+                "descripcion": p.get("description") or f"Mesada {len(tramos) + 1}",
+                "largo_m": _field(largo),
+                "ancho_m": _field(prof),
+                "m2": _field(m2),
+                "zocalos": [],
+                "frentin": [],
+                "regrueso": [],
+                "_manual": True,
+            }
+            # Si hay zócalos pendientes sin tramo previo, asignarlos al primer tramo
+            if pending_zocalos and not tramos:
+                tramo["zocalos"].extend(pending_zocalos)
+                pending_zocalos = []
+            tramos.append(tramo)
+        elif alto is not None and isinstance(alto, (int, float)) and alto > 0:
+            # Es un zócalo — asignar al último tramo, o dejarlo pendiente
+            zocalo = {
+                "lado": (p.get("description") or "trasero").replace("Zócalo ", "").replace("Zócalo", "").strip() or "trasero",
+                "ml": float(largo),
+                "alto_m": float(alto),
+                "status": "CONFIRMADO",
+                "opus_ml": None,
+                "sonnet_ml": None,
+            }
+            if tramos:
+                tramos[-1]["zocalos"].append(zocalo)
+            else:
+                pending_zocalos.append(zocalo)
+
+    if not tramos:
+        return None
+
+    # Cualquier zócalo todavía pendiente (no había tramos aún) se cuelga del primero
+    if pending_zocalos:
+        tramos[0]["zocalos"].extend(pending_zocalos)
+
+    m2_total_valor = round(
+        sum(t["m2"]["valor"] for t in tramos)
+        + sum(z["ml"] * z["alto_m"] for t in tramos for z in t["zocalos"]),
+        2,
+    )
+
+    sector = {
+        "id": "sector_1",
+        "tipo": "cocina",
+        "tramos": tramos,
+        "m2_total": _field(m2_total_valor),
+        "ambiguedades": [],
+        "_manual": True,
+    }
+
+    return {
+        "sectores": [sector],
+        "requires_human_review": False,
+        "conflict_fields": [],
+        "source": "TEXT",
+        "view_type": "texto",
+        "view_type_reason": "Card generada desde texto del operador (sin plano adjunto)",
+        "m2_warning": None,
+        "_retry": True,
+    }
+
+
+async def parse_brief_to_card(notes: str, material: str, project: str = "") -> dict | None:
+    """Parsea un brief de texto y devuelve la card editable lista para
+    emitir como chunk `dual_read_result`, o `None` si no hay medidas.
+    """
+    parsed = await parse_measurements(notes, material, project)
+    if not parsed:
+        return None
+    return parsed_pieces_to_card(parsed)

--- a/api/tests/test_text_parse_card.py
+++ b/api/tests/test_text_parse_card.py
@@ -1,0 +1,146 @@
+"""Tests del adapter text-brief → card editable (mismo shape que dual_read).
+
+`parsed_pieces_to_card()` transforma el output crudo del parser a la shape
+que espera el frontend `DualReadResult.tsx`. `parse_brief_to_card()` es el
+entry-point async usado por `stream_chat` cuando no hay archivos adjuntos.
+"""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.modules.quote_engine.text_parser import (
+    parsed_pieces_to_card,
+    parse_brief_to_card,
+)
+
+
+# ── Adapter: parsed dict → card JSON ──────────────────────────────────────────
+
+class TestParsedPiecesToCard:
+    def test_simple_recta(self):
+        parsed = {
+            "pieces": [
+                {"description": "Mesada cocina", "largo": 2.40, "prof": 0.60},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        assert card is not None
+        assert card["source"] == "TEXT"
+        assert card["view_type"] == "texto"
+        assert card["_retry"] is True
+        assert card["requires_human_review"] is False
+        assert len(card["sectores"]) == 1
+        sector = card["sectores"][0]
+        assert sector["_manual"] is True
+        assert len(sector["tramos"]) == 1
+        tramo = sector["tramos"][0]
+        assert tramo["_manual"] is True
+        assert tramo["largo_m"]["valor"] == 2.40
+        assert tramo["ancho_m"]["valor"] == 0.60
+        # m2 re-calculado (el adapter no confía en el parser)
+        assert tramo["m2"]["valor"] == round(2.40 * 0.60, 2)
+        # opus/sonnet null — fuente única, no hay reconciliación
+        assert tramo["largo_m"]["opus"] is None
+        assert tramo["largo_m"]["sonnet"] is None
+        # status semánticamente separado del source
+        assert tramo["largo_m"]["status"] == "CONFIRMADO"
+
+    def test_en_l_dos_tramos(self):
+        parsed = {
+            "pieces": [
+                {"description": "Mesada L tramo 1", "largo": 2.40, "prof": 0.60},
+                {"description": "Mesada L tramo 2", "largo": 1.80, "prof": 0.60},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        tramos = card["sectores"][0]["tramos"]
+        assert len(tramos) == 2
+        assert tramos[0]["largo_m"]["valor"] == 2.40
+        assert tramos[1]["largo_m"]["valor"] == 1.80
+        expected_total = round(2.40 * 0.60 + 1.80 * 0.60, 2)
+        assert card["sectores"][0]["m2_total"]["valor"] == expected_total
+
+    def test_mesada_con_zocalos(self):
+        parsed = {
+            "pieces": [
+                {"description": "Mesada", "largo": 2.40, "prof": 0.60},
+                {"description": "Zócalo trasero", "largo": 2.40, "alto": 0.05},
+                {"description": "Zócalo lateral", "largo": 0.60, "alto": 0.05},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        tramo = card["sectores"][0]["tramos"][0]
+        # Zócalos van asignados al último tramo previo
+        assert len(tramo["zocalos"]) == 2
+        # m2 total incluye mesada + zócalos
+        expected_total = round(2.40 * 0.60 + 2.40 * 0.05 + 0.60 * 0.05, 2)
+        assert card["sectores"][0]["m2_total"]["valor"] == expected_total
+
+    def test_m2_recalculated_ignores_parser_value(self):
+        """Si el parser devuelve m2 inconsistente (bug conocido), el adapter
+        lo pisa con largo × ancho. Seguridad GPT #9."""
+        parsed = {
+            "pieces": [
+                {"description": "Mesada", "largo": 2.0, "prof": 0.6, "m2": 999.0},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        tramo = card["sectores"][0]["tramos"][0]
+        assert tramo["m2"]["valor"] == round(2.0 * 0.6, 2)  # 1.2, no 999
+
+    def test_no_pieces_returns_none(self):
+        assert parsed_pieces_to_card({"pieces": []}) is None
+        assert parsed_pieces_to_card({}) is None
+        assert parsed_pieces_to_card(None) is None
+
+    def test_zero_largo_skipped(self):
+        parsed = {"pieces": [{"description": "mal", "largo": 0, "prof": 0.6}]}
+        assert parsed_pieces_to_card(parsed) is None
+
+    def test_non_numeric_largo_skipped(self):
+        parsed = {"pieces": [{"description": "mal", "largo": "dos metros", "prof": 0.6}]}
+        assert parsed_pieces_to_card(parsed) is None
+
+    def test_only_zocalos_no_mesada_returns_none(self):
+        """Sin mesada pero con zócalos → None (no hay tramo donde colgarlos)."""
+        parsed = {"pieces": [{"description": "Zócalo", "largo": 2.0, "alto": 0.05}]}
+        assert parsed_pieces_to_card(parsed) is None
+
+    def test_pending_zocalos_attached_to_first_tramo_when_order_reversed(self):
+        """Si zócalo aparece antes de mesada, se cuelga del primer tramo luego."""
+        parsed = {
+            "pieces": [
+                {"description": "Zócalo", "largo": 2.0, "alto": 0.05},
+                {"description": "Mesada", "largo": 2.0, "prof": 0.6},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        tramo = card["sectores"][0]["tramos"][0]
+        assert len(tramo["zocalos"]) == 1
+        assert tramo["zocalos"][0]["ml"] == 2.0
+
+
+# ── Entry-point async ─────────────────────────────────────────────────────────
+
+class TestParseBriefToCard:
+    @pytest.mark.asyncio
+    async def test_returns_card_when_parser_succeeds(self):
+        parsed = {"pieces": [{"description": "Mesada", "largo": 2.4, "prof": 0.6}]}
+        with patch(
+            "app.modules.quote_engine.text_parser.parse_measurements",
+            new=AsyncMock(return_value=parsed),
+        ):
+            card = await parse_brief_to_card(
+                "mesada 2.40 x 0.60 silestone cliente Juan", "", ""
+            )
+        assert card is not None
+        assert card["source"] == "TEXT"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_parser_returns_none(self):
+        with patch(
+            "app.modules.quote_engine.text_parser.parse_measurements",
+            new=AsyncMock(return_value=None),
+        ):
+            card = await parse_brief_to_card("cliente Juan material silestone", "", "")
+        assert card is None

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -81,6 +81,11 @@ const VIEW_TYPE_META: Record<string, { label: string; cls: string; emoji: string
     cls: "bg-gray-500/10 text-gray-400 border-gray-400/30",
     emoji: "❓",
   },
+  texto: {
+    label: "Desde texto",
+    cls: "bg-indigo-500/10 text-indigo-300 border-indigo-400/30",
+    emoji: "📝",
+  },
 };
 
 interface Props {
@@ -438,7 +443,11 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
       {/* Header */}
       <div className="flex items-center gap-3 px-5 py-4 bg-gradient-to-b from-s3 to-s2 border-b border-b1">
         <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-acc bg-acc-bg border border-acc/30 px-2 py-1 rounded-md">
-          {data.source === "DUAL" ? "Doble lectura" : data.source.replace("SOLO_", "Solo ")}
+          {data.source === "DUAL"
+            ? "Doble lectura"
+            : data.source === "TEXT"
+            ? "Desde texto"
+            : data.source.replace("SOLO_", "Solo ")}
         </span>
         {/* PR #71 — badge de tipo de vista (planta / render 3D / etc) */}
         {(() => {


### PR DESCRIPTION
## Problema
Hoy el card editable (`dual_read_result` → `DualReadResult.tsx`) aparece **solo cuando hay archivos adjuntos**. Si el operador manda solo texto con medidas (`"cocina L 2.40x0.60 + 1.80x0.60 silestone cliente Juan"`), va al loop clásico con tabla Markdown freeform y Valentina improvisa. Queda flujo desparejo: en un camino hay card editable obligatoria antes del cálculo, en el otro no.

## Solución
Cuando no hay archivos y el primer turno tiene medidas parseables, el backend parsea el texto (`parse_measurements()` ya existía para el endpoint público `/v1/quote`) y emite el **mismo chunk `dual_read_result`** que dual_read. El frontend renderiza la misma card con el componente existente.

### Contrato del chunk (respeta separación origen ↔ reconciliación)

| Campo | Valor | Por qué |
|---|---|---|
| `source` | `"TEXT"` | **Separa origen de reconciliación** (GPT feedback #1). Nuevo badge "Desde texto" en header |
| `view_type` | `"texto"` | Nueva entrada en `VIEW_TYPE_META` (📝 índigo) |
| status de fields | `"CONFIRMADO"` | Reutiliza enum existente, no inventa `TEXT_PARSED` |
| `_retry` | `true` | Oculta "reintentar con Opus" (no hay plano para releer) |
| `opus`/`sonnet` | `null` | Valor único, sin reconciliación — semánticamente honesto |

### Seguridad
- **`m2` se recalcula** siempre como `round(largo*ancho, 2)` (GPT feedback #9). No confía en el parser para consistencia largo/ancho/m2.
- **Dedup**: si ya hay `dual_read_result` en el breakdown o medidas confirmadas, no re-emite.
- **No parser gate por regex** — sigue directo al parser LLM. Si devuelve `None`, fallback al LLM loop clásico (GPT feedback #2).
- **Integración con card-editor existente (PR #79)**: las modificaciones por chat siguen funcionando sobre la card emitida desde texto (misma shape).

## Frontend
Cambios mínimos en `DualReadResult.tsx`:
- Header badge: nuevo caso `source === "TEXT"` → "Desde texto"
- `VIEW_TYPE_META`: entrada `texto` con estilo índigo y emoji 📝
- Retry button y reconciliation UI quedan ocultos automáticamente por los flags del contrato

## Tests
`test_text_parse_card.py` (~150 líneas, 12 casos):
- **Adapter** `parsed_pieces_to_card()`: recta, L con 2 tramos, con zócalos, m2 recalculado (pisa valor malo del parser), validación de inputs inválidos (no pieces / largo=0 / largo string / solo zócalos / zócalos pending)
- **Entry-point** `parse_brief_to_card()` async: happy path + None fallback (mockeando `parse_measurements`)

## Test plan manual
- [ ] Crear presupuesto nuevo, enviar solo texto "mesada 2.40 x 0.60 silestone blanco cliente Juan" → aparece card editable con 1 tramo
- [ ] Editar el tramo en la card (agregar zócalo, cambiar medidas) → Confirmar → Valentina pasa a Paso 2
- [ ] Enviar texto sin medidas ("cliente Juan material silestone") → Valentina pide medidas
- [ ] Enviar texto + archivo PDF → sigue dual_read visual (no text-parse)

## Scope NO incluido
- Inferencia de múltiples sectores del texto (iteración 1 usa 1 sector fijo con N tramos; el operador puede partir en sectores con "+ Agregar sector" si quiere)
- Integration test del flujo completo de `stream_chat` (cubierto por tests unitarios del adapter + entry-point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)