### PR TITLE
fix(dual-read): Opus retry timeout + graceful fallback (500 → 200 con card previa)

### DIFF
--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -1371,13 +1371,29 @@ async def dual_read_retry(
     with open(crop_path, "rb") as f:
         crop_bytes = f.read()
 
-    # Call Opus directly
+    # Call Opus directly. Timeout alto porque Opus vision toma 60-90s para
+    # planos con mucho vector/detalle. El operador disparó esto a propósito,
+    # ok hacerlo esperar.
     opus_model = get_ai_config().get("opus_model", "claude-opus-4-6")
-    logging.info(f"[dual-read-retry] Quote {quote_id}: calling Opus for second opinion")
-    opus_result = await _call_vision(crop_bytes, opus_model, timeout=30)
+    _opus_timeout = int(get_ai_config().get("opus_retry_timeout_seconds", 120))
+    logging.info(
+        f"[dual-read-retry] Quote {quote_id}: calling Opus for second opinion "
+        f"(timeout={_opus_timeout}s)"
+    )
+    opus_result = await _call_vision(crop_bytes, opus_model, timeout=_opus_timeout)
 
     if opus_result.get("error"):
-        raise HTTPException(status_code=500, detail=f"Opus failed: {opus_result['error']}")
+        # Antes: 500 → frontend mostraba "Error" y perdía el contexto.
+        # Ahora: 200 con flag de error + la card previa de Sonnet intacta.
+        # El frontend ve opus_error y muestra mensaje amigable sin romper
+        # la card que ya tenía.
+        logging.warning(
+            f"[dual-read-retry] Opus failed for {quote_id}: {opus_result['error']}"
+        )
+        graceful = dict(prev_result)
+        graceful["opus_error"] = opus_result["error"]
+        graceful["_retry"] = True
+        return graceful
 
     # Retrieve original Sonnet result (saved as _sonnet_raw in prev result)
     sonnet_raw = prev_result.get("_sonnet_raw")

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -52,6 +52,10 @@ interface DualReadData {
   view_type?: string;
   view_type_reason?: string;
   _retry?: boolean;
+  /** Si Opus falló en el retry (timeout / error), el backend devuelve la
+   *  card previa de Sonnet intacta + este flag. Mostramos un mensaje
+   *  amigable pero preservamos las medidas que el operador ya tenía. */
+  opus_error?: string;
 }
 
 // PR #71 — metadata del tipo de vista para el badge
@@ -288,8 +292,16 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
         const err = await res.json().catch(() => ({}));
         throw new Error(err.detail || `HTTP ${res.status}`);
       }
-      const newData = await res.json();
-      if (onRetry) onRetry(newData);
+      const newData: DualReadData = await res.json();
+      if (newData.opus_error) {
+        // El backend nos devolvió la card previa + un flag de error.
+        // No pisamos onRetry (no hay nueva lectura), mostramos el aviso.
+        setRetryError(
+          `Opus no respondió a tiempo (${newData.opus_error}). Corregí las medidas manualmente con doble-click en los valores.`
+        );
+      } else if (onRetry) {
+        onRetry(newData);
+      }
     } catch (e: unknown) {
       setRetryError(e instanceof Error ? e.message : "Error");
     } finally {


### PR DESCRIPTION
## Root cause del 500 en caso Bernardi

Cuando el operador clickea "⚠️ Las medidas no coinciden — verificar con Opus":
- Backend llama a Opus con `timeout=30s`
- Opus 4.6 con planos vectoriales densos toma 60-90s → timeout
- Endpoint devuelve **500** → frontend muestra "Error" y pierde la card de Sonnet previamente guardada

Logs reales del deploy actual:
\`\`\`
WARNING: claude-opus-4-6 timed out after 30s
POST /quotes/.../dual-read-retry HTTP/1.1 500 Internal Server Error
\`\`\`

Inutilizable.

## Fix

- **Timeout**: 30s → 120s, configurable via `config.ai_engine.opus_retry_timeout_seconds`. El retry es disparado explícitamente por el operador, ok hacerlo esperar más.
- **Si Opus falla igual** (timeout/error): ya NO devolvemos 500. Devolvemos **200 con la card previa de Sonnet intacta** + `opus_error` flag. El frontend muestra aviso amigable pero **preserva las medidas de Sonnet** que el operador puede corregir con doble-click (PR #282).
- **Frontend**: `handleRetry` distingue entre `opus_error` (preservar card, mostrar aviso con guía a dbl-click manual) y nueva lectura exitosa (reemplazar card normal).

## Test plan manual
- [ ] Card SOLO_SONNET con advertencia → click "verificar con Opus" → Opus responde OK → card se actualiza a `DUAL`
- [ ] Mismo, pero Opus tarda >120s → sale mensaje "Opus no respondió a tiempo... corregí manualmente con doble-click" → card de Sonnet SIGUE visible + editable
- [ ] No aparecer más 500 en la response del endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)