### PR TITLE
rules(plan-reader): cotas externas ≠ mesada + contar regiones + render cross-check

### DIFF
--- a/api/rules/plan-reader-v1.md
+++ b/api/rules/plan-reader-v1.md
@@ -40,10 +40,9 @@ Antes de cualquier otra lectura, determiná qué TIPO de plano es esto:
   Tratar cada vista según su tipo.
 
 - `"render_fotorrealista"` → Foto 3D (Blender/V-Ray, texturas y luces,
-  sin cotas). NO extraer medidas. Solo contexto. Si no hay planta técnica
-  → PEDIRLA antes de calcular. Si hay planta + render: usá el render
-  como **cross-check topológico** (contar mesadas/isla/banquetas/anafes
-  visibles) — si discrepa con la planta, flaguear ambigüedad.
+  sin cotas). NO extraer medidas. Si hay planta + render: cross-check
+  topológico (contar mesadas/isla/anafes); discrepancia → ambigüedad.
+  Si solo hay renders, PEDIR planta técnica antes de calcular.
 
 - `"unknown"` → Si realmente no es claro. Usar reglas conservadoras de
   planta y flaguear alta `requires_human_review`.
@@ -60,9 +59,7 @@ El `view_type` condiciona las pasadas siguientes:
 
 **Pasada 1 — Inventario**
 Identificá todos los sectores presentes (cocina, baño, lavadero, etc.)
-Cada **región rellena contigua** (gris/hatch) dentro de un sector =
-1 mesada. Cocina U con isla = 4 regiones (3 lados + isla), no 2 tramos.
-NO colapsar regiones separadas en un tramo continuo largo.
+Cada región rellena contigua = 1 mesada. U+isla = 4 regiones, no 2.
 
 **Pasada 2 — Geometría por sector**
 Determiná el tipo de mesada:
@@ -75,11 +72,8 @@ Determiná el tipo de mesada:
 - VISTA EN PLANTA    : largo (eje horizontal) × ancho (profundidad)
 - VISTA EN ELEVACIÓN : dimensión SOBRE línea de mesada = zócalo | dimensión BAJO = frentin/faldón
 - Z antes de número  = longitud de zócalo en cm
-- ⛔ **Cotas EXTERNAS** (fuera del dibujo, con líneas de extensión que
-  llegan al muro, suelen estar en el perímetro del ambiente: ej 4.15,
-  2.75) = dimensión del **ambiente**, NO de mesadas. Descartar para
-  mesada. Usar SOLO cotas **INTERNAS** anotadas junto a cada región
-  rellena (ej 2.95, 2.05, 1.60).
+- ⛔ Cotas EXTERNAS (fuera del dibujo, al muro) = ambiente, NO mesada.
+  Usar SOLO cotas INTERNAS junto a cada región rellena.
 
 **Pasada 4 — Validación**
 Verificá consistencia entre vistas. Si hay contradicción → anotá en ambiguedades.

--- a/api/rules/plan-reader-v1.md
+++ b/api/rules/plan-reader-v1.md
@@ -39,10 +39,9 @@ Antes de cualquier otra lectura, determiná qué TIPO de plano es esto:
 - `"mixed"` → Plano con múltiples vistas (planta + elevación + detalle).
   Tratar cada vista según su tipo.
 
-- `"render_fotorrealista"` → Foto 3D (Blender/V-Ray, texturas y luces,
-  sin cotas). NO extraer medidas. Si hay planta + render: cross-check
-  topológico (contar mesadas/isla/anafes); discrepancia → ambigüedad.
-  Si solo hay renders, PEDIR planta técnica antes de calcular.
+- `"render_fotorrealista"` → Foto 3D (Blender/V-Ray, sin cotas). NO
+  medir. Con planta: cross-check topológico (mesadas/isla/anafes);
+  discrepancia → ambigüedad. Sin planta: pedirla.
 
 - `"unknown"` → Si realmente no es claro. Usar reglas conservadoras de
   planta y flaguear alta `requires_human_review`.
@@ -72,8 +71,7 @@ Determiná el tipo de mesada:
 - VISTA EN PLANTA    : largo (eje horizontal) × ancho (profundidad)
 - VISTA EN ELEVACIÓN : dimensión SOBRE línea de mesada = zócalo | dimensión BAJO = frentin/faldón
 - Z antes de número  = longitud de zócalo en cm
-- ⛔ Cotas EXTERNAS (fuera del dibujo, al muro) = ambiente, NO mesada.
-  Usar SOLO cotas INTERNAS junto a cada región rellena.
+- ⛔ Cotas EXTERNAS (al muro) = ambiente, NO mesada. Usar solo INTERNAS.
 
 **Pasada 4 — Validación**
 Verificá consistencia entre vistas. Si hay contradicción → anotá en ambiguedades.
@@ -94,12 +92,8 @@ NUNCA asumir prof silenciosamente sin ambigüedad explícita.
 Si el plano es un **render 3D / vista isométrica / SketchUp-style** (no es
 una planta arquitectónica cenital), aplicar estas reglas:
 
-**Señales de render 3D:**
-- Se ven electrodomésticos como objetos 3D (no símbolos 2D)
-- Perspectiva/proyección isométrica visible (líneas oblicuas)
-- Falta hatching de paredes
-- Cotas solo horizontales en el borde superior (largos), sin cotas de prof
-- No hay carátula técnica ni cuadro de rotulación
+**Señales de render 3D:** electrodomésticos 3D, proyección isométrica,
+sin hatching, cotas solo horizontales, sin carátula técnica.
 
 **Reglas específicas:**
 

--- a/api/rules/plan-reader-v1.md
+++ b/api/rules/plan-reader-v1.md
@@ -40,7 +40,7 @@ Antes de cualquier otra lectura, determiná qué TIPO de plano es esto:
   Tratar cada vista según su tipo.
 
 - `"render_fotorrealista"` → Foto 3D (Blender/V-Ray, sin cotas). NO
-  medir. Con planta: cross-check topológico (mesadas/isla/anafes);
+  leer medidas. Con planta: cross-check topológico (mesadas/isla/anafes);
   discrepancia → ambigüedad. Sin planta: pedirla.
 
 - `"unknown"` → Si realmente no es claro. Usar reglas conservadoras de

--- a/api/rules/plan-reader-v1.md
+++ b/api/rules/plan-reader-v1.md
@@ -41,7 +41,9 @@ Antes de cualquier otra lectura, determiná qué TIPO de plano es esto:
 
 - `"render_fotorrealista"` → Foto 3D (Blender/V-Ray, texturas y luces,
   sin cotas). NO extraer medidas. Solo contexto. Si no hay planta técnica
-  → PEDIRLA antes de calcular.
+  → PEDIRLA antes de calcular. Si hay planta + render: usá el render
+  como **cross-check topológico** (contar mesadas/isla/banquetas/anafes
+  visibles) — si discrepa con la planta, flaguear ambigüedad.
 
 - `"unknown"` → Si realmente no es claro. Usar reglas conservadoras de
   planta y flaguear alta `requires_human_review`.
@@ -58,6 +60,9 @@ El `view_type` condiciona las pasadas siguientes:
 
 **Pasada 1 — Inventario**
 Identificá todos los sectores presentes (cocina, baño, lavadero, etc.)
+Cada **región rellena contigua** (gris/hatch) dentro de un sector =
+1 mesada. Cocina U con isla = 4 regiones (3 lados + isla), no 2 tramos.
+NO colapsar regiones separadas en un tramo continuo largo.
 
 **Pasada 2 — Geometría por sector**
 Determiná el tipo de mesada:
@@ -70,6 +75,11 @@ Determiná el tipo de mesada:
 - VISTA EN PLANTA    : largo (eje horizontal) × ancho (profundidad)
 - VISTA EN ELEVACIÓN : dimensión SOBRE línea de mesada = zócalo | dimensión BAJO = frentin/faldón
 - Z antes de número  = longitud de zócalo en cm
+- ⛔ **Cotas EXTERNAS** (fuera del dibujo, con líneas de extensión que
+  llegan al muro, suelen estar en el perímetro del ambiente: ej 4.15,
+  2.75) = dimensión del **ambiente**, NO de mesadas. Descartar para
+  mesada. Usar SOLO cotas **INTERNAS** anotadas junto a cada región
+  rellena (ej 2.95, 2.05, 1.60).
 
 **Pasada 4 — Validación**
 Verificá consistencia entre vistas. Si hay contradicción → anotá en ambiguedades.


### PR DESCRIPTION
## Root cause del despiece mal del caso Bernardi

Plano: cocina en U con isla (3 mesadas laterales + 1 isla = **4 regiones rellenas** en el dibujo). Sonnet reportó:
- "Mesada tramo principal": **4.15 × 0.60** ← cota del perímetro del ambiente, no mesada
- "Mesada retorno L": **2.35 × 0.60** ← cota interna, pero fuera de contexto
- No vio isla
- No vio mesada bajo pileta (2.05)
- Inventó zócalos larguísimos (4.15 ml, 2.35 ml)

Tres gaps que este caso expuso:

### 1. Cotas externas vs internas
Las cotas del perímetro (4.15, 2.75 — con líneas de extensión al muro) se interpretaron como mesadas. Regla nueva en **Pasada 3 — Cotas**: cotas externas = dimensión del ambiente, NO de mesadas. Usar solo cotas internas junto a cada región rellena.

### 2. Contar regiones rellenas como mesadas
Sonnet colapsó las 4 regiones en 2 tramos. Regla nueva en **Pasada 1 — Inventario**: cada región rellena contigua = 1 mesada independiente. Cocina U + isla = 4 regiones (3 lados + isla), no 2.

### 3. Renders como cross-check topológico
Los 2 renders fotorrealistas del caso ya se descartan (no medidas) por la regla de PR #279. Pero podían haber sido útiles para **confirmar topología**: contar mesadas/isla/banquetas/anafes visibles. Amplío la regla: si hay planta + render, el render sirve como cross-check topológico; discrepancia con la planta → flaguear ambigüedad.

## Token budget
Las 3 adiciones son de 2-3 líneas cada una. El test `test_raw_prompt_under_50k` valida que la suma cabe bajo 55K (verificado en CI).

## Test plan manual (caso Bernardi)
- [ ] Subir de nuevo el PDF + los 2 renders con el brief "material pura prima onix white mate, cliente Erica Bernardi"
- [ ] Dual_read sobre el PDF debería ahora:
  - Contar 3 mesadas + 1 isla (no 2 tramos)
  - Usar cotas internas (2.95, 2.05, 1.60) no las externas (4.15, 2.75)
  - Reportar cross-check con los renders (banquetas visibles = isla, 2 anafes visibles)
- [ ] Si aún sale mal, con dbl-click + Agregar mesada corregís, pero el punto de partida debería ser mejor

🤖 Generated with [Claude Code](https://claude.com/claude-code)