### PR TITLE
feat(dual-read): extraer cotas en single-cocina + anchor validator post-LLM

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -213,6 +213,7 @@ async def _run_dual_read(
     crop_label: str = "plano",
     planilla_m2: float | None = None,
     cotas_text: str | None = None,
+    extracted_cota_values: list[float] | None = None,
     user_message: str = "",
     plan_filename: str = "",
     plan_hash: str | None = None,
@@ -388,6 +389,28 @@ async def _run_dual_read(
         if _dual_result.get("error"):
             logging.warning(f"[dual-read] Error: {_dual_result.get('error')}")
             return (False, chunks)
+
+        # Anchor validator — rechaza medidas que el VLM emitió sin respaldo
+        # en el text layer del PDF. Caso Bernardi: "1.75" y "2.35" inventados
+        # (no existen en las cotas extraídas con pdfplumber). Quedan marcadas
+        # UNANCHORED y el operador las corrige con dbl-click en la card.
+        if extracted_cota_values:
+            try:
+                from app.modules.quote_engine.plan_anchor_validator import annotate_anchoring
+                annotate_anchoring(_dual_result, extracted_cota_values)
+                _un = sum(
+                    1 for s in _dual_result.get("sectores") or []
+                    for t in s.get("tramos") or []
+                    for f in ("largo_m", "ancho_m")
+                    if (t.get(f) or {}).get("status") == "UNANCHORED"
+                )
+                if _un:
+                    logging.info(
+                        f"[dual-read] anchor validator flagged {_un} unanchored "
+                        f"fields ({len(extracted_cota_values)} cotas in text layer)"
+                    )
+            except Exception as _e_av:
+                logging.warning(f"[dual-read] anchor validator failed (non-fatal): {_e_av}")
 
         # Save crop for Opus retry
         try:
@@ -2530,6 +2553,7 @@ class AgentService:
                                     _handled = False
                                     _dr_chunks = []
                                 else:
+                                    _extracted_cota_values_pl = [c.value for c in _cotas] if _cotas else []
                                     _handled, _dr_chunks = await _run_dual_read(
                                         db,
                                         quote_id,
@@ -2537,6 +2561,7 @@ class AgentService:
                                         crop_label=_planilla_data.ubicacion or "cocina",
                                         planilla_m2=_planilla_data.m2,
                                         cotas_text=_cotas_text,
+                                        extracted_cota_values=_extracted_cota_values_pl,
                                         user_message=user_message,
                                         plan_filename=plan_filename,
                                         plan_hash=_raw_plan_hash,
@@ -2595,13 +2620,45 @@ class AgentService:
                                 _buf_nopl = _io_nopl.BytesIO()
                                 _pages_nopl[0].save(_buf_nopl, format="JPEG", quality=85)
                                 _draw_bytes_nopl = _buf_nopl.getvalue()
+                                # Extraer cotas del text layer del PDF (single-cocina sin
+                                # planilla). Antes solo se extraía en el path edificio;
+                                # para una planta residencial simple el cotas_text quedaba
+                                # None y el LLM trabajaba 100% desde la imagen → fuente
+                                # principal de errores tipo "1.75 / 2.35 inventados".
+                                _cotas_nopl_text = None
+                                _cotas_nopl_values: list[float] = []
+                                try:
+                                    import pdfplumber as _pp_nopl
+                                    from app.modules.quote_engine.cotas_extractor import (
+                                        extract_cotas_from_drawing,
+                                        format_cotas_for_prompt,
+                                    )
+                                    with _pp_nopl.open(_io_nopl.BytesIO(plan_bytes)) as _pdf_nopl:
+                                        if _pdf_nopl.pages:
+                                            _page_nopl = _pdf_nopl.pages[0]
+                                            _page_w = float(getattr(_page_nopl, "width", 0) or 1e9)
+                                            _cotas_nopl = extract_cotas_from_drawing(
+                                                _page_nopl,
+                                                table_x0=_page_w,  # full width — no planilla
+                                                dpi=_plan_dpi_nopl,
+                                            )
+                                            if _cotas_nopl:
+                                                _cotas_nopl_text = format_cotas_for_prompt(_cotas_nopl)
+                                                _cotas_nopl_values = [c.value for c in _cotas_nopl]
+                                                logging.info(
+                                                    f"[cotas/single-cocina] extracted {len(_cotas_nopl)} cotas "
+                                                    f"from text layer: {[c.value for c in _cotas_nopl][:20]}"
+                                                )
+                                except Exception as _e_cot:
+                                    logging.warning(f"[cotas/single-cocina] extraction failed (non-fatal): {_e_cot}")
                                 _handled_nopl, _chunks_nopl = await _run_dual_read(
                                     db,
                                     quote_id,
                                     _draw_bytes_nopl,
                                     crop_label="plano",
                                     planilla_m2=None,
-                                    cotas_text=None,
+                                    cotas_text=_cotas_nopl_text,
+                                    extracted_cota_values=_cotas_nopl_values,
                                     user_message=user_message,
                                     plan_filename=plan_filename,
                                     plan_hash=_raw_plan_hash,

--- a/api/app/modules/quote_engine/plan_anchor_validator.py
+++ b/api/app/modules/quote_engine/plan_anchor_validator.py
@@ -1,0 +1,87 @@
+"""Post-hoc validator for dual_reader output.
+
+Rechaza (marca UNANCHORED) cualquier valor numérico emitido por el LLM que
+no esté presente en las cotas extraídas del text layer del PDF. Esto
+apaga la clase de bugs donde el VLM inventa medidas geométricamente
+plausibles pero ausentes del plano (caso Bernardi: "1.75", "2.35"
+como ancho de isla).
+
+No rechaza hard — baja el status del field a UNANCHORED y lo flaguea en
+ambiguedades. El operador ve que ese valor no está anclado y lo corrige
+con doble-click (PR #282) o borra/agrega el tramo con los botones ± ya
+existentes.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+
+TOLERANCE = 0.02  # metros — margen para error de redondeo o rotación OCR
+
+
+def _matches_any(value: float, reference: Iterable[float], tol: float = TOLERANCE) -> bool:
+    """True si `value` está dentro de `tol` metros de algún valor de referencia."""
+    if value is None:
+        return True  # valores null no se validan (el frontend los renderiza como edit inputs)
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return True
+    return any(abs(v - float(r)) <= tol for r in reference if r is not None)
+
+
+def annotate_anchoring(result: dict, extracted_values: list[float]) -> dict:
+    """Marca fields del output de dual_read como UNANCHORED cuando su `valor`
+    no aparece en la lista de cotas extraídas del text layer.
+
+    Muta (y devuelve) `result` in-place para conservar todos los campos del
+    schema. Si `extracted_values` está vacío (ej: PDF escaneado sin text
+    layer), no hace nada — el validator queda en modo "no-op" y no empeora
+    el flujo existente.
+    """
+    if not extracted_values:
+        return result
+
+    unanchored_count = 0
+    warnings: list[str] = []
+
+    for sector in result.get("sectores") or []:
+        for tramo in sector.get("tramos") or []:
+            # largo / ancho
+            for field_name in ("largo_m", "ancho_m"):
+                fv = tramo.get(field_name)
+                if not isinstance(fv, dict):
+                    continue
+                val = fv.get("valor")
+                if not _matches_any(val, extracted_values):
+                    fv["status"] = "UNANCHORED"
+                    fv["unanchored_reason"] = (
+                        f"{val}m no está en las cotas del plano"
+                    )
+                    unanchored_count += 1
+            # zócalos ml
+            for z in tramo.get("zocalos") or []:
+                ml = z.get("ml")
+                if ml is not None and not _matches_any(ml, extracted_values):
+                    z["status"] = "UNANCHORED"
+                    z["unanchored_reason"] = (
+                        f"{ml}ml no está en las cotas del plano"
+                    )
+                    unanchored_count += 1
+
+        if unanchored_count > 0 and warnings == []:
+            existing = list(sector.get("ambiguedades") or [])
+            existing.append({
+                "tipo": "REVISION",
+                "texto": (
+                    f"{unanchored_count} medida(s) no coinciden con cotas "
+                    "leídas del PDF — verificá doble-click en el despiece."
+                ),
+            })
+            sector["ambiguedades"] = existing
+            warnings.append(sector.get("id", "?"))
+
+    if unanchored_count > 0:
+        result["requires_human_review"] = True
+
+    return result

--- a/api/tests/test_plan_anchor_validator.py
+++ b/api/tests/test_plan_anchor_validator.py
@@ -1,0 +1,102 @@
+"""Tests del anchor validator — marca UNANCHORED cotas inventadas por el VLM."""
+from app.modules.quote_engine.plan_anchor_validator import annotate_anchoring
+
+
+def _make_field(valor: float, status: str = "CONFIRMADO") -> dict:
+    return {"opus": None, "sonnet": None, "valor": valor, "status": status}
+
+
+def _make_tramo(largo: float, ancho: float, zocalos: list | None = None) -> dict:
+    return {
+        "id": "t1",
+        "descripcion": "Mesada",
+        "largo_m": _make_field(largo),
+        "ancho_m": _make_field(ancho),
+        "m2": _make_field(round(largo * ancho, 2)),
+        "zocalos": zocalos or [],
+        "frentin": [],
+        "regrueso": [],
+    }
+
+
+def _make_result(tramos: list) -> dict:
+    return {
+        "sectores": [
+            {"id": "s1", "tipo": "cocina", "tramos": tramos, "ambiguedades": []},
+        ],
+        "requires_human_review": False,
+        "conflict_fields": [],
+        "source": "SOLO_SONNET",
+    }
+
+
+class TestAnnotateAnchoring:
+    def test_bernardi_invented_values_flagged(self):
+        """Caso real: 1.75 y 2.35 como ancho/largo no están en las cotas del plano."""
+        cotas = [2.95, 2.05, 1.60, 0.60, 4.15, 2.75, 1.20, 2.35]  # del PDF Bernardi
+        result = _make_result([
+            _make_tramo(2.05, 0.60),   # OK
+            _make_tramo(1.75, 0.60),   # 1.75 NO está en las cotas → UNANCHORED
+            _make_tramo(1.60, 2.35),   # 2.35 sí está (pero malinterpretado como ancho) — NO se flaguea por valor
+        ])
+        annotate_anchoring(result, cotas)
+        tramos = result["sectores"][0]["tramos"]
+        assert tramos[0]["largo_m"]["status"] == "CONFIRMADO"
+        assert tramos[0]["ancho_m"]["status"] == "CONFIRMADO"
+        assert tramos[1]["largo_m"]["status"] == "UNANCHORED"
+        assert "unanchored_reason" in tramos[1]["largo_m"]
+        # 2.35 SÍ está en cotas; el validator no sabe que es un contexto equivocado
+        assert tramos[2]["ancho_m"]["status"] == "CONFIRMADO"
+        # Al menos 1 UNANCHORED → requires_human_review
+        assert result["requires_human_review"] is True
+
+    def test_all_values_anchored_no_flags(self):
+        cotas = [2.40, 0.60]
+        result = _make_result([_make_tramo(2.40, 0.60)])
+        annotate_anchoring(result, cotas)
+        for f in ("largo_m", "ancho_m"):
+            assert result["sectores"][0]["tramos"][0][f]["status"] != "UNANCHORED"
+        assert result["requires_human_review"] is False
+
+    def test_empty_cotas_list_is_noop(self):
+        """Si no extrajimos cotas del text layer (PDF escaneado), el validator
+        no debe flaguear nada — preservar comportamiento previo."""
+        result = _make_result([_make_tramo(99.99, 88.88)])
+        annotate_anchoring(result, [])
+        for f in ("largo_m", "ancho_m"):
+            assert result["sectores"][0]["tramos"][0][f]["status"] == "CONFIRMADO"
+
+    def test_tolerance_allows_small_rounding_diffs(self):
+        """Valores a < 2cm del real cuentan como anclados (OCR rounding)."""
+        cotas = [2.95, 0.60]
+        result = _make_result([_make_tramo(2.94, 0.61)])  # 1cm off
+        annotate_anchoring(result, cotas)
+        for f in ("largo_m", "ancho_m"):
+            assert result["sectores"][0]["tramos"][0][f]["status"] == "CONFIRMADO"
+
+    def test_zocalo_ml_validated(self):
+        cotas = [2.05, 0.60]
+        zocalo_ok = {"lado": "trasero", "ml": 2.05, "alto_m": 0.07, "status": "CONFIRMADO"}
+        zocalo_bad = {"lado": "lateral", "ml": 1.75, "alto_m": 0.07, "status": "CONFIRMADO"}
+        result = _make_result([_make_tramo(2.05, 0.60, zocalos=[zocalo_ok, zocalo_bad])])
+        annotate_anchoring(result, cotas)
+        zs = result["sectores"][0]["tramos"][0]["zocalos"]
+        assert zs[0]["status"] == "CONFIRMADO"
+        assert zs[1]["status"] == "UNANCHORED"
+
+    def test_ambiguedad_added_when_unanchored(self):
+        cotas = [2.05, 0.60]
+        result = _make_result([_make_tramo(1.75, 0.60)])
+        annotate_anchoring(result, cotas)
+        ambs = result["sectores"][0]["ambiguedades"]
+        assert len(ambs) == 1
+        assert ambs[0]["tipo"] == "REVISION"
+        assert "no coinciden" in ambs[0]["texto"].lower()
+
+    def test_none_value_not_flagged(self):
+        """Fields con valor None no deben romperse — se validan como OK."""
+        tramo = _make_tramo(2.0, 0.6)
+        tramo["largo_m"]["valor"] = None
+        result = _make_result([tramo])
+        annotate_anchoring(result, [2.0, 0.6])
+        assert result["sectores"][0]["tramos"][0]["largo_m"]["status"] != "UNANCHORED"

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -107,6 +107,7 @@ const STATUS_STYLE: Record<string, IconStyle> = {
   DUDOSO:       { cls: "bg-[rgba(191,85,236,0.15)] text-[#bf55ec]", char: "?" },
   SOLO_SONNET:  { cls: "bg-grn-bg text-grn",                        char: "✓" },
   SOLO_OPUS:    { cls: "bg-grn-bg text-grn",                        char: "✓" },
+  UNANCHORED:   { cls: "bg-amb-bg text-amb",                        char: "⚠" },
 };
 
 const STATUS_TITLE: Record<string, string> = {
@@ -116,6 +117,7 @@ const STATUS_TITLE: Record<string, string> = {
   DUDOSO: "Valor dudoso — requiere revisión",
   SOLO_SONNET: "Solo Sonnet detectó este valor",
   SOLO_OPUS: "Solo Opus detectó este valor",
+  UNANCHORED: "Este valor no coincide con las cotas del plano — corregí con doble-click",
 };
 
 function StatusIcon({
@@ -167,7 +169,10 @@ function EditableNumber({
    *  edit mode. Enter/blur commit (solo si valor válido), Esc cancela. */
   dblClickEdit?: boolean;
 }) {
-  const alwaysEditable = forceEditable || field.status === "CONFLICTO" || field.status === "DUDOSO";
+  const alwaysEditable = forceEditable
+    || field.status === "CONFLICTO"
+    || field.status === "DUDOSO"
+    || field.status === "UNANCHORED";
   const [editing, setEditing] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement | null>(null);
   const originalRef = React.useRef<number>(field.valor);


### PR DESCRIPTION
## Contexto
Basado en el review externo (GPT-5) del contexto del bug Bernardi — ver `~/Desktop/contexto-bug-plan-reader.md`. Diagnóstico compartido: el VLM está haciendo demasiadas tareas a la vez (segmentar regiones + OCR espacial + topología + razonar + emitir JSON) sobre una imagen full-page sin anclaje geométrico duro. Resultado: inventa medidas plausibles pero inexistentes (`1.75`, `2.35` como ancho de isla).

Este PR implementa los fixes de **ROI más alto y menor esfuerzo** del plan propuesto:

## Cambios

### 1. Extracción de cotas en single-cocina PDF path
La infra `extract_cotas_from_drawing` (pdfplumber) ya existía, pero sólo se invocaba en el path edificio/planilla. Para PDFs residenciales single-cocina (caso Bernardi) `cotas_text=None` se pasaba hardcoded.

Ahora se abre el PDF con pdfplumber también en `agent.py:2598` (single-cocina) y en `_run_dual_read` (planilla) se conserva la lista de valores, extraídos del text layer con bbox.

Log esperado: `[cotas/single-cocina] extracted 8 cotas from text layer: [2.95, 2.05, 1.60, 0.60, 4.15, 2.75, 1.20, 2.35]`

### 2. Anchor validator post-LLM
Nuevo módulo `plan_anchor_validator.py`:
- Cada `largo_m` / `ancho_m` / `zocalo.ml` emitido por el VLM se compara (±2cm tolerancia) contra la lista de cotas extraídas.
- Si no matchea → `status="UNANCHORED"` + `unanchored_reason`.
- Sector suma una ambigüedad REVISION.
- `requires_human_review=True` si al menos 1 UNANCHORED.
- Si `extracted_values=[]` (PDF escaneado sin text layer), validator queda no-op.

### 3. Frontend
- Nuevo status `UNANCHORED` con badge ámbar ⚠ + tooltip "Este valor no coincide con las cotas del plano — corregí con doble-click".
- El valor UNANCHORED cae en la rama `alwaysEditable` del `EditableNumber` (se abre como input directo, misma experiencia que CONFLICTO/DUDOSO).

## Tests
`test_plan_anchor_validator.py` — 7 casos:
- Caso Bernardi literal (1.75 flagueado, 2.05/0.60 anclados OK)
- All-anchored → sin flags
- Empty cotas (PDF escaneado) → no-op
- Tolerancia 2cm para rounding OCR
- Zócalos validados igual que largo/ancho
- Ambigüedad REVISION agregada al sector
- `valor=None` no rompe

## Efecto esperado en caso Bernardi
Con el mismo PDF + brief del caso real:
- Sonnet (o Opus) emite output con `1.75` como largo del retorno L.
- Anchor validator detecta que `1.75` no está en `[2.95, 2.05, 1.60, 0.60, 4.15, 2.75, 1.20, 2.35]`.
- Frontend muestra el tramo con status ⚠ UNANCHORED + input directo para corregir.
- Operador reemplaza `1.75` → `2.95` con doble-click o tipeo directo.

El validator no "arregla mágicamente" el reading — **apunta al error** y **fuerza revisión humana** en vez de dejar pasar valores inventados con cara de confirmado.

## Roadmap (fuera de este PR)
Del mismo review externo:
- **Multi-crop**: 1 LLM call global (topología) + N llamadas por región rellena con cotas cercanas
- **Schema con selected/rejected**: el LLM expone su razonamiento (qué cotas consideró, cuáles descartó y por qué)
- **Test de Opus 4.7** vs 4.6 para la call global

🤖 Generated with [Claude Code](https://claude.com/claude-code)