### PR TITLE
fix(multi-crop): fail-hard per-region — kill 0.60×0.60 silent fallback

### DIFF
--- a/api/app/modules/quote_engine/multi_crop_reader.py
+++ b/api/app/modules/quote_engine/multi_crop_reader.py
@@ -219,7 +219,17 @@ async def _measure_region(
     model: str,
     brief_text: str = "",
 ) -> dict:
-    """Mide una región usando un crop local + cotas candidatas filtradas."""
+    """Mide una región usando un crop local + cotas candidatas filtradas.
+
+    Fail-hard behavior:
+    - Si el bbox es inválido o el crop sale vacío → error, sin LLM call.
+    - Si la región tiene < 2 cotas locales en el bbox → error, sin LLM call.
+      (el LLM no tiene evidencia suficiente para elegir largo + ancho).
+    - Después del LLM: si los valores no anclan a las cotas locales o
+      largo == ancho (fallback silencioso del LLM cuando no sabe) →
+      flaguea `suspicious_reasons` para que el aggregator lo marque
+      DUDOSO en vez de CONFIRMADO.
+    """
     img_w, img_h = image_size
     bbox = region.get("bbox_rel") or {}
     x = max(0, int((bbox.get("x") or 0) * img_w) - REGION_CROP_PADDING_PX)
@@ -230,6 +240,27 @@ async def _measure_region(
     y2 = min(img_h, y + max(h, 1))
     if x2 - x < 10 or y2 - y < 10:
         return {"error": "region_bbox_too_small", "region_id": region.get("id")}
+
+    # Filtrar cotas candidatas ANTES de croppear: si no hay evidencia
+    # suficiente para elegir largo + ancho, cortamos acá sin gastar la
+    # llamada al LLM. Menos latencia + menos tokens + menos chance de
+    # que el modelo fabrique un 0.60×0.60 silencioso.
+    local_cotas: list[Cota] = []
+    for c in candidate_cotas:
+        if x <= c.x <= x2 and y <= c.y <= y2:
+            local_cotas.append(c)
+
+    MIN_LOCAL_COTAS = 2
+    if candidate_cotas and len(local_cotas) < MIN_LOCAL_COTAS:
+        logger.info(
+            f"[multi-crop] region {region.get('id')} has only {len(local_cotas)} "
+            f"local cotas (<{MIN_LOCAL_COTAS}) — skip LLM, return DUDOSO"
+        )
+        return {
+            "error": "insufficient_local_cotas",
+            "region_id": region.get("id"),
+            "local_cotas_count": len(local_cotas),
+        }
 
     # Crop la imagen con PIL
     try:
@@ -242,14 +273,6 @@ async def _measure_region(
         crop_bytes = buf.getvalue()
     except Exception as e:
         return {"error": f"crop_failed: {e}", "region_id": region.get("id")}
-
-    # Filtrar cotas candidatas: sólo las que caen dentro del bbox (con el
-    # mismo padding). Las cotas ya tienen x/y en crop-pixel space de la
-    # imagen original, así que comparamos contra el bbox absoluto.
-    local_cotas: list[Cota] = []
-    for c in candidate_cotas:
-        if x <= c.x <= x2 and y <= c.y <= y2:
-            local_cotas.append(c)
 
     client = anthropic.AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY)
     cotas_txt = format_cotas_for_prompt(local_cotas) if local_cotas else "(sin cotas extraídas en esta región)"
@@ -329,6 +352,38 @@ async def _measure_region(
 
     parsed["region_id"] = region.get("id")
     parsed["_local_cotas_count"] = len(local_cotas)
+
+    # Sanity checks post-LLM: marcamos suspicious_reasons para que el
+    # aggregator emita DUDOSO en vez de CONFIRMADO. Regla: no aceptar
+    # output del VLM con "cara de confiado" cuando la evidencia no cierra.
+    largo = parsed.get("largo_m")
+    ancho = parsed.get("ancho_m")
+    suspicious: list[str] = []
+    cota_values = [c.value for c in local_cotas]
+
+    def _anchored(v) -> bool:
+        if v is None or not isinstance(v, (int, float)):
+            return False
+        return any(abs(float(v) - cv) <= 0.02 for cv in cota_values)
+
+    if local_cotas:
+        if largo is not None and not _anchored(largo):
+            suspicious.append(f"largo {largo}m no está en las cotas locales de la región")
+        if ancho is not None and not _anchored(ancho):
+            suspicious.append(f"ancho {ancho}m no está en las cotas locales de la región")
+
+    # Fallback silencioso típico: el modelo devuelve L==A cuando no puede
+    # elegir → usualmente agarra 0.60 (el ancho estándar) dos veces.
+    if (
+        isinstance(largo, (int, float))
+        and isinstance(ancho, (int, float))
+        and abs(float(largo) - float(ancho)) < 0.01
+    ):
+        suspicious.append(f"largo == ancho ({largo}m) — probable fallback silencioso del VLM")
+
+    if suspicious:
+        parsed["suspicious_reasons"] = suspicious
+
     return parsed
 
 
@@ -364,11 +419,27 @@ def _aggregate(topology: dict, region_results: list[dict]) -> dict:
             m2 = round(float(largo) * float(ancho), 2) if (
                 isinstance(largo, (int, float)) and isinstance(ancho, (int, float))
             ) else None
-            # status: si hubo error en la medición → DUDOSO, si OK → CONFIRMADO
-            status = "DUDOSO" if r_result.get("error") else "CONFIRMADO"
+
+            # status: DUDOSO si hubo error, medida sospechosa, o faltan valores.
+            # CONFIRMADO solo si la medición se ancló a las cotas locales y no
+            # hay señales de fallback silencioso.
+            error = r_result.get("error")
+            suspicious = r_result.get("suspicious_reasons") or []
+            if error or suspicious or largo is None or ancho is None:
+                status = "DUDOSO"
+            else:
+                status = "CONFIRMADO"
+
+            # Descripción: NO propagamos region.notes porque la fase global
+            # hoy confunde artefactos (puso "anafe en isla" cuando el anafe
+            # estaba en la lateral). Hasta que PR C implemente el contrato
+            # feature-based, usamos label genérico. El operador ve el crop
+            # en la card y asocia visualmente.
+            desc = f"Mesada {len(tramos) + 1}" if status == "CONFIRMADO" else f"Mesada {len(tramos) + 1} — revisar"
+
             tramo = {
                 "id": rid or f"t{len(tramos) + 1}",
-                "descripcion": region.get("notes") or f"Mesada {rid}",
+                "descripcion": desc,
                 "largo_m": _field(largo, status),
                 "ancho_m": _field(ancho, status),
                 "m2": _field(m2, status),
@@ -377,17 +448,25 @@ def _aggregate(topology: dict, region_results: list[dict]) -> dict:
                 "regrueso": [],
             }
             tramos.append(tramo)
-            if r_result.get("error"):
+
+            if error:
                 all_ambiguedades.append({
                     "tipo": "REVISION",
-                    "texto": f"Región {rid} no pudo medirse: {r_result.get('error')}",
+                    "texto": f"Región {rid}: no se pudo medir ({error}) — completá manual",
+                })
+            elif suspicious:
+                all_ambiguedades.append({
+                    "tipo": "REVISION",
+                    "texto": f"Región {rid}: medida dudosa ({'; '.join(suspicious)[:120]})",
                 })
 
         sectores.append({
             "id": f"sector_{sec_name}",
             "tipo": sec_name,
             "tramos": tramos,
-            "ambiguedades": [],
+            # Propagamos las ambigüedades del aggregator al primer sector
+            # (el frontend las rendera como "Revisar en plano" + bullets).
+            "ambiguedades": list(all_ambiguedades) if sec_name == next(iter(by_sector)) else [],
         })
 
     if not sectores:

--- a/api/tests/test_multi_crop_reader.py
+++ b/api/tests/test_multi_crop_reader.py
@@ -1,9 +1,11 @@
-"""Tests del multi_crop_reader — aggregator + orquestación.
+"""Tests del multi_crop_reader — aggregator + orquestación + fail-hard.
 
 LLM calls y PIL image ops se mockean. La idea es verificar:
 - aggregator arma el schema dual_read correcto desde topology + results
 - fallback graceful si global topology falla
-- crop + filter de cotas locales por bbox funciona
+- per-region fail-hard: <2 cotas locales → skip LLM, devolver DUDOSO
+- detección de fallback silencioso (largo == ancho, valores no anclados)
+- labels genéricos hasta que PR C defina contrato feature-based
 """
 from unittest.mock import AsyncMock, patch
 
@@ -14,6 +16,7 @@ from PIL import Image
 from app.modules.quote_engine.cotas_extractor import Cota
 from app.modules.quote_engine.multi_crop_reader import (
     _aggregate,
+    _measure_region,
     read_plan_multi_crop,
 )
 
@@ -68,6 +71,49 @@ class TestAggregate:
         tramo = out["sectores"][0]["tramos"][0]
         assert tramo["largo_m"]["status"] == "DUDOSO"
         assert out["requires_human_review"] is True
+
+    def test_suspicious_reasons_become_dudoso(self):
+        """Fallback silencioso detectado (L==A) → DUDOSO, no CONFIRMADO."""
+        topology = {"regions": [{"id": "R1", "sector": "cocina"}]}
+        results = [{
+            "region_id": "R1",
+            "largo_m": 0.60,
+            "ancho_m": 0.60,
+            "suspicious_reasons": ["largo == ancho (0.60m) — probable fallback silencioso"],
+        }]
+        out = _aggregate(topology, results)
+        tramo = out["sectores"][0]["tramos"][0]
+        assert tramo["largo_m"]["status"] == "DUDOSO"
+        assert tramo["ancho_m"]["status"] == "DUDOSO"
+        assert "— revisar" in tramo["descripcion"]
+
+    def test_region_notes_not_propagated_to_description(self):
+        """Hasta PR C, no propagamos artefactos de la fase global (que confunde
+        qué región tiene qué). Label genérico 'Mesada N'."""
+        topology = {
+            "regions": [
+                {"id": "R1", "sector": "cocina", "notes": "isla central con anafe a gas 4 hornallas"},
+            ],
+        }
+        results = [{"region_id": "R1", "largo_m": 2.05, "ancho_m": 0.60}]
+        out = _aggregate(topology, results)
+        desc = out["sectores"][0]["tramos"][0]["descripcion"]
+        assert "anafe" not in desc.lower()
+        assert "isla" not in desc.lower()
+        assert desc.startswith("Mesada")
+
+    def test_ambiguedades_propagated_to_first_sector(self):
+        topology = {"regions": [{"id": "R1", "sector": "cocina"}, {"id": "R2", "sector": "cocina"}]}
+        results = [
+            {"region_id": "R1", "largo_m": 2.05, "ancho_m": 0.60},
+            {"region_id": "R2", "error": "insufficient_local_cotas"},
+        ]
+        out = _aggregate(topology, results)
+        # El sector cocina recibe la ambigüedad
+        ambs = out["sectores"][0]["ambiguedades"]
+        assert len(ambs) >= 1
+        assert ambs[0]["tipo"] == "REVISION"
+        assert "R2" in ambs[0]["texto"]
 
     def test_no_regions_fallback_empty_sector(self):
         out = _aggregate({"regions": []}, [])
@@ -142,6 +188,71 @@ class TestReadPlanMultiCrop:
         assert cocina["tramos"][0]["largo_m"]["valor"] == 2.95
         assert cocina["tramos"][1]["largo_m"]["valor"] == 2.05
         assert isla["tramos"][0]["largo_m"]["valor"] == 1.60
+
+    @pytest.mark.asyncio
+    async def test_measure_region_insufficient_cotas_skips_llm(self):
+        """Fail-hard: <2 cotas locales → error sin llamar al LLM.
+
+        Evita el fallback silencioso 0.60×0.60 que el VLM produce cuando
+        no tiene evidencia suficiente. Mejor DUDOSO que falsa certeza.
+        """
+        image = _make_image_bytes(1000, 800)
+        region = {"id": "R1", "bbox_rel": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.3}}
+        # Una sola cota en el bbox — insuficiente
+        cotas = [_make_cota(0.60, x=200, y=200)]
+
+        # Patch el anthropic client para asegurar que NO se llama
+        with patch("app.modules.quote_engine.multi_crop_reader.anthropic.AsyncAnthropic") as mock_client:
+            result = await _measure_region(image, (1000, 800), region, cotas, model="test", brief_text="")
+            mock_client.assert_not_called()
+        assert result.get("error") == "insufficient_local_cotas"
+        assert result.get("local_cotas_count") == 1
+
+    @pytest.mark.asyncio
+    async def test_measure_region_detects_unanchored_values(self):
+        """LLM devuelve valor que no está en las cotas locales → suspicious_reasons."""
+        image = _make_image_bytes(1000, 800)
+        region = {"id": "R1", "bbox_rel": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.3}}
+        # 3 cotas dentro del bbox
+        cotas = [
+            _make_cota(2.95, x=200, y=200),
+            _make_cota(0.60, x=210, y=220),
+            _make_cota(4.15, x=230, y=240),
+        ]
+        # Mock LLM returns 1.75 (no está en cotas) + 0.60 (sí está)
+        mock_response = type("R", (), {
+            "content": [type("B", (), {"text": '{"largo_m": 1.75, "ancho_m": 0.60, "confidence": 0.9}'})()]
+        })()
+        with patch(
+            "app.modules.quote_engine.multi_crop_reader.anthropic.AsyncAnthropic"
+        ) as mock_anth:
+            mock_client_instance = mock_anth.return_value
+            mock_client_instance.messages.create = AsyncMock(return_value=mock_response)
+            result = await _measure_region(image, (1000, 800), region, cotas, model="test")
+        assert "suspicious_reasons" in result
+        assert any("1.75" in s for s in result["suspicious_reasons"])
+
+    @pytest.mark.asyncio
+    async def test_measure_region_detects_silent_fallback(self):
+        """LLM devuelve largo == ancho → fallback silencioso detectado."""
+        image = _make_image_bytes(1000, 800)
+        region = {"id": "R1", "bbox_rel": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.3}}
+        cotas = [
+            _make_cota(2.05, x=200, y=200),
+            _make_cota(0.60, x=210, y=220),
+        ]
+        # LLM responde 0.60 x 0.60 (clásico fallback cuando no sabe)
+        mock_response = type("R", (), {
+            "content": [type("B", (), {"text": '{"largo_m": 0.60, "ancho_m": 0.60}'})()]
+        })()
+        with patch(
+            "app.modules.quote_engine.multi_crop_reader.anthropic.AsyncAnthropic"
+        ) as mock_anth:
+            mock_client_instance = mock_anth.return_value
+            mock_client_instance.messages.create = AsyncMock(return_value=mock_response)
+            result = await _measure_region(image, (1000, 800), region, cotas, model="test")
+        assert "suspicious_reasons" in result
+        assert any("largo == ancho" in s for s in result["suspicious_reasons"])
 
     @pytest.mark.asyncio
     async def test_partial_region_failure_still_aggregates(self):


### PR DESCRIPTION
## PR A del roadmap multi-crop v2
Siguiendo el review externo (GPT v2) sobre los errores del multi-crop en el test V2 del caso Bernardi. Separamos en 3 PRs; este es el primero: **robustez**, sin tocar semántica todavía.

## Root cause
En el test V2, multi-crop emitió una "mesada inferior con pileta" con `0.60 × 0.60 = 0.36 m²`. Síntoma clásico de **fallback silencioso del VLM** cuando no tiene evidencia suficiente: agarra el ancho estándar (0.60) como default para ambos campos y devuelve con cara de CONFIRMADO.

Resultado: valor sin sentido físico (ninguna mesada real es cuadrada de 0.60×0.60) presentado al operador como si fuera confirmado.

## Fix

1. **Fail-hard antes del LLM**: si `len(local_cotas) < 2` en el bbox de la región → devolver `{"error": "insufficient_local_cotas"}` sin gastar la llamada. Menos latencia, menos tokens, menos chance de fabricación.

2. **Sanity checks post-LLM**: flaggear `suspicious_reasons` cuando:
   - `largo` o `ancho` no anclan a las cotas locales (±2cm tolerancia)
   - `largo == ancho` (diff < 1cm) — fallback silencioso típico

3. **Aggregator más estricto**: `CONFIRMADO` solo si la medición ancló y pasó los checks. Si hay error, suspicious, o valores faltantes → `DUDOSO` con desc "— revisar".

4. **Labels genéricos**: no propagamos `region.notes` del global topology porque hoy confunde qué región tiene qué artefacto (test V2 puso "anafe en isla", "horno en lateral" cuando era al revés). Hasta PR E: "Mesada N" simple. El operador asocia visualmente con el crop.

5. **Ambigüedades visibles**: propagadas al primer sector con detalle por región. Frontend las rinde como "Revisar en plano" + bullets.

## Tests
`test_multi_crop_reader.py` añadidos:
- `<2` cotas locales → error sin llamar al LLM (se patchea el client y se verifica que no se invoca)
- Valor no anclado → `suspicious_reasons`
- `L == A` → `suspicious_reasons`
- Aggregator: suspicious → DUDOSO + "— revisar"
- `region.notes` NO aparece en la descripción del tramo
- Ambigüedades propagadas al primer sector

## Efecto esperado
Con el mismo input del test V2:
- El tramo que era `0.60 × 0.60 CONFIRMADO` → ahora `DUDOSO` con "Mesada — revisar" + input abierto para corregir.
- Los tramos que antes tenían labels inventados ("isla con anafe" cuando no tenía anafe) → ahora "Mesada 1/2/3" neutral.
- El operador ve claramente qué celdas dudosas hay que revisar en lugar de medidas con falsa certeza.

## Próximos PRs (roadmap v2)
- **PR B**: `pending_questions` infra + zócalos detector (preguntar antes de asumir; bloquear Confirmar)
- **PR C**: pileta cocina = empotrada hard-coded
- **PR D**: más pending questions (isla profundidad, patas, colocación, anafe count)
- **PR E**: global topology con contrato feature-based
- **PR F**: validación completa por tipo de trabajo (cocina/baño/lavadero)

🤖 Generated with [Claude Code](https://claude.com/claude-code)