### PR TITLE
feat(pending-questions): infra preguntar antes de asumir + detector de zócalos

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -441,6 +441,22 @@ async def _run_dual_read(
             except Exception as _e_av:
                 logging.warning(f"[dual-read] anchor validator failed (non-fatal): {_e_av}")
 
+        # Pending questions — "preguntar antes de asumir". Si el brief no
+        # menciona zócalos (u otros datos) y el plano tampoco los aclara,
+        # emitimos preguntas que bloquean el Confirmar hasta que el operador
+        # responda. Evita que Valentina asuma defaults silenciosos.
+        try:
+            from app.modules.quote_engine.pending_questions import detect_pending_questions
+            _pending = detect_pending_questions(user_message or "", _dual_result)
+            if _pending:
+                _dual_result["pending_questions"] = _pending
+                logging.info(
+                    f"[dual-read] {len(_pending)} pending question(s): "
+                    f"{[q['id'] for q in _pending]}"
+                )
+        except Exception as _e_pq:
+            logging.warning(f"[dual-read] pending_questions detection failed (non-fatal): {_e_pq}")
+
         # Save crop for Opus retry
         try:
             from app.core.static import OUTPUT_DIR as _OUT
@@ -1244,6 +1260,21 @@ class AgentService:
             _just_confirmed_dual_read = True
             try:
                 _confirmed_json = json.loads(user_message[len("[DUAL_READ_CONFIRMED]"):])
+                # Aplicar respuestas de pending_questions (ej: zócalos agregados
+                # determinísticamente cuando el operador eligió la opción default).
+                # El confirmed_json viene con `pending_answers` si el frontend
+                # las incluyó.
+                try:
+                    from app.modules.quote_engine.pending_questions import apply_answers
+                    _answers = _confirmed_json.get("pending_answers") or []
+                    if _answers:
+                        apply_answers(_confirmed_json, _answers)
+                        logging.info(
+                            f"[pending-questions] applied {len(_answers)} answer(s): "
+                            f"{[a.get('id') for a in _answers]}"
+                        )
+                except Exception as _e_ans:
+                    logging.warning(f"[pending-questions] apply_answers failed: {_e_ans}")
                 from app.modules.quote_engine.dual_reader import build_verified_context
                 _verified_ctx = build_verified_context(_confirmed_json)
                 _qr0 = await db.execute(select(Quote).where(Quote.id == quote_id))

--- a/api/app/modules/quote_engine/pending_questions.py
+++ b/api/app/modules/quote_engine/pending_questions.py
@@ -1,0 +1,199 @@
+"""Pending questions — infra para "preguntar antes de asumir".
+
+Principio rector del operador D'Angelo: Valentina nunca asume datos que no
+están en el brief ni en el plano. En vez de rellenar defaults silenciosos,
+emite una `pending_question` que bloquea el Confirmar de la card hasta que
+el operador responda (o marque "no aplica").
+
+Este módulo define:
+- El shape del objeto PendingQuestion.
+- Detectores (funciones puras que toman contexto y devuelven preguntas).
+- Un aplicador que toma las respuestas del operador y las materializa en el
+  JSON de medidas verificadas (ej: "Sí, trasero 7cm" → agrega zócalos).
+
+Arranca con UN detector: zócalos cuando el brief no los menciona. Siguientes
+PRs agregan más (profundidad de isla, patas, anafe count, etc.) sobre la
+misma infra.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Brief matchers (keyword detection sobre el texto libre del operador)
+# ─────────────────────────────────────────────────────────────────────────────
+
+_ZOCALO_WITH = re.compile(
+    r"\b(con\s+z[oó]c|lleva(n)?\s+z[oó]c|z[oó]calos?\s*s[ií]|"
+    r"z[oó]c\s*[=:]\s*\d)",
+    re.IGNORECASE,
+)
+_ZOCALO_WITHOUT = re.compile(
+    r"\b(sin\s+z[oó]c|no\s+(lleva|van)\s+z[oó]c|z[oó]calos?\s*no|"
+    r"no\s+z[oó]c)",
+    re.IGNORECASE,
+)
+
+
+def brief_mentions_zocalos(brief: str) -> str | None:
+    """Devuelve 'yes' si el brief pide zócalos, 'no' si los excluye, None si
+    no los menciona (→ hay que preguntar)."""
+    if not brief:
+        return None
+    if _ZOCALO_WITHOUT.search(brief):
+        return "no"
+    if _ZOCALO_WITH.search(brief):
+        return "yes"
+    return None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Question detectors
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _detect_zocalos_question(brief: str, dual_result: dict) -> dict | None:
+    """Si el brief no menciona zócalos y la card tampoco los detectó, preguntar.
+
+    No se pregunta cuando:
+    - Brief dice "con zócalos" / "sin zócalos" (ya hay respuesta).
+    - La card ya tiene zócalos con ml > 0 (el plan reader los vio).
+    """
+    mentioned = brief_mentions_zocalos(brief or "")
+    if mentioned is not None:
+        return None
+
+    has_zocalos_in_card = any(
+        (z.get("ml") or 0) > 0
+        for s in (dual_result.get("sectores") or [])
+        for t in (s.get("tramos") or [])
+        for z in (t.get("zocalos") or [])
+    )
+    if has_zocalos_in_card:
+        return None
+
+    return {
+        "id": "zocalos",
+        "label": "Zócalos",
+        "question": (
+            "¿Lleva zócalos? El brief no los menciona y en el plano no se "
+            "ven explícitamente. Si sí, ¿de qué alto y contra qué paredes?"
+        ),
+        "type": "radio_with_detail",
+        "options": [
+            {
+                "value": "default_trasero",
+                "label": "Sí — trasero por tramo, 7cm (default)",
+                "apply": {"mode": "trasero_default", "alto_m": 0.07},
+            },
+            {
+                "value": "custom",
+                "label": "Sí — otro alto o qué lados (detallar)",
+                "apply": {"mode": "custom"},
+            },
+            {
+                "value": "no",
+                "label": "No lleva zócalos",
+                "apply": {"mode": "none"},
+            },
+        ],
+        "detail_placeholder": (
+            "Ej: 'trasero y lateral izq, 5cm' o '10cm solo trasero'"
+        ),
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Entry point: detect all pending questions for this card
+# ─────────────────────────────────────────────────────────────────────────────
+
+def detect_pending_questions(brief: str, dual_result: dict) -> list[dict]:
+    """Devuelve la lista de preguntas pendientes. Vacía si todos los datos
+    detectables están presentes.
+
+    Cada detector corre independiente — si uno falla o no aplica, los otros
+    siguen. Orden de la lista = orden de presentación en la UI (primero lo
+    más crítico).
+    """
+    questions: list[dict] = []
+    q_zoc = _detect_zocalos_question(brief, dual_result)
+    if q_zoc:
+        questions.append(q_zoc)
+    # Futuros detectores (PR C/D):
+    # - pileta simple vs doble si fase global no es conclusiva
+    # - profundidad isla si no hay cota
+    # - patas isla
+    # - colocación
+    # - anafe count
+    return questions
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Answer applicator — materializa las respuestas del operador en el card
+# ─────────────────────────────────────────────────────────────────────────────
+
+def apply_zocalos_answer(dual_result: dict, answer: dict, default_alto_m: float = 0.07) -> dict:
+    """Dada la respuesta del operador a la pregunta de zócalos, agrega
+    los zócalos determinísticamente al card.
+
+    `answer` formato (viene del frontend):
+    {
+      "id": "zocalos",
+      "value": "default_trasero" | "custom" | "no",
+      "detail": "texto libre si value == custom" (opcional),
+      "alto_m": 0.07 (opcional, override del default),
+    }
+
+    Muta y devuelve dual_result in-place.
+    """
+    if not isinstance(answer, dict):
+        return dual_result
+    value = answer.get("value")
+    if value == "no":
+        # nada que agregar
+        return dual_result
+
+    alto = float(answer.get("alto_m") or default_alto_m)
+    for sector in dual_result.get("sectores") or []:
+        for tramo in sector.get("tramos") or []:
+            largo = ((tramo.get("largo_m") or {}).get("valor")) or 0
+            # Si el tramo ya tiene zócalos explícitos (de dual_read), no pisar
+            has_existing = any(
+                (z.get("ml") or 0) > 0 for z in (tramo.get("zocalos") or [])
+            )
+            if has_existing:
+                continue
+            if value == "default_trasero":
+                tramo.setdefault("zocalos", []).append({
+                    "lado": "trasero",
+                    "ml": float(largo),
+                    "alto_m": alto,
+                    "status": "CONFIRMADO",
+                    "opus_ml": None,
+                    "sonnet_ml": None,
+                    "source": "brief_rule",
+                })
+            elif value == "custom":
+                # El detalle es texto libre — lo dejamos en metadata para
+                # que Valentina o el operador lo lean post-confirm. No
+                # inferimos lados automáticamente.
+                tramo.setdefault("zocalos", []).append({
+                    "lado": answer.get("detail", "trasero")[:50],
+                    "ml": float(largo),
+                    "alto_m": alto,
+                    "status": "CONFIRMADO",
+                    "opus_ml": None,
+                    "sonnet_ml": None,
+                    "source": "brief_rule_custom",
+                    "detail_raw": answer.get("detail"),
+                })
+    return dual_result
+
+
+def apply_answers(dual_result: dict, answers: list[dict]) -> dict:
+    """Aplica todas las respuestas del operador al card. Extensible por
+    question_id. Hoy solo `zocalos`; siguientes PRs agregan más."""
+    for ans in answers or []:
+        if ans.get("id") == "zocalos":
+            apply_zocalos_answer(dual_result, ans)
+    return dual_result

--- a/api/tests/test_pending_questions.py
+++ b/api/tests/test_pending_questions.py
@@ -1,0 +1,157 @@
+"""Tests de pending_questions — detección + aplicación de respuestas.
+
+Principio: nunca asumir. Si falta info en brief y plano, preguntar y
+bloquear Confirmar hasta que el operador conteste.
+"""
+from app.modules.quote_engine.pending_questions import (
+    apply_answers,
+    apply_zocalos_answer,
+    brief_mentions_zocalos,
+    detect_pending_questions,
+)
+
+
+def _make_dual_result(has_zocalos: bool = False) -> dict:
+    zocalos = [{"lado": "trasero", "ml": 2.05, "alto_m": 0.07}] if has_zocalos else []
+    return {
+        "sectores": [
+            {
+                "id": "s1",
+                "tipo": "cocina",
+                "tramos": [
+                    {
+                        "id": "t1",
+                        "descripcion": "Mesada 1",
+                        "largo_m": {"valor": 2.05, "status": "CONFIRMADO"},
+                        "ancho_m": {"valor": 0.60, "status": "CONFIRMADO"},
+                        "m2": {"valor": 1.23, "status": "CONFIRMADO"},
+                        "zocalos": zocalos,
+                        "frentin": [],
+                        "regrueso": [],
+                    }
+                ],
+                "ambiguedades": [],
+            }
+        ],
+        "source": "MULTI_CROP",
+    }
+
+
+# ── Brief keyword detection ──────────────────────────────────────────────────
+
+class TestBriefMentionsZocalos:
+    def test_explicit_yes(self):
+        assert brief_mentions_zocalos("cocina con zocalos") == "yes"
+        assert brief_mentions_zocalos("Cliente Juan, lleva zócalos") == "yes"
+        assert brief_mentions_zocalos("zócalos sí, alto 5cm") == "yes"
+
+    def test_explicit_no(self):
+        assert brief_mentions_zocalos("cocina sin zocalos") == "no"
+        assert brief_mentions_zocalos("no lleva zocalos") == "no"
+        assert brief_mentions_zocalos("no van zócalos") == "no"
+
+    def test_not_mentioned_returns_none(self):
+        assert brief_mentions_zocalos("cliente juan material silestone") is None
+        assert brief_mentions_zocalos("") is None
+        assert brief_mentions_zocalos("") is None
+
+
+# ── Zocalos question detector ────────────────────────────────────────────────
+
+class TestDetectZocalosQuestion:
+    def test_emits_when_brief_silent_and_plano_no_zocalos(self):
+        """Caso Bernardi: brief no dice nada, plano tampoco → preguntar."""
+        qs = detect_pending_questions(
+            brief="material puraprima onix white cliente Erica",
+            dual_result=_make_dual_result(has_zocalos=False),
+        )
+        assert len(qs) == 1
+        assert qs[0]["id"] == "zocalos"
+        assert len(qs[0]["options"]) == 3
+        # Sí con default, Sí custom, No lleva
+        vals = [o["value"] for o in qs[0]["options"]]
+        assert "default_trasero" in vals
+        assert "custom" in vals
+        assert "no" in vals
+
+    def test_skips_when_brief_says_con_zocalos(self):
+        qs = detect_pending_questions(
+            brief="cocina con zocalos",
+            dual_result=_make_dual_result(has_zocalos=False),
+        )
+        assert all(q["id"] != "zocalos" for q in qs)
+
+    def test_skips_when_brief_says_sin_zocalos(self):
+        qs = detect_pending_questions(
+            brief="cocina sin zocalos",
+            dual_result=_make_dual_result(has_zocalos=False),
+        )
+        assert all(q["id"] != "zocalos" for q in qs)
+
+    def test_skips_when_card_already_has_zocalos(self):
+        """Si dual_read ya detectó zócalos (ml > 0), no preguntar."""
+        qs = detect_pending_questions(
+            brief="",
+            dual_result=_make_dual_result(has_zocalos=True),
+        )
+        assert all(q["id"] != "zocalos" for q in qs)
+
+
+# ── Apply answers ────────────────────────────────────────────────────────────
+
+class TestApplyZocalosAnswer:
+    def test_default_trasero_adds_zocalo_per_tramo(self):
+        result = _make_dual_result(has_zocalos=False)
+        # Agregar un segundo tramo para verificar que aplica a todos
+        result["sectores"][0]["tramos"].append({
+            "id": "t2",
+            "descripcion": "Mesada 2",
+            "largo_m": {"valor": 2.95, "status": "CONFIRMADO"},
+            "ancho_m": {"valor": 0.60, "status": "CONFIRMADO"},
+            "m2": {"valor": 1.77, "status": "CONFIRMADO"},
+            "zocalos": [],
+            "frentin": [],
+            "regrueso": [],
+        })
+        apply_zocalos_answer(result, {"id": "zocalos", "value": "default_trasero"})
+        t1_z = result["sectores"][0]["tramos"][0]["zocalos"]
+        t2_z = result["sectores"][0]["tramos"][1]["zocalos"]
+        assert len(t1_z) == 1
+        assert t1_z[0]["lado"] == "trasero"
+        assert t1_z[0]["ml"] == 2.05
+        assert t1_z[0]["alto_m"] == 0.07
+        assert t1_z[0]["source"] == "brief_rule"
+        assert len(t2_z) == 1
+        assert t2_z[0]["ml"] == 2.95
+
+    def test_no_answer_does_nothing(self):
+        result = _make_dual_result(has_zocalos=False)
+        apply_zocalos_answer(result, {"id": "zocalos", "value": "no"})
+        assert result["sectores"][0]["tramos"][0]["zocalos"] == []
+
+    def test_custom_preserves_detail(self):
+        result = _make_dual_result(has_zocalos=False)
+        apply_zocalos_answer(
+            result,
+            {"id": "zocalos", "value": "custom", "detail": "10cm trasero y lateral izq", "alto_m": 0.10},
+        )
+        z = result["sectores"][0]["tramos"][0]["zocalos"][0]
+        assert z["source"] == "brief_rule_custom"
+        assert z["alto_m"] == 0.10
+        assert z["detail_raw"] == "10cm trasero y lateral izq"
+
+    def test_does_not_overwrite_existing_zocalos(self):
+        """Si dual_read ya puso zócalos, la respuesta del brief no pisa."""
+        result = _make_dual_result(has_zocalos=True)
+        apply_zocalos_answer(result, {"id": "zocalos", "value": "default_trasero"})
+        # Aún hay solo 1 zócalo (el original), no se agregó otro
+        assert len(result["sectores"][0]["tramos"][0]["zocalos"]) == 1
+
+    def test_apply_answers_entry_point(self):
+        """apply_answers dispatchea por question id."""
+        result = _make_dual_result(has_zocalos=False)
+        apply_answers(result, [
+            {"id": "zocalos", "value": "default_trasero"},
+            {"id": "unknown_id", "value": "whatever"},  # ignored
+        ])
+        assert len(result["sectores"][0]["tramos"][0]["zocalos"]) == 1

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -43,6 +43,28 @@ interface Sector {
   _manual?: boolean;
 }
 
+interface PendingQuestionOption {
+  value: string;
+  label: string;
+  apply?: Record<string, unknown>;
+}
+
+interface PendingQuestion {
+  id: string;
+  label: string;
+  question: string;
+  type: "radio_with_detail" | "text" | "select";
+  options?: PendingQuestionOption[];
+  detail_placeholder?: string;
+}
+
+interface PendingAnswer {
+  id: string;
+  value: string;
+  detail?: string;
+  alto_m?: number;
+}
+
 interface DualReadData {
   sectores: Sector[];
   requires_human_review: boolean;
@@ -56,6 +78,10 @@ interface DualReadData {
    *  card previa de Sonnet intacta + este flag. Mostramos un mensaje
    *  amigable pero preservamos las medidas que el operador ya tenía. */
   opus_error?: string;
+  /** Preguntas que el operador tiene que responder antes de confirmar.
+   *  Principio: nunca asumir — si el brief no lo dice y el plano no lo
+   *  muestra, preguntar. Confirmar queda bloqueado hasta responder todas. */
+  pending_questions?: PendingQuestion[];
 }
 
 // PR #71 — metadata del tipo de vista para el badge
@@ -284,6 +310,11 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
   const [retrying, setRetrying] = useState(false);
   const [retryError, setRetryError] = useState<string | null>(null);
   const [editedData, setEditedData] = useState<DualReadData>(data);
+  // Respuestas a pending_questions — se arman a medida que el operador
+  // selecciona opciones. Confirmar se bloquea hasta que todas tengan valor.
+  const [pendingAnswers, setPendingAnswers] = useState<Record<string, PendingAnswer>>({});
+  const pendingQuestions = data.pending_questions || [];
+  const allQuestionsAnswered = pendingQuestions.every(q => pendingAnswers[q.id]?.value);
 
   const handleRetry = async () => {
     setRetrying(true);
@@ -850,13 +881,80 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
         </div>
       )}
 
+      {/* Pending questions — Valentina no asume: si falta info, pregunta.
+          Confirmar queda bloqueado hasta que el operador elija opción para
+          cada pregunta (o marque "no" explícito). */}
+      {pendingQuestions.length > 0 && (
+        <div className="mx-5 mb-4 p-4 rounded-xl border border-amb/30 bg-amb-bg">
+          <h4 className="text-[11px] font-semibold uppercase tracking-[0.1em] text-amb mb-3">
+            Antes de confirmar — {pendingQuestions.length} pregunta{pendingQuestions.length > 1 ? "s" : ""} pendiente{pendingQuestions.length > 1 ? "s" : ""}
+          </h4>
+          <div className="flex flex-col gap-4">
+            {pendingQuestions.map((q) => {
+              const current = pendingAnswers[q.id];
+              return (
+                <div key={q.id} className="flex flex-col gap-2">
+                  <div className="text-[13px] text-t1 leading-[1.5]">{q.question}</div>
+                  <div className="flex flex-col gap-1.5">
+                    {q.options?.map((opt) => (
+                      <label
+                        key={opt.value}
+                        className={`flex items-start gap-2 text-[12px] cursor-pointer px-2.5 py-1.5 rounded-md border transition ${
+                          current?.value === opt.value
+                            ? "border-acc bg-acc/10 text-t1"
+                            : "border-b1 bg-transparent text-t2 hover:border-b2"
+                        }`}
+                      >
+                        <input
+                          type="radio"
+                          name={`q-${q.id}`}
+                          checked={current?.value === opt.value}
+                          onChange={() => setPendingAnswers(prev => ({
+                            ...prev,
+                            [q.id]: { id: q.id, value: opt.value, detail: current?.detail },
+                          }))}
+                          className="mt-0.5"
+                        />
+                        <span>{opt.label}</span>
+                      </label>
+                    ))}
+                    {current?.value === "custom" && q.detail_placeholder && (
+                      <input
+                        type="text"
+                        placeholder={q.detail_placeholder}
+                        value={current?.detail || ""}
+                        onChange={(e) => setPendingAnswers(prev => ({
+                          ...prev,
+                          [q.id]: { ...(prev[q.id] || { id: q.id, value: "custom" }), detail: e.target.value },
+                        }))}
+                        className="mt-1 w-full px-2.5 py-1.5 bg-s1 border border-b2 rounded-md text-[12px] text-t1 focus:border-acc/50 outline-none"
+                      />
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
       {/* Actions */}
       <div className="flex gap-2 px-5 py-4 border-t border-b1 bg-s2">
         <button
-          className="flex-1 py-2.5 px-4 rounded-xl text-[13px] font-semibold bg-acc hover:bg-acc-hover text-white transition"
-          onClick={() => onConfirm(editedData)}
+          className="flex-1 py-2.5 px-4 rounded-xl text-[13px] font-semibold bg-acc hover:bg-acc-hover text-white transition disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-acc"
+          onClick={() => {
+            const payload = {
+              ...editedData,
+              pending_answers: Object.values(pendingAnswers),
+            };
+            onConfirm(payload as DualReadData);
+          }}
+          disabled={!allQuestionsAnswered}
+          title={!allQuestionsAnswered ? "Respondé las preguntas pendientes primero" : undefined}
         >
-          Confirmar medidas · {totalM2.toFixed(2)} m²
+          {allQuestionsAnswered
+            ? `Confirmar medidas · ${totalM2.toFixed(2)} m²`
+            : `Respondé ${pendingQuestions.length - Object.values(pendingAnswers).filter(a => a.value).length} pregunta(s) pendiente(s)`}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## PR B del roadmap multi-crop v2

Infra para "**preguntar antes de asumir**". Principio confirmado con el operador: Valentina NUNCA debe asumir datos que no están en el brief ni en el plano.

## Problema que ataca

Hoy cuando el brief no menciona zócalos, Valentina asume el default (ej: 7cm trasero por tramo) y sigue calculando. El operador se entera cuando ve el PDF final y descubre que puso zócalos que no correspondían — o al revés, no los puso cuando sí.

Claude web Sonnet hace lo correcto: identifica la info faltante y pregunta antes de calcular. Valentina no.

## Solución

### Backend

**Nuevo módulo** `pending_questions.py`:
- Detectores puros que toman `(brief, dual_result)` y devuelven preguntas.
- Aplicador que materializa las respuestas del operador en el JSON de medidas verificadas.

**Schema nuevo** en `dual_read_result`:
```json
{
  "pending_questions": [
    {
      "id": "zocalos",
      "label": "Zócalos",
      "question": "¿Lleva zócalos? El brief no los menciona...",
      "type": "radio_with_detail",
      "options": [
        {"value": "default_trasero", "label": "Sí — trasero por tramo, 7cm (default)"},
        {"value": "custom", "label": "Sí — otro alto o qué lados (detallar)"},
        {"value": "no", "label": "No lleva zócalos"}
      ],
      "detail_placeholder": "Ej: 'trasero y lateral izq, 5cm'"
    }
  ]
}
```

**Agent hook**: después de que dual_read emita result + pase por el anchor validator, corre el detector y adjunta las preguntas al result.

**`[DUAL_READ_CONFIRMED]` handler**: lee `pending_answers` del JSON confirmado por el frontend y aplica via `apply_answers()` antes de guardar `verified_measurements`.

### Primer detector: zócalos

Reglas:
- Brief dice "con zócalos" / "lleva zócalos" → ya hay respuesta, no preguntar.
- Brief dice "sin zócalos" / "no lleva zócalos" → no preguntar.
- Card ya tiene zócalos con `ml > 0` (plan reader los detectó) → no preguntar.
- En cualquier otro caso → **preguntar**.

Aplicador cuando el operador elige `default_trasero`:
- 1 zócalo trasero por tramo, `ml = largo del tramo`, `alto_m = 0.07`.
- Marca `source: "brief_rule"` (trazabilidad: no fue leído del plano).
- **No pisa** zócalos ya detectados por dual_read.

### Frontend (DualReadResult.tsx)

- Bloque ámbar arriba del botón Confirmar con las preguntas pendientes.
- Radios por opción + textbox condicional cuando el operador elige "custom".
- **Botón Confirmar DESHABILITADO** mientras haya preguntas sin responder. El texto del botón muestra cuántas faltan.
- Al confirmar, el JSON enviado incluye `pending_answers: [...]` que el backend procesa.

## Tests

`test_pending_questions.py` — 14 casos:
- Keyword detection (`con zocalos` / `sin zocalos` / silencio)
- Detector emite pregunta en brief silencioso + card sin zócalos
- Detector no emite si brief dice sí/no o card ya los tiene
- `apply_zocalos_answer`: default_trasero per-tramo, no answer noop, custom preserva detail, no pisa zócalos existentes
- Dispatch por id en `apply_answers`

## Efecto esperado en caso Bernardi

Brief: `"material en pura prima onix white... con zócalos en rosario con colocación"`.

Con este PR:
- Brief matchea "con zócalos" → el detector NO emite pregunta.
- Valentina avanza al cálculo con la regla "sí zócalos".
- Siguiente PR (PR D) agregará detectores para las otras 4 preguntas que hoy asume (profundidad isla, patas, colocación, anafe count).

Test manual equivalente: subir el mismo plano con brief SIN "con zócalos" → aparece el bloque ámbar con la pregunta + botón Confirmar deshabilitado.

## Roadmap restante
- **PR C**: pileta en cocina = empotrada (hard-coded, nunca preguntar apoyo vs empotrada)
- **PR D**: más detectores (profundidad isla, patas frontales+laterales, colocación, anafe count)
- **PR E**: global topology con features intermedias (cooktop_groups, sink_double, touches_wall)
- **PR F**: validación completa por tipo de trabajo (cocina/baño/lavadero)

🤖 Generated with [Claude Code](https://claude.com/claude-code)