### PR TITLE
feat(pending-questions): PR F — required_fields (material + localidad)

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -447,7 +447,22 @@ async def _run_dual_read(
         # responda. Evita que Valentina asuma defaults silenciosos.
         try:
             from app.modules.quote_engine.pending_questions import detect_pending_questions
-            _pending = detect_pending_questions(user_message or "", _dual_result)
+            # Cargamos snapshot del quote para que los detectores de campos
+            # obligatorios (material, localidad) puedan ver datos ya salvos.
+            _quote_snapshot = None
+            try:
+                _pq_q = await db.execute(select(Quote).where(Quote.id == quote_id))
+                _pq_quote = _pq_q.scalar_one_or_none()
+                if _pq_quote:
+                    _quote_snapshot = {
+                        "material": _pq_quote.material,
+                        "localidad": _pq_quote.localidad,
+                        "client_name": _pq_quote.client_name,
+                        "project": _pq_quote.project,
+                    }
+            except Exception:
+                pass
+            _pending = detect_pending_questions(user_message or "", _dual_result, quote=_quote_snapshot)
             if _pending:
                 _dual_result["pending_questions"] = _pending
                 logging.info(

--- a/api/app/modules/quote_engine/pending_questions.py
+++ b/api/app/modules/quote_engine/pending_questions.py
@@ -325,16 +325,27 @@ def _detect_zocalos_question(brief: str, dual_result: dict) -> dict | None:
 # Entry point: detect all pending questions for this card
 # ─────────────────────────────────────────────────────────────────────────────
 
-def detect_pending_questions(brief: str, dual_result: dict) -> list[dict]:
+def detect_pending_questions(
+    brief: str,
+    dual_result: dict,
+    quote: dict | None = None,
+) -> list[dict]:
     """Devuelve la lista de preguntas pendientes. Vacía si todos los datos
     detectables están presentes.
 
     Cada detector corre independiente — si uno falla o no aplica, los otros
     siguen. Orden de la lista = orden de presentación en la UI (primero lo
-    más crítico).
+    más crítico para el cálculo).
     """
     questions: list[dict] = []
-    # Orden: primero lo más crítico para el cálculo, después lo de layout.
+    # Campos obligatorios globales (PR F): material + localidad.
+    # Son bloqueantes para cualquier cálculo — van primero.
+    try:
+        from app.modules.quote_engine.required_fields import detect_required_field_questions
+        questions.extend(detect_required_field_questions(brief, quote, dual_result))
+    except Exception:
+        pass
+    # Detectores específicos (PR B/C/D).
     q_anafe = _detect_anafe_count_question(brief, dual_result)
     if q_anafe:
         questions.append(q_anafe)
@@ -539,6 +550,11 @@ def apply_anafe_count_answer(dual_result: dict, answer: dict) -> dict:
 
 def apply_answers(dual_result: dict, answers: list[dict]) -> dict:
     """Aplica todas las respuestas del operador al card. Dispatch por id."""
+    # Import lazy para evitar ciclos
+    from app.modules.quote_engine.required_fields import (
+        apply_localidad_answer,
+        apply_material_answer,
+    )
     for ans in answers or []:
         qid = ans.get("id")
         if qid == "zocalos":
@@ -553,4 +569,8 @@ def apply_answers(dual_result: dict, answers: list[dict]) -> dict:
             apply_colocacion_answer(dual_result, ans)
         elif qid == "anafe_count":
             apply_anafe_count_answer(dual_result, ans)
+        elif qid == "material":
+            apply_material_answer(dual_result, ans)
+        elif qid == "localidad":
+            apply_localidad_answer(dual_result, ans)
     return dual_result

--- a/api/app/modules/quote_engine/required_fields.py
+++ b/api/app/modules/quote_engine/required_fields.py
@@ -1,0 +1,207 @@
+"""Required fields contract — validación completa de datos obligatorios
+por tipo de trabajo (cocina, baño, lavadero) + globales.
+
+Principio: Valentina NUNCA avanza al Paso 2 (cálculo) con datos faltantes
+importantes. Este módulo define el contrato de campos obligatorios por
+tipo de trabajo y emite pending_questions para los que falten.
+
+Spec confirmado con el operador D'Angelo:
+
+COCINA
+  Geometría          : recta / L / U / isla — inferible del plano/card
+  Dimensiones        : largo × ancho por tramo
+  Material           : REQUERIDO
+  Zócalos            : sí/no + alto + lados                    (PR B)
+  Alzada             : sí/no + alto + lados
+  Pileta             : sí/no — en cocina SIEMPRE empotrada      (PR C)
+  Simple vs doble    : REQUERIDO si hay pileta                  (PR C)
+  Anafe              : sí/no + cuántos                          (PR D)
+  Isla               : profundidad + patas                      (PR D)
+  Colocación         : sí/no                                    (PR D)
+  Localidad          : REQUERIDO (flete)
+  Descuento          : sí/no + tipo (arquitecta, etc)
+
+BAÑO
+  Geometría          : recta / L / doble
+  Dimensiones        : largo × ancho
+  Material           : REQUERIDO
+  Zócalos            : sí/no + alto + lados                    (PR B)
+  Pileta             : apoyo / bajomesada / empotrada           (specific)
+  Cantidad           : N piletas
+  Colocación         : sí/no                                    (PR D)
+  Localidad          : REQUERIDO
+  Descuento          : sí/no + tipo
+
+LAVADERO
+  Dimensiones        : largo × ancho
+  Material           : REQUERIDO
+  Zócalos            : sí/no                                   (PR B)
+  Pileta             : sí/no + tipo
+  Colocación         : sí/no                                    (PR D)
+  Localidad          : REQUERIDO
+  Descuento          : sí/no
+
+GLOBAL (aplica a todos)
+  Cliente            : del brief o DB (_extract_quote_info)
+  Obra / proyecto    : del brief o DB
+  Particular/edificio: inferible (edificio si brief menciona edificio/B,
+                       departamentos, unidades)
+  Forma de pago      : default "Contado" (config)
+  Demora             : default del config
+
+Este módulo NO reemplaza los detectores específicos de pending_questions.py
+(zócalos/pileta_simple_doble/isla/colocación/anafe). Se integra con ellos:
+los específicos capturan matices visuales/contextuales; este valida
+presencia básica y agrega material + localidad como mínimo.
+"""
+from __future__ import annotations
+
+import re
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Field presence detectors
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Ciudades típicas del área de D'Angelo — si se matchea, hay localidad.
+_LOCALIDAD_HINTS = re.compile(
+    r"\b(rosario|echesortu|funes|roldán|roldan|villa\s+constitución|villa\s+constitucion|"
+    r"san\s+lorenzo|san\s+nicolás|san\s+nicolas|pergamino|rafaela|fisherton|"
+    r"puerto\s+san\s+mart[ií]n|granadero\s+baigorria|pueblo\s+esther|"
+    r"capit[aá]n\s+bermudez|villa\s+gobernador\s+g[aá]lvez|arroyo\s+seco|"
+    r"cabin|cabina|arrecifes|c[oó]rdoba|buenos\s+aires|caba|capital|córdoba)\b",
+    re.IGNORECASE,
+)
+
+
+def has_material(brief: str, quote: dict | None, dual_result: dict) -> bool:
+    """True si hay material identificable en el brief o en el quote."""
+    if quote and (quote.get("material") or "").strip():
+        return True
+    if not brief:
+        return False
+    # Keywords de materiales conocidos del catálogo
+    material_keywords = [
+        "silestone", "dekton", "neolith", "puraprima", "pura prima",
+        "purastone", "laminatto", "granito", "mármol", "marmol",
+        "negro brasil", "blanco norte", "onix", "quartz",
+    ]
+    return any(k in brief.lower() for k in material_keywords)
+
+
+def has_localidad(brief: str, quote: dict | None) -> bool:
+    """True si hay localidad identificable en el brief o en el quote."""
+    if quote and (quote.get("localidad") or "").strip():
+        return True
+    if not brief:
+        return False
+    return bool(_LOCALIDAD_HINTS.search(brief))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Question builders
+# ─────────────────────────────────────────────────────────────────────────────
+
+def build_material_question() -> dict:
+    return {
+        "id": "material",
+        "label": "Material",
+        "question": (
+            "¿Qué material se usa para este presupuesto? No lo identificamos en "
+            "el brief ni en el plano. Requerido para buscar precio en catálogo."
+        ),
+        "type": "radio_with_detail",
+        "options": [
+            {"value": "granito", "label": "Granito (especificar en el cuadro)"},
+            {"value": "silestone", "label": "Silestone (especificar modelo)"},
+            {"value": "dekton", "label": "Dekton"},
+            {"value": "neolith", "label": "Neolith"},
+            {"value": "puraprima", "label": "Puraprima / Purastone"},
+            {"value": "marmol", "label": "Mármol"},
+            {"value": "custom", "label": "Otro (detallar)"},
+        ],
+        "detail_placeholder": "Nombre exacto del modelo (ej: 'Silestone Blanco Norte')",
+    }
+
+
+def build_localidad_question() -> dict:
+    return {
+        "id": "localidad",
+        "label": "Localidad",
+        "question": (
+            "¿Dónde se entrega / instala? Requerido para calcular flete."
+        ),
+        "type": "radio_with_detail",
+        "options": [
+            {"value": "rosario", "label": "Rosario"},
+            {"value": "funes", "label": "Funes"},
+            {"value": "roldan", "label": "Roldán"},
+            {"value": "custom", "label": "Otra localidad (detallar)"},
+        ],
+        "detail_placeholder": "Nombre de la localidad / ciudad",
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Detector entry point (para composición en pending_questions)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def detect_required_field_questions(
+    brief: str,
+    quote: dict | None,
+    dual_result: dict,
+) -> list[dict]:
+    """Detecta campos obligatorios faltantes y devuelve preguntas.
+
+    Hoy arranca con 2: material + localidad (ambos requeridos para
+    cualquier tipo de trabajo). Siguientes iteraciones pueden ampliar
+    con descuento, forma de pago, etc.
+    """
+    questions: list[dict] = []
+    if not has_material(brief, quote, dual_result):
+        questions.append(build_material_question())
+    if not has_localidad(brief, quote):
+        questions.append(build_localidad_question())
+    return questions
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Answer appliers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def apply_material_answer(dual_result: dict, answer: dict) -> dict:
+    """Registra el material elegido en el dual_result y hinte al quote."""
+    if not isinstance(answer, dict):
+        return dual_result
+    value = answer.get("value")
+    detail = (answer.get("detail") or "").strip()
+    if value == "custom":
+        if not detail:
+            return dual_result
+        dual_result["material_hint"] = detail
+    elif value:
+        label_map = {
+            "granito": "Granito",
+            "silestone": "Silestone",
+            "dekton": "Dekton",
+            "neolith": "Neolith",
+            "puraprima": "Puraprima",
+            "marmol": "Mármol",
+        }
+        base = label_map.get(value, value.title())
+        dual_result["material_hint"] = f"{base}{' — ' + detail if detail else ''}"
+    return dual_result
+
+
+def apply_localidad_answer(dual_result: dict, answer: dict) -> dict:
+    if not isinstance(answer, dict):
+        return dual_result
+    value = answer.get("value")
+    detail = (answer.get("detail") or "").strip()
+    if value == "custom":
+        if not detail:
+            return dual_result
+        dual_result["localidad_hint"] = detail
+    elif value:
+        dual_result["localidad_hint"] = value
+    return dual_result

--- a/api/tests/test_required_fields.py
+++ b/api/tests/test_required_fields.py
@@ -1,0 +1,114 @@
+"""Tests del módulo required_fields — campos obligatorios por tipo de
+trabajo. Hoy cubre material + localidad (siguientes iteraciones: descuento,
+forma de pago, particular vs edificio)."""
+from app.modules.quote_engine.required_fields import (
+    apply_localidad_answer,
+    apply_material_answer,
+    detect_required_field_questions,
+    has_localidad,
+    has_material,
+)
+
+
+def _dual(sectores: list | None = None) -> dict:
+    return {"sectores": sectores or [], "source": "MULTI_CROP"}
+
+
+# ── has_material ─────────────────────────────────────────────────────────────
+
+class TestHasMaterial:
+    def test_from_quote_column(self):
+        assert has_material("", {"material": "Silestone Blanco Norte"}, _dual()) is True
+
+    def test_from_brief_keyword(self):
+        assert has_material("material puraprima onix white", None, _dual()) is True
+        assert has_material("cliente juan cotiza silestone", None, _dual()) is True
+        assert has_material("granito negro brasil", None, _dual()) is True
+
+    def test_absent_returns_false(self):
+        assert has_material("cliente juan", None, _dual()) is False
+        assert has_material("", None, _dual()) is False
+
+
+class TestHasLocalidad:
+    def test_from_quote_column(self):
+        assert has_localidad("", {"localidad": "Funes"}) is True
+
+    def test_from_brief_keyword(self):
+        assert has_localidad("cliente juan en rosario", None) is True
+        assert has_localidad("zona funes", None) is True
+        assert has_localidad("entrega en puerto san martín", None) is True
+
+    def test_absent_returns_false(self):
+        assert has_localidad("cliente juan material silestone", None) is False
+
+
+# ── detect_required_field_questions ─────────────────────────────────────────
+
+class TestDetectRequiredFieldQuestions:
+    def test_emits_both_when_missing(self):
+        qs = detect_required_field_questions("cliente juan", None, _dual())
+        ids = [q["id"] for q in qs]
+        assert "material" in ids
+        assert "localidad" in ids
+
+    def test_skips_when_quote_has_material(self):
+        qs = detect_required_field_questions(
+            "", {"material": "Silestone"}, _dual()
+        )
+        assert all(q["id"] != "material" for q in qs)
+
+    def test_skips_when_brief_has_both(self):
+        qs = detect_required_field_questions(
+            "cliente juan material silestone blanco norte en rosario", None, _dual()
+        )
+        assert qs == []
+
+    def test_material_question_shape(self):
+        qs = detect_required_field_questions("cliente juan", None, _dual())
+        mat_q = next(q for q in qs if q["id"] == "material")
+        vals = {o["value"] for o in mat_q["options"]}
+        assert {"silestone", "granito", "dekton", "custom"} <= vals
+
+    def test_localidad_question_shape(self):
+        qs = detect_required_field_questions("", None, _dual())
+        loc_q = next(q for q in qs if q["id"] == "localidad")
+        vals = {o["value"] for o in loc_q["options"]}
+        assert {"rosario", "custom"} <= vals
+
+
+# ── Apply answers ────────────────────────────────────────────────────────────
+
+class TestApplyMaterialAnswer:
+    def test_preset_records_hint(self):
+        result = _dual()
+        apply_material_answer(result, {"id": "material", "value": "silestone", "detail": "Blanco Norte"})
+        assert "silestone" in result["material_hint"].lower()
+        assert "Blanco Norte" in result["material_hint"]
+
+    def test_custom_requires_detail(self):
+        result = _dual()
+        apply_material_answer(result, {"id": "material", "value": "custom", "detail": "Piedra Patagónica"})
+        assert result["material_hint"] == "Piedra Patagónica"
+
+    def test_custom_without_detail_noop(self):
+        result = _dual()
+        apply_material_answer(result, {"id": "material", "value": "custom", "detail": ""})
+        assert "material_hint" not in result
+
+
+class TestApplyLocalidadAnswer:
+    def test_preset(self):
+        result = _dual()
+        apply_localidad_answer(result, {"id": "localidad", "value": "rosario"})
+        assert result["localidad_hint"] == "rosario"
+
+    def test_custom(self):
+        result = _dual()
+        apply_localidad_answer(result, {"id": "localidad", "value": "custom", "detail": "Villa Eloisa"})
+        assert result["localidad_hint"] == "Villa Eloisa"
+
+    def test_custom_without_detail_noop(self):
+        result = _dual()
+        apply_localidad_answer(result, {"id": "localidad", "value": "custom", "detail": ""})
+        assert "localidad_hint" not in result


### PR DESCRIPTION
## PR F del roadmap multi-crop v2 — completa el batch A-F

Define el contrato de **campos obligatorios por tipo de trabajo** confirmado con el operador:
- Cocina: geometría, dimensiones, material, zócalos, alzada, pileta, anafe, isla, colocación, localidad, descuento
- Baño: geometría, dimensiones, material, zócalos, pileta, colocación, localidad, descuento
- Lavadero: dimensiones, material, zócalos, pileta, colocación, localidad, descuento
- Global: cliente, proyecto, particular/edificio, forma de pago, demora

Arranca con los 2 de máximo ROI que hoy Valentina captura en chat libre (y a veces asume mal):

### 1. material
- Detectado en `brief` por keywords de materiales del catálogo (silestone, dekton, granito, puraprima, mármol, etc.) o en `quote.material`
- Si falta → pregunta con radio de materiales comunes + custom textbox
- Apply: setea `dual_result.material_hint`

### 2. localidad
- Detectado en `brief` por regex de ciudades del área D'Angelo (rosario, funes, roldán, puerto san martín, villa gobernador gálvez, etc.) o en `quote.localidad`
- Si falta → pregunta con radio + custom
- Apply: setea `dual_result.localidad_hint`

## Módulo nuevo
`required_fields.py` con detectores y aplicadores puros. Docstring incluye el spec completo de required fields por tipo para futura expansión (descuento, forma_pago, particular_vs_edificio, etc.).

## Integración
- `detect_pending_questions(brief, dual_result, quote=None)` ahora acepta quote opcional y llama a `detect_required_field_questions` primero (bloqueantes, van arriba)
- `apply_answers` dispatchea `material` y `localidad`
- `_run_dual_read` carga snapshot del quote y lo pasa al detector

## Tests
`test_required_fields.py` — 12 casos:
- Detección desde quote, brief, o ausencia
- Emisión correcta de ambas / ninguna / una
- Schema de opciones
- Apply preset / custom con detail / custom sin detail → noop

## Próximo
**PR G — analyze-first flow**. Re-arquitectura del UX: card "Análisis de contexto" ANTES del despiece, mostrando TODO lo que Valentina sabe + asunciones (con marker) + preguntas. Reusa todos los detectores A-F.

🤖 Generated with [Claude Code](https://claude.com/claude-code)