### PR TITLE
feat(context): PR G — Análisis de contexto antes del despiece

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -483,6 +483,70 @@ async def _run_dual_read(
         except Exception as e:
             logging.warning(f"[dual-read] Failed to save crop: {e}")
 
+        # PR G — gate: antes de emitir el dual_read_result al frontend,
+        # chequeamos si tenemos "context confirmado". Si NO hay
+        # verified_context_analysis guardado en el breakdown, primero
+        # emitimos un chunk `context_analysis` (la card de análisis previa)
+        # y guardamos el dual_read_result en DB para levantarlo cuando el
+        # operador confirme el contexto.
+        _context_already_confirmed = False
+        try:
+            _ck_q = await db.execute(select(Quote).where(Quote.id == quote_id))
+            _ck_quote = _ck_q.scalar_one_or_none()
+            _ck_bd = (_ck_quote.quote_breakdown or {}) if _ck_quote else {}
+            _context_already_confirmed = bool(_ck_bd.get("verified_context_analysis"))
+        except Exception:
+            _ck_bd = {}
+
+        if not _context_already_confirmed:
+            # Construir y emitir context_analysis
+            try:
+                from app.modules.quote_engine.context_analyzer import build_context_analysis
+                from app.modules.agent.tools.catalog_tool import get_ai_config as _get_ai
+                _cfg_defaults = {
+                    "default_zocalo_height": (_get_ai() or {}).get("default_zocalo_height", 0.07),
+                    "default_payment": "Contado",
+                    "default_delivery_days": "30 días",
+                }
+                _ctx_quote = {
+                    "client_name": _ck_quote.client_name if _ck_quote else None,
+                    "project": _ck_quote.project if _ck_quote else None,
+                    "material": _ck_quote.material if _ck_quote else None,
+                    "localidad": _ck_quote.localidad if _ck_quote else None,
+                    "is_building": _ck_quote.is_building if _ck_quote else False,
+                } if _ck_quote else None
+                _context = build_context_analysis(
+                    user_message or "", _ctx_quote, _dual_result, _cfg_defaults
+                )
+                # Persistimos el dual_read_result en DB (para levantarlo al
+                # confirmar contexto) pero NO lo emitimos aún al frontend.
+                try:
+                    _bd2 = dict(_ck_bd)
+                    _bd2["dual_read_result"] = _dual_result
+                    _bd2["dual_read_plan_hash"] = _plan_hash
+                    _bd2["dual_read_planilla_m2"] = planilla_m2
+                    _bd2["dual_read_crop_label"] = crop_label
+                    _bd2["context_analysis_pending"] = _context
+                    await db.execute(update(Quote).where(Quote.id == quote_id).values(quote_breakdown=_bd2))
+                    await db.commit()
+                except Exception as _e_px:
+                    logging.warning(f"[context-analysis] persist pending failed: {_e_px}")
+                chunks.append({
+                    "type": "context_analysis",
+                    "content": _json.dumps(_context, ensure_ascii=False),
+                })
+                logging.info(
+                    f"[context-analysis] emitted for {quote_id}: "
+                    f"{len(_context.get('data_known') or [])} known, "
+                    f"{len(_context.get('assumptions') or [])} assumptions, "
+                    f"{len(_context.get('pending_questions') or [])} questions"
+                )
+                return (True, chunks)
+            except Exception as _e_ctx:
+                logging.warning(f"[context-analysis] build failed, fallback a dual_read_result: {_e_ctx}")
+                # Fallback: si falla el context analyzer, emitimos dual_read
+                # como antes para no romper el flow.
+
         chunks.append({"type": "dual_read_result", "content": _json.dumps(_dual_result, ensure_ascii=False)})
 
         # Persist in DB — SIEMPRE guardar hash + result para dedup en turnos
@@ -1265,6 +1329,62 @@ class AgentService:
         extra_files: Optional[list] = None,
         db: AsyncSession = None,
     ) -> AsyncGenerator[dict, None]:
+
+        # ── Handle CONTEXT_CONFIRMED EARLY (PR G): el operador confirmó la card
+        # de análisis de contexto (datos + asunciones + preguntas). Aplicamos
+        # las respuestas al dual_read_result guardado, emitimos el chunk de
+        # despiece real, y terminamos turno. El próximo [DUAL_READ_CONFIRMED]
+        # cerrará el flow.
+        if user_message.startswith("[CONTEXT_CONFIRMED]"):
+            try:
+                _ctx_payload = json.loads(user_message[len("[CONTEXT_CONFIRMED]"):])
+                _answers = _ctx_payload.get("answers") or []
+                _qr = await db.execute(select(Quote).where(Quote.id == quote_id))
+                _q_ctx = _qr.scalar_one_or_none()
+                _bd_ctx = (_q_ctx.quote_breakdown or {}) if _q_ctx else {}
+                _saved_dual = _bd_ctx.get("dual_read_result") or {}
+                # Aplicar las respuestas al dual_read_result
+                if _answers and _saved_dual:
+                    from app.modules.quote_engine.pending_questions import apply_answers
+                    apply_answers(_saved_dual, _answers)
+                    # Limpiar pending_questions ya que están respondidas
+                    _saved_dual.pop("pending_questions", None)
+                # Guardar verified_context_analysis (gate para no re-preguntar)
+                _bd_ctx["verified_context_analysis"] = _ctx_payload
+                _bd_ctx["dual_read_result"] = _saved_dual
+                _bd_ctx.pop("context_analysis_pending", None)
+                if _q_ctx:
+                    await db.execute(
+                        update(Quote).where(Quote.id == quote_id).values(quote_breakdown=_bd_ctx)
+                    )
+                    await db.commit()
+                logging.info(
+                    f"[context-confirmed] {quote_id} applied {len(_answers)} answers, "
+                    "emitting dual_read_result"
+                )
+                yield {"type": "dual_read_result", "content": json.dumps(_saved_dual, ensure_ascii=False)}
+                yield {"type": "done", "content": ""}
+                # Persist assistant entry en historial
+                try:
+                    _turn = [
+                        {"role": "user", "content": [{"type": "text", "text": "(contexto confirmado)"}]},
+                        {"role": "assistant", "content": "__DUAL_READ_CARD_SHOWN__"},
+                    ]
+                    if _q_ctx:
+                        await db.execute(
+                            update(Quote).where(Quote.id == quote_id).values(
+                                messages=list(_q_ctx.messages or []) + _turn
+                            )
+                        )
+                        await db.commit()
+                except Exception:
+                    pass
+                return
+            except Exception as _e_ctx:
+                logging.error(f"[context-confirmed] handler failed: {_e_ctx}", exc_info=True)
+                yield {"type": "text", "content": "No se pudo procesar la confirmación del contexto. Reintentá."}
+                yield {"type": "done", "content": ""}
+                return
 
         # ── Handle DUAL_READ_CONFIRMED EARLY: save verified_context + replace
         # user_message BEFORE content is built. Si hacemos esto más tarde,

--- a/api/app/modules/quote_engine/context_analyzer.py
+++ b/api/app/modules/quote_engine/context_analyzer.py
@@ -66,11 +66,11 @@ def _extract_localidad_from_brief(brief: str) -> str | None:
 
 
 _ZOCALO_YES = re.compile(
-    r"\b(con\s+z[oó]c|lleva(n)?\s+z[oó]c|z[oó]calos?\s*s[ií])\b",
+    r"\b(con\s+z[oó]c|lleva(n)?\s+z[oó]c|z[oó]calos?\s*s[ií])",
     re.IGNORECASE,
 )
-_COLOC_YES = re.compile(r"\b(con\s+colocaci[oó]n|incluye\s+colocaci[oó]n)\b", re.IGNORECASE)
-_COLOC_NO = re.compile(r"\b(sin\s+colocaci[oó]n|no\s+(incluye\s+)?colocaci[oó]n)\b", re.IGNORECASE)
+_COLOC_YES = re.compile(r"\b(con\s+colocaci[oó]n|incluye\s+colocaci[oó]n)", re.IGNORECASE)
+_COLOC_NO = re.compile(r"\b(sin\s+colocaci[oó]n|no\s+(incluye\s+)?colocaci[oó]n)", re.IGNORECASE)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/api/app/modules/quote_engine/context_analyzer.py
+++ b/api/app/modules/quote_engine/context_analyzer.py
@@ -1,0 +1,240 @@
+"""Context analyzer — construye el resumen de contexto que se muestra al
+operador ANTES del despiece.
+
+Principio del operador D'Angelo: Valentina nunca avanza al despiece (ni
+menos al Paso 2) con datos faltantes o asunciones sin confirmar. Este
+módulo arma una card de 3 secciones:
+
+1. **Datos conocidos**: cosas que sabemos del brief o de la quote saved.
+   Source: "brief" | "quote" | "catalog_match". Estos son hechos.
+
+2. **Asunciones aplicadas**: defaults de regla de negocio o del config
+   que arrancamos usando. Source: "rule" | "config_default". Estos
+   requieren validación del operador.
+
+3. **Preguntas bloqueantes**: lo que pending_questions.py detectó. Sin
+   respuesta a estas, no se avanza al despiece.
+
+Output va en un chunk `context_analysis` que el frontend renderea como
+card nueva (ContextAnalysis.tsx). Cuando el operador confirma con
+[CONTEXT_CONFIRMED], recién ahí se emite el `dual_read_result`.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers: extractores del brief
+# ─────────────────────────────────────────────────────────────────────────────
+
+_MATERIAL_BRIEF_KEYWORDS = (
+    "silestone", "dekton", "neolith", "puraprima", "pura prima",
+    "purastone", "laminatto", "granito", "mármol", "marmol",
+    "negro brasil", "blanco norte", "onix", "quartz",
+)
+
+
+def _extract_material_from_brief(brief: str) -> str | None:
+    if not brief:
+        return None
+    low = brief.lower()
+    for k in _MATERIAL_BRIEF_KEYWORDS:
+        if k in low:
+            # Devuelve una slice corta alrededor del match (primeros 60 chars)
+            idx = low.index(k)
+            snippet = brief[idx : idx + 60].strip()
+            return snippet
+    return None
+
+
+_LOCALIDAD_KEYWORDS = re.compile(
+    r"\b(rosario|echesortu|funes|rold[aá]n|puerto\s+san\s+mart[ií]n|"
+    r"granadero\s+baigorria|pueblo\s+esther|capit[aá]n\s+bermudez|"
+    r"villa\s+gobernador\s+g[aá]lvez|arroyo\s+seco|san\s+lorenzo|"
+    r"san\s+nicol[aá]s|pergamino|rafaela|fisherton)\b",
+    re.IGNORECASE,
+)
+
+
+def _extract_localidad_from_brief(brief: str) -> str | None:
+    if not brief:
+        return None
+    m = _LOCALIDAD_KEYWORDS.search(brief)
+    return m.group(0) if m else None
+
+
+_ZOCALO_YES = re.compile(
+    r"\b(con\s+z[oó]c|lleva(n)?\s+z[oó]c|z[oó]calos?\s*s[ií])\b",
+    re.IGNORECASE,
+)
+_COLOC_YES = re.compile(r"\b(con\s+colocaci[oó]n|incluye\s+colocaci[oó]n)\b", re.IGNORECASE)
+_COLOC_NO = re.compile(r"\b(sin\s+colocaci[oó]n|no\s+(incluye\s+)?colocaci[oó]n)\b", re.IGNORECASE)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Section builders
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _build_data_known(brief: str, quote: dict | None) -> list[dict]:
+    """Datos que sabemos con certeza (del brief o del quote guardado)."""
+    known: list[dict] = []
+
+    # Cliente
+    client = (quote or {}).get("client_name")
+    if client:
+        known.append({"field": "Cliente", "value": client, "source": "quote"})
+    else:
+        # Intentar extraer del brief
+        m = re.search(r"cliente\s*[:=]?\s*([A-Za-zÁÉÍÓÚÑáéíóúñ][A-Za-zÁÉÍÓÚÑáéíóúñ\s]{1,40})", brief or "", re.IGNORECASE)
+        if m:
+            known.append({"field": "Cliente", "value": m.group(1).strip(), "source": "brief"})
+
+    # Proyecto
+    project = (quote or {}).get("project")
+    if project:
+        known.append({"field": "Proyecto", "value": project, "source": "quote"})
+
+    # Material
+    mat = (quote or {}).get("material") or _extract_material_from_brief(brief)
+    if mat:
+        known.append({
+            "field": "Material",
+            "value": mat,
+            "source": "quote" if (quote or {}).get("material") else "brief",
+        })
+
+    # Localidad
+    loc = (quote or {}).get("localidad") or _extract_localidad_from_brief(brief)
+    if loc:
+        known.append({
+            "field": "Localidad",
+            "value": loc,
+            "source": "quote" if (quote or {}).get("localidad") else "brief",
+        })
+
+    return known
+
+
+def _build_assumptions(
+    brief: str,
+    quote: dict | None,
+    dual_result: dict,
+    config_defaults: dict,
+) -> list[dict]:
+    """Asunciones: reglas de negocio + defaults del config. El operador
+    debe confirmar (o corregir)."""
+    assumptions: list[dict] = []
+
+    # Regla D'Angelo: pileta en cocina SIEMPRE empotrada.
+    has_cocina = any(
+        (s.get("tipo") or "").lower() == "cocina"
+        for s in (dual_result.get("sectores") or [])
+    )
+    if has_cocina:
+        assumptions.append({
+            "field": "Pileta (tipo de montaje)",
+            "value": "Empotrada (PEGADOPILETA)",
+            "source": "rule",
+            "note": "Regla D'Angelo: en cocina siempre empotrada, nunca apoyo.",
+        })
+
+    # Zócalos: brief dice "con zócalos" → regla = trasero por tramo, 7cm
+    if brief and _ZOCALO_YES.search(brief):
+        alto = config_defaults.get("default_zocalo_height", 0.07)
+        assumptions.append({
+            "field": "Zócalos",
+            "value": f"Trasero por tramo, {alto * 100:.0f} cm",
+            "source": "brief+rule",
+            "note": "Brief dice 'con zócalos'. Regla D'Angelo: trasero por tramo del largo real.",
+        })
+
+    # Colocación: brief dice sí/no
+    if brief and _COLOC_YES.search(brief):
+        assumptions.append({
+            "field": "Colocación",
+            "value": "Incluye",
+            "source": "brief",
+        })
+    elif brief and _COLOC_NO.search(brief):
+        assumptions.append({
+            "field": "Colocación",
+            "value": "No incluye",
+            "source": "brief",
+        })
+
+    # Forma de pago default
+    pago = config_defaults.get("default_payment", "Contado")
+    assumptions.append({
+        "field": "Forma de pago",
+        "value": pago,
+        "source": "config_default",
+        "note": "Default del sistema. Corrigí si el cliente acordó otra forma.",
+    })
+
+    # Demora default
+    demora = config_defaults.get("default_delivery_days", "30 días")
+    assumptions.append({
+        "field": "Demora",
+        "value": demora if isinstance(demora, str) else f"{demora} días",
+        "source": "config_default",
+    })
+
+    # Tipo (particular / edificio)
+    is_building = bool((quote or {}).get("is_building"))
+    tipo = "Edificio" if is_building else "Particular"
+    assumptions.append({
+        "field": "Tipo",
+        "value": tipo,
+        "source": "inferred",
+        "note": "Inferido del brief / flag del quote. Si tiene >3 unidades, probablemente edificio.",
+    })
+
+    return assumptions
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Entry point
+# ─────────────────────────────────────────────────────────────────────────────
+
+def build_context_analysis(
+    brief: str,
+    quote: dict | None,
+    dual_result: dict,
+    config_defaults: dict | None = None,
+) -> dict:
+    """Arma el objeto `context_analysis` que emite el backend como chunk SSE.
+
+    Shape:
+    {
+      "data_known": [{field, value, source}, ...],
+      "assumptions": [{field, value, source, note?}, ...],
+      "pending_questions": [...],  # copy de dual_result.pending_questions si existe
+      "sector_summary": "Cocina U con isla" | None,  # opcional, del topology
+    }
+    """
+    config_defaults = config_defaults or {}
+    data = _build_data_known(brief or "", quote)
+    assumptions = _build_assumptions(brief or "", quote, dual_result, config_defaults)
+    pending = list(dual_result.get("pending_questions") or [])
+
+    # Sector summary: cuántos sectores y de qué tipo
+    sectores = dual_result.get("sectores") or []
+    sector_desc = None
+    if sectores:
+        tipos = [(s.get("tipo") or "").lower() for s in sectores]
+        tramos_count = sum(len(s.get("tramos") or []) for s in sectores)
+        unique = []
+        for t in tipos:
+            if t and t not in unique:
+                unique.append(t)
+        if unique:
+            sector_desc = f"{tramos_count} mesada(s) en {' + '.join(unique)}"
+
+    return {
+        "data_known": data,
+        "assumptions": assumptions,
+        "pending_questions": pending,
+        "sector_summary": sector_desc,
+    }

--- a/api/tests/test_context_analyzer.py
+++ b/api/tests/test_context_analyzer.py
@@ -1,0 +1,90 @@
+"""Tests de context_analyzer — construye la card de análisis previa al despiece."""
+from app.modules.quote_engine.context_analyzer import build_context_analysis
+
+
+def _dual(has_cocina: bool = True) -> dict:
+    sectores = []
+    if has_cocina:
+        sectores.append({
+            "id": "s1",
+            "tipo": "cocina",
+            "tramos": [{
+                "id": "t1",
+                "descripcion": "Mesada",
+                "largo_m": {"valor": 2.0, "status": "CONFIRMADO"},
+                "ancho_m": {"valor": 0.6, "status": "CONFIRMADO"},
+                "m2": {"valor": 1.2, "status": "CONFIRMADO"},
+                "zocalos": [], "frentin": [], "regrueso": [],
+            }],
+            "ambiguedades": [],
+        })
+    return {"sectores": sectores, "source": "MULTI_CROP"}
+
+
+class TestBuildContextAnalysis:
+    def test_shape(self):
+        out = build_context_analysis("brief", {"client_name": "Juan"}, _dual())
+        assert "data_known" in out
+        assert "assumptions" in out
+        assert "pending_questions" in out
+        assert "sector_summary" in out
+
+    def test_client_from_quote(self):
+        out = build_context_analysis("", {"client_name": "Juan"}, _dual())
+        clientes = [r for r in out["data_known"] if r["field"] == "Cliente"]
+        assert len(clientes) == 1
+        assert clientes[0]["value"] == "Juan"
+        assert clientes[0]["source"] == "quote"
+
+    def test_material_from_brief(self):
+        out = build_context_analysis("material silestone blanco norte", None, _dual())
+        materiales = [r for r in out["data_known"] if r["field"] == "Material"]
+        assert len(materiales) == 1
+        assert "silestone" in materiales[0]["value"].lower()
+        assert materiales[0]["source"] == "brief"
+
+    def test_localidad_from_brief(self):
+        out = build_context_analysis("cliente en rosario", None, _dual())
+        assert any(r["field"] == "Localidad" for r in out["data_known"])
+
+    def test_cocina_triggers_pileta_empotrada_rule(self):
+        out = build_context_analysis("", None, _dual(has_cocina=True))
+        piletas = [a for a in out["assumptions"] if "Pileta" in a["field"]]
+        assert len(piletas) == 1
+        assert "empotrada" in piletas[0]["value"].lower()
+        assert piletas[0]["source"] == "rule"
+
+    def test_no_cocina_no_pileta_rule(self):
+        out = build_context_analysis("", None, _dual(has_cocina=False))
+        assert not any("Pileta" in a["field"] for a in out["assumptions"])
+
+    def test_con_zocalos_triggers_assumption(self):
+        out = build_context_analysis("cocina con zocalos en rosario", None, _dual())
+        zoc = [a for a in out["assumptions"] if a["field"] == "Zócalos"]
+        assert len(zoc) == 1
+        assert "trasero" in zoc[0]["value"].lower()
+
+    def test_con_colocacion_included(self):
+        out = build_context_analysis("cocina con colocacion", None, _dual())
+        coloc = [a for a in out["assumptions"] if a["field"] == "Colocación"]
+        assert len(coloc) == 1
+        assert "incluye" in coloc[0]["value"].lower()
+
+    def test_defaults_always_included(self):
+        out = build_context_analysis("", None, _dual())
+        fields = [a["field"] for a in out["assumptions"]]
+        assert "Forma de pago" in fields
+        assert "Demora" in fields
+        assert "Tipo" in fields
+
+    def test_pending_questions_propagated(self):
+        dual = _dual()
+        dual["pending_questions"] = [{"id": "q1", "label": "X", "question": "¿?", "type": "radio_with_detail"}]
+        out = build_context_analysis("", None, dual)
+        assert len(out["pending_questions"]) == 1
+        assert out["pending_questions"][0]["id"] == "q1"
+
+    def test_sector_summary(self):
+        out = build_context_analysis("", None, _dual())
+        assert out["sector_summary"] is not None
+        assert "cocina" in out["sector_summary"].lower()

--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -13,6 +13,7 @@ import { EmailDraftCard } from "@/components/quote/EmailDraftCard";
 import { CondicionesCard } from "@/components/quote/CondicionesCard";
 import RegenerateButton from "@/components/quote/RegenerateButton";
 import EditableField from "@/components/quote/EditableField";
+import ContextAnalysis from "@/components/chat/ContextAnalysis";
 import clsx from "clsx";
 import { A, I, O, N, DOT, SUP2, DASH, ITEM, WARN, CIRCLE, ARROW, XMARK, CLOUD, WAVE, PAGE, PICTURE, CLIP, RULER, TAG, FOLDER, CHART } from "@/lib/chars";
 
@@ -65,7 +66,9 @@ function buildFullSnapshot(quote: QuoteDetail | null, messages: UIMessage[]): st
     const content = m.content.trim();
     if (!content || content === "." || content === "..") return;
     if (content.startsWith("__ZONE_SELECTOR__")) return;
+    if (content.startsWith("__CONTEXT_ANALYSIS__")) return;
     if (content.startsWith("[SYSTEM_TRIGGER")) return;
+    if (content.startsWith("[CONTEXT_CONFIRMED]")) return;
 
     if (content.startsWith("[DUAL_READ_CONFIRMED]")) {
       parts.push("**Operador:** \u2705 Medidas verificadas", "");
@@ -331,6 +334,12 @@ export default function QuotePage() {
             acc = `__DUAL_READ__${chunk.content}`;
             setMessages(p => p.map(m => m.id === aid ? { ...m, content: acc, isStreaming: false } : m));
           } catch { /* ignore parse errors */ }
+        } else if (chunk.type === "context_analysis") {
+          // PR G — análisis de contexto previo al despiece
+          try {
+            acc = `__CONTEXT_ANALYSIS__${chunk.content}`;
+            setMessages(p => p.map(m => m.id === aid ? { ...m, content: acc, isStreaming: false } : m));
+          } catch { /* ignore parse errors */ }
         } else if (chunk.type === "action") {
           if (fromDetail) setInlineActionText(chunk.content); else setActionText(chunk.content);
         } else if (chunk.type === "done") {
@@ -553,6 +562,24 @@ export default function QuotePage() {
                                   } catch (err) {
                                     console.error("zone-select failed:", err);
                                   }
+                                }}
+                              />
+                            </div>
+                          </div>
+                        );
+                      } catch { return null; }
+                    })()
+                  ) : msg.content.startsWith("__CONTEXT_ANALYSIS__") ? (
+                    (() => {
+                      try {
+                        const ctxData = JSON.parse(msg.content.replace("__CONTEXT_ANALYSIS__", ""));
+                        return (
+                          <div className="msg-anim flex gap-3 items-start">
+                            <div className="max-w-full">
+                              <ContextAnalysis
+                                data={ctxData}
+                                onConfirm={(payload) => {
+                                  send(`[CONTEXT_CONFIRMED]${JSON.stringify(payload)}`);
                                 }}
                               />
                             </div>

--- a/web/src/components/chat/ContextAnalysis.tsx
+++ b/web/src/components/chat/ContextAnalysis.tsx
@@ -1,0 +1,228 @@
+"use client";
+import React, { useState } from "react";
+
+interface DataRow {
+  field: string;
+  value: string;
+  source: string;
+  note?: string;
+}
+
+interface PendingQuestionOption {
+  value: string;
+  label: string;
+}
+
+interface PendingQuestion {
+  id: string;
+  label: string;
+  question: string;
+  type: string;
+  options?: PendingQuestionOption[];
+  detail_placeholder?: string;
+}
+
+interface PendingAnswer {
+  id: string;
+  value: string;
+  detail?: string;
+}
+
+export interface ContextAnalysisData {
+  data_known: DataRow[];
+  assumptions: DataRow[];
+  pending_questions: PendingQuestion[];
+  sector_summary?: string | null;
+}
+
+interface Props {
+  data: ContextAnalysisData;
+  onConfirm: (payload: { answers: PendingAnswer[]; corrections: Record<string, string> }) => void;
+}
+
+const SOURCE_BADGE: Record<string, { label: string; cls: string }> = {
+  brief: { label: "del brief", cls: "bg-acc/10 text-acc border-acc/30" },
+  quote: { label: "del quote", cls: "bg-grn/10 text-grn border-grn/30" },
+  rule: { label: "regla D'Angelo", cls: "bg-amb/10 text-amb border-amb/30" },
+  "brief+rule": { label: "brief + regla", cls: "bg-amb/10 text-amb border-amb/30" },
+  config_default: { label: "default", cls: "bg-white/5 text-t3 border-b1" },
+  inferred: { label: "inferido", cls: "bg-white/5 text-t3 border-b1" },
+};
+
+function SourceBadge({ source }: { source: string }) {
+  const meta = SOURCE_BADGE[source] || SOURCE_BADGE.inferred;
+  return (
+    <span className={`text-[10px] uppercase tracking-[0.08em] px-1.5 py-0.5 rounded border ${meta.cls}`}>
+      {meta.label}
+    </span>
+  );
+}
+
+export default function ContextAnalysis({ data, onConfirm }: Props) {
+  const [answers, setAnswers] = useState<Record<string, PendingAnswer>>({});
+  const [corrections, setCorrections] = useState<Record<string, string>>({});
+  const [editingField, setEditingField] = useState<string | null>(null);
+
+  const questions = data.pending_questions || [];
+  const allAnswered = questions.every(q => answers[q.id]?.value);
+
+  const handleConfirm = () => {
+    onConfirm({
+      answers: Object.values(answers),
+      corrections,
+    });
+  };
+
+  const renderRow = (row: DataRow, editable = true) => (
+    <div key={row.field} className="grid grid-cols-[140px_1fr_auto] gap-3 items-start py-2 border-t border-b1/50">
+      <div className="text-[12px] text-t3 uppercase tracking-[0.06em]">{row.field}</div>
+      <div className="text-[13px] text-t1">
+        {editingField === row.field ? (
+          <input
+            autoFocus
+            defaultValue={corrections[row.field] ?? row.value}
+            onBlur={(e) => {
+              const v = e.target.value.trim();
+              if (v && v !== row.value) {
+                setCorrections(prev => ({ ...prev, [row.field]: v }));
+              }
+              setEditingField(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") { e.currentTarget.blur(); }
+              else if (e.key === "Escape") { setEditingField(null); }
+            }}
+            className="w-full bg-s1 border border-acc/60 rounded px-2 py-1 text-[13px] text-t1 outline-none"
+          />
+        ) : (
+          <span
+            className={editable ? "cursor-text hover:text-t1 transition-colors" : ""}
+            onDoubleClick={() => editable && setEditingField(row.field)}
+            title={editable ? "Doble-click para corregir" : undefined}
+          >
+            {corrections[row.field] ?? row.value}
+          </span>
+        )}
+        {row.note && <div className="text-[11px] text-t3 mt-0.5 italic">{row.note}</div>}
+      </div>
+      <SourceBadge source={row.source} />
+    </div>
+  );
+
+  return (
+    <div className="my-2 w-full rounded-2xl border border-b1 bg-s1 overflow-hidden shadow-[0_20px_40px_-20px_rgba(0,0,0,0.5)]">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-5 py-4 bg-gradient-to-b from-s3 to-s2 border-b border-b1">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-acc bg-acc-bg border border-acc/30 px-2 py-1 rounded-md">
+          🔍 Análisis de contexto
+        </span>
+        <h3 className="text-[15px] font-semibold text-t1">
+          Paso previo al despiece
+        </h3>
+        {data.sector_summary && (
+          <span className="ml-auto text-[12px] text-t3 font-mono">{data.sector_summary}</span>
+        )}
+      </div>
+
+      <div className="p-5">
+        <p className="text-[12px] text-t3 mb-4 leading-[1.55]">
+          Antes de medir el plano, validemos lo que sé del trabajo. Corregí lo que esté mal
+          con doble-click y respondé las preguntas bloqueantes.
+        </p>
+
+        {/* Datos leídos */}
+        {data.data_known.length > 0 && (
+          <div className="mb-5">
+            <h4 className="text-[11px] font-semibold uppercase tracking-[0.1em] text-grn mb-2">
+              📋 Datos que tengo
+            </h4>
+            <div>
+              {data.data_known.map(row => renderRow(row))}
+            </div>
+          </div>
+        )}
+
+        {/* Asunciones */}
+        {data.assumptions.length > 0 && (
+          <div className="mb-5">
+            <h4 className="text-[11px] font-semibold uppercase tracking-[0.1em] text-amb mb-2">
+              ✨ Reglas / defaults que aplico
+            </h4>
+            <div>
+              {data.assumptions.map(row => renderRow(row))}
+            </div>
+          </div>
+        )}
+
+        {/* Preguntas bloqueantes */}
+        {questions.length > 0 && (
+          <div className="mb-5 p-4 rounded-xl border border-amb/30 bg-amb-bg">
+            <h4 className="text-[11px] font-semibold uppercase tracking-[0.1em] text-amb mb-3">
+              ⚠ Preguntas bloqueantes ({questions.length})
+            </h4>
+            <div className="flex flex-col gap-4">
+              {questions.map((q) => {
+                const current = answers[q.id];
+                return (
+                  <div key={q.id} className="flex flex-col gap-2">
+                    <div className="text-[13px] text-t1 leading-[1.5]">{q.question}</div>
+                    <div className="flex flex-col gap-1.5">
+                      {q.options?.map((opt) => (
+                        <label
+                          key={opt.value}
+                          className={`flex items-start gap-2 text-[12px] cursor-pointer px-2.5 py-1.5 rounded-md border transition ${
+                            current?.value === opt.value
+                              ? "border-acc bg-acc/10 text-t1"
+                              : "border-b1 bg-transparent text-t2 hover:border-b2"
+                          }`}
+                        >
+                          <input
+                            type="radio"
+                            name={`q-${q.id}`}
+                            checked={current?.value === opt.value}
+                            onChange={() => setAnswers(prev => ({
+                              ...prev,
+                              [q.id]: { id: q.id, value: opt.value, detail: current?.detail },
+                            }))}
+                            className="mt-0.5"
+                          />
+                          <span>{opt.label}</span>
+                        </label>
+                      ))}
+                      {current?.value === "custom" && q.detail_placeholder && (
+                        <input
+                          type="text"
+                          placeholder={q.detail_placeholder}
+                          value={current?.detail || ""}
+                          onChange={(e) => setAnswers(prev => ({
+                            ...prev,
+                            [q.id]: { ...(prev[q.id] || { id: q.id, value: "custom" }), detail: e.target.value },
+                          }))}
+                          className="mt-1 w-full px-2.5 py-1.5 bg-s1 border border-b2 rounded-md text-[12px] text-t1 focus:border-acc/50 outline-none"
+                        />
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex gap-2 px-5 py-4 border-t border-b1 bg-s2">
+        <button
+          className="flex-1 py-2.5 px-4 rounded-xl text-[13px] font-semibold bg-acc hover:bg-acc-hover text-white transition disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-acc"
+          onClick={handleConfirm}
+          disabled={!allAnswered}
+          title={!allAnswered ? "Respondé las preguntas pendientes primero" : undefined}
+        >
+          {allAnswered
+            ? "Confirmar contexto — seguir al despiece"
+            : `Respondé ${questions.length - Object.values(answers).filter(a => a.value).length} pregunta(s)`}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -450,7 +450,7 @@ export async function updateUsageBudget(data: { monthly_budget_usd?: number; ena
 // ── Chat SSE ──────────────────────────────────────────────────────────────────
 
 export interface ChatChunk {
-  type: "text" | "action" | "done" | "zone_selector" | "dual_read_result";
+  type: "text" | "action" | "done" | "zone_selector" | "dual_read_result" | "context_analysis";
   content: string;
 }
 


### PR DESCRIPTION
## PR G del roadmap multi-crop v2 — re-arquitectura del flow

Confirmado con el operador: Valentina NUNCA avanza al despiece hasta tener todo el contexto saldado. Cada asunción y cada dato leído se muestra con su fuente para transparencia total.

## Flow nuevo

**Antes**:
```
Brief + plano → dual_read → card despiece (con preguntas apiladas arriba) → Paso 2
```

**Ahora**:
```
Brief + plano
  → dual_read corre (silencioso, guarda en DB)
  → Emite card "🔍 ANÁLISIS DE CONTEXTO" con:
      📋 Datos que tengo (del brief/quote)
      ✨ Reglas / defaults que aplico
      ⚠ Preguntas bloqueantes
  → Operador confirma/corrige
  → RECIÉN ahí sale el dual_read_result (card despiece, limpia, sin preguntas)
  → Confirmar medidas → Paso 2
```

## Backend

**Nuevo módulo `context_analyzer.py`**:
- `build_context_analysis(brief, quote, dual_result, config)` arma las 3 secciones con `source` por cada row (brief / quote / rule / config_default / inferred)
- Extractores: material, localidad, zócalos keyword, colocación keyword
- Regla D'Angelo: si hay sector cocina → pileta siempre empotrada
- Defaults del config: Contado + 30 días

**Hook en `_run_dual_read`**:
- Si no hay `verified_context_analysis` → emite chunk `context_analysis` + guarda dual_read en DB pero **NO lo emite**
- Si ya hay → flow normal

**Handler `[CONTEXT_CONFIRMED]`**:
- Aplica answers al dual_read guardado (reusa `apply_answers` de PR B/C/D/F)
- Limpia pending_questions (ya fueron respondidas)
- Emite dual_read_result al frontend

## Frontend

**Nuevo componente `ContextAnalysis.tsx`**:
- Header con badge del paso
- 3 secciones con colores: verde (datos), ámbar (asunciones), ámbar fuerte (preguntas)
- Cada row editable por **doble-click** (corrige asunciones/datos)
- Badges de source en cada row
- Confirmar **DESHABILITADO** hasta responder todas las preguntas

**Chunk type nuevo** `context_analysis` en StreamChunk. `page.tsx` renderea ContextAnalysis cuando el mensaje empieza con `__CONTEXT_ANALYSIS__`.

## Tests
`test_context_analyzer.py` — 11 casos (shape, datos, asunciones, defaults, pending propagation, sector_summary)

## Efecto esperado en caso Bernardi

Brief: `"material en pura prima onix white mate, cliente Erica Bernardi, con zocalos en rosario con colocacion"`

Card de contexto saldrá:
- **Datos**: Cliente=Érica, Material=Pura Prima Onix, Localidad=Rosario
- **Asunciones** (con source): Zócalos trasero 7cm [brief+rule], Pileta empotrada [rule cocina], Colocación sí [brief], Pago Contado [default], Demora 30 días [default], Particular [inferred]
- **Preguntas**: Pileta simple/doble, Anafes count, Isla profundidad, Isla patas

Operador confirma → sale card de despiece ya con todas las medidas limpias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)