### PR TITLE
fix(sse): whitelist context_analysis chunk en streaming loop

### DIFF
--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -1684,6 +1684,9 @@ async def chat(
                     yield f"data: {json.dumps(chunk)}\n\n"
                 elif chunk["type"] == "dual_read_result":
                     yield f"data: {json.dumps(chunk)}\n\n"
+                elif chunk["type"] == "context_analysis":
+                    # PR G — card de análisis de contexto ANTES del despiece
+                    yield f"data: {json.dumps(chunk)}\n\n"
                 elif chunk["type"] == "done":
                     logging.info(f"[SSE] Sending done for quote {quote_id}")
                     yield f"data: {json.dumps(chunk)}\n\n"


### PR DESCRIPTION
## Hotfix de PR #293

En producción el backend emitía el chunk `context_analysis` correctamente (logs confirman: \`[context-analysis] emitted for ...: 3 known, 3 assumptions, 2 questions\`), pero el SSE handler en \`router.py\` no lo conocía y tiraba:

\`\`\`
WARNING: [SSE] Unknown chunk type: context_analysis
\`\`\`

Resultado: el chunk nunca llegaba al frontend → operador veía "servicio saturado — reintentar" spurio.

## Fix

Una línea en \`router.py\` — agregar el chunk a la whitelist del streaming loop:

\`\`\`python
elif chunk["type"] == "context_analysis":
    yield f"data: {json.dumps(chunk)}\n\n"
\`\`\`

Zero cambios de lógica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)