### PR TITLE
fix(context-analysis): emit done chunk + persist turn (arregla retry spurio)

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -535,6 +535,28 @@ async def _run_dual_read(
                     "type": "context_analysis",
                     "content": _json.dumps(_context, ensure_ascii=False),
                 })
+                chunks.append({"type": "done", "content": ""})
+                # Persistir el turno en messages (igual que Case 2 re-emit).
+                # Sin esto, el fetchQuote post-stream no trae el turno y el
+                # frontend re-renderea sin la card → aparece el retry spurio.
+                try:
+                    _user_entry = {
+                        "role": "user",
+                        "content": [{
+                            "type": "text",
+                            "text": (user_message or "").strip() or f"(adjuntó plano: {plan_filename})",
+                        }],
+                    }
+                    _asst_entry = {"role": "assistant", "content": "__CONTEXT_ANALYSIS_SHOWN__"}
+                    if _ck_quote:
+                        await db.execute(
+                            update(Quote).where(Quote.id == quote_id).values(
+                                messages=list(_ck_quote.messages or []) + [_user_entry, _asst_entry]
+                            )
+                        )
+                        await db.commit()
+                except Exception as _e_pm:
+                    logging.warning(f"[context-analysis] persist turn failed: {_e_pm}")
                 logging.info(
                     f"[context-analysis] emitted for {quote_id}: "
                     f"{len(_context.get('data_known') or [])} known, "

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -490,13 +490,15 @@ async def _run_dual_read(
         # y guardamos el dual_read_result en DB para levantarlo cuando el
         # operador confirme el contexto.
         _context_already_confirmed = False
+        _ck_quote = None
+        _ck_bd: dict = {}
         try:
             _ck_q = await db.execute(select(Quote).where(Quote.id == quote_id))
             _ck_quote = _ck_q.scalar_one_or_none()
             _ck_bd = (_ck_quote.quote_breakdown or {}) if _ck_quote else {}
             _context_already_confirmed = bool(_ck_bd.get("verified_context_analysis"))
-        except Exception:
-            _ck_bd = {}
+        except Exception as _e_ctx_q:
+            logging.warning(f"[context-analysis] quote lookup failed: {_e_ctx_q}")
 
         if not _context_already_confirmed:
             # Construir y emitir context_analysis

--- a/api/tests/test_context_analyzer.py
+++ b/api/tests/test_context_analyzer.py
@@ -88,3 +88,119 @@ class TestBuildContextAnalysis:
         out = build_context_analysis("", None, _dual())
         assert out["sector_summary"] is not None
         assert "cocina" in out["sector_summary"].lower()
+
+    def test_empty_inputs_does_not_crash(self):
+        """Brief vacío + dual vacío: no debería romper, devuelve shape mínima."""
+        out = build_context_analysis("", None, {"sectores": []})
+        assert "data_known" in out
+        assert "assumptions" in out
+        assert out["pending_questions"] == []
+
+
+# ── Round-trip: build context → apply answers → verify result ──────────────
+# Simula el flow end-to-end de PR G sin DB ni LLM. Verifica que las
+# respuestas del operador a pending_questions efectivamente modifican el
+# dual_read_result via apply_answers del módulo pending_questions.
+
+
+class TestContextConfirmationRoundTrip:
+    def _dual_with_pending(self, pending: list[dict]) -> dict:
+        d = _dual()
+        d["pending_questions"] = pending
+        return d
+
+    def test_apply_answers_removes_pending_from_dual(self):
+        """Handler [CONTEXT_CONFIRMED] aplica respuestas y limpia pending."""
+        from app.modules.quote_engine.pending_questions import apply_answers
+
+        pending = [{
+            "id": "zocalos", "label": "Zócalos", "question": "?",
+            "type": "radio_with_detail",
+            "options": [{"value": "default_trasero", "label": "Sí"}],
+        }]
+        dual = self._dual_with_pending(pending)
+        # Simulación del handler: aplica answers, limpia pending
+        apply_answers(dual, [{"id": "zocalos", "value": "default_trasero"}])
+        dual.pop("pending_questions", None)
+        # Zócalos agregados al tramo con source=brief_rule
+        assert len(dual["sectores"][0]["tramos"][0]["zocalos"]) == 1
+        assert dual["sectores"][0]["tramos"][0]["zocalos"][0]["source"] == "brief_rule"
+        assert "pending_questions" not in dual
+
+    def test_pileta_simple_doble_applies_sink_type(self):
+        from app.modules.quote_engine.pending_questions import apply_answers
+        dual = _dual()
+        dual["sectores"][0]["tramos"][0]["features"] = {"has_pileta": True}
+        apply_answers(dual, [{"id": "pileta_simple_doble", "value": "doble"}])
+        sector = dual["sectores"][0]
+        assert sector["sink_type"]["basin_count"] == "doble"
+        assert sector["pileta_type_hint"] == "empotrada"
+
+    def test_multiple_answers_apply_in_one_pass(self):
+        """Varios answers en un solo CONTEXT_CONFIRMED se aplican todos."""
+        from app.modules.quote_engine.pending_questions import apply_answers
+        dual = _dual()
+        apply_answers(dual, [
+            {"id": "zocalos", "value": "default_trasero"},
+            {"id": "colocacion", "value": "si"},
+            {"id": "anafe_count", "value": "2"},
+        ])
+        assert len(dual["sectores"][0]["tramos"][0]["zocalos"]) == 1
+        assert dual["colocacion"] is True
+        assert dual["anafe"] is True
+        assert dual["anafe_qty"] == 2
+
+    def test_full_flow_bernardi_like(self):
+        """Caso Bernardi end-to-end (sin DB ni LLM):
+        1. Construye context analysis desde brief + quote + dual_read
+        2. Operador responde las preguntas bloqueantes
+        3. apply_answers materializa todo en el dual_result
+        4. pending_questions se limpia → card despiece queda lista.
+        """
+        from app.modules.quote_engine.pending_questions import apply_answers
+
+        brief = "material pura prima onix white cliente erica bernardi con zocalos en rosario con colocacion"
+        quote = None  # operador recién lo sube, sin datos previos en quote
+
+        dual = _dual()
+        dual["sectores"].append({
+            "id": "s2", "tipo": "isla",
+            "tramos": [{
+                "id": "t_isla",
+                "descripcion": "Mesada",
+                "largo_m": {"valor": 1.60, "status": "CONFIRMADO"},
+                "ancho_m": {"valor": 0.60, "status": "DUDOSO"},  # dispara pregunta
+                "m2": {"valor": 0.96, "status": "DUDOSO"},
+                "zocalos": [], "frentin": [], "regrueso": [],
+            }],
+            "ambiguedades": [],
+        })
+        # Agregar pending_questions típicos del caso
+        dual["pending_questions"] = [
+            {"id": "pileta_simple_doble", "label": "Pileta", "question": "?", "type": "radio_with_detail"},
+            {"id": "isla_profundidad", "label": "Isla prof", "question": "?", "type": "radio_with_detail"},
+            {"id": "isla_patas", "label": "Patas", "question": "?", "type": "radio_with_detail"},
+        ]
+
+        context = build_context_analysis(brief, quote, dual)
+        assert any(r["field"] == "Material" for r in context["data_known"])
+        assert any(r["field"] == "Localidad" for r in context["data_known"])
+        assert any(a["field"] == "Pileta (tipo de montaje)" for a in context["assumptions"])
+        assert any(a["field"] == "Zócalos" for a in context["assumptions"])
+        assert any(a["field"] == "Colocación" for a in context["assumptions"])
+
+        # Operador confirma respondiendo las 3 preguntas
+        apply_answers(dual, [
+            {"id": "pileta_simple_doble", "value": "doble"},
+            {"id": "isla_profundidad", "value": "0.60"},
+            {"id": "isla_patas", "value": "frontal_y_ambos_laterales", "alto_m": 0.90},
+        ])
+        dual.pop("pending_questions", None)
+
+        # Verificamos el estado final listo para despiece:
+        cocina = next(s for s in dual["sectores"] if s["tipo"] == "cocina")
+        isla = next(s for s in dual["sectores"] if s["tipo"] == "isla")
+        assert cocina["sink_type"]["basin_count"] == "doble"
+        assert isla["tramos"][0]["ancho_m"]["valor"] == 0.60
+        assert isla["patas"]["sides"] == ["frontal", "lateral_izq", "lateral_der"]
+        assert "pending_questions" not in dual


### PR DESCRIPTION
## Bug en prod (caso Bernardi post-PR #294)

Backend emitía `context_analysis` correctamente (logs confirman: `emitted ...: 3 known, 4 assumptions, 1 questions`), pero el frontend muestra botón "Reintentar" con espacio vacío encima. 

## 2 bugs relacionados en el path de PR G

### 1. Falta chunk `done`
Todos los otros paths emiten `done` antes de return. El mío no lo hacía → frontend nunca cierra el stream → cae al fallback de "respuesta incompleta" → muestra retry.

### 2. Falta persistir el turno en messages
Case 2 del dual_read flow (re-emit) sí persiste user+assistant placeholder. Mi nuevo PR G path (emit context_analysis en Case 3) no lo hacía → `fetchQuote` post-`done` trae historial sin el turno → frontend confundido.

## Fix
Una línea para `done`, un bloque para persistir el turno con placeholder `__CONTEXT_ANALYSIS_SHOWN__` (idéntico al patrón `__DUAL_READ_CARD_SHOWN__` existente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)