### PR TITLE
fix(pending-questions): isla_profundidad siempre pregunta (no asumir silencioso)

### DIFF
--- a/api/app/modules/quote_engine/pending_questions.py
+++ b/api/app/modules/quote_engine/pending_questions.py
@@ -138,42 +138,35 @@ def _detect_pileta_type_question(brief: str, dual_result: dict) -> dict | None:
 
 
 def _detect_isla_profundidad_question(brief: str, dual_result: dict) -> dict | None:
-    """Isla sin cota de profundidad → preguntar. Nunca asumir 0.60 silencioso.
+    """Isla → SIEMPRE preguntar profundidad (nunca asumir). Skip solo si el
+    brief lo dice explícito (ej: "isla de 0.80", "profundidad isla X").
 
-    Dispara cuando:
-    - Hay sector isla.
-    - El tramo de isla tiene ancho_m con status DUDOSO/UNANCHORED o valor
-      igual al largo (fallback silencioso del VLM).
+    Regla D'Angelo: el plano rara vez muestra la cota de profundidad de la
+    isla con claridad → mejor preguntar que asumir silencioso.
     """
     if not _has_sector_type(dual_result, "isla"):
         return None
-    for s in dual_result.get("sectores") or []:
-        if (s.get("tipo") or "").lower() != "isla":
-            continue
-        for t in s.get("tramos") or []:
-            ancho = t.get("ancho_m") or {}
-            status = ancho.get("status", "")
-            val = ancho.get("valor")
-            largo = (t.get("largo_m") or {}).get("valor")
-            if status in ("DUDOSO", "UNANCHORED") or (
-                val is not None and largo is not None and abs(float(val) - float(largo)) < 0.01
-            ):
-                return {
-                    "id": "isla_profundidad",
-                    "label": "Profundidad de la isla",
-                    "question": (
-                        "¿Cuál es la profundidad (ancho) de la isla? El plano no la "
-                        "muestra explícita — no queremos asumir."
-                    ),
-                    "type": "radio_with_detail",
-                    "options": [
-                        {"value": "0.60", "label": "0.60 m (estándar residencial)"},
-                        {"value": "0.70", "label": "0.70 m"},
-                        {"value": "custom", "label": "Otra medida (detallar)"},
-                    ],
-                    "detail_placeholder": "Ej: 0.80",
-                }
-    return None
+    if brief:
+        if re.search(r"isla\s+(de\s+)?\d+[,.]\d", brief, re.IGNORECASE):
+            return None
+        if re.search(r"profundidad\s+isla\s*[=:]?\s*\d", brief, re.IGNORECASE):
+            return None
+    return {
+        "id": "isla_profundidad",
+        "label": "Profundidad de la isla",
+        "question": (
+            "¿Cuál es la profundidad (ancho) de la isla? En general el plano "
+            "no la muestra explícitamente — preferimos no asumir."
+        ),
+        "type": "radio_with_detail",
+        "options": [
+            {"value": "0.60", "label": "0.60 m (estándar residencial)"},
+            {"value": "0.70", "label": "0.70 m"},
+            {"value": "0.80", "label": "0.80 m"},
+            {"value": "custom", "label": "Otra medida (detallar)"},
+        ],
+        "detail_placeholder": "Ej: 0.75",
+    }
 
 
 def _detect_isla_patas_question(brief: str, dual_result: dict) -> dict | None:

--- a/api/tests/test_pending_questions.py
+++ b/api/tests/test_pending_questions.py
@@ -271,21 +271,24 @@ def _make_with_isla(ancho_status: str = "CONFIRMADO", ancho_val: float = 0.60):
 
 
 class TestDetectIslaProfundidad:
+    def test_always_emits_when_isla_present(self):
+        """Regla nueva: siempre preguntar profundidad isla cuando hay isla."""
+        result = _make_with_isla(ancho_status="CONFIRMADO", ancho_val=0.60)
+        qs = detect_pending_questions("", result)
+        assert any(q["id"] == "isla_profundidad" for q in qs)
+
     def test_emits_when_ancho_is_dudoso(self):
         result = _make_with_isla(ancho_status="DUDOSO")
         qs = detect_pending_questions("", result)
         assert any(q["id"] == "isla_profundidad" for q in qs)
 
-    def test_emits_when_ancho_equals_largo(self):
-        """Fallback silencioso del VLM (L==A) → pedir al operador."""
-        result = _make_with_isla(ancho_status="CONFIRMADO", ancho_val=1.60)
-        qs = detect_pending_questions("", result)
-        assert any(q["id"] == "isla_profundidad" for q in qs)
-
-    def test_skips_when_ancho_confirmed_sensible(self):
+    def test_skips_when_brief_gives_profundidad_explicit(self):
+        """Skip solo si brief da la profundidad explícita."""
         result = _make_with_isla(ancho_status="CONFIRMADO", ancho_val=0.60)
-        qs = detect_pending_questions("", result)
+        qs = detect_pending_questions("isla de 0.80", result)
         assert all(q["id"] != "isla_profundidad" for q in qs)
+        qs2 = detect_pending_questions("profundidad isla 0.70", result)
+        assert all(q["id"] != "isla_profundidad" for q in qs2)
 
     def test_skips_when_no_isla_sector(self):
         qs = detect_pending_questions("", _make_cocina_with_pileta())


### PR DESCRIPTION
Follow-up de PR #296. La regla 'nunca asumir silencioso' requiere que isla_profundidad siempre dispare la pregunta cuando hay isla, no solo cuando el VLM dudó.

Skip solo si el brief explícitamente dice la profundidad (ej: 'isla de 0.80').

Options: 0.60 / 0.70 / 0.80 / custom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)