### PR TITLE
feat(context): isla profundidad + patas se emiten junto con isla_presence

### DIFF
--- a/api/app/modules/quote_engine/pending_questions.py
+++ b/api/app/modules/quote_engine/pending_questions.py
@@ -162,14 +162,21 @@ def _detect_pileta_question(brief: str, dual_result: dict) -> dict | None:
     }
 
 
-def _detect_isla_profundidad_question(brief: str, dual_result: dict) -> dict | None:
+def _detect_isla_profundidad_question(
+    brief: str, dual_result: dict, *, force: bool = False,
+) -> dict | None:
     """Isla → SIEMPRE preguntar profundidad (nunca asumir). Dispara si
-    dual_read detectó isla O si brief la menciona (aunque multi-crop falló).
+    dual_read detectó isla, brief la menciona, o `force=True` (cuando la
+    pregunta de presencia fire y necesitamos el detalle pre-emitido).
 
     Skip solo si el brief da el valor explícito (ej: "isla de 0.80",
     "profundidad isla X").
     """
-    has_isla = _has_sector_type(dual_result, "isla") or _brief_mentions_isla(brief)
+    has_isla = (
+        force
+        or _has_sector_type(dual_result, "isla")
+        or _brief_mentions_isla(brief)
+    )
     if not has_isla:
         return None
     if brief:
@@ -195,11 +202,17 @@ def _detect_isla_profundidad_question(brief: str, dual_result: dict) -> dict | N
     }
 
 
-def _detect_isla_patas_question(brief: str, dual_result: dict) -> dict | None:
+def _detect_isla_patas_question(
+    brief: str, dual_result: dict, *, force: bool = False,
+) -> dict | None:
     """Isla → preguntar si lleva patas (frontal + ambos laterales) y alto.
     Siempre preguntar — no hay default razonable y afecta la cotización.
-    Dispara si dual_read detectó isla O brief la menciona."""
-    has_isla = _has_sector_type(dual_result, "isla") or _brief_mentions_isla(brief)
+    Dispara si dual_read detectó isla, brief la menciona, o `force=True`."""
+    has_isla = (
+        force
+        or _has_sector_type(dual_result, "isla")
+        or _brief_mentions_isla(brief)
+    )
     if not has_isla:
         return None
     return {
@@ -421,15 +434,27 @@ def detect_pending_questions(
     q_anafe = _detect_anafe_count_question(brief, dual_result)
     if q_anafe:
         questions.append(q_anafe)
+
+    # Bloque isla: si puede haber isla (detectada / mencionada en brief / no
+    # negada), emitimos las 3 preguntas juntas. La UI oculta/relaja las
+    # dependientes (profundidad + patas) cuando el operador responde "no"
+    # a la pregunta de presencia.
     q_isla_presence = _detect_isla_presence_question(brief, dual_result)
+    isla_possible = (
+        _has_sector_type(dual_result, "isla")
+        or _brief_mentions_isla(brief)
+        or q_isla_presence is not None
+    )
     if q_isla_presence:
         questions.append(q_isla_presence)
-    q_isla_prof = _detect_isla_profundidad_question(brief, dual_result)
-    if q_isla_prof:
-        questions.append(q_isla_prof)
-    q_isla_patas = _detect_isla_patas_question(brief, dual_result)
-    if q_isla_patas:
-        questions.append(q_isla_patas)
+    if isla_possible:
+        q_isla_prof = _detect_isla_profundidad_question(brief, dual_result, force=True)
+        if q_isla_prof:
+            questions.append(q_isla_prof)
+        q_isla_patas = _detect_isla_patas_question(brief, dual_result, force=True)
+        if q_isla_patas:
+            questions.append(q_isla_patas)
+
     q_zoc = _detect_zocalos_question(brief, dual_result)
     if q_zoc:
         questions.append(q_zoc)

--- a/api/tests/test_pending_questions.py
+++ b/api/tests/test_pending_questions.py
@@ -290,9 +290,23 @@ class TestDetectIslaProfundidad:
         qs2 = detect_pending_questions("profundidad isla 0.70", result)
         assert all(q["id"] != "isla_profundidad" for q in qs2)
 
-    def test_skips_when_no_isla_sector(self):
+    def test_emits_alongside_isla_presence_when_no_isla_sector(self):
+        """Nueva conducta: aunque no haya sector isla, si la pregunta
+        isla_presence se emite, profundidad y patas van juntas (cascada).
+        Se ocultan en frontend cuando operador responde 'no' a presence."""
         qs = detect_pending_questions("", _make_cocina_with_pileta())
-        assert all(q["id"] != "isla_profundidad" for q in qs)
+        ids = [q["id"] for q in qs]
+        assert "isla_presence" in ids
+        assert "isla_profundidad" in ids
+        assert "isla_patas" in ids
+
+    def test_skips_when_brief_says_sin_isla(self):
+        """Si brief niega isla, ni presence ni detalles se emiten."""
+        qs = detect_pending_questions("cocina sin isla", _make_cocina_with_pileta())
+        ids = [q["id"] for q in qs]
+        assert "isla_profundidad" not in ids
+        assert "isla_patas" not in ids
+        assert "isla_presence" not in ids
 
 
 class TestApplyIslaProfundidad:

--- a/web/src/components/chat/ContextAnalysis.tsx
+++ b/web/src/components/chat/ContextAnalysis.tsx
@@ -65,7 +65,18 @@ export default function ContextAnalysis({ data, onConfirm }: Props) {
   const [editingField, setEditingField] = useState<string | null>(null);
 
   const questions = data.pending_questions || [];
-  const allAnswered = questions.every(q => answers[q.id]?.value);
+
+  // Preguntas dependientes de isla: si el operador dijo "no" a isla_presence,
+  // las preguntas de profundidad + patas quedan no-aplicables. Las marcamos
+  // como auto-respondidas para no bloquear Confirmar, y las ocultamos.
+  const islaPresenceValue = answers["isla_presence"]?.value;
+  const islaNotApplicable = islaPresenceValue === "no";
+  const hiddenIfNoIsla = new Set(["isla_profundidad", "isla_patas"]);
+
+  const allAnswered = questions.every(q => {
+    if (islaNotApplicable && hiddenIfNoIsla.has(q.id)) return true;
+    return answers[q.id]?.value;
+  });
 
   // Markdown para "Copiar" — refleja el contenido de la card estructurado:
   // datos, asunciones, preguntas pendientes. Útil para pegar en otra
@@ -109,8 +120,13 @@ export default function ContextAnalysis({ data, onConfirm }: Props) {
   })();
 
   const handleConfirm = () => {
+    // Filtrar answers dependientes de isla cuando presence=no (no aplica).
+    const filteredAnswers = Object.values(answers).filter(a => {
+      if (islaNotApplicable && hiddenIfNoIsla.has(a.id)) return false;
+      return true;
+    });
     onConfirm({
-      answers: Object.values(answers),
+      answers: filteredAnswers,
       corrections,
     });
   };
@@ -218,6 +234,8 @@ export default function ContextAnalysis({ data, onConfirm }: Props) {
             <div className="flex flex-col gap-4">
               {questions.map((q) => {
                 const current = answers[q.id];
+                // Ocultar preguntas dependientes cuando isla_presence=no
+                if (islaNotApplicable && hiddenIfNoIsla.has(q.id)) return null;
                 return (
                   <div key={q.id} className="flex flex-col gap-2">
                     <div className="text-[13px] text-t1 leading-[1.5]">{q.question}</div>


### PR DESCRIPTION
Bug: operador responde "sí, hay isla" pero faltan profundidad + patas questions. Ahora las 3 preguntas se emiten juntas desde el inicio; si operador dice "no" a presence, las 2 dependientes se ocultan + auto-answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)