### PR TITLE
feat(context): tech_detections separa plano/brief de defaults comerciales

### DIFF
--- a/api/app/modules/quote_engine/context_analyzer.py
+++ b/api/app/modules/quote_engine/context_analyzer.py
@@ -230,6 +230,172 @@ def _card_has_pileta(dual_result: dict) -> bool:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Tech detections — lo que el plano / dual_read detectó técnicamente.
+#
+# Shape por detection:
+#   {
+#     "field":        id único (coincide con pending_questions cuando aplica),
+#     "label":        humano, para la UI,
+#     "value":        valor canónico (ej "doble" | "yes" | "2"),
+#     "display":      cómo mostrarlo en la card,
+#     "options":      lista de {value,label} para corrección inline (radio),
+#     "source":       "dual_read" | "brief" | "quote" | "rule",
+#     "confidence":   0.0-1.0,
+#     "status":       "verified"         — confidence >= 0.90, no necesita
+#                                           confirmación; igual mostramos
+#                                           badge con source.
+#                     "needs_confirmation" — 0.60-0.90, UI muestra radio
+#                                           inline con valor preseleccionado.
+#                     "low_confidence"   — < 0.60; el field también aparece
+#                                           como pending_question bloqueante.
+#   }
+#
+# Sólo cubre detecciones técnicas (lo que se ve en el plano o se confirma
+# en el brief con alta certeza). Los "commercial_defaults" (forma de pago,
+# demora, zócalos default, etc.) siguen en assumptions/.
+# ─────────────────────────────────────────────────────────────────────────────
+
+_VERIFIED_T = 0.90
+_LOW_T = 0.60
+
+
+def _status_for(confidence: float) -> str | None:
+    """verified si >= 0.90, needs_confirmation si 0.60-0.90, None si < 0.60
+    (en ese caso el campo vuelve a pending_question sin preselección)."""
+    if confidence >= _VERIFIED_T:
+        return "verified"
+    if confidence >= _LOW_T:
+        return "needs_confirmation"
+    return None
+
+
+def _scan_features(dual_result: dict) -> dict:
+    """Agrega features detectadas en el dual_result a nivel trabajo."""
+    summary = {
+        "sink_double": False,
+        "sink_simple": False,
+        "has_pileta": False,
+        "cooktop_groups": 0,
+        "has_isla": False,
+    }
+    for s in dual_result.get("sectores") or []:
+        if (s.get("tipo") or "").lower() == "isla":
+            summary["has_isla"] = True
+        for t in s.get("tramos") or []:
+            feats = t.get("features") or {}
+            if feats.get("sink_double"):
+                summary["sink_double"] = True
+            if feats.get("sink_simple"):
+                summary["sink_simple"] = True
+            if feats.get("has_pileta"):
+                summary["has_pileta"] = True
+            cg = feats.get("cooktop_groups")
+            if isinstance(cg, (int, float)) and cg > 0:
+                summary["cooktop_groups"] += int(cg)
+    return summary
+
+
+_PILETA_OPTIONS = [
+    {"value": "simple", "label": "Simple (1 bacha)"},
+    {"value": "doble", "label": "Doble (2 bachas)"},
+    {"value": "no", "label": "No lleva"},
+]
+_ISLA_OPTIONS = [
+    {"value": "yes", "label": "Sí, hay isla"},
+    {"value": "no", "label": "No hay isla"},
+]
+_ANAFE_OPTIONS = [
+    {"value": "0", "label": "No lleva"},
+    {"value": "1", "label": "1"},
+    {"value": "2", "label": "2 (gas + eléctrico)"},
+    {"value": "3", "label": "3+"},
+]
+
+
+def _detect_pileta(analysis: dict, feats: dict) -> dict | None:
+    # Brief explícito domina sobre dual_read
+    if analysis.get("pileta_simple_doble") in ("simple", "doble"):
+        v = analysis["pileta_simple_doble"]
+        return _mk("pileta_simple_doble", "Pileta", v, f"{v.capitalize()} (1 bacha)" if v == "simple" else "Doble (2 bachas)",
+                   _PILETA_OPTIONS, "brief", 0.95)
+    if analysis.get("pileta_mentioned") is False and _has_explicit_no_pileta(analysis):
+        return _mk("pileta_simple_doble", "Pileta", "no", "No lleva", _PILETA_OPTIONS, "brief", 0.95)
+    # Dual_read features
+    if feats["sink_double"]:
+        return _mk("pileta_simple_doble", "Pileta", "doble", "Doble (2 bachas) — detectada en plano",
+                   _PILETA_OPTIONS, "dual_read", 0.80)
+    if feats["sink_simple"]:
+        return _mk("pileta_simple_doble", "Pileta", "simple", "Simple (1 bacha) — detectada en plano",
+                   _PILETA_OPTIONS, "dual_read", 0.75)
+    if feats["has_pileta"]:
+        # sabemos que hay pileta pero no el tipo
+        return _mk("pileta_simple_doble", "Pileta", None, "Presente — tipo a confirmar",
+                   _PILETA_OPTIONS, "dual_read", 0.55)
+    return None
+
+
+def _detect_isla(analysis: dict, feats: dict) -> dict | None:
+    if analysis.get("isla_mentioned"):
+        return _mk("isla_presence", "Isla central", "yes", "Sí — del brief", _ISLA_OPTIONS, "brief", 0.95)
+    if feats["has_isla"]:
+        return _mk("isla_presence", "Isla central", "yes", "Sí — detectada en plano",
+                   _ISLA_OPTIONS, "dual_read", 0.85)
+    return None
+
+
+def _detect_anafe(analysis: dict, feats: dict) -> dict | None:
+    # Brief explícito primero
+    ac = analysis.get("anafe_count")
+    if isinstance(ac, int) and ac >= 0:
+        disp = f"{ac}" if ac != 2 else "2 (gas + eléctrico)" if analysis.get("anafe_gas_y_electrico") else "2"
+        return _mk("anafe_count", "Anafe", str(ac), disp, _ANAFE_OPTIONS, "brief", 0.95)
+    # Dual_read cooktop_groups
+    cg = feats["cooktop_groups"]
+    if cg > 0:
+        return _mk("anafe_count", "Anafe", str(cg), f"{cg} — detectado en plano",
+                   _ANAFE_OPTIONS, "dual_read", 0.70)
+    return None
+
+
+def _has_explicit_no_pileta(analysis: dict) -> bool:
+    raw = (analysis.get("raw_notes") or "").lower()
+    return "sin pileta" in raw or "no lleva pileta" in raw
+
+
+def _mk(field: str, label: str, value, display: str, options: list[dict],
+        source: str, confidence: float) -> dict | None:
+    status = _status_for(confidence)
+    if status is None:
+        return None
+    return {
+        "field": field,
+        "label": label,
+        "value": value,
+        "display": display,
+        "options": options,
+        "source": source,
+        "confidence": round(confidence, 2),
+        "status": status,
+    }
+
+
+def _extract_tech_detections(analysis: dict, dual_result: dict) -> list[dict]:
+    """Devuelve la lista ordenada de detecciones técnicas de plano/brief.
+
+    Orden: presencia de isla → pileta → anafe. (El operador valida la foto
+    del plano leyendo de arriba a abajo.) Detecciones ausentes quedan como
+    pending_questions en otro módulo.
+    """
+    feats = _scan_features(dual_result)
+    detections: list[dict] = []
+    for fn in (_detect_isla, _detect_pileta, _detect_anafe):
+        d = fn(analysis, feats)
+        if d is not None:
+            detections.append(d)
+    return detections
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Entry point (async porque llama al LLM analyzer)
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -248,7 +414,15 @@ async def build_context_analysis(
 
     data = _build_data_known(analysis, quote)
     assumptions = _build_assumptions(analysis, quote, dual_result, config_defaults)
-    pending = list(dual_result.get("pending_questions") or [])
+    tech_detections = _extract_tech_detections(analysis, dual_result)
+
+    # Suprimir pending_questions ya cubiertas por un tech_detection. Para
+    # status=verified no hay acción (sólo display). Para needs_confirmation
+    # el operador corrige inline con el radio del tech_detection. En ambos
+    # casos no queremos duplicar la pregunta bloqueante.
+    detected_fields = {d["field"] for d in tech_detections}
+    pending_src = list(dual_result.get("pending_questions") or [])
+    pending = [q for q in pending_src if q.get("id") not in detected_fields]
 
     # Sector summary descriptivo
     sectores = dual_result.get("sectores") or []
@@ -270,6 +444,7 @@ async def build_context_analysis(
     return {
         "data_known": data,
         "assumptions": assumptions,
+        "tech_detections": tech_detections,
         "pending_questions": pending,
         "sector_summary": sector_desc,
         "brief_analysis": {

--- a/api/tests/test_context_analyzer.py
+++ b/api/tests/test_context_analyzer.py
@@ -124,7 +124,109 @@ class TestBuildContextAnalysis:
         out = build_context_analysis("", None, {"sectores": []})
         assert "data_known" in out
         assert "assumptions" in out
+        assert "tech_detections" in out
         assert out["pending_questions"] == []
+        assert out["tech_detections"] == []
+
+
+class TestTechDetections:
+    """Separan lo que el plano/brief detectaron (verificable) de los defaults
+    comerciales. Los campos con confidence >=0.60 aparecen aquí y suprimen la
+    pending_question correspondiente."""
+
+    def _dual_with_features(self, features: dict, tipo: str = "cocina", extra_sectores: list | None = None) -> dict:
+        d = {
+            "sectores": [{
+                "id": "s1", "tipo": tipo,
+                "tramos": [{
+                    "id": "t1", "descripcion": "Mesada",
+                    "largo_m": {"valor": 2.0, "status": "CONFIRMADO"},
+                    "ancho_m": {"valor": 0.6, "status": "CONFIRMADO"},
+                    "m2": {"valor": 1.2, "status": "CONFIRMADO"},
+                    "zocalos": [], "frentin": [], "regrueso": [],
+                    "features": features,
+                }],
+                "ambiguedades": [],
+            }],
+            "source": "MULTI_CROP",
+        }
+        if extra_sectores:
+            d["sectores"].extend(extra_sectores)
+        return d
+
+    def test_sink_double_produces_verified_detection_from_brief(self):
+        """Brief dice 'pileta doble' → detection con source=brief y verified."""
+        out = build_context_analysis("cocina con pileta doble", None, self._dual_with_features({}))
+        det = [d for d in out["tech_detections"] if d["field"] == "pileta_simple_doble"]
+        assert len(det) == 1
+        assert det[0]["value"] == "doble"
+        assert det[0]["source"] == "brief"
+        assert det[0]["status"] == "verified"
+
+    def test_sink_double_from_plano_needs_confirmation(self):
+        """Dual_read detecta sink_double → needs_confirmation (no brief)."""
+        out = build_context_analysis("", None, self._dual_with_features({"sink_double": True}))
+        det = [d for d in out["tech_detections"] if d["field"] == "pileta_simple_doble"]
+        assert len(det) == 1
+        assert det[0]["value"] == "doble"
+        assert det[0]["source"] == "dual_read"
+        assert det[0]["status"] == "needs_confirmation"
+
+    def test_detection_suppresses_matching_pending_question(self):
+        """Si hay tech_detection para pileta, no aparece en pending_questions."""
+        dual = self._dual_with_features({"sink_double": True})
+        dual["pending_questions"] = [
+            {"id": "pileta_simple_doble", "label": "P", "question": "?", "type": "radio_with_detail"},
+            {"id": "alzada", "label": "A", "question": "?", "type": "radio_with_detail"},
+        ]
+        out = build_context_analysis("", None, dual)
+        ids = [q["id"] for q in out["pending_questions"]]
+        assert "pileta_simple_doble" not in ids  # suprimida por detection
+        assert "alzada" in ids  # otras preguntas intactas
+
+    def test_isla_detected_when_sector_present(self):
+        dual = self._dual_with_features({}, extra_sectores=[{
+            "id": "s2", "tipo": "isla",
+            "tramos": [{
+                "id": "t_isla", "descripcion": "Isla",
+                "largo_m": {"valor": 1.60, "status": "CONFIRMADO"},
+                "ancho_m": {"valor": 0.60, "status": "DUDOSO"},
+                "m2": {"valor": 0.96, "status": "DUDOSO"},
+                "zocalos": [], "frentin": [], "regrueso": [],
+            }], "ambiguedades": [],
+        }])
+        out = build_context_analysis("", None, dual)
+        det = [d for d in out["tech_detections"] if d["field"] == "isla_presence"]
+        assert len(det) == 1
+        assert det[0]["value"] == "yes"
+        assert det[0]["source"] == "dual_read"
+
+    def test_anafe_count_from_brief_is_verified(self):
+        out = build_context_analysis("cocina con 2 anafes", None, self._dual_with_features({}))
+        det = [d for d in out["tech_detections"] if d["field"] == "anafe_count"]
+        assert len(det) == 1
+        assert det[0]["value"] == "2"
+        assert det[0]["status"] == "verified"
+
+    def test_has_pileta_only_no_detection_still_question(self):
+        """has_pileta sin simple/doble → confidence 0.55 < 0.60, no se emite
+        detection y el campo debería seguir como pending_question."""
+        dual = self._dual_with_features({"has_pileta": True})
+        dual["pending_questions"] = [
+            {"id": "pileta_simple_doble", "label": "P", "question": "?", "type": "radio_with_detail"},
+        ]
+        out = build_context_analysis("", None, dual)
+        assert not any(d["field"] == "pileta_simple_doble" for d in out["tech_detections"])
+        assert any(q["id"] == "pileta_simple_doble" for q in out["pending_questions"])
+
+    def test_detection_shape_has_required_keys(self):
+        """Contrato: cada detection tiene field/label/value/display/options/source/confidence/status."""
+        out = build_context_analysis("cocina con pileta doble", None, self._dual_with_features({}))
+        d = next(x for x in out["tech_detections"] if x["field"] == "pileta_simple_doble")
+        for key in ("field", "label", "value", "display", "options", "source", "confidence", "status"):
+            assert key in d
+        assert isinstance(d["options"], list)
+        assert d["options"][0].keys() >= {"value", "label"}
 
 
 # ── Round-trip: build context → apply answers → verify result ──────────────

--- a/web/src/components/chat/ContextAnalysis.tsx
+++ b/web/src/components/chat/ContextAnalysis.tsx
@@ -29,9 +29,26 @@ interface PendingAnswer {
   detail?: string;
 }
 
+interface TechDetectionOption {
+  value: string;
+  label: string;
+}
+
+interface TechDetection {
+  field: string;
+  label: string;
+  value: string | null;
+  display: string;
+  options: TechDetectionOption[];
+  source: string;
+  confidence: number;
+  status: "verified" | "needs_confirmation";
+}
+
 export interface ContextAnalysisData {
   data_known: DataRow[];
   assumptions: DataRow[];
+  tech_detections?: TechDetection[];
   pending_questions: PendingQuestion[];
   sector_summary?: string | null;
 }
@@ -48,6 +65,12 @@ const SOURCE_BADGE: Record<string, { label: string; cls: string }> = {
   "brief+rule": { label: "brief + regla", cls: "bg-amb/10 text-amb border-amb/30" },
   config_default: { label: "default", cls: "bg-white/5 text-t3 border-b1" },
   inferred: { label: "inferido", cls: "bg-white/5 text-t3 border-b1" },
+  dual_read: { label: "del plano", cls: "bg-grn/10 text-grn border-grn/30" },
+};
+
+const STATUS_BADGE: Record<string, { label: string; cls: string }> = {
+  verified: { label: "confirmado", cls: "bg-grn/15 text-grn border-grn/40" },
+  needs_confirmation: { label: "confirmar", cls: "bg-amb/15 text-amb border-amb/40" },
 };
 
 function SourceBadge({ source }: { source: string }) {
@@ -63,6 +86,15 @@ export default function ContextAnalysis({ data, onConfirm }: Props) {
   const [answers, setAnswers] = useState<Record<string, PendingAnswer>>({});
   const [corrections, setCorrections] = useState<Record<string, string>>({});
   const [editingField, setEditingField] = useState<string | null>(null);
+
+  const techDetections = data.tech_detections || [];
+  // Un tech_detection se comporta como answer auto-aplicado: inicialmente
+  // con value detectado, el operador puede cambiarlo inline con radio.
+  const [techAnswers, setTechAnswers] = useState<Record<string, string>>(() => {
+    const init: Record<string, string> = {};
+    for (const d of techDetections) if (d.value) init[d.field] = d.value;
+    return init;
+  });
 
   const questions = data.pending_questions || [];
 
@@ -91,6 +123,15 @@ export default function ContextAnalysis({ data, onConfirm }: Props) {
       data.data_known.forEach(row => {
         const v = corrections[row.field] ?? row.value;
         lines.push(`- **${row.field}**: ${v} _(${row.source})_`);
+      });
+      lines.push("");
+    }
+
+    if (techDetections.length > 0) {
+      lines.push("### Detectado en plano / brief");
+      techDetections.forEach(d => {
+        const picked = d.options.find(o => o.value === techAnswers[d.field]);
+        lines.push(`- **${d.label}**: ${picked?.label || d.display} _(${d.source}, ${Math.round(d.confidence * 100)}%)_`);
       });
       lines.push("");
     }
@@ -125,8 +166,14 @@ export default function ContextAnalysis({ data, onConfirm }: Props) {
       if (islaNotApplicable && hiddenIfNoIsla.has(a.id)) return false;
       return true;
     });
+    // tech_detections con valor definido se envían como answers (mismo id
+    // dispatch en backend). Si el operador corrigió el radio inline, va su
+    // valor; si no, va el detectado por defecto.
+    const techAsAnswers: PendingAnswer[] = techDetections
+      .filter(d => techAnswers[d.field] !== undefined && techAnswers[d.field] !== null)
+      .map(d => ({ id: d.field, value: techAnswers[d.field] }));
     onConfirm({
-      answers: filteredAnswers,
+      answers: [...filteredAnswers, ...techAsAnswers],
       corrections,
     });
   };
@@ -209,6 +256,63 @@ export default function ContextAnalysis({ data, onConfirm }: Props) {
             </h4>
             <div>
               {data.data_known.map(row => renderRow(row))}
+            </div>
+          </div>
+        )}
+
+        {/* Detecciones técnicas del plano/brief */}
+        {techDetections.length > 0 && (
+          <div className="mb-5">
+            <h4 className="text-[11px] font-semibold uppercase tracking-[0.1em] text-grn mb-2">
+              🔎 Detectado en plano / brief
+            </h4>
+            <div className="flex flex-col gap-2">
+              {techDetections.map((d) => {
+                const current = techAnswers[d.field];
+                const statusMeta = STATUS_BADGE[d.status] || STATUS_BADGE.needs_confirmation;
+                const sourceMeta = SOURCE_BADGE[d.source] || SOURCE_BADGE.inferred;
+                return (
+                  <div key={d.field} className="py-2 border-t border-b1/50">
+                    <div className="flex items-center gap-2 mb-1.5">
+                      <span className="text-[12px] text-t3 uppercase tracking-[0.06em]">{d.label}</span>
+                      <span className={`text-[10px] uppercase tracking-[0.08em] px-1.5 py-0.5 rounded border ${sourceMeta.cls}`}>
+                        {sourceMeta.label}
+                      </span>
+                      <span className={`text-[10px] uppercase tracking-[0.08em] px-1.5 py-0.5 rounded border ${statusMeta.cls}`}>
+                        {statusMeta.label}
+                      </span>
+                      <span className="text-[10px] text-t3 ml-auto font-mono">
+                        {Math.round(d.confidence * 100)}%
+                      </span>
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {d.options.map((opt) => (
+                        <label
+                          key={opt.value}
+                          className={`flex items-center gap-1.5 text-[12px] cursor-pointer px-2.5 py-1 rounded-md border transition ${
+                            current === opt.value
+                              ? "border-acc bg-acc/10 text-t1"
+                              : "border-b1 bg-transparent text-t2 hover:border-b2"
+                          }`}
+                        >
+                          <input
+                            type="radio"
+                            name={`tech-${d.field}`}
+                            checked={current === opt.value}
+                            onChange={() => setTechAnswers(prev => ({ ...prev, [d.field]: opt.value }))}
+                          />
+                          <span>{opt.label}</span>
+                        </label>
+                      ))}
+                    </div>
+                    {d.status === "needs_confirmation" && (
+                      <div className="text-[11px] text-t3 mt-1 italic">
+                        {d.display}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary

- Nuevo bloque `tech_detections` en la card de Análisis de contexto: lista lo detectado técnicamente (plano/brief) con shape `{field, value, source, confidence, status}`.
- `verified` (conf ≥ 0.90) se muestra con badge; `needs_confirmation` (0.60-0.90) trae radio inline con valor preseleccionado. Bajo 0.60 vuelve a `pending_question`.
- Suprime pending_questions cuyo id coincide con un detection — sin duplicados entre "detectado" y "preguntas bloqueantes".
- Detecciones iniciales: `isla_presence`, `pileta_simple_doble`, `anafe_count`. Brief > dual_read > defaults.

## Test plan

- [ ] `pytest tests/test_context_analyzer.py` — 7 tests nuevos para tech_detections (shape, prioridad brief/dual_read, supresión de pending_questions)
- [ ] Subir plano Bernardi: ver que pileta doble y anafe salen como detection (no como pending_question)
- [ ] Verificar que el radio inline permite corregir el valor preseleccionado y se aplica al confirmar
- [ ] Copiar contexto: el markdown incluye la sección "Detectado en plano / brief"

🤖 Generated with [Claude Code](https://claude.com/claude-code)