### PR TITLE
docs(mockups): exportar 36 mockups HTML del estado actual del producto

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,33 @@
+# Backlog — Mejoras pendientes post-rediseño
+
+Anotaciones durante la implementación del rediseño UI/UX (Claude Design handoff v2, abril 2026).
+
+## UX — Navegación del chat
+
+### Scroll-to interno al chat (tabs decorativas → anclas)
+El rediseño propone tabs top-level **Desafío · Chat · Piezas · Resumen** para navegar rápido entre secciones. Decisión: diferido.
+
+Cuando se implemente, la versión preferida es **anclas scroll-to dentro del mismo chat** (no vistas separadas). El usuario hace click en "Piezas" y el chat hace smooth-scroll hasta la card de despiece. Mantiene el flujo conversacional lineal actual pero acelera la navegación en presupuestos largos.
+
+**Alternativa descartada:** vistas separadas por tab con estado persistido — implicaría refactor grande del ChatPage + nueva estructura de mensajes.
+
+## UX — Split view con panel Piezas persistente
+
+La propuesta "B" original (split view: chat a la izquierda, panel Piezas editable a la derecha en vivo) quedó descartada. Se mantiene el flujo actual: **todas las cards renderizan inline en el chat**.
+
+Razón: la interactividad inline actual (doble-click para editar medidas en DualReadResult, radios en ContextAnalysis) ya cubre el caso. Un panel fijo agregaría complejidad de sincronización sin beneficio claro.
+
+## Feature — "Desde obra anterior" (clonar quote con otro material)
+
+Chip visible en el Home hero **pero deshabilitado** (gris, sin acción).
+
+Feature propuesta: desde un presupuesto previo validado, crear uno nuevo **clonando estructura** (sectores, tramos, m², MO) pero permitiendo **cambiar el material**. Use case: cliente pidió Silestone, ahora quiere ver mismo plano en Dekton.
+
+Backend necesita:
+- Endpoint `POST /quotes/{id}/clone` que duplica el `dual_read_result` + `quote_breakdown` pero vacía `material` + `total_*`.
+- Front navega al nuevo `quoteId` con el chat pre-poblado y pide solo el material nuevo.
+- Valentina dispara directo el cálculo (sin volver a leer el plano).
+
+## Feature — "Solo medidas" (dictar medidas sin plano)
+
+Descartado. No había entry point en el backend actual y agregarlo implicaba un flow paralelo sin plano-reader. Si reaparece, el chip se re-habilita en HomeQuickActions.

--- a/docs/mockups/01-login-desktop.html
+++ b/docs/mockups/01-login-desktop.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Login · Desktop 1440×900</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --amb:#f5a623; --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame {
+    width:1440px; height:900px; background:var(--bg); color:var(--t1);
+    font-family:var(--font-sans); overflow:hidden; position:relative;
+    border:1px solid rgba(255,255,255,.06); border-radius:6px;
+  }
+  /* noise overlay */
+  .frame::after {
+    content:''; position:absolute; inset:0;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+    pointer-events:none;
+  }
+
+  .login-wrap { height:100%; display:flex; align-items:center; justify-content:center; }
+  .card {
+    width:400px;
+    background:var(--s1); border:1px solid var(--b1);
+    border-radius:32px; padding:40px 36px 36px;
+    box-shadow:0 24px 80px rgba(0,0,0,.5), 0 0 0 1px rgba(255,255,255,.03) inset;
+  }
+  .brand { display:flex; align-items:center; gap:14px; margin-bottom:26px; }
+  .brand-badge {
+    width:44px; height:44px; border-radius:12px;
+    background:var(--acc2); border:1px solid var(--acc3);
+    display:flex; align-items:center; justify-content:center;
+    color:var(--acc); font-size:20px; font-weight:700;
+  }
+  .brand-title { font-size:18px; font-weight:600; letter-spacing:-.03em; color:var(--t1); }
+  .brand-sub { font-size:12px; color:var(--t3); margin-top:2px; }
+  label { display:block; font-size:12px; color:var(--t2); margin:14px 0 6px; font-weight:500; }
+  .input {
+    width:100%; padding:10px 14px;
+    background:var(--s3); border:1px solid var(--b1);
+    border-radius:10px; color:var(--t1); font-size:14px;
+    font-family:var(--font-sans); outline:none;
+    transition:border-color .15s,box-shadow .15s;
+  }
+  .input:focus, .input.focused { border-color:var(--acc); box-shadow:0 0 0 3px rgba(79,143,255,.12); }
+  .input::placeholder { color:var(--t4); }
+  .submit {
+    width:100%; padding:12px 14px; margin-top:22px;
+    background:var(--acc); color:#fff; font-size:14px; font-weight:600;
+    border:none; border-radius:10px; cursor:pointer;
+    letter-spacing:-.01em;
+  }
+  .submit:hover { background:#3d7be6; }
+
+  .footer {
+    text-align:center; margin-top:22px;
+    font-size:11px; color:var(--t3);
+  }
+</style>
+</head>
+<body>
+<span class="frame-label">LOGIN · DESKTOP · 1440×900 · /login</span>
+<div class="frame">
+  <div class="login-wrap">
+    <div class="card">
+      <div class="brand">
+        <div class="brand-badge">D</div>
+        <div>
+          <div class="brand-title">D'Angelo</div>
+          <div class="brand-sub">Presupuestos de marmolería · Valentina</div>
+        </div>
+      </div>
+
+      <label for="email">Email</label>
+      <input id="email" class="input" type="email" placeholder="tu@dangelo.com.ar" value="javier@dangelo.com.ar" />
+
+      <label for="password">Contraseña</label>
+      <input id="password" class="input focused" type="password" placeholder="••••••••" value="•••••••••" />
+
+      <button class="submit">Entrar</button>
+
+      <div class="footer">
+        Uso interno · Solo personal autorizado
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/mockups/01-login-mobile.html
+++ b/docs/mockups/01-login-mobile.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Login · Mobile 390×844</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:14px; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:ui-monospace,"Geist Mono",monospace; font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame {
+    width:390px; height:844px; background:var(--bg); overflow:hidden; position:relative;
+    border-radius:38px; border:10px solid #0a0a10;
+  }
+  .frame::after {
+    content:''; position:absolute; inset:0;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+    pointer-events:none;
+  }
+
+  .login-wrap { height:100%; display:flex; align-items:center; justify-content:center; padding:20px; }
+  .card {
+    width:100%;
+    background:var(--s1); border:1px solid var(--b1);
+    border-radius:32px; padding:32px 20px 28px;
+    box-shadow:0 24px 80px rgba(0,0,0,.5), 0 0 0 1px rgba(255,255,255,.03) inset;
+  }
+  .brand { display:flex; align-items:center; gap:12px; margin-bottom:22px; }
+  .brand-badge {
+    width:40px; height:40px; border-radius:12px;
+    background:var(--acc2); border:1px solid var(--acc3);
+    display:flex; align-items:center; justify-content:center;
+    color:var(--acc); font-size:18px; font-weight:700;
+  }
+  .brand-title { font-size:17px; font-weight:600; letter-spacing:-.03em; }
+  .brand-sub { font-size:11px; color:var(--t3); margin-top:2px; }
+  label { display:block; font-size:12px; color:var(--t2); margin:14px 0 6px; }
+  .input {
+    width:100%; padding:10px 14px;
+    background:var(--s3); border:1px solid var(--b1);
+    border-radius:10px; color:var(--t1); font-size:14px;
+    outline:none;
+  }
+  .input.focused { border-color:var(--acc); box-shadow:0 0 0 3px rgba(79,143,255,.12); }
+  .submit {
+    width:100%; padding:12px 14px; margin-top:22px;
+    background:var(--acc); color:#fff; font-size:14px; font-weight:600;
+    border:none; border-radius:10px;
+  }
+  .footer {
+    text-align:center; margin-top:20px;
+    font-size:11px; color:var(--t3);
+  }
+</style>
+</head>
+<body>
+<span class="frame-label">LOGIN · MOBILE · 390×844 · /login</span>
+<div class="frame">
+  <div class="login-wrap">
+    <div class="card">
+      <div class="brand">
+        <div class="brand-badge">D</div>
+        <div>
+          <div class="brand-title">D'Angelo</div>
+          <div class="brand-sub">Valentina · presupuestos</div>
+        </div>
+      </div>
+
+      <label>Email</label>
+      <input class="input" type="email" value="javier@dangelo.com.ar" />
+
+      <label>Contraseña</label>
+      <input class="input focused" type="password" value="•••••••••" />
+
+      <button class="submit">Entrar</button>
+
+      <div class="footer">Uso interno · Solo personal autorizado</div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/mockups/02-dashboard-populated-desktop.html
+++ b/docs/mockups/02-dashboard-populated-desktop.html
@@ -1,0 +1,373 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Dashboard · populado · Desktop 1440×900</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:1440px; height:900px; background:var(--bg); overflow:hidden; position:relative; border:1px solid rgba(255,255,255,.06); border-radius:6px; display:flex; }
+  .frame::after {
+    content:''; position:absolute; inset:0; pointer-events:none;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+  }
+
+  /* ======== SIDEBAR ======== */
+  .sidebar {
+    width:212px; flex-shrink:0; background:var(--s1); border-right:1px solid var(--b1);
+    display:flex; flex-direction:column; padding:18px 10px 20px;
+  }
+  .side-logo { display:flex; align-items:center; gap:10px; padding:2px 8px 20px; cursor:pointer; }
+  .side-logo-badge { width:26px; height:26px; border-radius:6px; background:var(--acc); color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; letter-spacing:-.5px; }
+  .side-logo-text { font-size:13px; font-weight:500; letter-spacing:-.02em; }
+  .side-label { font-size:10px; font-weight:500; color:var(--t4); text-transform:uppercase; letter-spacing:.1em; padding:0 8px 4px; }
+  .side-label.mt { margin-top:14px; }
+  .side-item { display:flex; align-items:center; gap:8px; padding:8px; border-radius:6px; font-size:12px; color:var(--t2); cursor:pointer; border:none; background:transparent; width:100%; text-align:left; }
+  .side-item.active { color:var(--acc); background:rgba(79,143,255,.11); }
+  .side-item svg { flex-shrink:0; opacity:.65; }
+  .side-item.active svg { opacity:1; }
+  .side-item .count { margin-left:auto; font-size:10px; font-weight:500; padding:1px 7px; border-radius:99px; background:rgba(255,255,255,.07); color:var(--t3); font-family:var(--font-mono); }
+  .side-item.active .count { background:var(--acc); color:#fff; font-weight:600; }
+  .side-divider { height:1px; background:var(--b1); margin:12px 0; }
+  .side-spacer { flex:1; }
+  .side-new {
+    width:100%; padding:10px 12px; background:var(--acc); color:#fff; font-size:13px; font-weight:500;
+    border:none; border-radius:8px; display:flex; align-items:center; justify-content:center; gap:7px;
+    letter-spacing:-.01em;
+  }
+  .side-logout {
+    width:100%; padding:7px 8px; background:transparent; border:none; color:var(--t3); font-size:11px;
+    display:flex; align-items:center; justify-content:center; gap:6px; margin-top:10px; cursor:pointer;
+  }
+
+  /* ======== MAIN ======== */
+  .main { flex:1; display:flex; flex-direction:column; min-width:0; }
+  .main-header { padding:20px 28px 18px; border-bottom:1px solid var(--b1); }
+  .main-h1 { font-size:18px; font-weight:500; letter-spacing:-.03em; color:var(--t1); }
+  .main-sub { font-size:11px; color:var(--t3); margin-top:2px; }
+
+  /* ======== FILTER BAR ======== */
+  .filterbar { display:flex; align-items:center; gap:8px; padding:10px 16px; background:var(--s2); border-bottom:1px solid var(--b1); }
+  .ftab { display:flex; align-items:center; gap:6px; padding:5px 12px; border:1px solid var(--b1); border-radius:6px; background:transparent; font-size:12px; font-weight:500; color:var(--t3); cursor:pointer; }
+  .ftab.active { background:var(--acc2); border-color:var(--acc); color:var(--acc); }
+  .ftab .count { font-size:10px; padding:1px 6px; border-radius:99px; background:rgba(255,255,255,.08); color:var(--t3); font-family:var(--font-mono); }
+  .ftab.active .count { background:var(--acc3); color:var(--acc); }
+  .fspacer { flex:1; }
+  .finput { padding:6px 10px; border:1px solid var(--b1); background:var(--s3); border-radius:8px; font-size:12px; color:var(--t1); outline:none; }
+  .finput.search { width:240px; }
+  .finput.date { width:120px; font-family:var(--font-mono); }
+  .fbtn { padding:7px 12px; border:1px solid var(--b1); border-radius:6px; background:transparent; color:var(--t2); font-size:12px; font-weight:500; display:inline-flex; align-items:center; gap:6px; cursor:pointer; }
+
+  /* ======== TABLE ======== */
+  .tablewrap { flex:1; overflow:auto; }
+  table { width:100%; border-collapse:collapse; }
+  thead tr { background:var(--s2); border-bottom:1px solid var(--b1); }
+  th { padding:10px 18px; text-align:left; font-size:10px; font-weight:500; color:var(--t3); text-transform:uppercase; letter-spacing:.09em; }
+  th.right { text-align:right; }
+  tbody tr { border-bottom:1px solid rgba(255,255,255,.045); border-left:2px solid transparent; cursor:pointer; }
+  tbody tr:hover { background:rgba(255,255,255,.035); }
+  tbody tr.unread { background:rgba(79,143,255,.04); }
+  tbody tr.selected { background:rgba(79,143,255,.07); border-left-color:var(--acc); }
+  td { padding:13px 18px; font-size:13px; color:var(--t1); vertical-align:middle; }
+  td.num { font-family:var(--font-mono); letter-spacing:-.02em; }
+  td.right { text-align:right; }
+  .cli-main { font-size:13px; color:var(--t1); font-weight:500; }
+  tbody tr.unread .cli-main { font-weight:600; }
+  .cli-sub { font-size:11px; color:var(--t3); margin-top:2px; }
+  .mat { font-size:12px; color:var(--t2); display:inline-flex; align-items:center; gap:6px; }
+  .chip-obra { padding:1px 6px; font-size:9px; font-weight:600; letter-spacing:.05em; color:var(--amb); background:var(--amb2); border:1px solid rgba(245,166,35,.25); border-radius:4px; text-transform:uppercase; }
+  .amt-usd { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .status { display:inline-flex; align-items:center; gap:6px; padding:3px 8px; border-radius:99px; font-size:11px; font-weight:500; }
+  .status .dot { width:5px; height:5px; border-radius:99px; background:currentColor; }
+  .status.draft { color:var(--amb); background:var(--amb2); }
+  .status.pending { color:#b299ff; background:rgba(180,160,255,.1); }
+  .status.validated { color:var(--grn); background:var(--grn2); }
+  .status.sent { color:var(--acc); background:var(--acc2); }
+  .status.web { color:var(--t2); background:rgba(255,255,255,.05); }
+  .filechips { display:inline-flex; gap:4px; }
+  .fchip { height:26px; padding:0 6px; border:1px solid var(--b1); border-radius:5px; font-size:11px; color:var(--t2); display:inline-flex; align-items:center; gap:3px; background:transparent; }
+  .fchip.drive { border-color:rgba(79,143,255,.2); color:var(--acc); }
+  .fchip.xls { border-color:rgba(48,209,88,.2); color:var(--grn); }
+  .delbtn { width:28px; height:28px; border:1px solid var(--b1); border-radius:6px; background:transparent; color:var(--t3); font-size:10px; display:inline-flex; align-items:center; justify-content:center; }
+
+  /* ======== PAGINATION ======== */
+  .pagbar { display:flex; align-items:center; justify-content:space-between; padding:10px 16px; background:rgba(16,16,24,.8); border-top:1px solid var(--b1); }
+  .paginfo { font-size:12px; color:var(--t3); font-family:var(--font-mono); }
+  .pagnav { display:flex; gap:6px; }
+  .pagbtn { padding:4px 10px; border:1px solid var(--b1); border-radius:6px; background:transparent; color:var(--t2); font-size:11px; font-weight:500; cursor:pointer; font-family:var(--font-mono); }
+  .pagbtn:disabled { opacity:.3; }
+
+  /* ======== STALE BANNER (above filter bar) ======== */
+  .stale {
+    display:flex; align-items:center; gap:10px; margin:12px 16px 0;
+    padding:10px 14px; border:1px solid rgba(245,166,35,.16); background:rgba(245,166,35,.06);
+    border-radius:8px; font-size:12px; color:var(--amb);
+  }
+  .stale .dot { width:6px; height:6px; border-radius:99px; background:var(--amb); }
+</style>
+</head>
+<body>
+<span class="frame-label">DASHBOARD · POBLADO · DESKTOP · 1440×900 · /</span>
+<div class="frame">
+
+  <!-- SIDEBAR -->
+  <aside class="sidebar">
+    <div class="side-logo">
+      <div class="side-logo-badge">D</div>
+      <span class="side-logo-text">D'Angelo</span>
+    </div>
+
+    <div class="side-label">Principal</div>
+    <button class="side-item active">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Presupuestos
+      <span class="count">3</span>
+    </button>
+
+    <div class="side-label mt">Sistema</div>
+    <button class="side-item">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/><path d="M19 12a7 7 0 01-1 3.5l2 2-3 3-2-2a7 7 0 01-3.5 1"/></svg>
+      Catálogo
+    </button>
+    <button class="side-item">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
+      Configuración
+    </button>
+
+    <div class="side-divider"></div>
+
+    <div class="side-spacer"></div>
+
+    <button class="side-new">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+      Nuevo presupuesto
+    </button>
+    <button class="side-logout">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+      Cerrar sesión
+    </button>
+  </aside>
+
+  <!-- MAIN -->
+  <main class="main">
+    <header class="main-header">
+      <div class="main-h1">Presupuestos</div>
+      <div class="main-sub">abril de 2026 · 8 registros · 3 sin leer</div>
+    </header>
+
+    <div class="stale">
+      <span class="dot"></span>
+      Hay 2 borradores sin actualizar hace más de 30 días
+    </div>
+
+    <div class="filterbar" style="margin-top:12px">
+      <button class="ftab active">Todos <span class="count">8</span></button>
+      <button class="ftab">Borrador <span class="count">2</span></button>
+      <button class="ftab">Pendiente <span class="count">2</span></button>
+      <button class="ftab">Validado <span class="count">2</span></button>
+      <button class="ftab">Enviado <span class="count">1</span></button>
+      <button class="ftab">Web <span class="count">1</span></button>
+      <span class="fspacer"></span>
+      <input class="finput date" value="01/04/2026" />
+      <span style="color:var(--t4);font-size:11px">—</span>
+      <input class="finput date" value="18/04/2026" />
+      <input class="finput search" placeholder="Buscar cliente, obra, material…" value="" />
+      <button class="fbtn">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M12 4v12m0 0l-5-5m5 5l5-5M4 20h16"/></svg>
+        Exportar CSV
+      </button>
+    </div>
+
+    <div class="tablewrap">
+      <table>
+        <thead>
+          <tr>
+            <th style="width:28%">Cliente</th>
+            <th>Material</th>
+            <th class="right">Importe</th>
+            <th>Estado</th>
+            <th>Fecha</th>
+            <th>Archivos</th>
+            <th style="width:40px"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <!-- Bernardi (unread, in progress) -->
+          <tr class="unread">
+            <td>
+              <div class="cli-main">Erica Bernardi</div>
+              <div class="cli-sub">Casa Bernardi · cocina + isla</div>
+            </td>
+            <td><span class="mat">Puraprima Onix White Mate</span></td>
+            <td class="right">
+              <div class="num">$ 4.284.000</div>
+              <div class="amt-usd">USD 3.180</div>
+            </td>
+            <td><span class="status draft"><span class="dot"></span>Borrador</span></td>
+            <td class="num">18/04</td>
+            <td><span class="filechips"><span class="fchip">—</span></span></td>
+            <td><button class="delbtn">×</button></td>
+          </tr>
+
+          <!-- Pereyra -->
+          <tr>
+            <td>
+              <div class="cli-main">Carlos Pereyra</div>
+              <div class="cli-sub">Cocina Pereyra · mesada L</div>
+            </td>
+            <td><span class="mat">Granito Negro Brasil</span></td>
+            <td class="right">
+              <div class="num">$ 1.842.000</div>
+            </td>
+            <td><span class="status validated"><span class="dot"></span>Validado</span></td>
+            <td class="num">17/04</td>
+            <td>
+              <span class="filechips">
+                <span class="fchip drive">PDF</span>
+                <span class="fchip xls">Excel</span>
+              </span>
+            </td>
+            <td><button class="delbtn">×</button></td>
+          </tr>
+
+          <!-- Johnson (edificio OBRA) unread -->
+          <tr class="unread">
+            <td>
+              <div class="cli-main">Johnson Arquitectura</div>
+              <div class="cli-sub">Residencia Álzaga — 12 unidades</div>
+            </td>
+            <td><span class="mat"><span class="chip-obra">Obra</span> Silestone Blanco Norte</span></td>
+            <td class="right">
+              <div class="num">$ 24.820.000</div>
+              <div class="amt-usd">USD 18.400</div>
+            </td>
+            <td><span class="status pending"><span class="dot"></span>Pendiente</span></td>
+            <td class="num">16/04</td>
+            <td><span class="filechips"><span class="fchip">PDF</span></span></td>
+            <td><button class="delbtn">×</button></td>
+          </tr>
+
+          <!-- Álvarez -->
+          <tr>
+            <td>
+              <div class="cli-main">Marta Álvarez</div>
+              <div class="cli-sub">Baño suite — vanitory</div>
+            </td>
+            <td><span class="mat">Silestone Blanco Norte</span></td>
+            <td class="right">
+              <div class="num">$ 907.200</div>
+              <div class="amt-usd">USD 672</div>
+            </td>
+            <td><span class="status sent"><span class="dot"></span>Enviado</span></td>
+            <td class="num">14/04</td>
+            <td>
+              <span class="filechips">
+                <span class="fchip drive">PDF</span>
+                <span class="fchip xls">Excel</span>
+              </span>
+            </td>
+            <td><button class="delbtn">×</button></td>
+          </tr>
+
+          <!-- Estudio Nómade -->
+          <tr class="unread">
+            <td>
+              <div class="cli-main">Estudio Nómade</div>
+              <div class="cli-sub">Obra Fisherton — cocina + isla</div>
+            </td>
+            <td><span class="mat">Dekton Kreta</span></td>
+            <td class="right">
+              <div class="num">$ 4.320.000</div>
+              <div class="amt-usd">USD 3.200</div>
+            </td>
+            <td><span class="status pending"><span class="dot"></span>Pendiente</span></td>
+            <td class="num">12/04</td>
+            <td><span class="filechips"><span class="fchip">—</span></span></td>
+            <td><button class="delbtn">×</button></td>
+          </tr>
+
+          <!-- Taller Iván -->
+          <tr>
+            <td>
+              <div class="cli-main">Taller Iván</div>
+              <div class="cli-sub">Revestimiento loft</div>
+            </td>
+            <td><span class="mat">Neolith Calacatta</span></td>
+            <td class="right">
+              <div class="num">$ 2.902.500</div>
+              <div class="amt-usd">USD 2.150</div>
+            </td>
+            <td><span class="status validated"><span class="dot"></span>Validado</span></td>
+            <td class="num">08/04</td>
+            <td>
+              <span class="filechips">
+                <span class="fchip drive">PDF</span>
+                <span class="fchip xls">Excel</span>
+              </span>
+            </td>
+            <td><button class="delbtn">×</button></td>
+          </tr>
+
+          <!-- Gastón Ruiz -->
+          <tr>
+            <td>
+              <div class="cli-main">Gastón Ruiz</div>
+              <div class="cli-sub">Ampliación Fisherton</div>
+            </td>
+            <td><span class="mat">Mármol Carrara</span></td>
+            <td class="right">
+              <div class="num">$ 6.480.000</div>
+              <div class="amt-usd">USD 4.800</div>
+            </td>
+            <td><span class="status draft"><span class="dot"></span>Borrador</span></td>
+            <td class="num">04/04</td>
+            <td><span class="filechips"><span class="fchip">—</span></span></td>
+            <td><button class="delbtn">×</button></td>
+          </tr>
+
+          <!-- Ramiro Díaz — WEB -->
+          <tr>
+            <td>
+              <div class="cli-main">Ramiro Díaz</div>
+              <div class="cli-sub">Vía formulario web</div>
+            </td>
+            <td><span class="mat">Puraprima Titanium</span></td>
+            <td class="right">
+              <div class="num">$ 607.500</div>
+              <div class="amt-usd">USD 450</div>
+            </td>
+            <td><span class="status web"><span class="dot"></span>Web</span></td>
+            <td class="num">03/04</td>
+            <td><span class="filechips"><span class="fchip">—</span></span></td>
+            <td><button class="delbtn">×</button></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="pagbar">
+      <span class="paginfo">1–8 de 8</span>
+      <div class="pagnav">
+        <button class="pagbtn" disabled>‹</button>
+        <span class="paginfo" style="align-self:center">1 / 1</span>
+        <button class="pagbtn" disabled>›</button>
+      </div>
+    </div>
+  </main>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/02-dashboard-populated-mobile.html
+++ b/docs/mockups/02-dashboard-populated-mobile.html
@@ -1,0 +1,255 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Dashboard · populado · Mobile 390×844</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame {
+    width:390px; height:844px; background:var(--bg); overflow:hidden; position:relative;
+    border-radius:38px; border:10px solid #0a0a10; display:flex; flex-direction:column;
+  }
+  .frame::after {
+    content:''; position:absolute; inset:0; pointer-events:none;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+  }
+
+  /* Mobile top bar */
+  .mtop {
+    display:flex; align-items:center; gap:10px; padding:12px 16px;
+    background:var(--s1); border-bottom:1px solid var(--b1);
+  }
+  .mburger { width:28px; height:28px; border-radius:6px; display:flex; align-items:center; justify-content:center; color:var(--t2); background:transparent; border:none; }
+  .mlogo-badge {
+    width:24px; height:24px; border-radius:6px; background:var(--acc); color:#fff;
+    font-weight:600; font-size:11px; display:flex; align-items:center; justify-content:center; letter-spacing:-.5px;
+  }
+  .mlogo-text { font-size:13px; font-weight:500; letter-spacing:-.02em; }
+
+  .mhead { padding:16px 16px 12px; }
+  .mhead-h1 { font-size:18px; font-weight:500; letter-spacing:-.03em; color:var(--t1); }
+  .mhead-sub { font-size:11px; color:var(--t3); margin-top:2px; }
+
+  /* Tabs (horizontal scroll) */
+  .mtabs {
+    display:flex; gap:6px; padding:8px 16px; overflow-x:auto;
+    background:var(--s2); border-top:1px solid var(--b1); border-bottom:1px solid var(--b1);
+    white-space:nowrap;
+  }
+  .mtabs::-webkit-scrollbar { display:none; }
+  .ftab {
+    display:inline-flex; align-items:center; gap:6px; padding:5px 11px;
+    border:1px solid var(--b1); border-radius:6px; background:transparent;
+    font-size:12px; font-weight:500; color:var(--t3); cursor:pointer; flex-shrink:0;
+  }
+  .ftab.active { background:var(--acc2); border-color:var(--acc); color:var(--acc); }
+  .ftab .count { font-size:10px; padding:1px 6px; border-radius:99px; background:rgba(255,255,255,.08); color:var(--t3); font-family:var(--font-mono); }
+  .ftab.active .count { background:var(--acc3); color:var(--acc); }
+
+  /* Cards list */
+  .list { flex:1; overflow-y:auto; }
+  .card-row {
+    display:grid; grid-template-columns:1fr auto; gap:8px;
+    padding:12px; border-bottom:1px solid rgba(255,255,255,.045); cursor:pointer;
+  }
+  .card-row.unread { background:rgba(79,143,255,.04); }
+  .cli-main { font-size:13px; color:var(--t1); font-weight:500; }
+  .card-row.unread .cli-main { font-weight:600; }
+  .cli-sub { font-size:11px; color:var(--t3); margin-top:2px; }
+  .price { text-align:right; font-size:13px; font-family:var(--font-mono); color:var(--t1); letter-spacing:-.02em; }
+  .amt-usd { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .meta-row { grid-column:1/-1; display:flex; align-items:center; justify-content:space-between; margin-top:6px; }
+  .status { display:inline-flex; align-items:center; gap:6px; padding:3px 8px; border-radius:99px; font-size:11px; font-weight:500; }
+  .status .dot { width:5px; height:5px; border-radius:99px; background:currentColor; }
+  .status.draft { color:var(--amb); background:var(--amb2); }
+  .status.pending { color:#b299ff; background:rgba(180,160,255,.1); }
+  .status.validated { color:var(--grn); background:var(--grn2); }
+  .status.sent { color:var(--acc); background:var(--acc2); }
+  .status.web { color:var(--t2); background:rgba(255,255,255,.05); }
+  .fecha { font-size:11px; color:var(--t3); font-family:var(--font-mono); }
+
+  /* FAB */
+  .fab {
+    position:absolute; bottom:24px; right:16px;
+    padding:12px 20px; border-radius:99px; background:var(--acc); color:#fff;
+    font-size:13px; font-weight:500; border:none; display:inline-flex; align-items:center; gap:7px;
+    box-shadow:0 10px 30px rgba(79,143,255,.35), 0 0 0 1px rgba(255,255,255,.05) inset;
+    letter-spacing:-.01em;
+  }
+</style>
+</head>
+<body>
+<span class="frame-label">DASHBOARD · POBLADO · MOBILE · 390×844 · /</span>
+<div class="frame">
+
+  <!-- MobileTopBar -->
+  <div class="mtop">
+    <button class="mburger">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <div class="mlogo-badge">D</div>
+    <span class="mlogo-text">D'Angelo</span>
+  </div>
+
+  <!-- Header -->
+  <div class="mhead">
+    <div class="mhead-h1">Presupuestos</div>
+    <div class="mhead-sub">abril de 2026 · 8 registros · 3 sin leer</div>
+  </div>
+
+  <!-- Filter tabs -->
+  <div class="mtabs">
+    <button class="ftab active">Todos <span class="count">8</span></button>
+    <button class="ftab">Borrador <span class="count">2</span></button>
+    <button class="ftab">Pendiente <span class="count">2</span></button>
+    <button class="ftab">Validado <span class="count">2</span></button>
+    <button class="ftab">Enviado <span class="count">1</span></button>
+    <button class="ftab">Web <span class="count">1</span></button>
+  </div>
+
+  <!-- Cards -->
+  <div class="list">
+
+    <div class="card-row unread">
+      <div>
+        <div class="cli-main">Erica Bernardi</div>
+        <div class="cli-sub">Casa Bernardi · cocina U + isla</div>
+      </div>
+      <div>
+        <div class="price">$ 4.284.000</div>
+        <div class="amt-usd">USD 3.180</div>
+      </div>
+      <div class="meta-row">
+        <span class="status draft"><span class="dot"></span>Borrador</span>
+        <span class="fecha">18/04</span>
+      </div>
+    </div>
+
+    <div class="card-row">
+      <div>
+        <div class="cli-main">Carlos Pereyra</div>
+        <div class="cli-sub">Cocina Pereyra · mesada L</div>
+      </div>
+      <div>
+        <div class="price">$ 1.842.000</div>
+      </div>
+      <div class="meta-row">
+        <span class="status validated"><span class="dot"></span>Validado</span>
+        <span class="fecha">17/04</span>
+      </div>
+    </div>
+
+    <div class="card-row unread">
+      <div>
+        <div class="cli-main">Johnson Arquitectura</div>
+        <div class="cli-sub">Residencia Álzaga — 12 unidades</div>
+      </div>
+      <div>
+        <div class="price">$ 24.820.000</div>
+        <div class="amt-usd">USD 18.400</div>
+      </div>
+      <div class="meta-row">
+        <span class="status pending"><span class="dot"></span>Pendiente</span>
+        <span class="fecha">16/04</span>
+      </div>
+    </div>
+
+    <div class="card-row">
+      <div>
+        <div class="cli-main">Marta Álvarez</div>
+        <div class="cli-sub">Baño suite — vanitory</div>
+      </div>
+      <div>
+        <div class="price">$ 907.200</div>
+        <div class="amt-usd">USD 672</div>
+      </div>
+      <div class="meta-row">
+        <span class="status sent"><span class="dot"></span>Enviado</span>
+        <span class="fecha">14/04</span>
+      </div>
+    </div>
+
+    <div class="card-row unread">
+      <div>
+        <div class="cli-main">Estudio Nómade</div>
+        <div class="cli-sub">Obra Fisherton — cocina + isla</div>
+      </div>
+      <div>
+        <div class="price">$ 4.320.000</div>
+        <div class="amt-usd">USD 3.200</div>
+      </div>
+      <div class="meta-row">
+        <span class="status pending"><span class="dot"></span>Pendiente</span>
+        <span class="fecha">12/04</span>
+      </div>
+    </div>
+
+    <div class="card-row">
+      <div>
+        <div class="cli-main">Taller Iván</div>
+        <div class="cli-sub">Revestimiento loft</div>
+      </div>
+      <div>
+        <div class="price">$ 2.902.500</div>
+        <div class="amt-usd">USD 2.150</div>
+      </div>
+      <div class="meta-row">
+        <span class="status validated"><span class="dot"></span>Validado</span>
+        <span class="fecha">08/04</span>
+      </div>
+    </div>
+
+    <div class="card-row">
+      <div>
+        <div class="cli-main">Gastón Ruiz</div>
+        <div class="cli-sub">Ampliación Fisherton</div>
+      </div>
+      <div>
+        <div class="price">$ 6.480.000</div>
+        <div class="amt-usd">USD 4.800</div>
+      </div>
+      <div class="meta-row">
+        <span class="status draft"><span class="dot"></span>Borrador</span>
+        <span class="fecha">04/04</span>
+      </div>
+    </div>
+
+    <div class="card-row">
+      <div>
+        <div class="cli-main">Ramiro Díaz</div>
+        <div class="cli-sub">Vía formulario web</div>
+      </div>
+      <div>
+        <div class="price">$ 607.500</div>
+        <div class="amt-usd">USD 450</div>
+      </div>
+      <div class="meta-row">
+        <span class="status web"><span class="dot"></span>Web</span>
+        <span class="fecha">03/04</span>
+      </div>
+    </div>
+
+  </div>
+
+  <button class="fab">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+    Nuevo presupuesto
+  </button>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/02b-dashboard-empty-desktop.html
+++ b/docs/mockups/02b-dashboard-empty-desktop.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Dashboard · vacío · Desktop 1440×900</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:1440px; height:900px; background:var(--bg); overflow:hidden; position:relative; border:1px solid rgba(255,255,255,.06); border-radius:6px; display:flex; }
+  .frame::after {
+    content:''; position:absolute; inset:0; pointer-events:none;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+  }
+
+  /* SIDEBAR */
+  .sidebar { width:212px; flex-shrink:0; background:var(--s1); border-right:1px solid var(--b1); display:flex; flex-direction:column; padding:18px 10px 20px; }
+  .side-logo { display:flex; align-items:center; gap:10px; padding:2px 8px 20px; cursor:pointer; }
+  .side-logo-badge { width:26px; height:26px; border-radius:6px; background:var(--acc); color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; letter-spacing:-.5px; }
+  .side-logo-text { font-size:13px; font-weight:500; letter-spacing:-.02em; }
+  .side-label { font-size:10px; font-weight:500; color:var(--t4); text-transform:uppercase; letter-spacing:.1em; padding:0 8px 4px; }
+  .side-label.mt { margin-top:14px; }
+  .side-item { display:flex; align-items:center; gap:8px; padding:8px; border-radius:6px; font-size:12px; color:var(--t2); cursor:pointer; border:none; background:transparent; width:100%; text-align:left; }
+  .side-item.active { color:var(--acc); background:rgba(79,143,255,.11); }
+  .side-item svg { flex-shrink:0; opacity:.65; }
+  .side-item.active svg { opacity:1; }
+  .side-item .count { margin-left:auto; font-size:10px; font-weight:500; padding:1px 7px; border-radius:99px; background:rgba(255,255,255,.07); color:var(--t3); font-family:var(--font-mono); }
+  .side-item.active .count { background:var(--acc); color:#fff; font-weight:600; }
+  .side-divider { height:1px; background:var(--b1); margin:12px 0; }
+  .side-spacer { flex:1; }
+  .side-new { width:100%; padding:10px 12px; background:var(--acc); color:#fff; font-size:13px; font-weight:500; border:none; border-radius:8px; display:flex; align-items:center; justify-content:center; gap:7px; letter-spacing:-.01em; }
+  .side-logout { width:100%; padding:7px 8px; background:transparent; border:none; color:var(--t3); font-size:11px; display:flex; align-items:center; justify-content:center; gap:6px; margin-top:10px; cursor:pointer; }
+
+  /* MAIN */
+  .main { flex:1; display:flex; flex-direction:column; min-width:0; }
+  .main-header { padding:20px 28px 18px; border-bottom:1px solid var(--b1); }
+  .main-h1 { font-size:18px; font-weight:500; letter-spacing:-.03em; color:var(--t1); }
+  .main-sub { font-size:11px; color:var(--t3); margin-top:2px; }
+
+  /* FILTER BAR */
+  .filterbar { display:flex; align-items:center; gap:8px; padding:10px 16px; background:var(--s2); border-bottom:1px solid var(--b1); }
+  .ftab { display:flex; align-items:center; gap:6px; padding:5px 12px; border:1px solid var(--b1); border-radius:6px; background:transparent; font-size:12px; font-weight:500; color:var(--t3); cursor:pointer; }
+  .ftab.active { background:var(--acc2); border-color:var(--acc); color:var(--acc); }
+  .ftab .count { font-size:10px; padding:1px 6px; border-radius:99px; background:rgba(255,255,255,.08); color:var(--t3); font-family:var(--font-mono); }
+  .ftab.active .count { background:var(--acc3); color:var(--acc); }
+  .fspacer { flex:1; }
+  .finput { padding:6px 10px; border:1px solid var(--b1); background:var(--s3); border-radius:8px; font-size:12px; color:var(--t1); outline:none; }
+  .finput.search { width:240px; }
+  .finput.date { width:120px; font-family:var(--font-mono); }
+  .fbtn { padding:7px 12px; border:1px solid var(--b1); border-radius:6px; background:transparent; color:var(--t2); font-size:12px; font-weight:500; display:inline-flex; align-items:center; gap:6px; cursor:pointer; }
+
+  /* EMPTY STATE */
+  .empty-wrap { flex:1; display:flex; align-items:center; justify-content:center; padding:40px; }
+  .empty {
+    display:flex; flex-direction:column; align-items:center; text-align:center; gap:16px; max-width:420px;
+  }
+  .empty-icon {
+    width:56px; height:56px; border-radius:99px; background:var(--acc2); border:1px solid var(--acc3);
+    display:flex; align-items:center; justify-content:center; color:var(--acc);
+  }
+  .empty-title { font-size:15px; font-weight:500; color:var(--t1); letter-spacing:-.02em; }
+  .empty-sub { font-size:13px; color:var(--t3); max-width:340px; line-height:1.5; }
+  .empty-cta {
+    margin-top:4px; padding:10px 16px; background:var(--acc); color:#fff; font-size:13px; font-weight:500;
+    border:none; border-radius:8px; display:inline-flex; align-items:center; gap:7px; letter-spacing:-.01em; cursor:pointer;
+    box-shadow:0 6px 24px rgba(79,143,255,.25);
+  }
+</style>
+</head>
+<body>
+<span class="frame-label">DASHBOARD · VACÍO · DESKTOP · 1440×900 · /</span>
+<div class="frame">
+
+  <!-- SIDEBAR -->
+  <aside class="sidebar">
+    <div class="side-logo">
+      <div class="side-logo-badge">D</div>
+      <span class="side-logo-text">D'Angelo</span>
+    </div>
+
+    <div class="side-label">Principal</div>
+    <button class="side-item active">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Presupuestos
+      <span class="count">0</span>
+    </button>
+
+    <div class="side-label mt">Sistema</div>
+    <button class="side-item">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/><path d="M19 12a7 7 0 01-1 3.5l2 2-3 3-2-2a7 7 0 01-3.5 1"/></svg>
+      Catálogo
+    </button>
+    <button class="side-item">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
+      Configuración
+    </button>
+
+    <div class="side-divider"></div>
+    <div class="side-spacer"></div>
+
+    <button class="side-new">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+      Nuevo presupuesto
+    </button>
+    <button class="side-logout">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+      Cerrar sesión
+    </button>
+  </aside>
+
+  <!-- MAIN -->
+  <main class="main">
+    <header class="main-header">
+      <div class="main-h1">Presupuestos</div>
+      <div class="main-sub">0 registros</div>
+    </header>
+
+    <div class="filterbar">
+      <button class="ftab active">Todos <span class="count">0</span></button>
+      <button class="ftab">Borrador <span class="count">0</span></button>
+      <button class="ftab">Pendiente <span class="count">0</span></button>
+      <button class="ftab">Validado <span class="count">0</span></button>
+      <button class="ftab">Enviado <span class="count">0</span></button>
+      <button class="ftab">Web <span class="count">0</span></button>
+      <span class="fspacer"></span>
+      <input class="finput date" value="01/04/2026" />
+      <span style="color:var(--t4);font-size:11px">—</span>
+      <input class="finput date" value="18/04/2026" />
+      <input class="finput search" placeholder="Buscar cliente, obra, material…" value="" />
+      <button class="fbtn">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M12 4v12m0 0l-5-5m5 5l5-5M4 20h16"/></svg>
+        Exportar CSV
+      </button>
+    </div>
+
+    <div class="empty-wrap">
+      <div class="empty">
+        <div class="empty-icon">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+            <path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.64 5.64l2.12 2.12M16.24 16.24l2.12 2.12M5.64 18.36l2.12-2.12M16.24 7.76l2.12-2.12"/>
+            <circle cx="12" cy="12" r="3"/>
+          </svg>
+        </div>
+        <div class="empty-title">Sin presupuestos todavía</div>
+        <div class="empty-sub">Subí un plano o dictá un enunciado para que Valentina arme el primero</div>
+        <button class="empty-cta">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          Nuevo presupuesto
+        </button>
+      </div>
+    </div>
+  </main>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/02b-dashboard-empty-mobile.html
+++ b/docs/mockups/02b-dashboard-empty-mobile.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Dashboard · vacío · Mobile 390×844</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame {
+    width:390px; height:844px; background:var(--bg); overflow:hidden; position:relative;
+    border-radius:38px; border:10px solid #0a0a10; display:flex; flex-direction:column;
+  }
+  .frame::after {
+    content:''; position:absolute; inset:0; pointer-events:none;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+  }
+
+  .mtop {
+    display:flex; align-items:center; gap:10px; padding:12px 16px;
+    background:var(--s1); border-bottom:1px solid var(--b1);
+  }
+  .mburger { width:28px; height:28px; border-radius:6px; display:flex; align-items:center; justify-content:center; color:var(--t2); background:transparent; border:none; }
+  .mlogo-badge { width:24px; height:24px; border-radius:6px; background:var(--acc); color:#fff; font-weight:600; font-size:11px; display:flex; align-items:center; justify-content:center; letter-spacing:-.5px; }
+  .mlogo-text { font-size:13px; font-weight:500; letter-spacing:-.02em; }
+
+  .mhead { padding:16px 16px 12px; }
+  .mhead-h1 { font-size:18px; font-weight:500; letter-spacing:-.03em; color:var(--t1); }
+  .mhead-sub { font-size:11px; color:var(--t3); margin-top:2px; }
+
+  .mtabs {
+    display:flex; gap:6px; padding:8px 16px; overflow-x:auto;
+    background:var(--s2); border-top:1px solid var(--b1); border-bottom:1px solid var(--b1);
+    white-space:nowrap;
+  }
+  .mtabs::-webkit-scrollbar { display:none; }
+  .ftab { display:inline-flex; align-items:center; gap:6px; padding:5px 11px; border:1px solid var(--b1); border-radius:6px; background:transparent; font-size:12px; font-weight:500; color:var(--t3); cursor:pointer; flex-shrink:0; }
+  .ftab.active { background:var(--acc2); border-color:var(--acc); color:var(--acc); }
+  .ftab .count { font-size:10px; padding:1px 6px; border-radius:99px; background:rgba(255,255,255,.08); color:var(--t3); font-family:var(--font-mono); }
+  .ftab.active .count { background:var(--acc3); color:var(--acc); }
+
+  .empty-wrap { flex:1; display:flex; align-items:center; justify-content:center; padding:24px; }
+  .empty { display:flex; flex-direction:column; align-items:center; text-align:center; gap:14px; max-width:320px; width:100%; }
+  .empty-icon { width:52px; height:52px; border-radius:99px; background:var(--acc2); border:1px solid var(--acc3); display:flex; align-items:center; justify-content:center; color:var(--acc); }
+  .empty-title { font-size:15px; font-weight:500; color:var(--t1); letter-spacing:-.02em; }
+  .empty-sub { font-size:13px; color:var(--t3); line-height:1.5; }
+  .empty-cta { margin-top:8px; width:100%; padding:12px 16px; background:var(--acc); color:#fff; font-size:13px; font-weight:500; border:none; border-radius:10px; display:inline-flex; align-items:center; justify-content:center; gap:7px; box-shadow:0 6px 24px rgba(79,143,255,.25); }
+</style>
+</head>
+<body>
+<span class="frame-label">DASHBOARD · VACÍO · MOBILE · 390×844 · /</span>
+<div class="frame">
+
+  <div class="mtop">
+    <button class="mburger">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <div class="mlogo-badge">D</div>
+    <span class="mlogo-text">D'Angelo</span>
+  </div>
+
+  <div class="mhead">
+    <div class="mhead-h1">Presupuestos</div>
+    <div class="mhead-sub">0 registros</div>
+  </div>
+
+  <div class="mtabs">
+    <button class="ftab active">Todos <span class="count">0</span></button>
+    <button class="ftab">Borrador <span class="count">0</span></button>
+    <button class="ftab">Pendiente <span class="count">0</span></button>
+    <button class="ftab">Validado <span class="count">0</span></button>
+    <button class="ftab">Enviado <span class="count">0</span></button>
+    <button class="ftab">Web <span class="count">0</span></button>
+  </div>
+
+  <div class="empty-wrap">
+    <div class="empty">
+      <div class="empty-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+          <path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.64 5.64l2.12 2.12M16.24 16.24l2.12 2.12M5.64 18.36l2.12-2.12M16.24 7.76l2.12-2.12"/>
+          <circle cx="12" cy="12" r="3"/>
+        </svg>
+      </div>
+      <div class="empty-title">Sin presupuestos todavía</div>
+      <div class="empty-sub">Subí un plano o dictá un enunciado para que Valentina arme el primero</div>
+      <button class="empty-cta">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        Nuevo presupuesto
+      </button>
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/03-quote-detail-desktop.html
+++ b/docs/mockups/03-quote-detail-desktop.html
@@ -1,0 +1,270 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Presupuesto detalle · Desktop 1440×900</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:1440px; height:900px; background:var(--bg); overflow:hidden; position:relative; border:1px solid rgba(255,255,255,.06); border-radius:6px; display:flex; }
+  .frame::after {
+    content:''; position:absolute; inset:0; pointer-events:none;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+  }
+
+  /* SIDEBAR */
+  .sidebar { width:212px; flex-shrink:0; background:var(--s1); border-right:1px solid var(--b1); display:flex; flex-direction:column; padding:18px 10px 20px; }
+  .side-logo { display:flex; align-items:center; gap:10px; padding:2px 8px 20px; cursor:pointer; }
+  .side-logo-badge { width:26px; height:26px; border-radius:6px; background:var(--acc); color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; letter-spacing:-.5px; }
+  .side-logo-text { font-size:13px; font-weight:500; letter-spacing:-.02em; }
+  .side-label { font-size:10px; font-weight:500; color:var(--t4); text-transform:uppercase; letter-spacing:.1em; padding:0 8px 4px; }
+  .side-label.mt { margin-top:14px; }
+  .side-item { display:flex; align-items:center; gap:8px; padding:8px; border-radius:6px; font-size:12px; color:var(--t2); cursor:pointer; border:none; background:transparent; width:100%; text-align:left; }
+  .side-item.active { color:var(--acc); background:rgba(79,143,255,.11); }
+  .side-item svg { flex-shrink:0; opacity:.65; }
+  .side-item.active svg { opacity:1; }
+  .side-item .count { margin-left:auto; font-size:10px; font-weight:500; padding:1px 7px; border-radius:99px; background:rgba(255,255,255,.07); color:var(--t3); font-family:var(--font-mono); }
+  .side-item.active .count { background:var(--acc); color:#fff; font-weight:600; }
+  .side-divider { height:1px; background:var(--b1); margin:12px 0; }
+  .side-spacer { flex:1; }
+  .side-new { width:100%; padding:10px 12px; background:var(--acc); color:#fff; font-size:13px; font-weight:500; border:none; border-radius:8px; display:flex; align-items:center; justify-content:center; gap:7px; letter-spacing:-.01em; }
+  .side-logout { width:100%; padding:7px 8px; background:transparent; border:none; color:var(--t3); font-size:11px; display:flex; align-items:center; justify-content:center; gap:6px; margin-top:10px; cursor:pointer; }
+
+  /* MAIN */
+  .main { flex:1; display:flex; flex-direction:column; min-width:0; }
+
+  /* HEADER */
+  .q-header { display:flex; align-items:center; gap:12px; padding:14px 28px; border-bottom:1px solid var(--b1); }
+  .backbtn { width:30px; height:30px; border:1px solid var(--b1); border-radius:6px; background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; }
+  .q-title { font-size:16px; font-weight:600; color:var(--t1); letter-spacing:-.02em; }
+  .q-status { display:inline-flex; align-items:center; gap:6px; padding:3px 8px; border-radius:99px; background:var(--grn2); color:var(--grn); font-size:10px; font-weight:600; letter-spacing:.02em; }
+  .q-status .dot { width:5px; height:5px; border-radius:99px; background:currentColor; }
+  .q-meta { font-size:12px; color:var(--t3); font-family:var(--font-mono); }
+  .q-spacer { flex:1; }
+  .filepill { padding:6px 12px; border-radius:6px; font-size:12px; font-weight:500; display:inline-flex; align-items:center; gap:6px; border:1px solid; background:transparent; }
+  .filepill.pdf { border-color:rgba(79,143,255,.2); color:var(--acc); }
+  .filepill.xls { border-color:rgba(52,211,153,.2); color:#34d399; }
+
+  /* TABS */
+  .q-tabs { display:flex; padding-left:28px; border-bottom:1px solid var(--b1); background:var(--s2); }
+  .q-tab { padding:10px 20px; font-size:13px; color:var(--t3); cursor:pointer; border:none; background:transparent; border-bottom:2px solid transparent; }
+  .q-tab.active { color:var(--acc); border-bottom-color:var(--acc); font-weight:500; }
+
+  /* SCROLL AREA */
+  .q-scroll { flex:1; overflow-y:auto; padding:24px 28px; display:flex; flex-direction:column; gap:20px; }
+  .q-section-title { font-size:15px; font-weight:600; color:var(--t1); letter-spacing:-.02em; margin-bottom:10px; }
+
+  /* META GRID */
+  .meta-grid { display:grid; grid-template-columns:repeat(4,1fr); gap:16px; }
+  .meta-item { display:flex; flex-direction:column; gap:4px; }
+  .meta-label { font-size:11px; font-weight:600; letter-spacing:.06em; color:var(--t3); text-transform:uppercase; }
+  .meta-value { font-size:13px; color:var(--t2); }
+
+  /* TABLES */
+  .tbl-wrap { border:1px solid var(--b1); border-radius:10px; overflow:hidden; }
+  table.q-tbl { width:100%; border-collapse:collapse; }
+  table.q-tbl thead tr { background:rgba(255,255,255,.03); }
+  table.q-tbl th { padding:8px 12px; text-align:left; font-size:10px; font-weight:500; color:var(--t3); text-transform:uppercase; letter-spacing:.08em; border-bottom:1px solid var(--b1); }
+  table.q-tbl th.right { text-align:right; }
+  table.q-tbl td { padding:8px 12px; font-size:12px; color:var(--t2); vertical-align:middle; }
+  table.q-tbl tbody tr:nth-child(odd) td { background:rgba(255,255,255,.03); }
+  table.q-tbl td.num { font-family:var(--font-mono); color:var(--t1); text-align:right; letter-spacing:-.02em; }
+  table.q-tbl td.strong { color:var(--t1); font-weight:500; }
+
+  /* TOTALS ROW */
+  .totals {
+    margin-top:12px; background:var(--s3); border:1px solid var(--b2); border-radius:10px;
+    padding:10px 14px; display:flex; align-items:center; justify-content:space-between; gap:24px;
+  }
+  .totals-cell { display:flex; align-items:center; gap:10px; font-size:12px; color:var(--t2); }
+  .totals-cell strong { color:var(--t1); font-family:var(--font-mono); font-size:13px; font-weight:500; letter-spacing:-.02em; }
+
+  /* MO FOOTER */
+  .mo-total { margin-top:10px; display:flex; justify-content:flex-end; align-items:center; gap:10px; padding:10px 14px; background:var(--s3); border:1px solid var(--b2); border-radius:10px; }
+  .mo-total-label { font-size:11px; font-weight:600; letter-spacing:.06em; color:var(--t3); text-transform:uppercase; }
+  .mo-total-val { font-size:14px; font-family:var(--font-mono); color:var(--t1); font-weight:500; letter-spacing:-.02em; }
+
+  /* SUMMARY */
+  .summary { background:var(--s3); border:1px solid var(--b2); border-radius:10px; padding:16px 20px; display:flex; align-items:center; justify-content:space-between; }
+  .summary-left-lbl { font-size:14px; font-weight:600; color:var(--t1); }
+  .summary-left-sub { font-size:13px; color:var(--t3); margin-top:4px; }
+  .summary-right-main { font-size:18px; font-weight:700; color:var(--t1); font-family:var(--font-mono); letter-spacing:-.02em; text-align:right; }
+  .summary-right-usd { font-size:15px; font-weight:600; color:var(--acc); font-family:var(--font-mono); margin-top:4px; text-align:right; }
+</style>
+</head>
+<body>
+<span class="frame-label">PRESUPUESTO DETALLE · DESKTOP · 1440×900 · /quote/248</span>
+<div class="frame">
+
+  <!-- SIDEBAR -->
+  <aside class="sidebar">
+    <div class="side-logo">
+      <div class="side-logo-badge">D</div>
+      <span class="side-logo-text">D'Angelo</span>
+    </div>
+
+    <div class="side-label">Principal</div>
+    <button class="side-item active">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Presupuestos
+      <span class="count">3</span>
+    </button>
+
+    <div class="side-label mt">Sistema</div>
+    <button class="side-item">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/><path d="M19 12a7 7 0 01-1 3.5l2 2-3 3-2-2a7 7 0 01-3.5 1"/></svg>
+      Catálogo
+    </button>
+    <button class="side-item">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
+      Configuración
+    </button>
+
+    <div class="side-divider"></div>
+    <div class="side-spacer"></div>
+
+    <button class="side-new">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+      Nuevo presupuesto
+    </button>
+    <button class="side-logout">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+      Cerrar sesión
+    </button>
+  </aside>
+
+  <!-- MAIN -->
+  <main class="main">
+    <!-- HEADER -->
+    <div class="q-header" style="padding:14px 28px;">
+      <button class="backbtn">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><polyline points="15 18 9 12 15 6"/></svg>
+      </button>
+      <div class="q-title">Erica Bernardi — Casa Bernardi</div>
+      <span class="q-status"><span class="dot"></span>VALIDADO</span>
+      <span class="q-meta">#PR-0248 · hace 2 min</span>
+      <span class="q-spacer"></span>
+      <button class="filepill pdf">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+        Drive PDF
+      </button>
+      <button class="filepill xls">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+        Excel
+      </button>
+    </div>
+
+    <!-- TABS -->
+    <div class="q-tabs">
+      <button class="q-tab">Chat</button>
+      <button class="q-tab active">Detalle</button>
+    </div>
+
+    <!-- CONTENT -->
+    <div class="q-scroll">
+
+      <!-- SECTION 1: Datos del trabajo -->
+      <section>
+        <div class="q-section-title">Datos del trabajo</div>
+        <div class="meta-grid">
+          <div class="meta-item"><div class="meta-label">Cliente</div><div class="meta-value">Erica Bernardi</div></div>
+          <div class="meta-item"><div class="meta-label">Obra</div><div class="meta-value">Casa Bernardi</div></div>
+          <div class="meta-item"><div class="meta-label">Material</div><div class="meta-value">Puraprima Onix White Mate · 3 cm</div></div>
+          <div class="meta-item"><div class="meta-label">Localidad</div><div class="meta-value">Rosario</div></div>
+          <div class="meta-item"><div class="meta-label">Forma de pago</div><div class="meta-value">Contado</div></div>
+          <div class="meta-item"><div class="meta-label">Demora</div><div class="meta-value">30 días</div></div>
+          <div class="meta-item"><div class="meta-label">Tipo</div><div class="meta-value">Particular</div></div>
+          <div class="meta-item"><div class="meta-label">Descuento</div><div class="meta-value">No aplica</div></div>
+        </div>
+      </section>
+
+      <!-- SECTION 2: Despiece -->
+      <section>
+        <div class="q-section-title">Despiece</div>
+        <div class="tbl-wrap">
+          <table class="q-tbl">
+            <thead>
+              <tr>
+                <th>Sector</th>
+                <th>Tramo</th>
+                <th class="right">Largo</th>
+                <th class="right">Ancho</th>
+                <th class="right">m²</th>
+                <th class="right">Zóc. trasero</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td class="strong">Cocina U</td><td>T1 · Mesada principal contra pared</td><td class="num">3.20</td><td class="num">0.60</td><td class="num">1.92 m²</td><td class="num">3.20 ml</td></tr>
+              <tr><td class="strong">Cocina U</td><td>T2 · Ala derecha</td><td class="num">1.80</td><td class="num">0.60</td><td class="num">1.08 m²</td><td class="num">1.80 ml</td></tr>
+              <tr><td class="strong">Cocina U</td><td>T3 · Ala izquierda con pileta doble</td><td class="num">2.20</td><td class="num">0.60</td><td class="num">1.32 m²</td><td class="num">2.20 ml</td></tr>
+              <tr><td class="strong">Isla</td><td>T4 · Isla central</td><td class="num">1.60</td><td class="num">0.60</td><td class="num">0.96 m²</td><td class="num">—</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="totals">
+          <div class="totals-cell">Total m² material · <strong>5.28 m²</strong></div>
+          <div class="totals-cell">Total ml zócalo trasero · <strong>7.20 ml</strong></div>
+        </div>
+      </section>
+
+      <!-- SECTION 3: Mano de obra -->
+      <section>
+        <div class="q-section-title">Mano de obra</div>
+        <div class="tbl-wrap">
+          <table class="q-tbl">
+            <thead>
+              <tr>
+                <th>Descripción</th>
+                <th class="right">Cantidad</th>
+                <th class="right">Precio unit</th>
+                <th class="right">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td class="strong">Corte y pulido borde recto</td><td class="num">7.20 ml</td><td class="num">$ 6.500</td><td class="num">$ 46.800</td></tr>
+              <tr><td class="strong">Pegado pileta empotrada</td><td class="num">1 un</td><td class="num">$ 78.000</td><td class="num">$ 78.000</td></tr>
+              <tr><td class="strong">Agujero anafe</td><td class="num">2 un</td><td class="num">$ 32.000</td><td class="num">$ 64.000</td></tr>
+              <tr><td class="strong">Colocación</td><td class="num">5.28 m²</td><td class="num">$ 54.000</td><td class="num">$ 285.120</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="mo-total">
+          <span class="mo-total-label">MO total</span>
+          <span class="mo-total-val">$ 473.920</span>
+        </div>
+      </section>
+
+      <!-- SECTION 4: Resumen -->
+      <section>
+        <div class="q-section-title">Resumen</div>
+        <div class="summary">
+          <div>
+            <div class="summary-left-lbl">TOTAL</div>
+            <div class="summary-left-sub">Contado · 30 días demora</div>
+          </div>
+          <div>
+            <div class="summary-right-main">$ 4.284.000</div>
+            <div class="summary-right-usd">USD 3.180</div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+  </main>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/03-quote-detail-mobile.html
+++ b/docs/mockups/03-quote-detail-mobile.html
@@ -1,0 +1,221 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Presupuesto detalle · Mobile 390×844</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame {
+    width:390px; height:844px; background:var(--bg); overflow:hidden; position:relative;
+    border-radius:38px; border:10px solid #0a0a10; display:flex; flex-direction:column;
+  }
+  .frame::after {
+    content:''; position:absolute; inset:0; pointer-events:none;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+  }
+
+  .mtop { display:flex; align-items:center; gap:10px; padding:12px 16px; background:var(--s1); border-bottom:1px solid var(--b1); }
+  .mburger { width:28px; height:28px; border-radius:6px; display:flex; align-items:center; justify-content:center; color:var(--t2); background:transparent; border:none; }
+  .mlogo-badge { width:24px; height:24px; border-radius:6px; background:var(--acc); color:#fff; font-weight:600; font-size:11px; display:flex; align-items:center; justify-content:center; letter-spacing:-.5px; }
+  .mlogo-text { font-size:13px; font-weight:500; letter-spacing:-.02em; }
+
+  /* Quote header */
+  .q-header { display:flex; flex-direction:column; gap:4px; padding:12px 16px; border-bottom:1px solid var(--b1); }
+  .q-header-row1 { display:flex; align-items:center; gap:8px; }
+  .backbtn { width:28px; height:28px; border:1px solid var(--b1); border-radius:6px; background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; flex-shrink:0; }
+  .q-title { font-size:14px; font-weight:600; color:var(--t1); letter-spacing:-.02em; flex:1; min-width:0; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .q-status { display:inline-flex; align-items:center; gap:5px; padding:3px 8px; border-radius:99px; background:var(--grn2); color:var(--grn); font-size:10px; font-weight:600; flex-shrink:0; }
+  .q-status .dot { width:5px; height:5px; border-radius:99px; background:currentColor; }
+  .q-meta { font-size:11px; color:var(--t3); font-family:var(--font-mono); padding-left:36px; }
+  .filebar { display:flex; gap:6px; padding:8px 16px; border-bottom:1px solid var(--b1); background:var(--s2); }
+  .filepill { padding:5px 10px; border-radius:6px; font-size:11px; font-weight:500; display:inline-flex; align-items:center; gap:5px; border:1px solid; background:transparent; }
+  .filepill.pdf { border-color:rgba(79,143,255,.2); color:var(--acc); }
+  .filepill.xls { border-color:rgba(52,211,153,.2); color:#34d399; }
+
+  /* Tabs (horizontal scroll) */
+  .q-tabs { display:flex; overflow-x:auto; border-bottom:1px solid var(--b1); background:var(--s2); }
+  .q-tabs::-webkit-scrollbar { display:none; }
+  .q-tab { padding:10px 20px; font-size:13px; color:var(--t3); cursor:pointer; border:none; background:transparent; border-bottom:2px solid transparent; flex-shrink:0; white-space:nowrap; }
+  .q-tab.active { color:var(--acc); border-bottom-color:var(--acc); font-weight:500; }
+
+  /* Content scroll */
+  .q-scroll { flex:1; overflow-y:auto; padding:16px; display:flex; flex-direction:column; gap:16px; }
+  .q-section-title { font-size:14px; font-weight:600; color:var(--t1); letter-spacing:-.02em; margin-bottom:8px; }
+
+  .meta-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:12px; }
+  .meta-item { display:flex; flex-direction:column; gap:3px; }
+  .meta-label { font-size:10px; font-weight:600; letter-spacing:.06em; color:var(--t3); text-transform:uppercase; }
+  .meta-value { font-size:12px; color:var(--t2); }
+
+  .tbl-wrap { border:1px solid var(--b1); border-radius:10px; overflow:hidden; }
+  .tbl-scroll { overflow-x:auto; }
+  table.q-tbl { width:100%; border-collapse:collapse; min-width:560px; }
+  table.q-tbl thead tr { background:rgba(255,255,255,.03); }
+  table.q-tbl th { padding:8px 10px; text-align:left; font-size:10px; font-weight:500; color:var(--t3); text-transform:uppercase; letter-spacing:.08em; border-bottom:1px solid var(--b1); white-space:nowrap; }
+  table.q-tbl th.right { text-align:right; }
+  table.q-tbl td { padding:8px 10px; font-size:11px; color:var(--t2); white-space:nowrap; }
+  table.q-tbl tbody tr:nth-child(odd) td { background:rgba(255,255,255,.03); }
+  table.q-tbl td.num { font-family:var(--font-mono); color:var(--t1); text-align:right; letter-spacing:-.02em; }
+  table.q-tbl td.strong { color:var(--t1); font-weight:500; }
+
+  .totals { margin-top:10px; background:var(--s3); border:1px solid var(--b2); border-radius:10px; padding:10px 12px; display:flex; flex-direction:column; gap:6px; }
+  .totals-cell { display:flex; align-items:center; justify-content:space-between; font-size:11px; color:var(--t2); }
+  .totals-cell strong { color:var(--t1); font-family:var(--font-mono); font-size:12px; font-weight:500; letter-spacing:-.02em; }
+
+  .mo-total { margin-top:10px; display:flex; justify-content:space-between; align-items:center; padding:10px 12px; background:var(--s3); border:1px solid var(--b2); border-radius:10px; }
+  .mo-total-label { font-size:11px; font-weight:600; letter-spacing:.06em; color:var(--t3); text-transform:uppercase; }
+  .mo-total-val { font-size:13px; font-family:var(--font-mono); color:var(--t1); font-weight:500; letter-spacing:-.02em; }
+
+  .summary { background:var(--s3); border:1px solid var(--b2); border-radius:10px; padding:14px 16px; display:flex; align-items:center; justify-content:space-between; gap:12px; }
+  .summary-left-lbl { font-size:13px; font-weight:600; color:var(--t1); }
+  .summary-left-sub { font-size:11px; color:var(--t3); margin-top:2px; }
+  .summary-right-main { font-size:16px; font-weight:700; color:var(--t1); font-family:var(--font-mono); letter-spacing:-.02em; text-align:right; }
+  .summary-right-usd { font-size:13px; font-weight:600; color:var(--acc); font-family:var(--font-mono); margin-top:3px; text-align:right; }
+</style>
+</head>
+<body>
+<span class="frame-label">PRESUPUESTO DETALLE · MOBILE · 390×844 · /quote/248</span>
+<div class="frame">
+
+  <div class="mtop">
+    <button class="mburger">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <div class="mlogo-badge">D</div>
+    <span class="mlogo-text">D'Angelo</span>
+  </div>
+
+  <div class="q-header">
+    <div class="q-header-row1">
+      <button class="backbtn">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><polyline points="15 18 9 12 15 6"/></svg>
+      </button>
+      <div class="q-title">Erica Bernardi — Casa Bernardi</div>
+      <span class="q-status"><span class="dot"></span>VALIDADO</span>
+    </div>
+    <div class="q-meta">#PR-0248 · hace 2 min</div>
+  </div>
+
+  <div class="filebar">
+    <button class="filepill pdf">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+      Drive PDF
+    </button>
+    <button class="filepill xls">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+      Excel
+    </button>
+  </div>
+
+  <div class="q-tabs">
+    <button class="q-tab">Chat</button>
+    <button class="q-tab active">Detalle</button>
+  </div>
+
+  <div class="q-scroll">
+
+    <section>
+      <div class="q-section-title">Datos del trabajo</div>
+      <div class="meta-grid">
+        <div class="meta-item"><div class="meta-label">Cliente</div><div class="meta-value">Erica Bernardi</div></div>
+        <div class="meta-item"><div class="meta-label">Obra</div><div class="meta-value">Casa Bernardi</div></div>
+        <div class="meta-item" style="grid-column:1/-1"><div class="meta-label">Material</div><div class="meta-value">Puraprima Onix White Mate · 3 cm</div></div>
+        <div class="meta-item"><div class="meta-label">Localidad</div><div class="meta-value">Rosario</div></div>
+        <div class="meta-item"><div class="meta-label">Forma de pago</div><div class="meta-value">Contado</div></div>
+        <div class="meta-item"><div class="meta-label">Demora</div><div class="meta-value">30 días</div></div>
+        <div class="meta-item"><div class="meta-label">Tipo</div><div class="meta-value">Particular</div></div>
+        <div class="meta-item" style="grid-column:1/-1"><div class="meta-label">Descuento</div><div class="meta-value">No aplica</div></div>
+      </div>
+    </section>
+
+    <section>
+      <div class="q-section-title">Despiece</div>
+      <div class="tbl-wrap">
+        <div class="tbl-scroll">
+          <table class="q-tbl">
+            <thead>
+              <tr>
+                <th>Sector</th>
+                <th>Tramo</th>
+                <th class="right">Largo</th>
+                <th class="right">Ancho</th>
+                <th class="right">m²</th>
+                <th class="right">Zóc. tr.</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td class="strong">Cocina U</td><td>T1 · Mesada contra pared</td><td class="num">3.20</td><td class="num">0.60</td><td class="num">1.92</td><td class="num">3.20</td></tr>
+              <tr><td class="strong">Cocina U</td><td>T2 · Ala derecha</td><td class="num">1.80</td><td class="num">0.60</td><td class="num">1.08</td><td class="num">1.80</td></tr>
+              <tr><td class="strong">Cocina U</td><td>T3 · Ala izq. c/ pileta</td><td class="num">2.20</td><td class="num">0.60</td><td class="num">1.32</td><td class="num">2.20</td></tr>
+              <tr><td class="strong">Isla</td><td>T4 · Isla central</td><td class="num">1.60</td><td class="num">0.60</td><td class="num">0.96</td><td class="num">—</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="totals">
+        <div class="totals-cell">Total m² material<strong>5.28 m²</strong></div>
+        <div class="totals-cell">Total ml zócalo trasero<strong>7.20 ml</strong></div>
+      </div>
+    </section>
+
+    <section>
+      <div class="q-section-title">Mano de obra</div>
+      <div class="tbl-wrap">
+        <div class="tbl-scroll">
+          <table class="q-tbl">
+            <thead>
+              <tr>
+                <th>Descripción</th>
+                <th class="right">Cantidad</th>
+                <th class="right">Precio unit</th>
+                <th class="right">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td class="strong">Corte y pulido borde recto</td><td class="num">7.20 ml</td><td class="num">$ 6.500</td><td class="num">$ 46.800</td></tr>
+              <tr><td class="strong">Pegado pileta empotrada</td><td class="num">1 un</td><td class="num">$ 78.000</td><td class="num">$ 78.000</td></tr>
+              <tr><td class="strong">Agujero anafe</td><td class="num">2 un</td><td class="num">$ 32.000</td><td class="num">$ 64.000</td></tr>
+              <tr><td class="strong">Colocación</td><td class="num">5.28 m²</td><td class="num">$ 54.000</td><td class="num">$ 285.120</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="mo-total">
+        <span class="mo-total-label">MO total</span>
+        <span class="mo-total-val">$ 473.920</span>
+      </div>
+    </section>
+
+    <section>
+      <div class="q-section-title">Resumen</div>
+      <div class="summary">
+        <div>
+          <div class="summary-left-lbl">TOTAL</div>
+          <div class="summary-left-sub">Contado · 30 días</div>
+        </div>
+        <div>
+          <div class="summary-right-main">$ 4.284.000</div>
+          <div class="summary-right-usd">USD 3.180</div>
+        </div>
+      </div>
+    </section>
+
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/04-settings-catalog-desktop.html
+++ b/docs/mockups/04-settings-catalog-desktop.html
@@ -1,0 +1,251 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Catálogo · Desktop 1440×900</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:1440px; height:900px; background:var(--bg); overflow:hidden; position:relative; border:1px solid rgba(255,255,255,.06); border-radius:6px; display:flex; }
+  .frame::after {
+    content:''; position:absolute; inset:0; pointer-events:none;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+  }
+
+  /* SIDEBAR */
+  .sidebar { width:212px; flex-shrink:0; background:var(--s1); border-right:1px solid var(--b1); display:flex; flex-direction:column; padding:18px 10px 20px; }
+  .side-logo { display:flex; align-items:center; gap:10px; padding:2px 8px 20px; cursor:pointer; }
+  .side-logo-badge { width:26px; height:26px; border-radius:6px; background:var(--acc); color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; letter-spacing:-.5px; }
+  .side-logo-text { font-size:13px; font-weight:500; letter-spacing:-.02em; }
+  .side-label { font-size:10px; font-weight:500; color:var(--t4); text-transform:uppercase; letter-spacing:.1em; padding:0 8px 4px; }
+  .side-label.mt { margin-top:14px; }
+  .side-item { display:flex; align-items:center; gap:8px; padding:8px; border-radius:6px; font-size:12px; color:var(--t2); cursor:pointer; border:none; background:transparent; width:100%; text-align:left; }
+  .side-item.active { color:var(--acc); background:rgba(79,143,255,.11); }
+  .side-item svg { flex-shrink:0; opacity:.65; }
+  .side-item.active svg { opacity:1; }
+  .side-item .count { margin-left:auto; font-size:10px; font-weight:500; padding:1px 7px; border-radius:99px; background:rgba(255,255,255,.07); color:var(--t3); font-family:var(--font-mono); }
+  .side-item.active .count { background:var(--acc); color:#fff; font-weight:600; }
+  .side-divider { height:1px; background:var(--b1); margin:12px 0; }
+  .side-spacer { flex:1; }
+  .side-new { width:100%; padding:10px 12px; background:var(--acc); color:#fff; font-size:13px; font-weight:500; border:none; border-radius:8px; display:flex; align-items:center; justify-content:center; gap:7px; letter-spacing:-.01em; }
+  .side-logout { width:100%; padding:7px 8px; background:transparent; border:none; color:var(--t3); font-size:11px; display:flex; align-items:center; justify-content:center; gap:6px; margin-top:10px; cursor:pointer; }
+
+  /* MAIN */
+  .main { flex:1; display:flex; flex-direction:column; min-width:0; }
+
+  /* TOOLBAR */
+  .toolbar { display:flex; align-items:center; gap:12px; padding:12px 24px; border-bottom:1px solid var(--b1); }
+  .tb-title { font-size:14px; font-weight:500; color:var(--t1); font-family:var(--font-mono); }
+  .tb-sub { font-size:11px; color:var(--t3); }
+  .tb-spacer { flex:1; }
+  .btn { padding:7px 14px; border-radius:6px; font-size:12px; font-weight:500; border:1px solid var(--b1); cursor:pointer; display:inline-flex; align-items:center; gap:6px; }
+  .btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .btn.secondary { background:transparent; color:var(--t2); }
+
+  /* BODY: 2-col split */
+  .body2col { flex:1; display:flex; min-height:0; }
+  .catlist { width:200px; flex-shrink:0; background:var(--s1); border-right:1px solid var(--b1); overflow-y:auto; padding:10px 6px; }
+  .catlist-label { font-size:10px; font-weight:500; color:var(--t4); text-transform:uppercase; letter-spacing:.1em; padding:8px 10px 4px; }
+  .cat-item { display:block; width:100%; padding:8px 12px; border-radius:6px; font-size:12px; color:var(--t2); background:transparent; border:none; text-align:left; cursor:pointer; font-family:var(--font-mono); letter-spacing:-.02em; }
+  .cat-item.active { background:var(--acc2); color:var(--acc); }
+  .cat-item:hover:not(.active) { background:rgba(255,255,255,.04); }
+
+  /* RIGHT editor */
+  .editor { flex:1; overflow-y:auto; padding:20px 24px; display:flex; flex-direction:column; gap:14px; min-width:0; }
+
+  /* Warnings banner */
+  .warnings {
+    border:1px solid rgba(245,166,35,.25); background:rgba(245,166,35,.06);
+    border-radius:10px; padding:12px 14px;
+  }
+  .warn-head { display:flex; align-items:center; gap:8px; font-size:12px; font-weight:600; color:var(--amb); }
+  .warn-head .dot { width:6px; height:6px; border-radius:99px; background:var(--amb); }
+  .warn-list { margin-top:8px; display:flex; flex-direction:column; gap:6px; padding-left:16px; }
+  .warn-item { font-size:12px; color:rgba(245,166,35,.85); }
+
+  /* Code editor */
+  .editor-title { font-size:11px; font-weight:600; letter-spacing:.06em; color:var(--t3); text-transform:uppercase; }
+  .code { border:1px solid var(--b1); border-radius:10px; background:#08080f; padding:14px 16px; font-family:var(--font-mono); font-size:12px; line-height:1.6; color:var(--t2); min-height:400px; max-height:60vh; overflow:auto; }
+  .code .k { color:#79c0ff; }
+  .code .s { color:#a5d6ff; }
+  .code .n { color:#f2cc60; }
+  .code .c { color:var(--t4); font-style:italic; }
+  .code .ln { color:var(--t4); display:inline-block; width:28px; text-align:right; margin-right:14px; user-select:none; }
+
+  /* Backup history */
+  .backups { display:flex; flex-direction:column; gap:6px; margin-top:4px; }
+  .backup-row {
+    display:flex; align-items:center; gap:12px; padding:10px 14px;
+    border:1px solid var(--b1); border-radius:8px; background:var(--s2);
+  }
+  .bk-ts { font-family:var(--font-mono); font-size:12px; color:var(--t1); letter-spacing:-.02em; width:150px; }
+  .bk-src { font-size:12px; color:var(--t2); flex:1; }
+  .bk-restore { padding:5px 10px; font-size:11px; font-weight:500; border:1px solid var(--b1); border-radius:6px; color:var(--t2); background:transparent; cursor:pointer; }
+</style>
+</head>
+<body>
+<span class="frame-label">CATÁLOGO · DESKTOP · 1440×900 · /config/labor</span>
+<div class="frame">
+
+  <!-- SIDEBAR -->
+  <aside class="sidebar">
+    <div class="side-logo">
+      <div class="side-logo-badge">D</div>
+      <span class="side-logo-text">D'Angelo</span>
+    </div>
+
+    <div class="side-label">Principal</div>
+    <button class="side-item">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Presupuestos
+      <span class="count">3</span>
+    </button>
+
+    <div class="side-label mt">Sistema</div>
+    <button class="side-item active">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/><path d="M19 12a7 7 0 01-1 3.5l2 2-3 3-2-2a7 7 0 01-3.5 1"/></svg>
+      Catálogo
+    </button>
+    <button class="side-item">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
+      Configuración
+    </button>
+
+    <div class="side-divider"></div>
+    <div class="side-spacer"></div>
+
+    <button class="side-new">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+      Nuevo presupuesto
+    </button>
+    <button class="side-logout">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+      Cerrar sesión
+    </button>
+  </aside>
+
+  <!-- MAIN -->
+  <main class="main">
+    <div class="toolbar">
+      <div>
+        <div class="tb-title">labor.json</div>
+        <div class="tb-sub">Editado hace 2 días</div>
+      </div>
+      <span class="tb-spacer"></span>
+      <button class="btn secondary">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
+        Restaurar backup
+      </button>
+      <button class="btn primary">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h11l5 5v11a2 2 0 01-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>
+        Guardar
+      </button>
+    </div>
+
+    <div class="body2col">
+      <!-- Catalog list -->
+      <aside class="catlist">
+        <div class="catlist-label">Catálogos</div>
+        <button class="cat-item active">labor.json</button>
+        <button class="cat-item">delivery-zones.json</button>
+        <button class="cat-item">architects.json</button>
+        <button class="cat-item">materials-granito-nacional.json</button>
+        <button class="cat-item">materials-silestone.json</button>
+        <button class="cat-item">sinks.json</button>
+        <button class="cat-item">stock.json</button>
+        <button class="cat-item">config.json</button>
+      </aside>
+
+      <!-- Editor column -->
+      <section class="editor">
+        <div class="warnings">
+          <div class="warn-head"><span class="dot"></span>2 advertencias de validación</div>
+          <ul class="warn-list">
+            <li class="warn-item">Precio desactualizado hace 180 días</li>
+            <li class="warn-item">Campo 'pulido_esquinero' sin documentar</li>
+          </ul>
+        </div>
+
+        <div class="editor-title">labor.json</div>
+        <pre class="code"><span class="ln"> 1</span><span class="k">{</span>
+<span class="ln"> 2</span>  <span class="s">"version"</span>: <span class="s">"2026-03-25"</span>,
+<span class="ln"> 3</span>  <span class="s">"currency"</span>: <span class="s">"ARS"</span>,
+<span class="ln"> 4</span>  <span class="s">"notes"</span>: <span class="s">"Precios sin IVA. Actualizar con cada revisión del taller."</span>,
+<span class="ln"> 5</span>  <span class="s">"items"</span>: <span class="k">[</span>
+<span class="ln"> 6</span>    <span class="k">{</span>
+<span class="ln"> 7</span>      <span class="s">"code"</span>: <span class="s">"corte_pulido_recto"</span>,
+<span class="ln"> 8</span>      <span class="s">"label"</span>: <span class="s">"Corte y pulido borde recto"</span>,
+<span class="ln"> 9</span>      <span class="s">"unit"</span>: <span class="s">"ml"</span>,
+<span class="ln">10</span>      <span class="s">"price"</span>: <span class="n">6500</span>
+<span class="ln">11</span>    <span class="k">}</span>,
+<span class="ln">12</span>    <span class="k">{</span>
+<span class="ln">13</span>      <span class="s">"code"</span>: <span class="s">"pegado_pileta_empotrada"</span>,
+<span class="ln">14</span>      <span class="s">"label"</span>: <span class="s">"Pegado pileta empotrada"</span>,
+<span class="ln">15</span>      <span class="s">"unit"</span>: <span class="s">"un"</span>,
+<span class="ln">16</span>      <span class="s">"price"</span>: <span class="n">78000</span>
+<span class="ln">17</span>    <span class="k">}</span>,
+<span class="ln">18</span>    <span class="k">{</span>
+<span class="ln">19</span>      <span class="s">"code"</span>: <span class="s">"pegado_pileta_bajo"</span>,
+<span class="ln">20</span>      <span class="s">"label"</span>: <span class="s">"Pegado pileta bajomesada"</span>,
+<span class="ln">21</span>      <span class="s">"unit"</span>: <span class="s">"un"</span>,
+<span class="ln">22</span>      <span class="s">"price"</span>: <span class="n">52000</span>
+<span class="ln">23</span>    <span class="k">}</span>,
+<span class="ln">24</span>    <span class="k">{</span>
+<span class="ln">25</span>      <span class="s">"code"</span>: <span class="s">"agujero_anafe"</span>,
+<span class="ln">26</span>      <span class="s">"label"</span>: <span class="s">"Agujero anafe"</span>,
+<span class="ln">27</span>      <span class="s">"unit"</span>: <span class="s">"un"</span>,
+<span class="ln">28</span>      <span class="s">"price"</span>: <span class="n">32000</span>
+<span class="ln">29</span>    <span class="k">}</span>,
+<span class="ln">30</span>    <span class="k">{</span>
+<span class="ln">31</span>      <span class="s">"code"</span>: <span class="s">"agujero_bacha"</span>,
+<span class="ln">32</span>      <span class="s">"label"</span>: <span class="s">"Agujero bacha lavabo"</span>,
+<span class="ln">33</span>      <span class="s">"unit"</span>: <span class="s">"un"</span>,
+<span class="ln">34</span>      <span class="s">"price"</span>: <span class="n">28000</span>
+<span class="ln">35</span>    <span class="k">}</span>,
+<span class="ln">36</span>    <span class="k">{</span>
+<span class="ln">37</span>      <span class="s">"code"</span>: <span class="s">"colocacion"</span>,
+<span class="ln">38</span>      <span class="s">"label"</span>: <span class="s">"Colocación"</span>,
+<span class="ln">39</span>      <span class="s">"unit"</span>: <span class="s">"m2"</span>,
+<span class="ln">40</span>      <span class="s">"price"</span>: <span class="n">54000</span>
+<span class="ln">41</span>    <span class="k">}</span>
+<span class="ln">42</span>  <span class="k">]</span>
+<span class="ln">43</span><span class="k">}</span></pre>
+
+        <div class="editor-title">Backups recientes</div>
+        <div class="backups">
+          <div class="backup-row">
+            <span class="bk-ts">16/04/2026 18:03</span>
+            <span class="bk-src">Edición manual · javier@dangelo</span>
+            <button class="bk-restore">Restaurar</button>
+          </div>
+          <div class="backup-row">
+            <span class="bk-ts">25/03/2026 10:12</span>
+            <span class="bk-src">Validación IA · sugerencias aceptadas</span>
+            <button class="bk-restore">Restaurar</button>
+          </div>
+          <div class="backup-row">
+            <span class="bk-ts">08/02/2026 09:44</span>
+            <span class="bk-src">Edición manual · javier@dangelo</span>
+            <button class="bk-restore">Restaurar</button>
+          </div>
+        </div>
+      </section>
+    </div>
+  </main>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/04-settings-catalog-mobile.html
+++ b/docs/mockups/04-settings-catalog-mobile.html
@@ -1,0 +1,187 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Catálogo · Mobile 390×844</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame {
+    width:390px; height:844px; background:var(--bg); overflow:hidden; position:relative;
+    border-radius:38px; border:10px solid #0a0a10; display:flex; flex-direction:column;
+  }
+  .frame::after {
+    content:''; position:absolute; inset:0; pointer-events:none;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+  }
+
+  .mtop { display:flex; align-items:center; gap:10px; padding:12px 16px; background:var(--s1); border-bottom:1px solid var(--b1); }
+  .mburger { width:28px; height:28px; border-radius:6px; display:flex; align-items:center; justify-content:center; color:var(--t2); background:transparent; border:none; }
+  .mlogo-badge { width:24px; height:24px; border-radius:6px; background:var(--acc); color:#fff; font-weight:600; font-size:11px; display:flex; align-items:center; justify-content:center; letter-spacing:-.5px; }
+  .mlogo-text { font-size:13px; font-weight:500; letter-spacing:-.02em; }
+
+  /* Toolbar (dropdown picker + actions) */
+  .toolbar { padding:12px 16px; border-bottom:1px solid var(--b1); display:flex; flex-direction:column; gap:10px; }
+  .picker {
+    display:flex; align-items:center; gap:8px; padding:10px 12px;
+    border:1px solid var(--b1); border-radius:8px; background:var(--s3); color:var(--t1);
+    font-size:13px; font-family:var(--font-mono); letter-spacing:-.02em;
+  }
+  .picker .chev { margin-left:auto; color:var(--t3); }
+  .tb-sub { font-size:11px; color:var(--t3); }
+  .tb-actions { display:flex; gap:8px; }
+  .btn { flex:1; padding:8px 12px; border-radius:6px; font-size:12px; font-weight:500; border:1px solid var(--b1); cursor:pointer; display:inline-flex; align-items:center; justify-content:center; gap:6px; }
+  .btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .btn.secondary { background:transparent; color:var(--t2); }
+
+  /* Body */
+  .body { flex:1; overflow-y:auto; padding:12px 16px 16px; display:flex; flex-direction:column; gap:12px; }
+
+  /* Warnings */
+  .warnings {
+    border:1px solid rgba(245,166,35,.25); background:rgba(245,166,35,.06);
+    border-radius:10px; padding:10px 12px;
+  }
+  .warn-head { display:flex; align-items:center; gap:8px; font-size:12px; font-weight:600; color:var(--amb); }
+  .warn-head .dot { width:6px; height:6px; border-radius:99px; background:var(--amb); }
+  .warn-head .chev { margin-left:auto; opacity:.7; }
+  .warn-count { font-size:11px; font-family:var(--font-mono); opacity:.7; margin-left:auto; }
+
+  .editor-title { font-size:11px; font-weight:600; letter-spacing:.06em; color:var(--t3); text-transform:uppercase; }
+  .code {
+    border:1px solid var(--b1); border-radius:10px; background:#08080f; padding:12px 14px;
+    font-family:var(--font-mono); font-size:11px; line-height:1.55; color:var(--t2);
+    max-height:260px; overflow:auto; white-space:pre;
+  }
+  .code .k { color:#79c0ff; }
+  .code .s { color:#a5d6ff; }
+  .code .n { color:#f2cc60; }
+  .code .ln { color:var(--t4); display:inline-block; width:22px; text-align:right; margin-right:10px; user-select:none; }
+
+  .backups { display:flex; flex-direction:column; gap:6px; }
+  .backup-row {
+    display:flex; flex-direction:column; gap:6px; padding:10px 12px;
+    border:1px solid var(--b1); border-radius:8px; background:var(--s2);
+  }
+  .bk-top { display:flex; align-items:center; justify-content:space-between; }
+  .bk-ts { font-family:var(--font-mono); font-size:12px; color:var(--t1); letter-spacing:-.02em; }
+  .bk-src { font-size:11px; color:var(--t3); }
+  .bk-restore { padding:5px 10px; font-size:11px; font-weight:500; border:1px solid var(--b1); border-radius:6px; color:var(--t2); background:transparent; cursor:pointer; }
+</style>
+</head>
+<body>
+<span class="frame-label">CATÁLOGO · MOBILE · 390×844 · /config/labor</span>
+<div class="frame">
+
+  <div class="mtop">
+    <button class="mburger">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <div class="mlogo-badge">D</div>
+    <span class="mlogo-text">D'Angelo</span>
+  </div>
+
+  <div class="toolbar">
+    <button class="picker">
+      labor.json
+      <span class="chev">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><polyline points="6 9 12 15 18 9"/></svg>
+      </span>
+    </button>
+    <div class="tb-sub">Editado hace 2 días · ARS · sin IVA</div>
+    <div class="tb-actions">
+      <button class="btn secondary">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
+        Restaurar
+      </button>
+      <button class="btn primary">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h11l5 5v11a2 2 0 01-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>
+        Guardar
+      </button>
+    </div>
+  </div>
+
+  <div class="body">
+
+    <div class="warnings">
+      <div class="warn-head">
+        <span class="dot"></span>
+        Advertencias
+        <span class="warn-count">2</span>
+        <span class="chev">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><polyline points="6 9 12 15 18 9"/></svg>
+        </span>
+      </div>
+    </div>
+
+    <div class="editor-title">labor.json</div>
+    <pre class="code"><span class="ln"> 1</span><span class="k">{</span>
+<span class="ln"> 2</span>  <span class="s">"version"</span>: <span class="s">"2026-03-25"</span>,
+<span class="ln"> 3</span>  <span class="s">"currency"</span>: <span class="s">"ARS"</span>,
+<span class="ln"> 4</span>  <span class="s">"items"</span>: <span class="k">[</span>
+<span class="ln"> 5</span>    <span class="k">{</span>
+<span class="ln"> 6</span>      <span class="s">"code"</span>: <span class="s">"corte_pulido_recto"</span>,
+<span class="ln"> 7</span>      <span class="s">"unit"</span>: <span class="s">"ml"</span>,
+<span class="ln"> 8</span>      <span class="s">"price"</span>: <span class="n">6500</span>
+<span class="ln"> 9</span>    <span class="k">}</span>,
+<span class="ln">10</span>    <span class="k">{</span>
+<span class="ln">11</span>      <span class="s">"code"</span>: <span class="s">"pegado_pileta_empotrada"</span>,
+<span class="ln">12</span>      <span class="s">"unit"</span>: <span class="s">"un"</span>,
+<span class="ln">13</span>      <span class="s">"price"</span>: <span class="n">78000</span>
+<span class="ln">14</span>    <span class="k">}</span>,
+<span class="ln">15</span>    <span class="k">{</span>
+<span class="ln">16</span>      <span class="s">"code"</span>: <span class="s">"agujero_anafe"</span>,
+<span class="ln">17</span>      <span class="s">"unit"</span>: <span class="s">"un"</span>,
+<span class="ln">18</span>      <span class="s">"price"</span>: <span class="n">32000</span>
+<span class="ln">19</span>    <span class="k">}</span>,
+<span class="ln">20</span>    <span class="k">{</span>
+<span class="ln">21</span>      <span class="s">"code"</span>: <span class="s">"colocacion"</span>,
+<span class="ln">22</span>      <span class="s">"unit"</span>: <span class="s">"m2"</span>,
+<span class="ln">23</span>      <span class="s">"price"</span>: <span class="n">54000</span>
+<span class="ln">24</span>    <span class="k">}</span>
+<span class="ln">25</span>  <span class="k">]</span>
+<span class="ln">26</span><span class="k">}</span></pre>
+
+    <div class="editor-title">Backups recientes</div>
+    <div class="backups">
+      <div class="backup-row">
+        <div class="bk-top">
+          <span class="bk-ts">16/04 18:03</span>
+          <button class="bk-restore">Restaurar</button>
+        </div>
+        <span class="bk-src">Edición manual · javier@dangelo</span>
+      </div>
+      <div class="backup-row">
+        <div class="bk-top">
+          <span class="bk-ts">25/03 10:12</span>
+          <button class="bk-restore">Restaurar</button>
+        </div>
+        <span class="bk-src">Validación IA · sugerencias aceptadas</span>
+      </div>
+      <div class="backup-row">
+        <div class="bk-top">
+          <span class="bk-ts">08/02 09:44</span>
+          <button class="bk-restore">Restaurar</button>
+        </div>
+        <span class="bk-src">Edición manual · javier@dangelo</span>
+      </div>
+    </div>
+
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/10-chat-empty-desktop.html
+++ b/docs/mockups/10-chat-empty-desktop.html
@@ -1,0 +1,210 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Chat · vacío · Desktop 1440×900</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a; --red2:rgba(255,69,58,.08);
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:1440px; height:900px; background:var(--bg); overflow:hidden; position:relative; border:1px solid rgba(255,255,255,.06); border-radius:6px; display:flex; }
+
+  /* SIDEBAR */
+  .sidebar { width:212px; flex-shrink:0; background:var(--s1); border-right:1px solid var(--b1); display:flex; flex-direction:column; padding:18px 10px 20px; }
+  .side-logo { display:flex; align-items:center; gap:10px; padding:2px 8px 20px; cursor:pointer; }
+  .side-logo-badge { width:26px; height:26px; border-radius:6px; background:var(--acc); color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; letter-spacing:-.5px; }
+  .side-logo-text { font-size:13px; font-weight:500; letter-spacing:-.02em; }
+  .side-label { font-size:10px; font-weight:500; color:var(--t4); text-transform:uppercase; letter-spacing:.1em; padding:0 8px 4px; }
+  .side-label.mt { margin-top:14px; }
+  .side-item { display:flex; align-items:center; gap:8px; padding:8px; border-radius:6px; font-size:12px; color:var(--t2); cursor:pointer; border:none; background:transparent; width:100%; text-align:left; }
+  .side-item.active { color:var(--acc); background:rgba(79,143,255,.11); }
+  .side-item svg { flex-shrink:0; opacity:.65; }
+  .side-item.active svg { opacity:1; }
+  .side-item .count { margin-left:auto; font-size:10px; font-weight:500; padding:1px 7px; border-radius:99px; background:rgba(255,255,255,.07); color:var(--t3); font-family:var(--font-mono); }
+  .side-item.active .count { background:var(--acc); color:#fff; font-weight:600; }
+  .side-divider { height:1px; background:var(--b1); margin:12px 0; }
+  .side-spacer { flex:1; }
+  .side-new { width:100%; padding:10px 12px; background:var(--acc); color:#fff; font-size:13px; font-weight:500; border:none; border-radius:8px; display:flex; align-items:center; justify-content:center; gap:7px; letter-spacing:-.01em; }
+  .side-logout { width:100%; padding:7px 8px; background:transparent; border:none; color:var(--t3); font-size:11px; display:flex; align-items:center; justify-content:center; gap:6px; margin-top:10px; cursor:pointer; }
+
+  /* MAIN */
+  .main { flex:1; display:flex; flex-direction:column; min-width:0; }
+
+  /* HEADER */
+  .qh-header { padding:14px 28px; border-bottom:1px solid var(--b1); background:var(--s1); display:flex; align-items:center; gap:14px; }
+  .qh-back { width:30px; height:30px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; cursor:pointer; }
+  .qh-title-wrap { min-width:0; flex:1; }
+  .qh-title { font-size:15px; font-weight:600; color:var(--t1); letter-spacing:-.01em; display:flex; align-items:center; gap:10px; }
+  .qh-status { display:inline-flex; align-items:center; gap:5px; padding:2px 8px; border-radius:99px; font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.06em; }
+  .qh-status.draft { color:var(--amb); background:var(--amb2); }
+  .qh-status.valid { color:var(--grn); background:var(--grn2); }
+  .qh-status .dot { width:5px; height:5px; border-radius:99px; background:currentColor; }
+  .qh-sub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .qh-actions { display:flex; gap:8px; align-items:center; }
+  .qh-pill { display:inline-flex; align-items:center; gap:6px; padding:6px 12px; border-radius:6px; font-size:12px; font-weight:500; border:1px solid; text-decoration:none; }
+  .qh-pill.pdf { color:var(--acc); border-color:rgba(79,143,255,.20); background:transparent; }
+  .qh-pill.xls { color:#34d399; border-color:rgba(52,211,153,.20); background:transparent; }
+
+  /* TABS */
+  .tabs { display:flex; padding-left:28px; border-bottom:1px solid var(--b1); background:var(--s1); }
+  .tab { padding:10px 20px; font-size:13px; font-weight:500; color:var(--t3); background:transparent; border:none; cursor:pointer; border-bottom:2px solid transparent; opacity:.6; }
+  .tab.active { color:var(--acc); border-bottom-color:var(--acc); opacity:1; }
+  .tab.locked { opacity:.35; cursor:not-allowed; }
+
+  /* CHAT SCROLL */
+  .chat-scroll { flex:1; overflow-y:auto; padding:28px 28px 16px; display:flex; flex-direction:column; gap:20px; background:var(--bg); }
+
+  /* MESSAGES */
+  .msg { display:flex; gap:12px; align-items:flex-start; }
+  .msg.user { flex-direction:row-reverse; }
+  .avatar { width:30px; height:30px; border-radius:99px; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:11px; font-weight:600; }
+  .avatar.v { background:var(--acc); color:#fff; }
+  .avatar.u { background:var(--s3); color:var(--t2); border:1px solid var(--b2); }
+  .bubble.user { max-width:52%; padding:12px 16px; background:var(--acc2); border:1px solid rgba(79,143,255,.25); border-radius:12px 2px 12px 12px; font-size:15px; line-height:1.65; color:rgba(255,255,255,.78); }
+  .attach-badge { display:inline-flex; align-items:center; gap:5px; padding:4px 8px; border-radius:5px; background:rgba(255,255,255,.08); border:1px solid var(--b1); font-size:11px; color:var(--t2); margin-bottom:7px; }
+  .vwrap { flex:1; border:1px solid var(--b2); border-radius:2px 12px 12px 12px; overflow:hidden; }
+  .blk { padding:14px 18px; background:var(--s2); }
+  .blk + .blk { border-top:1px solid var(--b1); }
+  .blk.thinking { padding:12px 18px; display:flex; flex-direction:column; gap:6px; }
+  .think-line { display:flex; align-items:center; gap:7px; font-size:11px; color:var(--t3); font-style:italic; }
+  .think-dot { width:5px; height:5px; border-radius:99px; background:var(--acc); flex-shrink:0; animation:pulse 1.4s ease-in-out infinite; }
+  .think-dot.d2 { animation-delay:.3s; } .think-dot.d3 { animation-delay:.6s; } .think-dot.d4 { animation-delay:.9s; }
+  .think-dot.err { background:var(--red); animation:none; }
+  @keyframes pulse { 0%,100% { opacity:.35; } 50% { opacity:1; } }
+  .blk.text { font-size:15px; line-height:1.7; color:var(--t2); }
+  .blk.text h3 { font-size:15px; font-weight:600; color:var(--t1); border-bottom:1px solid var(--b1); padding-bottom:6px; margin-bottom:10px; letter-spacing:-.01em; }
+  .blk.text p { margin-bottom:2px; }
+  .blk.text p + p { margin-top:4px; }
+
+  /* TABLES */
+  .mdtable { margin:8px 0; border-radius:10px; overflow:hidden; border:1px solid var(--b1); background:rgba(255,255,255,.02); }
+  .mdtable table { width:100%; border-collapse:collapse; }
+  .mdtable th { padding:10px 14px; font-size:13px; font-weight:600; color:var(--t1); text-align:left; border-bottom:2px solid rgba(255,255,255,.10); }
+  .mdtable th + th, .mdtable td + td { text-align:right; }
+  .mdtable td { padding:10px 14px; font-size:14px; color:var(--t2); border-bottom:1px solid rgba(255,255,255,.06); }
+  .mdtable tr.total td { font-weight:600; color:var(--t1); background:rgba(255,255,255,.04); border-bottom:0; }
+
+  /* COMPOSER */
+  .composer { border-top:1px solid var(--b1); background:var(--s1); padding:14px 20px; }
+  .comp-row { display:flex; align-items:flex-end; gap:8px; background:var(--s3); border:1px solid var(--b2); border-radius:12px; padding:10px 10px 10px 16px; }
+  .comp-input { flex:1; background:transparent; border:none; outline:none; font-family:inherit; font-size:13px; color:var(--t1); line-height:1.5; min-height:20px; padding:2px 0; }
+  .comp-input.placeholder { color:var(--t4); }
+  .comp-btns { display:flex; gap:5px; flex-shrink:0; }
+  .icon-btn { width:32px; height:32px; border-radius:99px; display:flex; align-items:center; justify-content:center; cursor:pointer; border:1px solid var(--b1); background:transparent; color:var(--t2); }
+  .icon-btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .icon-btn:disabled { opacity:.4; cursor:not-allowed; }
+  .comp-foot { display:flex; justify-content:space-between; align-items:center; margin-top:6px; font-size:11px; color:var(--t3); }
+  .multi-check { display:inline-flex; align-items:center; gap:5px; cursor:pointer; }
+  .multi-check input { accent-color:var(--acc); cursor:pointer; }
+  .comp-hint { color:var(--t3); font-size:11px; }
+
+  /* Context card */
+  .card { margin:8px 0; width:100%; border-radius:16px; border:1px solid var(--b1); background:var(--s1); overflow:hidden; box-shadow:0 20px 40px -20px rgba(0,0,0,.5); }
+  .card-hdr { display:flex; align-items:center; gap:12px; padding:16px 20px; background:linear-gradient(180deg,var(--s3),var(--s2)); border-bottom:1px solid var(--b1); }
+  .card-tag { font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.1em; color:var(--acc); background:var(--acc2); border:1px solid rgba(79,143,255,.30); padding:4px 8px; border-radius:6px; }
+  .card-title { font-size:15px; font-weight:600; color:var(--t1); }
+  .card-sub { margin-left:auto; font-size:12px; color:var(--t3); font-family:var(--font-mono); }
+  .copy-btn { display:inline-flex; align-items:center; gap:5px; padding:5px 10px; border:1px solid var(--b2); border-radius:6px; background:transparent; color:var(--t2); font-size:11px; cursor:pointer; }
+  .card-body { padding:20px; }
+  .card-actions { display:flex; gap:8px; padding:16px 20px; border-top:1px solid var(--b1); background:var(--s2); }
+  .btn-primary { flex:1; padding:10px 16px; border-radius:12px; background:var(--acc); color:#fff; font-size:13px; font-weight:600; border:none; cursor:pointer; }
+  .btn-ghost { padding:10px 16px; border-radius:12px; background:transparent; border:1px solid var(--b1); color:var(--t2); font-size:13px; cursor:pointer; }
+
+  /* utilities */
+  .center-stack { display:flex; align-items:center; justify-content:center; gap:10px; padding:6px 0; }
+  .micro { font-size:12px; color:var(--t2); font-style:italic; }
+</style>
+</head>
+<body>
+<span class="frame-label">CHAT · VACÍO · DESKTOP · 1440×900 · /quote/pr-0248</span>
+<div class="frame">
+  <aside class="sidebar">
+    <div class="side-logo">
+      <div class="side-logo-badge">D</div>
+      <span class="side-logo-text">D'Angelo</span>
+    </div>
+    <div class="side-label">Principal</div>
+    <button class="side-item active">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Presupuestos
+      <span class="count">3</span>
+    </button>
+    <div class="side-label mt">Sistema</div>
+    <button class="side-item">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/><path d="M19 12a7 7 0 01-1 3.5l2 2-3 3-2-2a7 7 0 01-3.5 1"/></svg>
+      Catálogo
+    </button>
+    <button class="side-item">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/></svg>
+      Configuración
+    </button>
+    <div class="side-divider"></div>
+    <div class="side-spacer"></div>
+    <button class="side-new">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+      Nuevo presupuesto
+    </button>
+    <button class="side-logout">Cerrar sesión</button>
+  </aside>
+
+  <main class="main">
+    <header class="qh-header">
+      <button class="qh-back">←</button>
+      <div class="qh-title-wrap">
+        <div class="qh-title">
+          Nuevo presupuesto
+          <span class="qh-status draft"><span class="dot"></span>borrador</span>
+        </div>
+        <div class="qh-sub">#PR-0248 · recién creado</div>
+      </div>
+    </header>
+
+    <div class="tabs">
+      <button class="tab active">Chat</button>
+      <button class="tab locked">Detalle</button>
+    </div>
+
+    <div class="chat-scroll">
+      <div class="msg">
+        <div class="avatar v">V</div>
+        <div class="vwrap">
+          <div class="blk text">
+            <p>Hola. Pasame el plano (PDF, DWG, JPG hasta 25 MB) o contame el trabajo — material, geometría, extras. También podés dictar las medidas si ya las tenés.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="composer">
+      <div class="comp-row">
+        <div class="comp-input placeholder">Escribí el enunciado o arrastrá el plano…</div>
+        <div class="comp-btns">
+          <button class="icon-btn" title="Adjuntar plano">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg>
+          </button>
+          <button class="icon-btn primary" title="Enviar">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+          </button>
+        </div>
+      </div>
+      <div class="comp-foot">
+        <span>Enter para enviar · Shift+Enter para nueva línea</span>
+        <label class="multi-check"><input type="checkbox"/> multi-pieza</label>
+      </div>
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/docs/mockups/10-chat-empty-mobile.html
+++ b/docs/mockups/10-chat-empty-mobile.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Chat · vacío · Mobile 390×844</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:14px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame {
+    width:390px; height:844px; border-radius:38px; border:10px solid #0a0a10;
+    background:var(--bg); overflow:hidden; position:relative;
+    display:flex; flex-direction:column;
+  }
+  .frame::after {
+    content:''; position:absolute; inset:0; pointer-events:none;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+  }
+
+  /* TOPBAR */
+  .mobile-topbar { display:flex; align-items:center; gap:12px; padding:12px 16px; background:var(--s1); border-bottom:1px solid var(--b1); flex-shrink:0; }
+  .mobile-topbar .burger { background:transparent; border:none; color:var(--t2); padding:2px; display:flex; }
+  .mobile-topbar .dlogo { width:22px; height:22px; border-radius:6px; background:var(--acc); display:flex; align-items:center; justify-content:center; color:#fff; font-size:10px; font-weight:600; }
+  .mobile-topbar .brand { font-size:13px; font-weight:500; color:var(--t1); }
+
+  /* QUOTE HEADER */
+  .qh-header { padding:12px 16px; border-bottom:1px solid var(--b1); background:var(--s1); flex-shrink:0; }
+  .qh-row { display:flex; align-items:center; gap:10px; }
+  .qh-back { width:30px; height:30px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; flex-shrink:0; }
+  .qh-title-wrap { flex:1; min-width:0; }
+  .qh-title { font-size:14px; font-weight:600; color:var(--t1); max-width:200px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; letter-spacing:-.01em; }
+  .qh-sub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .qh-status { display:inline-flex; align-items:center; gap:4px; padding:2px 7px; border-radius:99px; font-size:9px; font-weight:600; text-transform:uppercase; letter-spacing:.05em; flex-shrink:0; }
+  .qh-status.draft { color:var(--amb); background:var(--amb2); }
+  .qh-status .dot { width:4px; height:4px; border-radius:99px; background:currentColor; }
+
+  /* TABS */
+  .tabs { display:flex; padding-left:16px; border-bottom:1px solid var(--b1); background:var(--s1); flex-shrink:0; }
+  .tab { padding:10px 16px; font-size:12px; font-weight:500; color:var(--t3); background:transparent; border:none; border-bottom:2px solid transparent; opacity:.6; }
+  .tab.active { color:var(--acc); border-bottom-color:var(--acc); opacity:1; }
+  .tab.locked { opacity:.35; }
+
+  /* CHAT SCROLL */
+  .chat-scroll { flex:1; overflow-y:auto; padding:20px 16px 16px; display:flex; flex-direction:column; gap:16px; }
+
+  /* MESSAGES */
+  .msg { display:flex; gap:10px; align-items:flex-start; }
+  .avatar { width:28px; height:28px; border-radius:99px; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:10px; font-weight:600; }
+  .avatar.v { background:var(--acc); color:#fff; }
+  .vwrap { flex:1; border:1px solid var(--b2); border-radius:2px 12px 12px 12px; overflow:hidden; }
+  .blk { padding:12px 14px; background:var(--s2); }
+  .blk + .blk { border-top:1px solid var(--b1); }
+  .blk.text { font-size:14px; line-height:1.65; color:var(--t2); }
+  .blk.text p + p { margin-top:4px; }
+
+  /* COMPOSER */
+  .composer { border-top:1px solid var(--b1); background:var(--s1); padding:12px 16px; flex-shrink:0; }
+  .comp-row { display:flex; align-items:center; gap:8px; background:var(--s3); border:1px solid var(--b2); border-radius:12px; padding:8px 10px 8px 12px; }
+  .comp-input { flex:1; background:transparent; border:none; outline:none; font-size:13px; color:var(--t4); }
+  .comp-btns { display:flex; gap:5px; flex-shrink:0; }
+  .icon-btn { width:28px; height:28px; border-radius:99px; display:flex; align-items:center; justify-content:center; border:1px solid var(--b1); background:transparent; color:var(--t2); }
+  .icon-btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .comp-hint { font-size:10px; color:var(--t3); margin-top:5px; text-align:right; }
+</style>
+</head>
+<body>
+<span class="frame-label">CHAT · VACÍO · MOBILE · 390×844 · /quote/pr-0248</span>
+<div class="frame">
+
+  <div class="mobile-topbar">
+    <button class="burger">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <div class="dlogo">D</div>
+    <span class="brand">D'Angelo</span>
+  </div>
+
+  <header class="qh-header">
+    <div class="qh-row">
+      <button class="qh-back">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><polyline points="15 18 9 12 15 6"/></svg>
+      </button>
+      <div class="qh-title-wrap">
+        <div class="qh-title">Nuevo presupuesto</div>
+        <div class="qh-sub">#PR-0248 · borrador</div>
+      </div>
+      <span class="qh-status draft"><span class="dot"></span>Borrador</span>
+    </div>
+  </header>
+
+  <div class="tabs">
+    <button class="tab active">Chat</button>
+    <button class="tab locked">Detalle</button>
+  </div>
+
+  <div class="chat-scroll">
+    <div class="msg">
+      <div class="avatar v">V</div>
+      <div class="vwrap">
+        <div class="blk text">
+          <p>Hola. Pasame el plano (PDF, DWG, JPG hasta 25 MB) o contame el trabajo.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="composer">
+    <div class="comp-row">
+      <span class="comp-input">Enunciado o adjuntar plano…</span>
+      <div class="comp-btns">
+        <button class="icon-btn">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg>
+        </button>
+        <button class="icon-btn primary">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+        </button>
+      </div>
+    </div>
+    <div class="comp-hint">Enter para enviar</div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/11-chat-brief-sent-desktop.html
+++ b/docs/mockups/11-chat-brief-sent-desktop.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Chat · brief enviado, pensando · Desktop 1440×900</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:1440px; height:900px; background:var(--bg); overflow:hidden; position:relative; border:1px solid rgba(255,255,255,.06); border-radius:6px; display:flex; }
+  .sidebar { width:212px; flex-shrink:0; background:var(--s1); border-right:1px solid var(--b1); display:flex; flex-direction:column; padding:18px 10px 20px; }
+  .side-logo { display:flex; align-items:center; gap:10px; padding:2px 8px 20px; }
+  .side-logo-badge { width:26px; height:26px; border-radius:6px; background:var(--acc); color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
+  .side-logo-text { font-size:13px; font-weight:500; letter-spacing:-.02em; }
+  .side-label { font-size:10px; font-weight:500; color:var(--t4); text-transform:uppercase; letter-spacing:.1em; padding:0 8px 4px; }
+  .side-label.mt { margin-top:14px; }
+  .side-item { display:flex; align-items:center; gap:8px; padding:8px; border-radius:6px; font-size:12px; color:var(--t2); border:none; background:transparent; width:100%; text-align:left; cursor:pointer; }
+  .side-item.active { color:var(--acc); background:rgba(79,143,255,.11); }
+  .side-item svg { flex-shrink:0; opacity:.65; }
+  .side-item.active svg { opacity:1; }
+  .side-item .count { margin-left:auto; font-size:10px; font-weight:500; padding:1px 7px; border-radius:99px; background:rgba(255,255,255,.07); color:var(--t3); font-family:var(--font-mono); }
+  .side-item.active .count { background:var(--acc); color:#fff; font-weight:600; }
+  .side-divider { height:1px; background:var(--b1); margin:12px 0; }
+  .side-spacer { flex:1; }
+  .side-new { width:100%; padding:10px 12px; background:var(--acc); color:#fff; font-size:13px; font-weight:500; border:none; border-radius:8px; display:flex; align-items:center; justify-content:center; gap:7px; }
+  .side-logout { width:100%; padding:7px 8px; background:transparent; border:none; color:var(--t3); font-size:11px; display:flex; align-items:center; justify-content:center; gap:6px; margin-top:10px; }
+
+  .main { flex:1; display:flex; flex-direction:column; min-width:0; }
+  .qh-header { padding:14px 28px; border-bottom:1px solid var(--b1); background:var(--s1); display:flex; align-items:center; gap:14px; }
+  .qh-back { width:30px; height:30px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; cursor:pointer; }
+  .qh-title-wrap { min-width:0; flex:1; }
+  .qh-title { font-size:15px; font-weight:600; color:var(--t1); display:flex; align-items:center; gap:10px; }
+  .qh-status { display:inline-flex; align-items:center; gap:5px; padding:2px 8px; border-radius:99px; font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.06em; }
+  .qh-status.draft { color:var(--amb); background:var(--amb2); }
+  .qh-status .dot { width:5px; height:5px; border-radius:99px; background:currentColor; }
+  .qh-sub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+
+  .tabs { display:flex; padding-left:28px; border-bottom:1px solid var(--b1); background:var(--s1); }
+  .tab { padding:10px 20px; font-size:13px; font-weight:500; color:var(--t3); background:transparent; border:none; cursor:pointer; border-bottom:2px solid transparent; opacity:.6; }
+  .tab.active { color:var(--acc); border-bottom-color:var(--acc); opacity:1; }
+  .tab.locked { opacity:.35; cursor:not-allowed; }
+
+  .chat-scroll { flex:1; overflow-y:auto; padding:28px 28px 16px; display:flex; flex-direction:column; gap:20px; background:var(--bg); }
+  .msg { display:flex; gap:12px; align-items:flex-start; }
+  .msg.user { flex-direction:row-reverse; }
+  .avatar { width:30px; height:30px; border-radius:99px; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:11px; font-weight:600; }
+  .avatar.v { background:var(--acc); color:#fff; }
+  .avatar.u { background:var(--s3); color:var(--t2); border:1px solid var(--b2); }
+  .bubble.user { max-width:52%; padding:12px 16px; background:var(--acc2); border:1px solid rgba(79,143,255,.25); border-radius:12px 2px 12px 12px; font-size:15px; line-height:1.65; color:rgba(255,255,255,.78); }
+  .vwrap { flex:1; border:1px solid var(--b2); border-radius:2px 12px 12px 12px; overflow:hidden; }
+  .blk { padding:14px 18px; background:var(--s2); }
+  .blk + .blk { border-top:1px solid var(--b1); }
+  .blk.thinking { padding:12px 18px; display:flex; flex-direction:column; gap:6px; }
+  .think-line { display:flex; align-items:center; gap:7px; font-size:11px; color:var(--t3); font-style:italic; }
+  .think-dot { width:5px; height:5px; border-radius:99px; background:var(--acc); flex-shrink:0; animation:pulse 1.4s ease-in-out infinite; }
+  .think-dot.d2 { animation-delay:.3s; } .think-dot.d3 { animation-delay:.6s; } .think-dot.d4 { animation-delay:.9s; }
+  @keyframes pulse { 0%,100% { opacity:.35; } 50% { opacity:1; } }
+
+  .composer { border-top:1px solid var(--b1); background:var(--s1); padding:14px 20px; }
+  .comp-row { display:flex; align-items:flex-end; gap:8px; background:var(--s3); border:1px solid var(--b2); border-radius:12px; padding:10px 10px 10px 16px; }
+  .comp-input { flex:1; background:transparent; border:none; outline:none; font-size:13px; color:var(--t1); line-height:1.5; min-height:20px; padding:2px 0; }
+  .comp-input.placeholder { color:var(--t4); }
+  .comp-btns { display:flex; gap:5px; flex-shrink:0; }
+  .icon-btn { width:32px; height:32px; border-radius:99px; display:flex; align-items:center; justify-content:center; cursor:pointer; border:1px solid var(--b1); background:transparent; color:var(--t2); }
+  .icon-btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .icon-btn:disabled { opacity:.4; cursor:not-allowed; }
+  .comp-foot { display:flex; justify-content:space-between; align-items:center; margin-top:6px; font-size:11px; color:var(--t3); }
+  .multi-check { display:inline-flex; align-items:center; gap:5px; cursor:pointer; }
+</style>
+</head>
+<body>
+<span class="frame-label">CHAT · BRIEF ENVIADO · DESKTOP · 1440×900 · /quote/pr-0248</span>
+<div class="frame">
+  <aside class="sidebar">
+    <div class="side-logo"><div class="side-logo-badge">D</div><span class="side-logo-text">D'Angelo</span></div>
+    <div class="side-label">Principal</div>
+    <button class="side-item active">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Presupuestos<span class="count">3</span>
+    </button>
+    <div class="side-label mt">Sistema</div>
+    <button class="side-item"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/><path d="M19 12a7 7 0 01-1 3.5l2 2-3 3-2-2a7 7 0 01-3.5 1"/></svg>Catálogo</button>
+    <button class="side-item"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/></svg>Configuración</button>
+    <div class="side-divider"></div>
+    <div class="side-spacer"></div>
+    <button class="side-new"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>Nuevo presupuesto</button>
+    <button class="side-logout">Cerrar sesión</button>
+  </aside>
+
+  <main class="main">
+    <header class="qh-header">
+      <button class="qh-back">←</button>
+      <div class="qh-title-wrap">
+        <div class="qh-title">
+          Erica Bernardi — Casa Bernardi
+          <span class="qh-status draft"><span class="dot"></span>borrador</span>
+        </div>
+        <div class="qh-sub">#PR-0248 · hace 12 s</div>
+      </div>
+    </header>
+
+    <div class="tabs">
+      <button class="tab active">Chat</button>
+      <button class="tab locked">Detalle</button>
+    </div>
+
+    <div class="chat-scroll">
+      <div class="msg user">
+        <div class="avatar u">EB</div>
+        <div class="bubble user">
+          Hola, necesito presupuesto para cocina de Erica Bernardi en Casa Bernardi (Rosario). Material Puraprima Onix White Mate 3 cm. Es cocina en U con isla central, pileta doble, 2 anafes (gas + eléctrico), con zócalos y colocación. Forma de pago contado.
+        </div>
+      </div>
+
+      <div class="msg">
+        <div class="avatar v">V</div>
+        <div class="vwrap">
+          <div class="blk thinking">
+            <div class="think-line"><span class="think-dot"></span>Analizando brief…</div>
+            <div class="think-line"><span class="think-dot d2"></span>Identificando material: Puraprima Onix White Mate</div>
+            <div class="think-line"><span class="think-dot d3"></span>Detectando sectores: cocina U, isla, pileta doble, anafe 2</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="composer">
+      <div class="comp-row">
+        <div class="comp-input placeholder">Escribí el enunciado o arrastrá el plano…</div>
+        <div class="comp-btns">
+          <button class="icon-btn"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg></button>
+          <button class="icon-btn primary"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg></button>
+        </div>
+      </div>
+      <div class="comp-foot">
+        <span>Enter para enviar · Shift+Enter para nueva línea</span>
+        <label class="multi-check"><input type="checkbox"/> multi-pieza</label>
+      </div>
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/docs/mockups/11-chat-brief-sent-mobile.html
+++ b/docs/mockups/11-chat-brief-sent-mobile.html
@@ -1,0 +1,142 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Chat · brief enviado · Mobile 390×844</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:14px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:390px; height:844px; border-radius:38px; border:10px solid #0a0a10; background:var(--bg); overflow:hidden; position:relative; display:flex; flex-direction:column; }
+  .frame::after { content:''; position:absolute; inset:0; pointer-events:none; background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E"); }
+
+  .mobile-topbar { display:flex; align-items:center; gap:12px; padding:12px 16px; background:var(--s1); border-bottom:1px solid var(--b1); flex-shrink:0; }
+  .mobile-topbar .burger { background:transparent; border:none; color:var(--t2); padding:2px; display:flex; }
+  .mobile-topbar .dlogo { width:22px; height:22px; border-radius:6px; background:var(--acc); display:flex; align-items:center; justify-content:center; color:#fff; font-size:10px; font-weight:600; }
+  .mobile-topbar .brand { font-size:13px; font-weight:500; color:var(--t1); }
+
+  .qh-header { padding:12px 16px; border-bottom:1px solid var(--b1); background:var(--s1); flex-shrink:0; }
+  .qh-row { display:flex; align-items:center; gap:10px; }
+  .qh-back { width:30px; height:30px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; flex-shrink:0; }
+  .qh-title-wrap { flex:1; min-width:0; }
+  .qh-title { font-size:14px; font-weight:600; color:var(--t1); max-width:200px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; letter-spacing:-.01em; }
+  .qh-sub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .qh-status { display:inline-flex; align-items:center; gap:4px; padding:2px 7px; border-radius:99px; font-size:9px; font-weight:600; text-transform:uppercase; letter-spacing:.05em; flex-shrink:0; }
+  .qh-status.draft { color:var(--amb); background:var(--amb2); }
+  .qh-status .dot { width:4px; height:4px; border-radius:99px; background:currentColor; }
+
+  .tabs { display:flex; padding-left:16px; border-bottom:1px solid var(--b1); background:var(--s1); flex-shrink:0; }
+  .tab { padding:10px 16px; font-size:12px; font-weight:500; color:var(--t3); background:transparent; border:none; border-bottom:2px solid transparent; opacity:.6; }
+  .tab.active { color:var(--acc); border-bottom-color:var(--acc); opacity:1; }
+  .tab.locked { opacity:.35; }
+
+  .chat-scroll { flex:1; overflow-y:auto; padding:20px 16px 16px; display:flex; flex-direction:column; gap:16px; }
+
+  .msg { display:flex; gap:10px; align-items:flex-start; }
+  .msg.user { flex-direction:row-reverse; }
+  .avatar { width:28px; height:28px; border-radius:99px; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:10px; font-weight:600; }
+  .avatar.v { background:var(--acc); color:#fff; }
+  .avatar.u { background:var(--s3); color:var(--t2); border:1px solid var(--b2); }
+
+  .bubble.user { max-width:85%; padding:10px 12px; background:var(--acc2); border:1px solid rgba(79,143,255,.25); border-radius:12px 2px 12px 12px; font-size:14px; line-height:1.65; color:rgba(255,255,255,.78); }
+  .vwrap { flex:1; border:1px solid var(--b2); border-radius:2px 12px 12px 12px; overflow:hidden; }
+  .blk { padding:12px 14px; background:var(--s2); }
+  .blk.thinking { display:flex; flex-direction:column; gap:6px; }
+  .think-line { display:flex; align-items:center; gap:7px; font-size:11px; color:var(--t3); font-style:italic; }
+  .think-dot { width:5px; height:5px; border-radius:99px; background:var(--acc); flex-shrink:0; animation:pulse 1.4s ease-in-out infinite; }
+  .think-dot.d2 { animation-delay:.3s; } .think-dot.d3 { animation-delay:.6s; }
+  @keyframes pulse { 0%,100% { opacity:.35; } 50% { opacity:1; } }
+
+  .composer { border-top:1px solid var(--b1); background:var(--s1); padding:12px 16px; flex-shrink:0; }
+  .comp-row { display:flex; align-items:center; gap:8px; background:var(--s3); border:1px solid var(--b2); border-radius:12px; padding:8px 10px 8px 12px; }
+  .comp-input { flex:1; background:transparent; border:none; outline:none; font-size:13px; color:var(--t4); }
+  .comp-btns { display:flex; gap:5px; flex-shrink:0; }
+  .icon-btn { width:28px; height:28px; border-radius:99px; display:flex; align-items:center; justify-content:center; border:1px solid var(--b1); background:transparent; color:var(--t2); }
+  .icon-btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .comp-hint { font-size:10px; color:var(--t3); margin-top:5px; text-align:right; }
+</style>
+</head>
+<body>
+<span class="frame-label">CHAT · BRIEF ENVIADO · MOBILE · 390×844 · /quote/pr-0248</span>
+<div class="frame">
+
+  <div class="mobile-topbar">
+    <button class="burger">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <div class="dlogo">D</div>
+    <span class="brand">D'Angelo</span>
+  </div>
+
+  <header class="qh-header">
+    <div class="qh-row">
+      <button class="qh-back">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><polyline points="15 18 9 12 15 6"/></svg>
+      </button>
+      <div class="qh-title-wrap">
+        <div class="qh-title">Erica Bernardi — Casa Bernardi</div>
+        <div class="qh-sub">#PR-0248 · hace 12 s</div>
+      </div>
+      <span class="qh-status draft"><span class="dot"></span>Borrador</span>
+    </div>
+  </header>
+
+  <div class="tabs">
+    <button class="tab active">Chat</button>
+    <button class="tab locked">Detalle</button>
+  </div>
+
+  <div class="chat-scroll">
+
+    <!-- User brief -->
+    <div class="msg user">
+      <div class="avatar u">OP</div>
+      <div class="bubble user">
+        Erica Bernardi, Rosario. Cocina en U + isla. Puraprima Onix White Mate 3 cm. Pileta doble empotrada, 2 anafes (gas + eléctrico). Zócalo trasero 7 cm. Con colocación.
+      </div>
+    </div>
+
+    <!-- Valentina thinking -->
+    <div class="msg">
+      <div class="avatar v">V</div>
+      <div class="vwrap">
+        <div class="blk thinking">
+          <div class="think-line"><span class="think-dot"></span>Analizando brief…</div>
+          <div class="think-line"><span class="think-dot d2"></span>Identificando material (Puraprima Onix White Mate)…</div>
+          <div class="think-line"><span class="think-dot d3"></span>Detectando sectores (cocina U + isla)…</div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="composer">
+    <div class="comp-row">
+      <span class="comp-input">Enunciado o adjuntar plano…</span>
+      <div class="comp-btns">
+        <button class="icon-btn">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg>
+        </button>
+        <button class="icon-btn primary">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+        </button>
+      </div>
+    </div>
+    <div class="comp-hint">Enter para enviar</div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/12-chat-plano-processing-desktop.html
+++ b/docs/mockups/12-chat-plano-processing-desktop.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Chat · plano procesando · Desktop 1440×900</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:1440px; height:900px; background:var(--bg); overflow:hidden; position:relative; border:1px solid rgba(255,255,255,.06); border-radius:6px; display:flex; }
+  .sidebar { width:212px; flex-shrink:0; background:var(--s1); border-right:1px solid var(--b1); display:flex; flex-direction:column; padding:18px 10px 20px; }
+  .side-logo { display:flex; align-items:center; gap:10px; padding:2px 8px 20px; }
+  .side-logo-badge { width:26px; height:26px; border-radius:6px; background:var(--acc); color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
+  .side-logo-text { font-size:13px; font-weight:500; letter-spacing:-.02em; }
+  .side-label { font-size:10px; font-weight:500; color:var(--t4); text-transform:uppercase; letter-spacing:.1em; padding:0 8px 4px; }
+  .side-label.mt { margin-top:14px; }
+  .side-item { display:flex; align-items:center; gap:8px; padding:8px; border-radius:6px; font-size:12px; color:var(--t2); border:none; background:transparent; width:100%; text-align:left; cursor:pointer; }
+  .side-item.active { color:var(--acc); background:rgba(79,143,255,.11); }
+  .side-item svg { flex-shrink:0; opacity:.65; }
+  .side-item.active svg { opacity:1; }
+  .side-item .count { margin-left:auto; font-size:10px; font-weight:500; padding:1px 7px; border-radius:99px; background:rgba(255,255,255,.07); color:var(--t3); font-family:var(--font-mono); }
+  .side-item.active .count { background:var(--acc); color:#fff; font-weight:600; }
+  .side-divider { height:1px; background:var(--b1); margin:12px 0; }
+  .side-spacer { flex:1; }
+  .side-new { width:100%; padding:10px 12px; background:var(--acc); color:#fff; font-size:13px; font-weight:500; border:none; border-radius:8px; display:flex; align-items:center; justify-content:center; gap:7px; }
+  .side-logout { width:100%; padding:7px 8px; background:transparent; border:none; color:var(--t3); font-size:11px; display:flex; align-items:center; justify-content:center; gap:6px; margin-top:10px; }
+  .main { flex:1; display:flex; flex-direction:column; min-width:0; }
+  .qh-header { padding:14px 28px; border-bottom:1px solid var(--b1); background:var(--s1); display:flex; align-items:center; gap:14px; }
+  .qh-back { width:30px; height:30px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; cursor:pointer; }
+  .qh-title-wrap { min-width:0; flex:1; }
+  .qh-title { font-size:15px; font-weight:600; color:var(--t1); display:flex; align-items:center; gap:10px; }
+  .qh-status { display:inline-flex; align-items:center; gap:5px; padding:2px 8px; border-radius:99px; font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.06em; }
+  .qh-status.draft { color:var(--amb); background:var(--amb2); }
+  .qh-status .dot { width:5px; height:5px; border-radius:99px; background:currentColor; }
+  .qh-sub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .tabs { display:flex; padding-left:28px; border-bottom:1px solid var(--b1); background:var(--s1); }
+  .tab { padding:10px 20px; font-size:13px; font-weight:500; color:var(--t3); background:transparent; border:none; cursor:pointer; border-bottom:2px solid transparent; opacity:.6; }
+  .tab.active { color:var(--acc); border-bottom-color:var(--acc); opacity:1; }
+  .tab.locked { opacity:.35; cursor:not-allowed; }
+
+  .chat-scroll { flex:1; overflow-y:auto; padding:28px 28px 16px; display:flex; flex-direction:column; gap:20px; background:var(--bg); }
+  .msg { display:flex; gap:12px; align-items:flex-start; }
+  .msg.user { flex-direction:row-reverse; }
+  .avatar { width:30px; height:30px; border-radius:99px; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:11px; font-weight:600; }
+  .avatar.v { background:var(--acc); color:#fff; }
+  .avatar.u { background:var(--s3); color:var(--t2); border:1px solid var(--b2); }
+  .bubble.user { max-width:52%; padding:12px 16px; background:var(--acc2); border:1px solid rgba(79,143,255,.25); border-radius:12px 2px 12px 12px; font-size:15px; line-height:1.65; color:rgba(255,255,255,.78); }
+  .bubble.user.collapsed { opacity:.7; font-size:13px; }
+  .attach-badge { display:inline-flex; align-items:center; gap:5px; padding:4px 8px; border-radius:5px; background:rgba(255,255,255,.08); border:1px solid var(--b1); font-size:11px; color:var(--t2); margin-bottom:7px; }
+  .vwrap { flex:1; border:1px solid var(--b2); border-radius:2px 12px 12px 12px; overflow:hidden; }
+  .blk { padding:14px 18px; background:var(--s2); }
+  .blk + .blk { border-top:1px solid var(--b1); }
+  .blk.thinking { padding:12px 18px; display:flex; flex-direction:column; gap:6px; }
+  .think-line { display:flex; align-items:center; gap:7px; font-size:11px; color:var(--t3); font-style:italic; }
+  .think-dot { width:5px; height:5px; border-radius:99px; background:var(--acc); flex-shrink:0; animation:pulse 1.4s ease-in-out infinite; }
+  .think-dot.d2 { animation-delay:.3s; } .think-dot.d3 { animation-delay:.6s; } .think-dot.d4 { animation-delay:.9s; }
+  @keyframes pulse { 0%,100% { opacity:.35; } 50% { opacity:1; } }
+  .blk.text { font-size:15px; line-height:1.7; color:var(--t2); }
+  .progress-wrap { margin-top:8px; }
+  .progress-lbl { font-size:12px; color:var(--t2); margin-bottom:8px; }
+  .progress-bar { width:100%; height:4px; background:rgba(255,255,255,.05); border-radius:99px; overflow:hidden; }
+  .progress-fill { width:75%; height:100%; background:var(--acc); border-radius:99px; }
+
+  .composer { border-top:1px solid var(--b1); background:var(--s1); padding:14px 20px; }
+  .comp-row { display:flex; align-items:flex-end; gap:8px; background:var(--s3); border:1px solid var(--b2); border-radius:12px; padding:10px 10px 10px 16px; }
+  .comp-input { flex:1; background:transparent; border:none; outline:none; font-size:13px; color:var(--t1); line-height:1.5; min-height:20px; padding:2px 0; }
+  .comp-input.placeholder { color:var(--t4); }
+  .comp-btns { display:flex; gap:5px; flex-shrink:0; }
+  .icon-btn { width:32px; height:32px; border-radius:99px; display:flex; align-items:center; justify-content:center; cursor:pointer; border:1px solid var(--b1); background:transparent; color:var(--t2); }
+  .icon-btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .icon-btn:disabled { opacity:.4; cursor:not-allowed; }
+  .comp-foot { display:flex; justify-content:space-between; align-items:center; margin-top:6px; font-size:11px; color:var(--t3); }
+  .multi-check { display:inline-flex; align-items:center; gap:5px; cursor:pointer; }
+</style>
+</head>
+<body>
+<span class="frame-label">CHAT · PLANO PROCESANDO · DESKTOP · 1440×900 · /quote/pr-0248</span>
+<div class="frame">
+  <aside class="sidebar">
+    <div class="side-logo"><div class="side-logo-badge">D</div><span class="side-logo-text">D'Angelo</span></div>
+    <div class="side-label">Principal</div>
+    <button class="side-item active">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Presupuestos<span class="count">3</span>
+    </button>
+    <div class="side-label mt">Sistema</div>
+    <button class="side-item"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/><path d="M19 12a7 7 0 01-1 3.5l2 2-3 3-2-2a7 7 0 01-3.5 1"/></svg>Catálogo</button>
+    <button class="side-item"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><line x1="4" y1="21" x2="4" y2="14"/></svg>Configuración</button>
+    <div class="side-divider"></div>
+    <div class="side-spacer"></div>
+    <button class="side-new"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>Nuevo presupuesto</button>
+    <button class="side-logout">Cerrar sesión</button>
+  </aside>
+
+  <main class="main">
+    <header class="qh-header">
+      <button class="qh-back">←</button>
+      <div class="qh-title-wrap">
+        <div class="qh-title">
+          Erica Bernardi — Casa Bernardi
+          <span class="qh-status draft"><span class="dot"></span>borrador</span>
+        </div>
+        <div class="qh-sub">#PR-0248 · hace 45 s</div>
+      </div>
+    </header>
+
+    <div class="tabs">
+      <button class="tab active">Chat</button>
+      <button class="tab locked">Detalle</button>
+    </div>
+
+    <div class="chat-scroll">
+      <div class="msg user">
+        <div class="avatar u">EB</div>
+        <div class="bubble user collapsed">
+          Hola, necesito presupuesto para cocina de Erica Bernardi en Casa Bernardi (Rosario). Material Puraprima Onix White Mate 3 cm…
+        </div>
+      </div>
+
+      <div class="msg">
+        <div class="avatar v">V</div>
+        <div class="vwrap">
+          <div class="blk text"><p>Anotado. Ahora mandame el plano así mido los tramos.</p></div>
+        </div>
+      </div>
+
+      <div class="msg user">
+        <div class="avatar u">EB</div>
+        <div class="bubble user">
+          <div class="attach-badge">📎 plano-cocina-U-bernardi.pdf · 2.3 MB · 3 páginas</div>
+          <p>Acá va, gracias.</p>
+        </div>
+      </div>
+
+      <div class="msg">
+        <div class="avatar v">V</div>
+        <div class="vwrap">
+          <div class="blk thinking">
+            <div class="think-line"><span class="think-dot"></span>Rasterizando PDF a 300 DPI…</div>
+            <div class="think-line"><span class="think-dot d2"></span>Extrayendo capa de texto con cotas…</div>
+            <div class="think-line"><span class="think-dot d3"></span>Identificando topología global (LLM)…</div>
+            <div class="think-line"><span class="think-dot d4"></span>Midiendo regiones en paralelo (4 crops)…</div>
+          </div>
+          <div class="blk text">
+            <div class="progress-wrap">
+              <div class="progress-lbl">3 de 4 tramos medidos</div>
+              <div class="progress-bar"><div class="progress-fill"></div></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="composer">
+      <div class="comp-row">
+        <div class="comp-input placeholder">Escribí el enunciado o arrastrá el plano…</div>
+        <div class="comp-btns">
+          <button class="icon-btn"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg></button>
+          <button class="icon-btn primary" disabled><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg></button>
+        </div>
+      </div>
+      <div class="comp-foot">
+        <span>Enter para enviar · Shift+Enter para nueva línea</span>
+        <label class="multi-check"><input type="checkbox"/> multi-pieza</label>
+      </div>
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/docs/mockups/12-chat-plano-processing-mobile.html
+++ b/docs/mockups/12-chat-plano-processing-mobile.html
@@ -1,0 +1,157 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Chat · plano procesando · Mobile 390×844</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:14px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:390px; height:844px; border-radius:38px; border:10px solid #0a0a10; background:var(--bg); overflow:hidden; position:relative; display:flex; flex-direction:column; }
+  .frame::after { content:''; position:absolute; inset:0; pointer-events:none; background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E"); }
+
+  .mobile-topbar { display:flex; align-items:center; gap:12px; padding:12px 16px; background:var(--s1); border-bottom:1px solid var(--b1); flex-shrink:0; }
+  .mobile-topbar .burger { background:transparent; border:none; color:var(--t2); padding:2px; display:flex; }
+  .mobile-topbar .dlogo { width:22px; height:22px; border-radius:6px; background:var(--acc); display:flex; align-items:center; justify-content:center; color:#fff; font-size:10px; font-weight:600; }
+  .mobile-topbar .brand { font-size:13px; font-weight:500; color:var(--t1); }
+
+  .qh-header { padding:12px 16px; border-bottom:1px solid var(--b1); background:var(--s1); flex-shrink:0; }
+  .qh-row { display:flex; align-items:center; gap:10px; }
+  .qh-back { width:30px; height:30px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; flex-shrink:0; }
+  .qh-title-wrap { flex:1; min-width:0; }
+  .qh-title { font-size:14px; font-weight:600; color:var(--t1); max-width:200px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; letter-spacing:-.01em; }
+  .qh-sub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .qh-status { display:inline-flex; align-items:center; gap:4px; padding:2px 7px; border-radius:99px; font-size:9px; font-weight:600; text-transform:uppercase; letter-spacing:.05em; flex-shrink:0; }
+  .qh-status.draft { color:var(--amb); background:var(--amb2); }
+  .qh-status .dot { width:4px; height:4px; border-radius:99px; background:currentColor; }
+
+  .tabs { display:flex; padding-left:16px; border-bottom:1px solid var(--b1); background:var(--s1); flex-shrink:0; }
+  .tab { padding:10px 16px; font-size:12px; font-weight:500; color:var(--t3); background:transparent; border:none; border-bottom:2px solid transparent; opacity:.6; }
+  .tab.active { color:var(--acc); border-bottom-color:var(--acc); opacity:1; }
+  .tab.locked { opacity:.35; }
+
+  .chat-scroll { flex:1; overflow-y:auto; padding:20px 16px 16px; display:flex; flex-direction:column; gap:16px; }
+
+  .msg { display:flex; gap:10px; align-items:flex-start; }
+  .msg.user { flex-direction:row-reverse; }
+  .avatar { width:28px; height:28px; border-radius:99px; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:10px; font-weight:600; }
+  .avatar.v { background:var(--acc); color:#fff; }
+  .avatar.u { background:var(--s3); color:var(--t2); border:1px solid var(--b2); }
+
+  .bubble.user { max-width:85%; padding:10px 12px; background:var(--acc2); border:1px solid rgba(79,143,255,.25); border-radius:12px 2px 12px 12px; font-size:14px; line-height:1.65; color:rgba(255,255,255,.78); }
+  .attach-badge { display:inline-flex; align-items:center; gap:5px; padding:4px 8px; border-radius:5px; background:rgba(255,255,255,.08); border:1px solid var(--b1); font-size:11px; color:var(--t2); margin-bottom:6px; }
+
+  .vwrap { flex:1; border:1px solid var(--b2); border-radius:2px 12px 12px 12px; overflow:hidden; }
+  .blk { padding:12px 14px; background:var(--s2); }
+  .blk + .blk { border-top:1px solid var(--b1); }
+  .blk.thinking { display:flex; flex-direction:column; gap:6px; }
+  .think-line { display:flex; align-items:center; gap:7px; font-size:11px; color:var(--t3); font-style:italic; }
+  .think-dot { width:5px; height:5px; border-radius:99px; background:var(--acc); flex-shrink:0; animation:pulse 1.4s ease-in-out infinite; }
+  .think-dot.d2 { animation-delay:.3s; } .think-dot.d3 { animation-delay:.6s; } .think-dot.d4 { animation-delay:.9s; }
+  .think-dot.ok { background:var(--grn); animation:none; }
+  @keyframes pulse { 0%,100% { opacity:.35; } 50% { opacity:1; } }
+
+  .progress-wrap { margin-top:8px; }
+  .progress-label { display:flex; justify-content:space-between; font-size:10px; color:var(--t3); font-family:var(--font-mono); margin-bottom:4px; }
+  .progress-bar { height:4px; border-radius:99px; background:var(--s3); overflow:hidden; }
+  .progress-fill { height:100%; background:var(--acc); width:75%; border-radius:99px; }
+
+  .composer { border-top:1px solid var(--b1); background:var(--s1); padding:12px 16px; flex-shrink:0; }
+  .comp-row { display:flex; align-items:center; gap:8px; background:var(--s3); border:1px solid var(--b2); border-radius:12px; padding:8px 10px 8px 12px; }
+  .comp-input { flex:1; background:transparent; border:none; outline:none; font-size:13px; color:var(--t4); }
+  .comp-btns { display:flex; gap:5px; flex-shrink:0; }
+  .icon-btn { width:28px; height:28px; border-radius:99px; display:flex; align-items:center; justify-content:center; border:1px solid var(--b1); background:transparent; color:var(--t2); }
+  .icon-btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .comp-hint { font-size:10px; color:var(--t3); margin-top:5px; text-align:right; }
+</style>
+</head>
+<body>
+<span class="frame-label">CHAT · PLANO PROCESANDO · MOBILE · 390×844 · /quote/pr-0248</span>
+<div class="frame">
+
+  <div class="mobile-topbar">
+    <button class="burger">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <div class="dlogo">D</div>
+    <span class="brand">D'Angelo</span>
+  </div>
+
+  <header class="qh-header">
+    <div class="qh-row">
+      <button class="qh-back">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><polyline points="15 18 9 12 15 6"/></svg>
+      </button>
+      <div class="qh-title-wrap">
+        <div class="qh-title">Erica Bernardi — Casa Bernardi</div>
+        <div class="qh-sub">#PR-0248 · hace 1 min</div>
+      </div>
+      <span class="qh-status draft"><span class="dot"></span>Borrador</span>
+    </div>
+  </header>
+
+  <div class="tabs">
+    <button class="tab active">Chat</button>
+    <button class="tab locked">Detalle</button>
+  </div>
+
+  <div class="chat-scroll">
+
+    <!-- User message with attachment -->
+    <div class="msg user">
+      <div class="avatar u">OP</div>
+      <div class="bubble user">
+        <div class="attach-badge">📎 plano-cocina-U-bernardi.pdf · 2.3 MB</div>
+        Subo el plano, fijate.
+      </div>
+    </div>
+
+    <!-- Valentina thinking + progress -->
+    <div class="msg">
+      <div class="avatar v">V</div>
+      <div class="vwrap">
+        <div class="blk thinking">
+          <div class="think-line"><span class="think-dot ok"></span>Brief recibido (cocina U + isla, Puraprima)</div>
+          <div class="think-line"><span class="think-dot"></span>Rasterizando plano a 300 DPI…</div>
+          <div class="think-line"><span class="think-dot d2"></span>Detectando páginas relevantes…</div>
+          <div class="think-line"><span class="think-dot d3"></span>Identificando cotas y sectores…</div>
+          <div class="progress-wrap">
+            <div class="progress-label"><span>Procesando</span><span>75%</span></div>
+            <div class="progress-bar"><div class="progress-fill"></div></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="composer">
+    <div class="comp-row">
+      <span class="comp-input">Enunciado o adjuntar plano…</span>
+      <div class="comp-btns">
+        <button class="icon-btn">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg>
+        </button>
+        <button class="icon-btn primary">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+        </button>
+      </div>
+    </div>
+    <div class="comp-hint">Enter para enviar</div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/13-chat-zone-selector-desktop.html
+++ b/docs/mockups/13-chat-zone-selector-desktop.html
@@ -1,0 +1,193 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Chat · zone selector · Desktop 1440×900</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:1440px; height:900px; background:var(--bg); overflow:hidden; position:relative; border:1px solid rgba(255,255,255,.06); border-radius:6px; display:flex; }
+  .sidebar { width:212px; flex-shrink:0; background:var(--s1); border-right:1px solid var(--b1); display:flex; flex-direction:column; padding:18px 10px 20px; }
+  .side-logo { display:flex; align-items:center; gap:10px; padding:2px 8px 20px; }
+  .side-logo-badge { width:26px; height:26px; border-radius:6px; background:var(--acc); color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
+  .side-logo-text { font-size:13px; font-weight:500; letter-spacing:-.02em; }
+  .side-label { font-size:10px; font-weight:500; color:var(--t4); text-transform:uppercase; letter-spacing:.1em; padding:0 8px 4px; }
+  .side-label.mt { margin-top:14px; }
+  .side-item { display:flex; align-items:center; gap:8px; padding:8px; border-radius:6px; font-size:12px; color:var(--t2); border:none; background:transparent; width:100%; text-align:left; cursor:pointer; }
+  .side-item.active { color:var(--acc); background:rgba(79,143,255,.11); }
+  .side-item svg { flex-shrink:0; opacity:.65; }
+  .side-item.active svg { opacity:1; }
+  .side-item .count { margin-left:auto; font-size:10px; font-weight:500; padding:1px 7px; border-radius:99px; background:rgba(255,255,255,.07); color:var(--t3); font-family:var(--font-mono); }
+  .side-item.active .count { background:var(--acc); color:#fff; font-weight:600; }
+  .side-divider { height:1px; background:var(--b1); margin:12px 0; }
+  .side-spacer { flex:1; }
+  .side-new { width:100%; padding:10px 12px; background:var(--acc); color:#fff; font-size:13px; font-weight:500; border:none; border-radius:8px; display:flex; align-items:center; justify-content:center; gap:7px; }
+  .side-logout { width:100%; padding:7px 8px; background:transparent; border:none; color:var(--t3); font-size:11px; display:flex; align-items:center; justify-content:center; gap:6px; margin-top:10px; }
+  .main { flex:1; display:flex; flex-direction:column; min-width:0; }
+  .qh-header { padding:14px 28px; border-bottom:1px solid var(--b1); background:var(--s1); display:flex; align-items:center; gap:14px; }
+  .qh-back { width:30px; height:30px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; cursor:pointer; }
+  .qh-title-wrap { min-width:0; flex:1; }
+  .qh-title { font-size:15px; font-weight:600; color:var(--t1); display:flex; align-items:center; gap:10px; }
+  .qh-status { display:inline-flex; align-items:center; gap:5px; padding:2px 8px; border-radius:99px; font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.06em; }
+  .qh-status.draft { color:var(--amb); background:var(--amb2); }
+  .qh-status .dot { width:5px; height:5px; border-radius:99px; background:currentColor; }
+  .qh-sub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .tabs { display:flex; padding-left:28px; border-bottom:1px solid var(--b1); background:var(--s1); }
+  .tab { padding:10px 20px; font-size:13px; font-weight:500; color:var(--t3); background:transparent; border:none; cursor:pointer; border-bottom:2px solid transparent; opacity:.6; }
+  .tab.active { color:var(--acc); border-bottom-color:var(--acc); opacity:1; }
+  .tab.locked { opacity:.35; cursor:not-allowed; }
+
+  .chat-scroll { flex:1; overflow-y:auto; padding:28px 28px 16px; display:flex; flex-direction:column; gap:20px; background:var(--bg); }
+  .msg { display:flex; gap:12px; align-items:flex-start; }
+  .msg.user { flex-direction:row-reverse; }
+  .avatar { width:30px; height:30px; border-radius:99px; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:11px; font-weight:600; }
+  .avatar.v { background:var(--acc); color:#fff; }
+  .avatar.u { background:var(--s3); color:var(--t2); border:1px solid var(--b2); }
+  .bubble.user { max-width:52%; padding:10px 14px; background:var(--acc2); border:1px solid rgba(79,143,255,.25); border-radius:12px 2px 12px 12px; font-size:13px; line-height:1.6; color:rgba(255,255,255,.6); }
+  .attach-badge { display:inline-flex; align-items:center; gap:5px; padding:4px 8px; border-radius:5px; background:rgba(255,255,255,.08); border:1px solid var(--b1); font-size:11px; color:var(--t2); }
+  .vwrap { flex:1; border:1px solid var(--b2); border-radius:2px 12px 12px 12px; overflow:hidden; }
+  .blk { padding:14px 18px; background:var(--s2); }
+  .blk.text { font-size:15px; line-height:1.7; color:var(--t2); }
+
+  .card { margin:0; width:100%; border-radius:16px; border:1px solid var(--b1); background:var(--s1); overflow:hidden; box-shadow:0 20px 40px -20px rgba(0,0,0,.5); }
+  .card-hdr { display:flex; align-items:center; gap:12px; padding:16px 20px; background:linear-gradient(180deg,var(--s3),var(--s2)); border-bottom:1px solid var(--b1); }
+  .card-tag { font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.1em; color:var(--acc); background:var(--acc2); border:1px solid rgba(79,143,255,.30); padding:4px 8px; border-radius:6px; }
+  .card-title { font-size:15px; font-weight:600; color:var(--t1); }
+  .card-body { padding:20px; }
+  .thumbs-grid { display:grid; grid-template-columns:repeat(3,1fr); gap:12px; }
+  .thumb { aspect-ratio:3/4; background:var(--s2); border:1px solid var(--b1); border-radius:8px; padding:8px; position:relative; cursor:pointer; display:flex; flex-direction:column; justify-content:space-between; }
+  .thumb.active { border-color:var(--acc); box-shadow:0 0 0 2px rgba(79,143,255,.30); }
+  .thumb-pg { position:absolute; top:8px; left:8px; font-size:10px; font-weight:600; color:var(--t3); font-family:var(--font-mono); background:rgba(0,0,0,.5); padding:2px 6px; border-radius:4px; }
+  .thumb-vis { flex:1; margin:20px 4px 8px; background:linear-gradient(135deg,rgba(255,255,255,.04) 0%,rgba(255,255,255,.02) 50%,rgba(255,255,255,.04) 100%); background-size:20px 20px; background-image:repeating-linear-gradient(45deg,rgba(255,255,255,.04) 0,rgba(255,255,255,.04) 1px,transparent 1px,transparent 10px),repeating-linear-gradient(-45deg,rgba(255,255,255,.04) 0,rgba(255,255,255,.04) 1px,transparent 1px,transparent 10px); border-radius:4px; }
+  .thumb.active .thumb-vis { background-image:repeating-linear-gradient(45deg,rgba(79,143,255,.2) 0,rgba(79,143,255,.2) 1px,transparent 1px,transparent 8px),repeating-linear-gradient(-45deg,rgba(79,143,255,.15) 0,rgba(79,143,255,.15) 1px,transparent 1px,transparent 8px); }
+  .thumb-lbl { font-size:12px; color:var(--t2); text-align:center; padding:4px 0 2px; }
+  .thumb.active .thumb-lbl { color:var(--t1); font-weight:500; }
+  .card-actions { display:flex; gap:8px; padding:16px 20px; border-top:1px solid var(--b1); background:var(--s2); }
+  .btn-primary { flex:1; padding:10px 16px; border-radius:12px; background:var(--acc); color:#fff; font-size:13px; font-weight:600; border:none; cursor:pointer; }
+  .btn-ghost { padding:10px 16px; border-radius:12px; background:transparent; border:1px solid var(--b1); color:var(--t2); font-size:13px; cursor:pointer; }
+
+  .composer { border-top:1px solid var(--b1); background:var(--s1); padding:14px 20px; }
+  .comp-row { display:flex; align-items:flex-end; gap:8px; background:var(--s3); border:1px solid var(--b2); border-radius:12px; padding:10px 10px 10px 16px; }
+  .comp-input { flex:1; background:transparent; border:none; outline:none; font-size:13px; color:var(--t1); line-height:1.5; min-height:20px; padding:2px 0; }
+  .comp-input.placeholder { color:var(--t4); }
+  .comp-btns { display:flex; gap:5px; flex-shrink:0; }
+  .icon-btn { width:32px; height:32px; border-radius:99px; display:flex; align-items:center; justify-content:center; cursor:pointer; border:1px solid var(--b1); background:transparent; color:var(--t2); }
+  .icon-btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .icon-btn:disabled { opacity:.4; cursor:not-allowed; }
+  .comp-foot { display:flex; justify-content:space-between; align-items:center; margin-top:6px; font-size:11px; color:var(--t3); }
+  .multi-check { display:inline-flex; align-items:center; gap:5px; cursor:pointer; }
+</style>
+</head>
+<body>
+<span class="frame-label">CHAT · ZONE SELECTOR · DESKTOP · 1440×900 · /quote/pr-0248</span>
+<div class="frame">
+  <aside class="sidebar">
+    <div class="side-logo"><div class="side-logo-badge">D</div><span class="side-logo-text">D'Angelo</span></div>
+    <div class="side-label">Principal</div>
+    <button class="side-item active">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Presupuestos<span class="count">3</span>
+    </button>
+    <div class="side-label mt">Sistema</div>
+    <button class="side-item"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/><path d="M19 12a7 7 0 01-1 3.5l2 2-3 3-2-2a7 7 0 01-3.5 1"/></svg>Catálogo</button>
+    <button class="side-item"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><line x1="4" y1="21" x2="4" y2="14"/></svg>Configuración</button>
+    <div class="side-divider"></div>
+    <div class="side-spacer"></div>
+    <button class="side-new"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>Nuevo presupuesto</button>
+    <button class="side-logout">Cerrar sesión</button>
+  </aside>
+
+  <main class="main">
+    <header class="qh-header">
+      <button class="qh-back">←</button>
+      <div class="qh-title-wrap">
+        <div class="qh-title">
+          Erica Bernardi — Casa Bernardi
+          <span class="qh-status draft"><span class="dot"></span>borrador</span>
+        </div>
+        <div class="qh-sub">#PR-0248 · hace 1 min</div>
+      </div>
+    </header>
+
+    <div class="tabs">
+      <button class="tab active">Chat</button>
+      <button class="tab locked">Detalle</button>
+    </div>
+
+    <div class="chat-scroll">
+      <div class="msg user">
+        <div class="avatar u">EB</div>
+        <div class="bubble user"><div class="attach-badge">📎 plano-cocina-U-bernardi.pdf · 2.3 MB · 3 páginas</div></div>
+      </div>
+
+      <div class="msg">
+        <div class="avatar v">V</div>
+        <div class="vwrap">
+          <div class="blk text"><p>El plano tiene 3 páginas. Confirmame qué zona corresponde a la mesada que vamos a presupuestar.</p></div>
+        </div>
+      </div>
+
+      <div class="msg">
+        <div class="avatar v">V</div>
+        <div class="card" style="flex:1;">
+          <div class="card-hdr">
+            <span class="card-tag">🔍 Seleccionar zona</span>
+            <span class="card-title">¿Qué página querés medir?</span>
+          </div>
+          <div class="card-body">
+            <div class="thumbs-grid">
+              <div class="thumb">
+                <span class="thumb-pg">p. 1</span>
+                <div class="thumb-vis"></div>
+                <div class="thumb-lbl">Vista general</div>
+              </div>
+              <div class="thumb active">
+                <span class="thumb-pg">p. 2</span>
+                <div class="thumb-vis"></div>
+                <div class="thumb-lbl">Planta cocina — U + isla</div>
+              </div>
+              <div class="thumb">
+                <span class="thumb-pg">p. 3</span>
+                <div class="thumb-vis"></div>
+                <div class="thumb-lbl">Cortes</div>
+              </div>
+            </div>
+          </div>
+          <div class="card-actions">
+            <button class="btn-primary">Confirmar</button>
+            <button class="btn-ghost">Subir otro plano</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="composer">
+      <div class="comp-row">
+        <div class="comp-input placeholder">Escribí el enunciado o arrastrá el plano…</div>
+        <div class="comp-btns">
+          <button class="icon-btn"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg></button>
+          <button class="icon-btn primary" disabled><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg></button>
+        </div>
+      </div>
+      <div class="comp-foot">
+        <span>Enter para enviar · Shift+Enter para nueva línea</span>
+        <label class="multi-check"><input type="checkbox"/> multi-pieza</label>
+      </div>
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/docs/mockups/13-chat-zone-selector-mobile.html
+++ b/docs/mockups/13-chat-zone-selector-mobile.html
@@ -1,0 +1,211 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Chat · zone selector · Mobile 390×844</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:14px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:390px; height:844px; border-radius:38px; border:10px solid #0a0a10; background:var(--bg); overflow:hidden; position:relative; display:flex; flex-direction:column; }
+  .frame::after { content:''; position:absolute; inset:0; pointer-events:none; background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E"); }
+
+  .mobile-topbar { display:flex; align-items:center; gap:12px; padding:12px 16px; background:var(--s1); border-bottom:1px solid var(--b1); flex-shrink:0; }
+  .mobile-topbar .burger { background:transparent; border:none; color:var(--t2); padding:2px; display:flex; }
+  .mobile-topbar .dlogo { width:22px; height:22px; border-radius:6px; background:var(--acc); display:flex; align-items:center; justify-content:center; color:#fff; font-size:10px; font-weight:600; }
+  .mobile-topbar .brand { font-size:13px; font-weight:500; color:var(--t1); }
+
+  .qh-header { padding:12px 16px; border-bottom:1px solid var(--b1); background:var(--s1); flex-shrink:0; }
+  .qh-row { display:flex; align-items:center; gap:10px; }
+  .qh-back { width:30px; height:30px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; flex-shrink:0; }
+  .qh-title-wrap { flex:1; min-width:0; }
+  .qh-title { font-size:14px; font-weight:600; color:var(--t1); max-width:200px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; letter-spacing:-.01em; }
+  .qh-sub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .qh-status { display:inline-flex; align-items:center; gap:4px; padding:2px 7px; border-radius:99px; font-size:9px; font-weight:600; text-transform:uppercase; letter-spacing:.05em; flex-shrink:0; }
+  .qh-status.draft { color:var(--amb); background:var(--amb2); }
+  .qh-status .dot { width:4px; height:4px; border-radius:99px; background:currentColor; }
+
+  .tabs { display:flex; padding-left:16px; border-bottom:1px solid var(--b1); background:var(--s1); flex-shrink:0; }
+  .tab { padding:10px 16px; font-size:12px; font-weight:500; color:var(--t3); background:transparent; border:none; border-bottom:2px solid transparent; opacity:.6; }
+  .tab.active { color:var(--acc); border-bottom-color:var(--acc); opacity:1; }
+  .tab.locked { opacity:.35; }
+
+  .chat-scroll { flex:1; overflow-y:auto; padding:20px 16px 16px; display:flex; flex-direction:column; gap:16px; }
+
+  .msg { display:flex; gap:10px; align-items:flex-start; }
+  .avatar { width:28px; height:28px; border-radius:99px; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:10px; font-weight:600; }
+  .avatar.v { background:var(--acc); color:#fff; }
+
+  .vwrap { flex:1; border:1px solid var(--b2); border-radius:2px 12px 12px 12px; overflow:hidden; }
+  .blk { padding:12px 14px; background:var(--s2); }
+  .blk + .blk { border-top:1px solid var(--b1); }
+  .blk.text { font-size:13px; line-height:1.65; color:var(--t2); }
+
+  /* Zone selector card */
+  .card { margin:4px 0; width:100%; border-radius:14px; border:1px solid var(--b1); background:var(--s1); overflow:hidden; }
+  .card-hdr { display:flex; align-items:center; gap:10px; padding:12px 14px; background:linear-gradient(180deg,var(--s3),var(--s2)); border-bottom:1px solid var(--b1); }
+  .card-tag { font-size:9px; font-weight:600; text-transform:uppercase; letter-spacing:.1em; color:var(--acc); background:var(--acc2); border:1px solid rgba(79,143,255,.30); padding:3px 7px; border-radius:5px; }
+  .card-title { font-size:13px; font-weight:600; color:var(--t1); }
+
+  .card-body { padding:14px; }
+  .card-caption { font-size:11px; color:var(--t3); margin-bottom:10px; line-height:1.5; }
+  .thumbs { display:grid; grid-template-columns:1fr 1fr; gap:8px; }
+  .thumb {
+    height:120px; border-radius:8px; border:1px solid var(--b1); background:var(--s3);
+    display:flex; flex-direction:column; overflow:hidden; cursor:pointer; position:relative;
+  }
+  .thumb.selected { border-color:var(--acc); box-shadow:0 0 0 2px rgba(79,143,255,.25); }
+  .thumb .preview {
+    flex:1;
+    background:
+      linear-gradient(135deg, rgba(255,255,255,.04) 0%, rgba(255,255,255,.01) 100%),
+      repeating-linear-gradient(0deg, transparent 0 14px, rgba(255,255,255,.04) 14px 15px),
+      repeating-linear-gradient(90deg, transparent 0 14px, rgba(255,255,255,.04) 14px 15px);
+    display:flex; align-items:center; justify-content:center;
+    color:var(--t4); font-size:28px;
+  }
+  .thumb.selected .preview { background:
+      linear-gradient(135deg, rgba(79,143,255,.08) 0%, rgba(79,143,255,.02) 100%),
+      repeating-linear-gradient(0deg, transparent 0 14px, rgba(79,143,255,.10) 14px 15px),
+      repeating-linear-gradient(90deg, transparent 0 14px, rgba(79,143,255,.10) 14px 15px); }
+  .thumb .foot {
+    padding:6px 8px; background:rgba(0,0,0,.3);
+    display:flex; align-items:center; justify-content:space-between;
+    font-size:10px; color:var(--t2); font-family:var(--font-mono);
+    border-top:1px solid var(--b1);
+  }
+  .thumb.selected .foot { color:var(--acc); }
+  .thumb .check {
+    position:absolute; top:6px; right:6px;
+    width:18px; height:18px; border-radius:99px;
+    background:var(--acc); color:#fff; display:none;
+    align-items:center; justify-content:center; font-size:11px; font-weight:700;
+  }
+  .thumb.selected .check { display:flex; }
+  .thumb.wide { grid-column:span 2; height:110px; }
+
+  .card-actions {
+    display:flex; flex-direction:column; gap:8px;
+    padding:14px; border-top:1px solid var(--b1); background:var(--s2);
+  }
+  .btn-primary {
+    padding:10px 14px; background:var(--acc); color:#fff;
+    font-size:13px; font-weight:600; border:none; border-radius:10px;
+  }
+  .btn-secondary {
+    padding:10px 14px; background:transparent; color:var(--t2);
+    font-size:12px; font-weight:500; border:1px solid var(--b2); border-radius:10px;
+  }
+
+  .composer { border-top:1px solid var(--b1); background:var(--s1); padding:12px 16px; flex-shrink:0; }
+  .comp-row { display:flex; align-items:center; gap:8px; background:var(--s3); border:1px solid var(--b2); border-radius:12px; padding:8px 10px 8px 12px; }
+  .comp-input { flex:1; background:transparent; border:none; outline:none; font-size:13px; color:var(--t4); }
+  .comp-btns { display:flex; gap:5px; flex-shrink:0; }
+  .icon-btn { width:28px; height:28px; border-radius:99px; display:flex; align-items:center; justify-content:center; border:1px solid var(--b1); background:transparent; color:var(--t2); }
+  .icon-btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .comp-hint { font-size:10px; color:var(--t3); margin-top:5px; text-align:right; }
+</style>
+</head>
+<body>
+<span class="frame-label">CHAT · ZONE SELECTOR · MOBILE · 390×844 · /quote/pr-0248</span>
+<div class="frame">
+
+  <div class="mobile-topbar">
+    <button class="burger">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <div class="dlogo">D</div>
+    <span class="brand">D'Angelo</span>
+  </div>
+
+  <header class="qh-header">
+    <div class="qh-row">
+      <button class="qh-back">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><polyline points="15 18 9 12 15 6"/></svg>
+      </button>
+      <div class="qh-title-wrap">
+        <div class="qh-title">Erica Bernardi — Casa Bernardi</div>
+        <div class="qh-sub">#PR-0248 · hace 2 min</div>
+      </div>
+      <span class="qh-status draft"><span class="dot"></span>Borrador</span>
+    </div>
+  </header>
+
+  <div class="tabs">
+    <button class="tab active">Chat</button>
+    <button class="tab locked">Detalle</button>
+  </div>
+
+  <div class="chat-scroll">
+
+    <div class="msg">
+      <div class="avatar v">V</div>
+      <div class="vwrap">
+        <div class="blk text">
+          <p>El plano tiene 3 páginas. Confirmame cuál querés que lea (cocina + isla) o subí una captura recortada.</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Zone selector card -->
+    <div class="card">
+      <div class="card-hdr">
+        <span class="card-tag">📐 Páginas del plano</span>
+        <span class="card-title">Elegí la vista</span>
+      </div>
+      <div class="card-body">
+        <div class="card-caption">Tocá la página que muestra la cocina + isla. Podés también subir una captura recortada.</div>
+        <div class="thumbs">
+          <div class="thumb">
+            <div class="preview">📄</div>
+            <div class="foot"><span>Pág. 1</span><span>A3</span></div>
+          </div>
+          <div class="thumb selected">
+            <div class="preview">📐</div>
+            <div class="check">✓</div>
+            <div class="foot"><span>Pág. 2</span><span>A3</span></div>
+          </div>
+          <div class="thumb wide">
+            <div class="preview">📄</div>
+            <div class="foot"><span>Pág. 3 — elevaciones</span><span>A3</span></div>
+          </div>
+        </div>
+      </div>
+      <div class="card-actions">
+        <button class="btn-primary">Usar página 2</button>
+        <button class="btn-secondary">📎 Subir captura recortada</button>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="composer">
+    <div class="comp-row">
+      <span class="comp-input">Enunciado o adjuntar plano…</span>
+      <div class="comp-btns">
+        <button class="icon-btn">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg>
+        </button>
+        <button class="icon-btn primary">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+        </button>
+      </div>
+    </div>
+    <div class="comp-hint">Enter para enviar</div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/14-chat-context-analysis-desktop.html
+++ b/docs/mockups/14-chat-context-analysis-desktop.html
@@ -1,0 +1,265 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Chat · context analysis · Desktop 1440×900</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:1440px; height:900px; background:var(--bg); overflow:hidden; position:relative; border:1px solid rgba(255,255,255,.06); border-radius:6px; display:flex; }
+  .sidebar { width:212px; flex-shrink:0; background:var(--s1); border-right:1px solid var(--b1); display:flex; flex-direction:column; padding:18px 10px 20px; }
+  .side-logo { display:flex; align-items:center; gap:10px; padding:2px 8px 20px; }
+  .side-logo-badge { width:26px; height:26px; border-radius:6px; background:var(--acc); color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
+  .side-logo-text { font-size:13px; font-weight:500; letter-spacing:-.02em; }
+  .side-label { font-size:10px; font-weight:500; color:var(--t4); text-transform:uppercase; letter-spacing:.1em; padding:0 8px 4px; }
+  .side-label.mt { margin-top:14px; }
+  .side-item { display:flex; align-items:center; gap:8px; padding:8px; border-radius:6px; font-size:12px; color:var(--t2); border:none; background:transparent; width:100%; text-align:left; cursor:pointer; }
+  .side-item.active { color:var(--acc); background:rgba(79,143,255,.11); }
+  .side-item svg { flex-shrink:0; opacity:.65; }
+  .side-item.active svg { opacity:1; }
+  .side-item .count { margin-left:auto; font-size:10px; font-weight:500; padding:1px 7px; border-radius:99px; background:rgba(255,255,255,.07); color:var(--t3); font-family:var(--font-mono); }
+  .side-item.active .count { background:var(--acc); color:#fff; font-weight:600; }
+  .side-divider { height:1px; background:var(--b1); margin:12px 0; }
+  .side-spacer { flex:1; }
+  .side-new { width:100%; padding:10px 12px; background:var(--acc); color:#fff; font-size:13px; font-weight:500; border:none; border-radius:8px; display:flex; align-items:center; justify-content:center; gap:7px; }
+  .side-logout { width:100%; padding:7px 8px; background:transparent; border:none; color:var(--t3); font-size:11px; display:flex; align-items:center; justify-content:center; gap:6px; margin-top:10px; }
+  .main { flex:1; display:flex; flex-direction:column; min-width:0; }
+  .qh-header { padding:14px 28px; border-bottom:1px solid var(--b1); background:var(--s1); display:flex; align-items:center; gap:14px; }
+  .qh-back { width:30px; height:30px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; cursor:pointer; }
+  .qh-title-wrap { min-width:0; flex:1; }
+  .qh-title { font-size:15px; font-weight:600; color:var(--t1); display:flex; align-items:center; gap:10px; }
+  .qh-status { display:inline-flex; align-items:center; gap:5px; padding:2px 8px; border-radius:99px; font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.06em; }
+  .qh-status.draft { color:var(--amb); background:var(--amb2); }
+  .qh-status .dot { width:5px; height:5px; border-radius:99px; background:currentColor; }
+  .qh-sub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .tabs { display:flex; padding-left:28px; border-bottom:1px solid var(--b1); background:var(--s1); }
+  .tab { padding:10px 20px; font-size:13px; font-weight:500; color:var(--t3); background:transparent; border:none; cursor:pointer; border-bottom:2px solid transparent; opacity:.6; }
+  .tab.active { color:var(--acc); border-bottom-color:var(--acc); opacity:1; }
+  .tab.locked { opacity:.35; cursor:not-allowed; }
+
+  .chat-scroll { flex:1; overflow-y:auto; padding:24px 28px 16px; display:flex; flex-direction:column; gap:16px; background:var(--bg); }
+  .msg { display:flex; gap:12px; align-items:flex-start; }
+  .msg.user { flex-direction:row-reverse; }
+  .avatar { width:30px; height:30px; border-radius:99px; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:11px; font-weight:600; }
+  .avatar.v { background:var(--acc); color:#fff; }
+  .avatar.u { background:var(--s3); color:var(--t2); border:1px solid var(--b2); }
+  .bubble.user { max-width:52%; padding:8px 14px; background:var(--acc2); border:1px solid rgba(79,143,255,.25); border-radius:12px 2px 12px 12px; font-size:13px; line-height:1.55; color:rgba(255,255,255,.55); }
+  .vwrap { flex:1; border:1px solid var(--b2); border-radius:2px 12px 12px 12px; overflow:hidden; }
+  .blk { padding:14px 18px; background:var(--s2); }
+  .blk.text { font-size:15px; line-height:1.7; color:var(--t2); }
+
+  /* CARD */
+  .card { margin:0; width:100%; border-radius:16px; border:1px solid var(--b1); background:var(--s1); overflow:hidden; box-shadow:0 20px 40px -20px rgba(0,0,0,.5); }
+  .card-hdr { display:flex; align-items:center; gap:12px; padding:16px 20px; background:linear-gradient(180deg,var(--s3),var(--s2)); border-bottom:1px solid var(--b1); }
+  .card-tag { font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.1em; color:var(--acc); background:var(--acc2); border:1px solid rgba(79,143,255,.30); padding:4px 8px; border-radius:6px; }
+  .card-title { font-size:15px; font-weight:600; color:var(--t1); }
+  .card-sub { margin-left:auto; font-size:12px; color:var(--t3); font-family:var(--font-mono); }
+  .copy-btn { display:inline-flex; align-items:center; gap:5px; padding:6px 10px; border:1px solid var(--b2); border-radius:6px; background:transparent; color:var(--t2); font-size:11px; cursor:pointer; }
+  .card-body { padding:20px; }
+  .intro { font-size:12px; color:var(--t3); margin-bottom:16px; line-height:1.55; }
+  .section-hd { font-size:11px; font-weight:600; text-transform:uppercase; letter-spacing:.1em; margin-bottom:8px; }
+  .section-hd.grn { color:var(--grn); }
+  .section-hd.amb { color:var(--amb); }
+  .section { margin-bottom:20px; }
+  .row { display:grid; grid-template-columns:140px 1fr auto; gap:12px; align-items:start; padding:8px 0; border-top:1px solid rgba(255,255,255,.035); }
+  .row-fld { font-size:12px; color:var(--t3); text-transform:uppercase; letter-spacing:.06em; }
+  .row-val { font-size:13px; color:var(--t1); }
+  .row-note { font-size:11px; color:var(--t3); font-style:italic; margin-top:2px; }
+  .src-badge { font-size:10px; text-transform:uppercase; letter-spacing:.08em; padding:2px 6px; border-radius:4px; border:1px solid; white-space:nowrap; }
+  .src.brief { color:var(--acc); background:rgba(79,143,255,.10); border-color:rgba(79,143,255,.30); }
+  .src.rule { color:var(--amb); background:rgba(245,166,35,.10); border-color:rgba(245,166,35,.30); }
+  .src.briefrule { color:var(--amb); background:rgba(245,166,35,.10); border-color:rgba(245,166,35,.30); }
+  .src.default { color:var(--t3); background:rgba(255,255,255,.05); border-color:var(--b1); }
+
+  /* tech row */
+  .tech-row { padding:10px 0; border-top:1px solid rgba(255,255,255,.035); }
+  .tech-hdr { display:flex; align-items:center; gap:8px; margin-bottom:8px; flex-wrap:wrap; }
+  .tech-fld { font-size:12px; color:var(--t3); text-transform:uppercase; letter-spacing:.06em; }
+  .status-badge { font-size:10px; text-transform:uppercase; letter-spacing:.08em; padding:2px 6px; border-radius:4px; border:1px solid; }
+  .status.conf { color:var(--grn); background:rgba(48,209,88,.15); border-color:rgba(48,209,88,.40); }
+  .confidence { font-size:10px; color:var(--t3); margin-left:auto; font-family:var(--font-mono); }
+  .radios { display:flex; flex-wrap:wrap; gap:6px; }
+  .radio-lbl { display:inline-flex; align-items:center; gap:6px; font-size:12px; padding:4px 10px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); cursor:pointer; }
+  .radio-lbl.selected { border-color:var(--acc); background:rgba(79,143,255,.10); color:var(--t1); }
+  .radio-dot { width:12px; height:12px; border-radius:99px; border:1px solid var(--b2); flex-shrink:0; display:inline-flex; align-items:center; justify-content:center; }
+  .radio-lbl.selected .radio-dot { border-color:var(--acc); }
+  .radio-lbl.selected .radio-dot::after { content:""; width:6px; height:6px; border-radius:99px; background:var(--acc); }
+
+  .card-actions { display:flex; gap:8px; padding:16px 20px; border-top:1px solid var(--b1); background:var(--s2); }
+  .btn-primary { flex:1; padding:10px 16px; border-radius:12px; background:var(--acc); color:#fff; font-size:13px; font-weight:600; border:none; cursor:pointer; }
+
+  .composer { border-top:1px solid var(--b1); background:var(--s1); padding:14px 20px; }
+  .comp-row { display:flex; align-items:flex-end; gap:8px; background:var(--s3); border:1px solid var(--b2); border-radius:12px; padding:10px 10px 10px 16px; }
+  .comp-input { flex:1; background:transparent; border:none; outline:none; font-size:13px; color:var(--t1); line-height:1.5; min-height:20px; padding:2px 0; }
+  .comp-input.placeholder { color:var(--t4); }
+  .comp-btns { display:flex; gap:5px; flex-shrink:0; }
+  .icon-btn { width:32px; height:32px; border-radius:99px; display:flex; align-items:center; justify-content:center; cursor:pointer; border:1px solid var(--b1); background:transparent; color:var(--t2); }
+  .icon-btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .icon-btn:disabled { opacity:.4; cursor:not-allowed; }
+  .comp-foot { display:flex; justify-content:space-between; align-items:center; margin-top:6px; font-size:11px; color:var(--t3); }
+  .multi-check { display:inline-flex; align-items:center; gap:5px; cursor:pointer; }
+</style>
+</head>
+<body>
+<span class="frame-label">CHAT · CONTEXT ANALYSIS · DESKTOP · 1440×900 · /quote/pr-0248</span>
+<div class="frame">
+  <aside class="sidebar">
+    <div class="side-logo"><div class="side-logo-badge">D</div><span class="side-logo-text">D'Angelo</span></div>
+    <div class="side-label">Principal</div>
+    <button class="side-item active">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Presupuestos<span class="count">3</span>
+    </button>
+    <div class="side-label mt">Sistema</div>
+    <button class="side-item"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/></svg>Catálogo</button>
+    <button class="side-item"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><line x1="4" y1="21" x2="4" y2="14"/></svg>Configuración</button>
+    <div class="side-divider"></div>
+    <div class="side-spacer"></div>
+    <button class="side-new"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>Nuevo presupuesto</button>
+    <button class="side-logout">Cerrar sesión</button>
+  </aside>
+
+  <main class="main">
+    <header class="qh-header">
+      <button class="qh-back">←</button>
+      <div class="qh-title-wrap">
+        <div class="qh-title">Erica Bernardi — Casa Bernardi <span class="qh-status draft"><span class="dot"></span>borrador</span></div>
+        <div class="qh-sub">#PR-0248 · hace 2 min</div>
+      </div>
+    </header>
+
+    <div class="tabs">
+      <button class="tab active">Chat</button>
+      <button class="tab locked">Detalle</button>
+    </div>
+
+    <div class="chat-scroll">
+      <div class="msg user"><div class="avatar u">EB</div><div class="bubble user">Brief inicial — cocina U + isla, Puraprima Onix White Mate…</div></div>
+      <div class="msg user"><div class="avatar u">EB</div><div class="bubble user">📎 plano-cocina-U-bernardi.pdf · 2.3 MB</div></div>
+      <div class="msg">
+        <div class="avatar v">V</div>
+        <div class="vwrap">
+          <div class="blk text"><p>Página 2 confirmada. Antes de medir, armé un resumen del contexto para que valides.</p></div>
+        </div>
+      </div>
+
+      <div class="msg">
+        <div class="avatar v">V</div>
+        <div class="card" style="flex:1;">
+          <div class="card-hdr">
+            <span class="card-tag">🔍 Análisis de contexto</span>
+            <span class="card-title">Paso previo al despiece</span>
+            <span class="card-sub">4 mesada(s) en cocina + isla</span>
+            <button class="copy-btn">📋 Copiar contexto</button>
+          </div>
+          <div class="card-body">
+            <div class="intro">Antes de medir el plano, validemos lo que sé del trabajo. Corregí lo que esté mal con doble-click y respondé las preguntas bloqueantes.</div>
+
+            <div class="section">
+              <div class="section-hd grn">📋 Datos que tengo</div>
+              <div class="row"><div class="row-fld">Cliente</div><div class="row-val">Erica Bernardi</div><span class="src-badge src brief">del brief</span></div>
+              <div class="row"><div class="row-fld">Proyecto</div><div class="row-val">Casa Bernardi</div><span class="src-badge src brief">del brief</span></div>
+              <div class="row"><div class="row-fld">Material</div><div class="row-val">Puraprima Onix White Mate</div><span class="src-badge src brief">del brief</span></div>
+              <div class="row"><div class="row-fld">Localidad</div><div class="row-val">Rosario</div><span class="src-badge src brief">del brief</span></div>
+              <div class="row"><div class="row-fld">Tipo de trabajo</div><div class="row-val">Cocina</div><span class="src-badge src brief">del brief</span></div>
+            </div>
+
+            <div class="section">
+              <div class="section-hd grn">🔎 Detectado en plano / brief</div>
+              <div class="tech-row">
+                <div class="tech-hdr">
+                  <span class="tech-fld">Isla central</span>
+                  <span class="src-badge src brief">del brief</span>
+                  <span class="status-badge status conf">confirmado</span>
+                  <span class="confidence">95%</span>
+                </div>
+                <div class="radios">
+                  <label class="radio-lbl selected"><span class="radio-dot"></span>Sí, hay isla</label>
+                  <label class="radio-lbl"><span class="radio-dot"></span>No hay isla</label>
+                </div>
+              </div>
+              <div class="tech-row">
+                <div class="tech-hdr">
+                  <span class="tech-fld">Pileta</span>
+                  <span class="src-badge src brief">del brief</span>
+                  <span class="status-badge status conf">confirmado</span>
+                  <span class="confidence">95%</span>
+                </div>
+                <div class="radios">
+                  <label class="radio-lbl"><span class="radio-dot"></span>Simple (1 bacha)</label>
+                  <label class="radio-lbl selected"><span class="radio-dot"></span>Doble (2 bachas)</label>
+                  <label class="radio-lbl"><span class="radio-dot"></span>No lleva</label>
+                </div>
+              </div>
+              <div class="tech-row">
+                <div class="tech-hdr">
+                  <span class="tech-fld">Anafe</span>
+                  <span class="src-badge src brief">del brief</span>
+                  <span class="status-badge status conf">confirmado</span>
+                  <span class="confidence">95%</span>
+                </div>
+                <div class="radios">
+                  <label class="radio-lbl"><span class="radio-dot"></span>No lleva</label>
+                  <label class="radio-lbl"><span class="radio-dot"></span>1</label>
+                  <label class="radio-lbl selected"><span class="radio-dot"></span>2 (gas + eléctrico)</label>
+                  <label class="radio-lbl"><span class="radio-dot"></span>3+</label>
+                </div>
+              </div>
+            </div>
+
+            <div class="section">
+              <div class="section-hd amb">✨ Reglas / defaults que aplico</div>
+              <div class="row">
+                <div class="row-fld">Pileta (tipo de montaje)</div>
+                <div class="row-val">Empotrada (PEGADOPILETA)<div class="row-note">Regla D'Angelo: en cocina la pileta siempre va empotrada, nunca apoyo.</div></div>
+                <span class="src-badge src rule">regla D'Angelo</span>
+              </div>
+              <div class="row">
+                <div class="row-fld">Zócalos</div>
+                <div class="row-val">Trasero por tramo, 7 cm<div class="row-note">Brief dice "con zócalos". Default 7 cm trasero por tramo del largo real.</div></div>
+                <span class="src-badge src briefrule">brief + regla</span>
+              </div>
+              <div class="row"><div class="row-fld">Colocación</div><div class="row-val">Incluye</div><span class="src-badge src brief">del brief</span></div>
+              <div class="row"><div class="row-fld">Forma de pago</div><div class="row-val">Contado</div><span class="src-badge src brief">del brief</span></div>
+              <div class="row"><div class="row-fld">Demora</div><div class="row-val">30 días</div><span class="src-badge src default">default</span></div>
+              <div class="row"><div class="row-fld">Tipo</div><div class="row-val">Particular</div><span class="src-badge src default">inferido</span></div>
+              <div class="row"><div class="row-fld">Descuento</div><div class="row-val">No aplica</div><span class="src-badge src default">default</span></div>
+            </div>
+          </div>
+          <div class="card-actions">
+            <button class="btn-primary">Confirmar contexto — seguir al despiece</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="composer">
+      <div class="comp-row">
+        <div class="comp-input placeholder">Escribí el enunciado o arrastrá el plano…</div>
+        <div class="comp-btns">
+          <button class="icon-btn"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg></button>
+          <button class="icon-btn primary" disabled><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg></button>
+        </div>
+      </div>
+      <div class="comp-foot">
+        <span>Enter para enviar · Shift+Enter para nueva línea</span>
+        <label class="multi-check"><input type="checkbox"/> multi-pieza</label>
+      </div>
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/docs/mockups/14-chat-context-analysis-mobile.html
+++ b/docs/mockups/14-chat-context-analysis-mobile.html
@@ -1,0 +1,269 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Chat · context analysis · Mobile 390×844</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:14px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:390px; height:844px; border-radius:38px; border:10px solid #0a0a10; background:var(--bg); overflow:hidden; position:relative; display:flex; flex-direction:column; }
+  .frame::after { content:''; position:absolute; inset:0; pointer-events:none; background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E"); }
+
+  .mobile-topbar { display:flex; align-items:center; gap:12px; padding:12px 16px; background:var(--s1); border-bottom:1px solid var(--b1); flex-shrink:0; }
+  .mobile-topbar .burger { background:transparent; border:none; color:var(--t2); padding:2px; display:flex; }
+  .mobile-topbar .dlogo { width:22px; height:22px; border-radius:6px; background:var(--acc); display:flex; align-items:center; justify-content:center; color:#fff; font-size:10px; font-weight:600; }
+  .mobile-topbar .brand { font-size:13px; font-weight:500; color:var(--t1); }
+
+  .qh-header { padding:12px 16px; border-bottom:1px solid var(--b1); background:var(--s1); flex-shrink:0; }
+  .qh-row { display:flex; align-items:center; gap:10px; }
+  .qh-back { width:30px; height:30px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; flex-shrink:0; }
+  .qh-title-wrap { flex:1; min-width:0; }
+  .qh-title { font-size:14px; font-weight:600; color:var(--t1); max-width:200px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; letter-spacing:-.01em; }
+  .qh-sub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .qh-status { display:inline-flex; align-items:center; gap:4px; padding:2px 7px; border-radius:99px; font-size:9px; font-weight:600; text-transform:uppercase; letter-spacing:.05em; flex-shrink:0; }
+  .qh-status.draft { color:var(--amb); background:var(--amb2); }
+  .qh-status .dot { width:4px; height:4px; border-radius:99px; background:currentColor; }
+
+  .tabs { display:flex; padding-left:16px; border-bottom:1px solid var(--b1); background:var(--s1); flex-shrink:0; }
+  .tab { padding:10px 16px; font-size:12px; font-weight:500; color:var(--t3); background:transparent; border:none; border-bottom:2px solid transparent; opacity:.6; }
+  .tab.active { color:var(--acc); border-bottom-color:var(--acc); opacity:1; }
+  .tab.locked { opacity:.35; }
+
+  .chat-scroll { flex:1; overflow-y:auto; padding:20px 16px 16px; display:flex; flex-direction:column; gap:16px; }
+
+  .msg { display:flex; gap:10px; align-items:flex-start; }
+  .avatar { width:28px; height:28px; border-radius:99px; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:10px; font-weight:600; }
+  .avatar.v { background:var(--acc); color:#fff; }
+
+  /* Context card */
+  .ctx-card { flex:1; border-radius:14px; border:1px solid var(--b1); background:var(--s1); overflow:hidden; }
+  .ctx-hdr { display:flex; align-items:center; gap:8px; padding:12px 14px; background:linear-gradient(180deg,var(--s3),var(--s2)); border-bottom:1px solid var(--b1); flex-wrap:wrap; }
+  .ctx-tag { font-size:9px; font-weight:600; text-transform:uppercase; letter-spacing:.1em; color:var(--acc); background:var(--acc2); border:1px solid rgba(79,143,255,.30); padding:3px 7px; border-radius:5px; }
+  .ctx-title { font-size:14px; font-weight:600; color:var(--t1); }
+  .ctx-copy { margin-left:auto; width:26px; height:26px; border-radius:6px; border:1px solid var(--b2); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; }
+
+  .ctx-body { padding:14px; }
+  .ctx-lede { font-size:11px; color:var(--t3); margin-bottom:14px; line-height:1.55; }
+
+  .sec { margin-bottom:16px; }
+  .sec-h { font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.1em; margin-bottom:8px; }
+  .sec-h.grn { color:var(--grn); }
+  .sec-h.amb { color:var(--amb); }
+
+  .row { padding:8px 0; border-top:1px solid rgba(255,255,255,.045); display:flex; flex-direction:column; gap:3px; }
+  .row:first-child { border-top:none; }
+  .row-label { font-size:10px; color:var(--t3); text-transform:uppercase; letter-spacing:.06em; }
+  .row-value { font-size:13px; color:var(--t1); }
+  .row-note { font-size:10px; color:var(--t3); font-style:italic; }
+  .badge { font-size:9px; text-transform:uppercase; letter-spacing:.08em; padding:2px 6px; border-radius:4px; border:1px solid; display:inline-block; width:fit-content; margin-top:2px; }
+  .badge.brief { color:var(--acc); background:rgba(79,143,255,.10); border-color:rgba(79,143,255,.30); }
+  .badge.rule { color:var(--amb); background:rgba(245,166,35,.10); border-color:rgba(245,166,35,.30); }
+  .badge.def { color:var(--t3); background:rgba(255,255,255,.05); border-color:var(--b1); }
+  .badge.plan { color:var(--grn); background:rgba(48,209,88,.10); border-color:rgba(48,209,88,.30); }
+
+  /* Tech detection row */
+  .tech { padding:10px 0; border-top:1px solid rgba(255,255,255,.045); }
+  .tech-head { display:flex; align-items:center; gap:6px; flex-wrap:wrap; margin-bottom:8px; }
+  .tech-label { font-size:10px; color:var(--t3); text-transform:uppercase; letter-spacing:.06em; }
+  .tech-conf { font-size:9px; color:var(--t3); font-family:var(--font-mono); margin-left:auto; }
+  .badge.verif { color:var(--grn); background:rgba(48,209,88,.15); border-color:rgba(48,209,88,.40); }
+  .badge.confirm { color:var(--amb); background:rgba(245,166,35,.15); border-color:rgba(245,166,35,.40); }
+
+  .radios { display:flex; flex-direction:column; gap:6px; }
+  .radio {
+    display:flex; align-items:center; gap:8px;
+    padding:7px 10px; border:1px solid var(--b1); border-radius:8px;
+    font-size:12px; color:var(--t2); background:transparent;
+  }
+  .radio.on { border-color:var(--acc); background:rgba(79,143,255,.10); color:var(--t1); }
+  .radio .dot { width:12px; height:12px; border-radius:99px; border:1.5px solid var(--t3); display:flex; align-items:center; justify-content:center; flex-shrink:0; }
+  .radio.on .dot { border-color:var(--acc); }
+  .radio.on .dot::after { content:''; width:5px; height:5px; border-radius:99px; background:var(--acc); }
+
+  .ctx-foot { padding:14px; border-top:1px solid var(--b1); background:var(--s2); }
+  .btn-primary { width:100%; padding:11px 14px; background:var(--acc); color:#fff; font-size:13px; font-weight:600; border:none; border-radius:10px; }
+
+  .composer { border-top:1px solid var(--b1); background:var(--s1); padding:12px 16px; flex-shrink:0; }
+  .comp-row { display:flex; align-items:center; gap:8px; background:var(--s3); border:1px solid var(--b2); border-radius:12px; padding:8px 10px 8px 12px; }
+  .comp-input { flex:1; background:transparent; border:none; outline:none; font-size:13px; color:var(--t4); }
+  .comp-btns { display:flex; gap:5px; flex-shrink:0; }
+  .icon-btn { width:28px; height:28px; border-radius:99px; display:flex; align-items:center; justify-content:center; border:1px solid var(--b1); background:transparent; color:var(--t2); }
+  .icon-btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .comp-hint { font-size:10px; color:var(--t3); margin-top:5px; text-align:right; }
+</style>
+</head>
+<body>
+<span class="frame-label">CHAT · CONTEXT ANALYSIS · MOBILE · 390×844 · /quote/pr-0248</span>
+<div class="frame">
+
+  <div class="mobile-topbar">
+    <button class="burger">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <div class="dlogo">D</div>
+    <span class="brand">D'Angelo</span>
+  </div>
+
+  <header class="qh-header">
+    <div class="qh-row">
+      <button class="qh-back">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><polyline points="15 18 9 12 15 6"/></svg>
+      </button>
+      <div class="qh-title-wrap">
+        <div class="qh-title">Erica Bernardi — Casa Bernardi</div>
+        <div class="qh-sub">#PR-0248 · hace 3 min</div>
+      </div>
+      <span class="qh-status draft"><span class="dot"></span>Borrador</span>
+    </div>
+  </header>
+
+  <div class="tabs">
+    <button class="tab active">Chat</button>
+    <button class="tab locked">Detalle</button>
+  </div>
+
+  <div class="chat-scroll">
+
+    <div class="msg">
+      <div class="avatar v">V</div>
+
+      <div class="ctx-card">
+        <div class="ctx-hdr">
+          <span class="ctx-tag">🔍 Análisis contexto</span>
+          <span class="ctx-title">Paso previo al despiece</span>
+          <button class="ctx-copy">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+          </button>
+        </div>
+
+        <div class="ctx-body">
+          <p class="ctx-lede">Validemos lo que sé del trabajo. Corregí con doble-tap lo que esté mal.</p>
+
+          <!-- Datos que tengo -->
+          <div class="sec">
+            <div class="sec-h grn">📋 Datos que tengo</div>
+
+            <div class="row">
+              <div class="row-label">Cliente</div>
+              <div class="row-value">Erica Bernardi</div>
+              <span class="badge brief">del brief</span>
+            </div>
+            <div class="row">
+              <div class="row-label">Obra</div>
+              <div class="row-value">Casa Bernardi — Rosario</div>
+              <span class="badge brief">del brief</span>
+            </div>
+            <div class="row">
+              <div class="row-label">Material</div>
+              <div class="row-value">Puraprima Onix White Mate · 3 cm</div>
+              <span class="badge brief">del brief</span>
+            </div>
+            <div class="row">
+              <div class="row-label">Sectores</div>
+              <div class="row-value">Cocina en U + isla</div>
+              <span class="badge brief">del brief</span>
+            </div>
+          </div>
+
+          <!-- Detectado en plano -->
+          <div class="sec">
+            <div class="sec-h grn">🔎 Detectado en plano / brief</div>
+
+            <div class="tech">
+              <div class="tech-head">
+                <span class="tech-label">Pileta</span>
+                <span class="badge plan">del plano</span>
+                <span class="badge verif">confirmado</span>
+                <span class="tech-conf">92%</span>
+              </div>
+              <div class="radios">
+                <label class="radio on"><span class="dot"></span>Doble empotrada</label>
+                <label class="radio"><span class="dot"></span>Simple empotrada</label>
+                <label class="radio"><span class="dot"></span>Sobre mesada</label>
+              </div>
+            </div>
+
+            <div class="tech">
+              <div class="tech-head">
+                <span class="tech-label">Anafe</span>
+                <span class="badge plan">del plano</span>
+                <span class="badge verif">confirmado</span>
+                <span class="tech-conf">88%</span>
+              </div>
+              <div class="radios">
+                <label class="radio on"><span class="dot"></span>2 anafes (gas + eléctrico)</label>
+                <label class="radio"><span class="dot"></span>1 anafe</label>
+                <label class="radio"><span class="dot"></span>Sin anafe</label>
+              </div>
+            </div>
+          </div>
+
+          <!-- Reglas / defaults -->
+          <div class="sec">
+            <div class="sec-h amb">✨ Reglas / defaults</div>
+
+            <div class="row">
+              <div class="row-label">Zócalo trasero</div>
+              <div class="row-value">7 cm</div>
+              <div class="row-note">default D'Angelo 5 cm, operador pidió 7</div>
+              <span class="badge brief">del brief</span>
+            </div>
+            <div class="row">
+              <div class="row-label">Merma</div>
+              <div class="row-value">5% (sintético)</div>
+              <div class="row-note">Puraprima es sintético — lleva merma</div>
+              <span class="badge rule">regla D'Angelo</span>
+            </div>
+            <div class="row">
+              <div class="row-label">Colocación</div>
+              <div class="row-value">Sí — incluida</div>
+              <span class="badge brief">del brief</span>
+            </div>
+            <div class="row">
+              <div class="row-label">PEGADOPILETA</div>
+              <div class="row-value">1 unidad (empotrada)</div>
+              <span class="badge rule">regla D'Angelo</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="ctx-foot">
+          <button class="btn-primary">Confirmar contexto — seguir al despiece</button>
+        </div>
+      </div>
+
+    </div>
+
+  </div>
+
+  <div class="composer">
+    <div class="comp-row">
+      <span class="comp-input">Enunciado o adjuntar plano…</span>
+      <div class="comp-btns">
+        <button class="icon-btn">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg>
+        </button>
+        <button class="icon-btn primary">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+        </button>
+      </div>
+    </div>
+    <div class="comp-hint">Enter para enviar</div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/15-chat-dual-read-desktop.html
+++ b/docs/mockups/15-chat-dual-read-desktop.html
@@ -1,0 +1,294 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Chat · despiece · Desktop 1440×900</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:1440px; height:900px; background:var(--bg); overflow:hidden; position:relative; border:1px solid rgba(255,255,255,.06); border-radius:6px; display:flex; }
+  .sidebar { width:212px; flex-shrink:0; background:var(--s1); border-right:1px solid var(--b1); display:flex; flex-direction:column; padding:18px 10px 20px; }
+  .side-logo { display:flex; align-items:center; gap:10px; padding:2px 8px 20px; }
+  .side-logo-badge { width:26px; height:26px; border-radius:6px; background:var(--acc); color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
+  .side-logo-text { font-size:13px; font-weight:500; letter-spacing:-.02em; }
+  .side-label { font-size:10px; font-weight:500; color:var(--t4); text-transform:uppercase; letter-spacing:.1em; padding:0 8px 4px; }
+  .side-label.mt { margin-top:14px; }
+  .side-item { display:flex; align-items:center; gap:8px; padding:8px; border-radius:6px; font-size:12px; color:var(--t2); border:none; background:transparent; width:100%; text-align:left; cursor:pointer; }
+  .side-item.active { color:var(--acc); background:rgba(79,143,255,.11); }
+  .side-item svg { flex-shrink:0; opacity:.65; }
+  .side-item.active svg { opacity:1; }
+  .side-item .count { margin-left:auto; font-size:10px; font-weight:500; padding:1px 7px; border-radius:99px; background:rgba(255,255,255,.07); color:var(--t3); font-family:var(--font-mono); }
+  .side-item.active .count { background:var(--acc); color:#fff; font-weight:600; }
+  .side-divider { height:1px; background:var(--b1); margin:12px 0; }
+  .side-spacer { flex:1; }
+  .side-new { width:100%; padding:10px 12px; background:var(--acc); color:#fff; font-size:13px; font-weight:500; border:none; border-radius:8px; display:flex; align-items:center; justify-content:center; gap:7px; }
+  .side-logout { width:100%; padding:7px 8px; background:transparent; border:none; color:var(--t3); font-size:11px; display:flex; align-items:center; justify-content:center; gap:6px; margin-top:10px; }
+  .main { flex:1; display:flex; flex-direction:column; min-width:0; }
+  .qh-header { padding:14px 28px; border-bottom:1px solid var(--b1); background:var(--s1); display:flex; align-items:center; gap:14px; }
+  .qh-back { width:30px; height:30px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; cursor:pointer; }
+  .qh-title-wrap { min-width:0; flex:1; }
+  .qh-title { font-size:15px; font-weight:600; color:var(--t1); display:flex; align-items:center; gap:10px; }
+  .qh-status { display:inline-flex; align-items:center; gap:5px; padding:2px 8px; border-radius:99px; font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.06em; }
+  .qh-status.draft { color:var(--amb); background:var(--amb2); }
+  .qh-status .dot { width:5px; height:5px; border-radius:99px; background:currentColor; }
+  .qh-sub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .tabs { display:flex; padding-left:28px; border-bottom:1px solid var(--b1); background:var(--s1); }
+  .tab { padding:10px 20px; font-size:13px; font-weight:500; color:var(--t3); background:transparent; border:none; cursor:pointer; border-bottom:2px solid transparent; opacity:.6; }
+  .tab.active { color:var(--acc); border-bottom-color:var(--acc); opacity:1; }
+  .tab.locked { opacity:.35; cursor:not-allowed; }
+
+  .chat-scroll { flex:1; overflow-y:auto; padding:24px 28px 16px; display:flex; flex-direction:column; gap:14px; background:var(--bg); }
+  .msg { display:flex; gap:12px; align-items:flex-start; }
+  .msg.user { flex-direction:row-reverse; }
+  .avatar { width:30px; height:30px; border-radius:99px; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:11px; font-weight:600; }
+  .avatar.v { background:var(--acc); color:#fff; }
+  .avatar.u { background:var(--s3); color:var(--t2); border:1px solid var(--b2); }
+  .bubble.user { max-width:52%; padding:8px 14px; background:var(--acc2); border:1px solid rgba(79,143,255,.25); border-radius:12px 2px 12px 12px; font-size:13px; line-height:1.55; color:rgba(255,255,255,.55); }
+  .vwrap { flex:1; border:1px solid var(--b2); border-radius:2px 12px 12px 12px; overflow:hidden; }
+  .blk { padding:14px 18px; background:var(--s2); }
+  .blk.text { font-size:15px; line-height:1.7; color:var(--t2); }
+
+  /* DualReadResult card */
+  .card { margin:0; width:100%; border-radius:16px; border:1px solid var(--b1); background:var(--s1); overflow:hidden; box-shadow:0 20px 40px -20px rgba(0,0,0,.5); }
+  .card-hdr { display:flex; align-items:center; gap:12px; padding:16px 20px; background:linear-gradient(180deg,var(--s3),var(--s2)); border-bottom:1px solid var(--b1); }
+  .card-tag { font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.1em; color:var(--acc); background:var(--acc2); border:1px solid rgba(79,143,255,.30); padding:4px 8px; border-radius:6px; }
+  .card-title { font-size:15px; font-weight:600; color:var(--t1); letter-spacing:-.01em; }
+  .card-sub { margin-left:auto; font-size:12px; color:var(--t3); font-family:var(--font-mono); }
+  .status-chip { font-size:10px; text-transform:uppercase; letter-spacing:.08em; padding:3px 7px; border-radius:4px; border:1px solid; }
+  .chip.grn { color:var(--grn); background:rgba(48,209,88,.15); border-color:rgba(48,209,88,.40); }
+  .copy-btn { display:inline-flex; align-items:center; gap:5px; padding:6px 10px; border:1px solid var(--b2); border-radius:6px; background:transparent; color:var(--t2); font-size:11px; cursor:pointer; }
+
+  .tbl-grid { display:grid; grid-template-columns:1fr 300px; }
+  .tbl-pieces { overflow-x:auto; }
+  .tbl-head { display:grid; grid-template-columns:22px 1fr 80px 80px 80px; gap:12px; padding:10px 20px; font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.1em; color:var(--t3); background:var(--s2); border-bottom:1px solid var(--b1); }
+  .tbl-head > span:nth-child(n+3) { text-align:right; }
+  .section-label { padding:14px 20px 6px; font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.14em; color:var(--t3); border-top:1px solid var(--b1); }
+  .piece-row { display:grid; grid-template-columns:22px 1fr 80px 80px 80px; gap:12px; padding:10px 20px; font-size:13px; border-top:1px solid var(--b1); align-items:center; font-family:var(--font-mono); font-variant-numeric:tabular-nums; }
+  .piece-row .pname { font-family:var(--font-sans); color:var(--t1); }
+  .piece-row .psub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-sans); }
+  .piece-row .num { text-align:right; color:var(--t2); }
+  .piece-row .m2 { text-align:right; color:var(--t1); font-weight:500; display:flex; justify-content:flex-end; align-items:center; gap:8px; }
+  .m2 .xbtn { width:20px; height:20px; border-radius:6px; border:1px solid transparent; background:transparent; color:var(--t4); font-size:11px; cursor:pointer; display:flex; align-items:center; justify-content:center; }
+  .statico { display:inline-grid; place-items:center; width:18px; height:18px; border-radius:5px; font-size:10px; font-weight:700; }
+  .statico.conf { background:rgba(48,209,88,.15); color:var(--grn); }
+  .statico.dudoso { background:rgba(191,85,236,.15); color:#bf55ec; }
+  .num-box { display:inline-block; padding:2px 6px; border:1px dashed rgba(255,255,255,.08); border-radius:4px; color:var(--t1); }
+  .pills-row { display:flex; flex-wrap:wrap; gap:4px; margin-top:4px; }
+  .pill-tiny { font-size:10px; color:var(--t3); padding:2px 6px; border:1px solid var(--b1); border-radius:4px; background:transparent; }
+  .unit { color:var(--t4); margin-left:1px; }
+
+  /* zocalo row */
+  .zoc-row { display:grid; grid-template-columns:22px 1fr 80px 80px 80px; gap:12px; padding:8px 20px; font-size:13px; border-top:1px solid var(--b1); align-items:center; font-family:var(--font-mono); font-variant-numeric:tabular-nums; }
+  .zoc-name { padding-left:16px; position:relative; font-family:var(--font-sans); color:var(--t2); }
+  .zoc-name::before { content:""; position:absolute; left:0; top:50%; width:10px; height:1px; background:var(--b2); }
+
+  /* Totals side */
+  .totals { border-left:1px solid var(--b1); background:linear-gradient(180deg,var(--s2),var(--s1)); padding:20px; }
+  .totals-lbl { font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.14em; color:var(--t3); }
+  .totals-big { margin-top:6px; font-size:44px; line-height:1; font-weight:600; letter-spacing:-1px; font-family:var(--font-mono); font-variant-numeric:tabular-nums; color:var(--t1); }
+  .totals-unit { font-size:16px; color:var(--t2); font-weight:500; margin-left:4px; font-family:var(--font-sans); letter-spacing:-.01em; }
+  .totals-grid { margin-top:16px; display:grid; grid-template-columns:1fr auto; gap:4px 16px; font-size:12px; font-family:var(--font-mono); font-variant-numeric:tabular-nums; }
+  .totals-grid .lbl { color:var(--t3); font-family:var(--font-sans); }
+  .totals-grid .lbl small { color:var(--t4); }
+  .totals-grid .val { text-align:right; color:var(--t1); }
+
+  .amb-warn { margin:12px 20px; padding:10px 14px; background:rgba(191,85,236,.06); border:1px solid rgba(191,85,236,.25); border-radius:10px; font-size:12px; color:#bf55ec; }
+
+  .card-actions { display:flex; gap:8px; padding:16px 20px; border-top:1px solid var(--b1); background:var(--s2); }
+  .btn-primary { flex:1; padding:10px 16px; border-radius:12px; background:var(--acc); color:#fff; font-size:13px; font-weight:600; border:none; cursor:pointer; }
+
+  .composer { border-top:1px solid var(--b1); background:var(--s1); padding:14px 20px; }
+  .comp-row { display:flex; align-items:flex-end; gap:8px; background:var(--s3); border:1px solid var(--b2); border-radius:12px; padding:10px 10px 10px 16px; }
+  .comp-input { flex:1; background:transparent; border:none; outline:none; font-size:13px; color:var(--t1); line-height:1.5; min-height:20px; padding:2px 0; }
+  .comp-input.placeholder { color:var(--t4); }
+  .comp-btns { display:flex; gap:5px; flex-shrink:0; }
+  .icon-btn { width:32px; height:32px; border-radius:99px; display:flex; align-items:center; justify-content:center; cursor:pointer; border:1px solid var(--b1); background:transparent; color:var(--t2); }
+  .icon-btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .icon-btn:disabled { opacity:.4; cursor:not-allowed; }
+  .comp-foot { display:flex; justify-content:space-between; align-items:center; margin-top:6px; font-size:11px; color:var(--t3); }
+  .multi-check { display:inline-flex; align-items:center; gap:5px; cursor:pointer; }
+</style>
+</head>
+<body>
+<span class="frame-label">CHAT · DESPIECE · DESKTOP · 1440×900 · /quote/pr-0248</span>
+<div class="frame">
+  <aside class="sidebar">
+    <div class="side-logo"><div class="side-logo-badge">D</div><span class="side-logo-text">D'Angelo</span></div>
+    <div class="side-label">Principal</div>
+    <button class="side-item active">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Presupuestos<span class="count">3</span>
+    </button>
+    <div class="side-label mt">Sistema</div>
+    <button class="side-item"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/></svg>Catálogo</button>
+    <button class="side-item"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><line x1="4" y1="21" x2="4" y2="14"/></svg>Configuración</button>
+    <div class="side-divider"></div>
+    <div class="side-spacer"></div>
+    <button class="side-new"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>Nuevo presupuesto</button>
+    <button class="side-logout">Cerrar sesión</button>
+  </aside>
+
+  <main class="main">
+    <header class="qh-header">
+      <button class="qh-back">←</button>
+      <div class="qh-title-wrap">
+        <div class="qh-title">Erica Bernardi — Casa Bernardi <span class="qh-status draft"><span class="dot"></span>borrador</span></div>
+        <div class="qh-sub">#PR-0248 · hace 3 min</div>
+      </div>
+    </header>
+
+    <div class="tabs">
+      <button class="tab active">Chat</button>
+      <button class="tab locked">Detalle</button>
+    </div>
+
+    <div class="chat-scroll">
+      <div class="msg user"><div class="avatar u">EB</div><div class="bubble user">Brief inicial + plano…</div></div>
+      <div class="msg"><div class="avatar v">V</div><div class="vwrap"><div class="blk text" style="padding:10px 18px; font-size:13px;">Contexto confirmado.</div></div></div>
+      <div class="msg">
+        <div class="avatar v">V</div>
+        <div class="vwrap">
+          <div class="blk text"><p>Medí los 4 tramos. Revisá los valores; si algo no cuadra, editá inline (doble-click).</p></div>
+        </div>
+      </div>
+
+      <div class="msg">
+        <div class="avatar v">V</div>
+        <div class="card" style="flex:1;">
+          <div class="card-hdr">
+            <span class="card-tag">📐 Despiece</span>
+            <span class="card-title">Medidas verificadas</span>
+            <span class="card-sub">4 mesadas · 7 zócalos</span>
+            <span class="status-chip chip grn">4 confirmados</span>
+            <button class="copy-btn">📋 Copiar despiece</button>
+          </div>
+
+          <div class="tbl-grid">
+            <div class="tbl-pieces">
+              <div class="tbl-head">
+                <span></span><span>Pieza</span><span>Largo</span><span>Ancho</span><span>m²</span>
+              </div>
+
+              <div class="section-label">cocina — Cocina (tipo U) · 3 tramos · 4.32 m²</div>
+
+              <div class="piece-row">
+                <span class="statico conf">✓</span>
+                <div>
+                  <div class="pname">P1 · Mesada principal contra pared</div>
+                  <div class="psub">mesada rectangular</div>
+                  <div class="pills-row"><span class="pill-tiny">toca pared</span></div>
+                </div>
+                <div class="num"><span class="num-box">3.20</span><span class="unit">m</span></div>
+                <div class="num"><span class="num-box">0.60</span><span class="unit">m</span></div>
+                <div class="m2">1.92<button class="xbtn">×</button></div>
+              </div>
+              <div class="zoc-row">
+                <span class="statico conf">✓</span>
+                <div class="zoc-name">Zóc. trasero</div>
+                <div class="num">3.20<span class="unit">ml</span></div>
+                <div class="num">0.07<span class="unit">m</span></div>
+                <div class="m2">0.22</div>
+              </div>
+
+              <div class="piece-row">
+                <span class="statico conf">✓</span>
+                <div>
+                  <div class="pname">P2 · Ala derecha</div>
+                  <div class="psub">mesada rectangular</div>
+                </div>
+                <div class="num"><span class="num-box">1.80</span><span class="unit">m</span></div>
+                <div class="num"><span class="num-box">0.60</span><span class="unit">m</span></div>
+                <div class="m2">1.08<button class="xbtn">×</button></div>
+              </div>
+              <div class="zoc-row">
+                <span class="statico conf">✓</span>
+                <div class="zoc-name">Zóc. trasero</div>
+                <div class="num">1.80<span class="unit">ml</span></div>
+                <div class="num">0.07<span class="unit">m</span></div>
+                <div class="m2">0.13</div>
+              </div>
+
+              <div class="piece-row">
+                <span class="statico conf">✓</span>
+                <div>
+                  <div class="pname">P3 · Ala izquierda con pileta doble</div>
+                  <div class="psub">mesada rectangular</div>
+                  <div class="pills-row"><span class="pill-tiny">sink_double</span><span class="pill-tiny">toca pared</span></div>
+                </div>
+                <div class="num"><span class="num-box">2.20</span><span class="unit">m</span></div>
+                <div class="num"><span class="num-box">0.60</span><span class="unit">m</span></div>
+                <div class="m2">1.32<button class="xbtn">×</button></div>
+              </div>
+              <div class="zoc-row">
+                <span class="statico conf">✓</span>
+                <div class="zoc-name">Zóc. trasero</div>
+                <div class="num">2.20<span class="unit">ml</span></div>
+                <div class="num">0.07<span class="unit">m</span></div>
+                <div class="m2">0.15</div>
+              </div>
+
+              <div class="section-label">isla — Isla · 1 tramo · 0.96 m²</div>
+
+              <div class="piece-row">
+                <span class="statico dudoso">?</span>
+                <div>
+                  <div class="pname">P4 · Isla central</div>
+                  <div class="psub">mesada rectangular</div>
+                  <div class="pills-row"><span class="pill-tiny">isla central</span></div>
+                </div>
+                <div class="num"><span class="num-box">1.60</span><span class="unit">m</span></div>
+                <div class="num"><span class="num-box">0.60</span><span class="unit">m</span></div>
+                <div class="m2">0.96<button class="xbtn">×</button></div>
+              </div>
+            </div>
+
+            <div class="totals">
+              <div class="totals-lbl">Total a cortar</div>
+              <div class="totals-big">5.81<span class="totals-unit">m²</span></div>
+              <div class="totals-grid">
+                <span class="lbl">Mesadas <small>(4)</small></span><span class="val">5.28 m²</span>
+                <span class="lbl">Zócalos <small>(3)</small></span><span class="val">0.50 m²</span>
+                <span class="lbl">ml zócalo trasero</span><span class="val">7.20 ml</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="amb-warn">Valor dudoso: ancho de la isla derivado por default — confirmar con doble-click en el campo.</div>
+
+          <div class="card-actions">
+            <button class="btn-primary">Confirmar despiece · 5.81 m²</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="composer">
+      <div class="comp-row">
+        <div class="comp-input placeholder">Escribí el enunciado o arrastrá el plano…</div>
+        <div class="comp-btns">
+          <button class="icon-btn"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg></button>
+          <button class="icon-btn primary" disabled><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg></button>
+        </div>
+      </div>
+      <div class="comp-foot">
+        <span>Enter para enviar · Shift+Enter para nueva línea</span>
+        <label class="multi-check"><input type="checkbox"/> multi-pieza</label>
+      </div>
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/docs/mockups/15-chat-dual-read-mobile.html
+++ b/docs/mockups/15-chat-dual-read-mobile.html
@@ -1,0 +1,326 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Chat · dual read · Mobile 390×844</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a; --dud:#bf55ec;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:14px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:390px; height:844px; border-radius:38px; border:10px solid #0a0a10; background:var(--bg); overflow:hidden; position:relative; display:flex; flex-direction:column; }
+  .frame::after { content:''; position:absolute; inset:0; pointer-events:none; background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E"); }
+
+  .mobile-topbar { display:flex; align-items:center; gap:12px; padding:12px 16px; background:var(--s1); border-bottom:1px solid var(--b1); flex-shrink:0; }
+  .mobile-topbar .burger { background:transparent; border:none; color:var(--t2); padding:2px; display:flex; }
+  .mobile-topbar .dlogo { width:22px; height:22px; border-radius:6px; background:var(--acc); display:flex; align-items:center; justify-content:center; color:#fff; font-size:10px; font-weight:600; }
+  .mobile-topbar .brand { font-size:13px; font-weight:500; color:var(--t1); }
+
+  .qh-header { padding:12px 16px; border-bottom:1px solid var(--b1); background:var(--s1); flex-shrink:0; }
+  .qh-row { display:flex; align-items:center; gap:10px; }
+  .qh-back { width:30px; height:30px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; flex-shrink:0; }
+  .qh-title-wrap { flex:1; min-width:0; }
+  .qh-title { font-size:14px; font-weight:600; color:var(--t1); max-width:200px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; letter-spacing:-.01em; }
+  .qh-sub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .qh-status { display:inline-flex; align-items:center; gap:4px; padding:2px 7px; border-radius:99px; font-size:9px; font-weight:600; text-transform:uppercase; letter-spacing:.05em; flex-shrink:0; }
+  .qh-status.draft { color:var(--amb); background:var(--amb2); }
+  .qh-status .dot { width:4px; height:4px; border-radius:99px; background:currentColor; }
+
+  .tabs { display:flex; padding-left:16px; border-bottom:1px solid var(--b1); background:var(--s1); flex-shrink:0; }
+  .tab { padding:10px 16px; font-size:12px; font-weight:500; color:var(--t3); background:transparent; border:none; border-bottom:2px solid transparent; opacity:.6; }
+  .tab.active { color:var(--acc); border-bottom-color:var(--acc); opacity:1; }
+  .tab.locked { opacity:.35; }
+
+  .chat-scroll { flex:1; overflow-y:auto; padding:20px 16px 16px; display:flex; flex-direction:column; gap:14px; }
+
+  .msg { display:flex; gap:10px; align-items:flex-start; }
+  .avatar { width:28px; height:28px; border-radius:99px; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:10px; font-weight:600; }
+  .avatar.v { background:var(--acc); color:#fff; }
+
+  /* Dual read card */
+  .dr-card { flex:1; border-radius:14px; border:1px solid var(--b1); background:var(--s1); overflow:hidden; }
+  .dr-hdr { display:flex; align-items:center; gap:6px; padding:12px 14px; background:linear-gradient(180deg,var(--s3),var(--s2)); border-bottom:1px solid var(--b1); flex-wrap:wrap; }
+  .dr-tag { font-size:9px; font-weight:600; text-transform:uppercase; letter-spacing:.1em; color:var(--acc); background:var(--acc2); border:1px solid rgba(79,143,255,.30); padding:3px 7px; border-radius:5px; }
+  .dr-tag.planta { color:#10b981; background:rgba(16,185,129,.10); border-color:rgba(16,185,129,.30); }
+  .dr-title { font-size:13px; font-weight:600; color:var(--t1); width:100%; margin-top:4px; }
+  .dr-copy { position:absolute; top:10px; right:10px; width:26px; height:26px; border-radius:6px; border:1px solid var(--b2); background:var(--s1); color:var(--t2); display:flex; align-items:center; justify-content:center; }
+
+  .dr-body { padding:12px; display:flex; flex-direction:column; gap:10px; }
+
+  /* Tramo card */
+  .tramo {
+    border:1px solid var(--b1); border-radius:10px; padding:12px;
+    background:var(--s2);
+  }
+  .tramo-head { display:flex; align-items:center; gap:8px; margin-bottom:10px; }
+  .tramo-status {
+    width:20px; height:20px; border-radius:5px;
+    display:flex; align-items:center; justify-content:center;
+    font-size:11px; font-weight:700;
+  }
+  .tramo-status.ok { background:var(--grn2); color:var(--grn); }
+  .tramo-status.warn { background:var(--amb2); color:var(--amb); }
+  .tramo-status.dud { background:rgba(191,85,236,.15); color:var(--dud); }
+  .tramo-title { font-size:13px; font-weight:600; color:var(--t1); }
+  .tramo-sub { font-size:10px; color:var(--t3); margin-top:1px; }
+  .tramo-grid {
+    display:grid; grid-template-columns:1fr 1fr; gap:8px;
+  }
+  .field { display:flex; flex-direction:column; gap:3px; }
+  .field-l { font-size:9px; text-transform:uppercase; letter-spacing:.08em; color:var(--t3); }
+  .field-v {
+    padding:6px 8px; background:var(--s3); border:1px solid var(--b1);
+    border-radius:6px; font-size:13px; color:var(--t1);
+    font-family:var(--font-mono); display:flex; align-items:center; justify-content:space-between;
+  }
+  .field-v .u { color:var(--t4); font-size:10px; }
+  .field-v.edited { border-color:var(--acc); background:rgba(79,143,255,.05); }
+  .field-v.dud { border-color:rgba(191,85,236,.4); background:rgba(191,85,236,.05); }
+
+  .zoc-list { margin-top:10px; padding-top:10px; border-top:1px dashed var(--b1); display:flex; flex-direction:column; gap:6px; }
+  .zoc-row {
+    display:flex; align-items:center; gap:8px;
+    font-size:11px; color:var(--t2);
+  }
+  .zoc-row .zs { width:16px; height:16px; border-radius:4px; background:var(--grn2); color:var(--grn); font-size:9px; display:flex; align-items:center; justify-content:center; font-weight:700; }
+  .zoc-row .label { flex:1; }
+  .zoc-row .val { font-family:var(--font-mono); color:var(--t1); }
+
+  /* Totals */
+  .dr-totals {
+    padding:14px; background:linear-gradient(180deg,var(--s2),var(--s1));
+    border-top:1px solid var(--b1);
+    display:flex; align-items:flex-end; justify-content:space-between;
+  }
+  .dr-tot-label { font-size:9px; text-transform:uppercase; letter-spacing:.14em; color:var(--t3); }
+  .dr-tot-big { font-size:32px; font-weight:600; letter-spacing:-1px; font-family:var(--font-mono); color:var(--t1); line-height:1; }
+  .dr-tot-big span { font-size:13px; color:var(--t2); margin-left:4px; font-family:var(--font-sans); }
+  .dr-tot-sub { font-size:10px; color:var(--t3); font-family:var(--font-mono); display:flex; flex-direction:column; gap:2px; text-align:right; }
+
+  .dr-foot { padding:14px; border-top:1px solid var(--b1); background:var(--s2); }
+  .btn-primary { width:100%; padding:11px 14px; background:var(--acc); color:#fff; font-size:13px; font-weight:600; border:none; border-radius:10px; }
+
+  .composer { border-top:1px solid var(--b1); background:var(--s1); padding:12px 16px; flex-shrink:0; }
+  .comp-row { display:flex; align-items:center; gap:8px; background:var(--s3); border:1px solid var(--b2); border-radius:12px; padding:8px 10px 8px 12px; }
+  .comp-input { flex:1; background:transparent; border:none; outline:none; font-size:13px; color:var(--t4); }
+  .comp-btns { display:flex; gap:5px; flex-shrink:0; }
+  .icon-btn { width:28px; height:28px; border-radius:99px; display:flex; align-items:center; justify-content:center; border:1px solid var(--b1); background:transparent; color:var(--t2); }
+  .icon-btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .comp-hint { font-size:10px; color:var(--t3); margin-top:5px; text-align:right; }
+</style>
+</head>
+<body>
+<span class="frame-label">CHAT · DESPIECE · MOBILE · 390×844 · /quote/pr-0248</span>
+<div class="frame">
+
+  <div class="mobile-topbar">
+    <button class="burger">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <div class="dlogo">D</div>
+    <span class="brand">D'Angelo</span>
+  </div>
+
+  <header class="qh-header">
+    <div class="qh-row">
+      <button class="qh-back">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><polyline points="15 18 9 12 15 6"/></svg>
+      </button>
+      <div class="qh-title-wrap">
+        <div class="qh-title">Erica Bernardi — Casa Bernardi</div>
+        <div class="qh-sub">#PR-0248 · hace 4 min</div>
+      </div>
+      <span class="qh-status draft"><span class="dot"></span>Borrador</span>
+    </div>
+  </header>
+
+  <div class="tabs">
+    <button class="tab active">Chat</button>
+    <button class="tab locked">Detalle</button>
+  </div>
+
+  <div class="chat-scroll">
+
+    <div class="msg">
+      <div class="avatar v">V</div>
+      <div class="dr-card" style="position:relative">
+        <div class="dr-hdr">
+          <span class="dr-tag">Doble lectura</span>
+          <span class="dr-tag planta">📐 Planta 2D</span>
+          <button class="dr-copy">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+          </button>
+          <span class="dr-title">Cocina — U + isla</span>
+        </div>
+
+        <div class="dr-body">
+
+          <!-- Tramo 1 -->
+          <div class="tramo">
+            <div class="tramo-head">
+              <span class="tramo-status ok">✓</span>
+              <div>
+                <div class="tramo-title">P1 · Mesada principal</div>
+                <div class="tramo-sub">cocina U · rectangular</div>
+              </div>
+            </div>
+            <div class="tramo-grid">
+              <div class="field">
+                <span class="field-l">Largo</span>
+                <div class="field-v">3.20 <span class="u">m</span></div>
+              </div>
+              <div class="field">
+                <span class="field-l">Ancho</span>
+                <div class="field-v">0.60 <span class="u">m</span></div>
+              </div>
+              <div class="field">
+                <span class="field-l">m²</span>
+                <div class="field-v">1.92 <span class="u">m²</span></div>
+              </div>
+              <div class="field">
+                <span class="field-l">Zócalos</span>
+                <div class="field-v">3.20 <span class="u">ml</span></div>
+              </div>
+            </div>
+            <div class="zoc-list">
+              <div class="zoc-row"><span class="zs">✓</span><span class="label">Zóc. trasero</span><span class="val">3.20 ml × 0.07</span></div>
+            </div>
+          </div>
+
+          <!-- Tramo 2 -->
+          <div class="tramo">
+            <div class="tramo-head">
+              <span class="tramo-status ok">✓</span>
+              <div>
+                <div class="tramo-title">P2 · Brazo izquierdo</div>
+                <div class="tramo-sub">cocina U · rectangular</div>
+              </div>
+            </div>
+            <div class="tramo-grid">
+              <div class="field">
+                <span class="field-l">Largo</span>
+                <div class="field-v">1.80 <span class="u">m</span></div>
+              </div>
+              <div class="field">
+                <span class="field-l">Ancho</span>
+                <div class="field-v">0.60 <span class="u">m</span></div>
+              </div>
+              <div class="field">
+                <span class="field-l">m²</span>
+                <div class="field-v">1.08 <span class="u">m²</span></div>
+              </div>
+              <div class="field">
+                <span class="field-l">Zócalos</span>
+                <div class="field-v">1.80 <span class="u">ml</span></div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Tramo 3 -->
+          <div class="tramo">
+            <div class="tramo-head">
+              <span class="tramo-status warn">!</span>
+              <div>
+                <div class="tramo-title">P3 · Brazo derecho</div>
+                <div class="tramo-sub">cocina U · alerta menor — promediado</div>
+              </div>
+            </div>
+            <div class="tramo-grid">
+              <div class="field">
+                <span class="field-l">Largo</span>
+                <div class="field-v edited">2.20 <span class="u">m</span></div>
+              </div>
+              <div class="field">
+                <span class="field-l">Ancho</span>
+                <div class="field-v">0.60 <span class="u">m</span></div>
+              </div>
+              <div class="field">
+                <span class="field-l">m²</span>
+                <div class="field-v">1.32 <span class="u">m²</span></div>
+              </div>
+              <div class="field">
+                <span class="field-l">Zócalos</span>
+                <div class="field-v">2.20 <span class="u">ml</span></div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Tramo 4 -->
+          <div class="tramo">
+            <div class="tramo-head">
+              <span class="tramo-status dud">?</span>
+              <div>
+                <div class="tramo-title">P4 · Isla</div>
+                <div class="tramo-sub">isla · dudoso — confirmar medidas</div>
+              </div>
+            </div>
+            <div class="tramo-grid">
+              <div class="field">
+                <span class="field-l">Largo</span>
+                <div class="field-v dud">1.60 <span class="u">m</span></div>
+              </div>
+              <div class="field">
+                <span class="field-l">Ancho</span>
+                <div class="field-v dud">0.60 <span class="u">m</span></div>
+              </div>
+              <div class="field">
+                <span class="field-l">m²</span>
+                <div class="field-v">0.96 <span class="u">m²</span></div>
+              </div>
+              <div class="field">
+                <span class="field-l">Zócalos</span>
+                <div class="field-v">— <span class="u">ml</span></div>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        <div class="dr-totals">
+          <div>
+            <div class="dr-tot-label">Total a cortar</div>
+            <div class="dr-tot-big">5.76<span>m²</span></div>
+          </div>
+          <div class="dr-tot-sub">
+            <span>Mesadas (4) · 5.28 m²</span>
+            <span>Zócalos (3) · 0.48 m²</span>
+          </div>
+        </div>
+
+        <div class="dr-foot">
+          <button class="btn-primary">Confirmar medidas · 5.76 m²</button>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="composer">
+    <div class="comp-row">
+      <span class="comp-input">Enunciado o adjuntar plano…</span>
+      <div class="comp-btns">
+        <button class="icon-btn">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg>
+        </button>
+        <button class="icon-btn primary">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+        </button>
+      </div>
+    </div>
+    <div class="comp-hint">Enter para enviar</div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/16-chat-calculating-desktop.html
+++ b/docs/mockups/16-chat-calculating-desktop.html
@@ -1,0 +1,176 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Chat · calculando · Desktop 1440×900</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:1440px; height:900px; background:var(--bg); overflow:hidden; position:relative; border:1px solid rgba(255,255,255,.06); border-radius:6px; display:flex; }
+  .sidebar { width:212px; flex-shrink:0; background:var(--s1); border-right:1px solid var(--b1); display:flex; flex-direction:column; padding:18px 10px 20px; }
+  .side-logo { display:flex; align-items:center; gap:10px; padding:2px 8px 20px; }
+  .side-logo-badge { width:26px; height:26px; border-radius:6px; background:var(--acc); color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
+  .side-logo-text { font-size:13px; font-weight:500; letter-spacing:-.02em; }
+  .side-label { font-size:10px; font-weight:500; color:var(--t4); text-transform:uppercase; letter-spacing:.1em; padding:0 8px 4px; }
+  .side-label.mt { margin-top:14px; }
+  .side-item { display:flex; align-items:center; gap:8px; padding:8px; border-radius:6px; font-size:12px; color:var(--t2); border:none; background:transparent; width:100%; text-align:left; cursor:pointer; }
+  .side-item.active { color:var(--acc); background:rgba(79,143,255,.11); }
+  .side-item svg { flex-shrink:0; opacity:.65; }
+  .side-item.active svg { opacity:1; }
+  .side-item .count { margin-left:auto; font-size:10px; font-weight:500; padding:1px 7px; border-radius:99px; background:rgba(255,255,255,.07); color:var(--t3); font-family:var(--font-mono); }
+  .side-item.active .count { background:var(--acc); color:#fff; font-weight:600; }
+  .side-divider { height:1px; background:var(--b1); margin:12px 0; }
+  .side-spacer { flex:1; }
+  .side-new { width:100%; padding:10px 12px; background:var(--acc); color:#fff; font-size:13px; font-weight:500; border:none; border-radius:8px; display:flex; align-items:center; justify-content:center; gap:7px; }
+  .side-logout { width:100%; padding:7px 8px; background:transparent; border:none; color:var(--t3); font-size:11px; display:flex; align-items:center; justify-content:center; gap:6px; margin-top:10px; }
+  .main { flex:1; display:flex; flex-direction:column; min-width:0; }
+  .qh-header { padding:14px 28px; border-bottom:1px solid var(--b1); background:var(--s1); display:flex; align-items:center; gap:14px; }
+  .qh-back { width:30px; height:30px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; cursor:pointer; }
+  .qh-title-wrap { min-width:0; flex:1; }
+  .qh-title { font-size:15px; font-weight:600; color:var(--t1); display:flex; align-items:center; gap:10px; }
+  .qh-status { display:inline-flex; align-items:center; gap:5px; padding:2px 8px; border-radius:99px; font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.06em; }
+  .qh-status.draft { color:var(--amb); background:var(--amb2); }
+  .qh-status .dot { width:5px; height:5px; border-radius:99px; background:currentColor; }
+  .qh-sub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .tabs { display:flex; padding-left:28px; border-bottom:1px solid var(--b1); background:var(--s1); }
+  .tab { padding:10px 20px; font-size:13px; font-weight:500; color:var(--t3); background:transparent; border:none; cursor:pointer; border-bottom:2px solid transparent; opacity:.6; }
+  .tab.active { color:var(--acc); border-bottom-color:var(--acc); opacity:1; }
+  .tab.locked { opacity:.35; cursor:not-allowed; }
+
+  .chat-scroll { flex:1; overflow-y:auto; padding:24px 28px 16px; display:flex; flex-direction:column; gap:16px; background:var(--bg); }
+  .msg { display:flex; gap:12px; align-items:flex-start; }
+  .msg.user { flex-direction:row-reverse; }
+  .avatar { width:30px; height:30px; border-radius:99px; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:11px; font-weight:600; }
+  .avatar.v { background:var(--acc); color:#fff; }
+  .avatar.u { background:var(--s3); color:var(--t2); border:1px solid var(--b2); }
+  .bubble.user { max-width:52%; padding:8px 14px; background:var(--acc2); border:1px solid rgba(79,143,255,.25); border-radius:12px 2px 12px 12px; font-size:13px; line-height:1.55; color:rgba(255,255,255,.55); }
+  .vwrap { flex:1; border:1px solid var(--b2); border-radius:2px 12px 12px 12px; overflow:hidden; }
+  .blk { padding:14px 18px; background:var(--s2); }
+  .blk + .blk { border-top:1px solid var(--b1); }
+  .blk.thinking { padding:12px 18px; display:flex; flex-direction:column; gap:6px; }
+  .think-line { display:flex; align-items:center; gap:7px; font-size:11px; color:var(--t3); font-style:italic; }
+  .think-dot { width:5px; height:5px; border-radius:99px; background:var(--acc); flex-shrink:0; animation:pulse 1.4s ease-in-out infinite; }
+  .think-dot.d2 { animation-delay:.3s; } .think-dot.d3 { animation-delay:.6s; } .think-dot.d4 { animation-delay:.9s; }
+  @keyframes pulse { 0%,100% { opacity:.35; } 50% { opacity:1; } }
+  .blk.text { font-size:15px; line-height:1.7; color:var(--t2); }
+  .blk.text h3 { font-size:15px; font-weight:600; color:var(--t1); border-bottom:1px solid var(--b1); padding-bottom:6px; margin-bottom:12px; letter-spacing:-.01em; }
+
+  .verified-ind { text-align:center; font-size:12px; color:var(--grn); font-style:italic; padding:4px 0; }
+
+  .mdtable { margin:4px 0; border-radius:10px; overflow:hidden; border:1px solid var(--b1); background:rgba(255,255,255,.02); }
+  .mdtable table { width:100%; border-collapse:collapse; }
+  .mdtable th { padding:10px 14px; font-size:13px; font-weight:600; color:var(--t1); text-align:left; border-bottom:2px solid rgba(255,255,255,.10); }
+  .mdtable th:not(:first-child), .mdtable td:not(:first-child) { text-align:right; }
+  .mdtable td { padding:9px 14px; font-size:14px; color:var(--t2); border-bottom:1px solid rgba(255,255,255,.06); }
+  .mdtable tr.total td { font-weight:600; color:var(--t1); background:rgba(255,255,255,.04); border-bottom:0; }
+
+  .composer { border-top:1px solid var(--b1); background:var(--s1); padding:14px 20px; opacity:.6; }
+  .comp-row { display:flex; align-items:flex-end; gap:8px; background:var(--s3); border:1px solid var(--b2); border-radius:12px; padding:10px 10px 10px 16px; }
+  .comp-input { flex:1; background:transparent; border:none; outline:none; font-size:13px; color:var(--t1); line-height:1.5; min-height:20px; padding:2px 0; }
+  .comp-input.placeholder { color:var(--t4); }
+  .comp-btns { display:flex; gap:5px; flex-shrink:0; }
+  .icon-btn { width:32px; height:32px; border-radius:99px; display:flex; align-items:center; justify-content:center; cursor:pointer; border:1px solid var(--b1); background:transparent; color:var(--t2); }
+  .icon-btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .icon-btn:disabled { opacity:.4; cursor:not-allowed; }
+  .comp-foot { display:flex; justify-content:space-between; align-items:center; margin-top:6px; font-size:11px; color:var(--t3); }
+  .multi-check { display:inline-flex; align-items:center; gap:5px; cursor:pointer; }
+</style>
+</head>
+<body>
+<span class="frame-label">CHAT · CALCULANDO · DESKTOP · 1440×900 · /quote/pr-0248</span>
+<div class="frame">
+  <aside class="sidebar">
+    <div class="side-logo"><div class="side-logo-badge">D</div><span class="side-logo-text">D'Angelo</span></div>
+    <div class="side-label">Principal</div>
+    <button class="side-item active">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Presupuestos<span class="count">3</span>
+    </button>
+    <div class="side-label mt">Sistema</div>
+    <button class="side-item"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/></svg>Catálogo</button>
+    <button class="side-item"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><line x1="4" y1="21" x2="4" y2="14"/></svg>Configuración</button>
+    <div class="side-divider"></div>
+    <div class="side-spacer"></div>
+    <button class="side-new"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>Nuevo presupuesto</button>
+    <button class="side-logout">Cerrar sesión</button>
+  </aside>
+
+  <main class="main">
+    <header class="qh-header">
+      <button class="qh-back">←</button>
+      <div class="qh-title-wrap">
+        <div class="qh-title">Erica Bernardi — Casa Bernardi <span class="qh-status draft"><span class="dot"></span>borrador</span></div>
+        <div class="qh-sub">#PR-0248 · hace 4 min</div>
+      </div>
+    </header>
+
+    <div class="tabs">
+      <button class="tab active">Chat</button>
+      <button class="tab locked">Detalle</button>
+    </div>
+
+    <div class="chat-scroll">
+      <div class="msg user"><div class="avatar u">EB</div><div class="bubble user">Brief + plano…</div></div>
+      <div class="msg"><div class="avatar v">V</div><div class="vwrap"><div class="blk text" style="padding:10px 18px; font-size:13px;">Contexto confirmado.</div></div></div>
+      <div class="msg"><div class="avatar v">V</div><div class="vwrap"><div class="blk text" style="padding:10px 18px; font-size:13px;">Despiece confirmado — 5.81 m².</div></div></div>
+
+      <div class="verified-ind">✅ Medidas verificadas</div>
+
+      <div class="msg">
+        <div class="avatar v">V</div>
+        <div class="vwrap">
+          <div class="blk thinking">
+            <div class="think-line"><span class="think-dot"></span>Consultando catalog/labor.json…</div>
+            <div class="think-line"><span class="think-dot d2"></span>Calculando MO por operación (corte, pegado, colocación)…</div>
+            <div class="think-line"><span class="think-dot d3"></span>Aplicando IVA (USD floor, ARS round)…</div>
+            <div class="think-line"><span class="think-dot d4"></span>Resolviendo merma y flete…</div>
+          </div>
+          <div class="blk text">
+            <h3>Cálculo en curso…</h3>
+            <div class="mdtable">
+              <table>
+                <thead><tr><th>Ítem</th><th>Cantidad</th><th>Unit</th><th>Total</th><th></th></tr></thead>
+                <tbody>
+                  <tr><td>Puraprima Onix White Mate 3 cm</td><td>5.81 m²</td><td>USD 485</td><td>USD 2.818</td><td>—</td></tr>
+                  <tr><td>Merma sintético 10%</td><td>0.58 m²</td><td>—</td><td>USD 281</td><td>—</td></tr>
+                  <tr><td>Corte y pegado</td><td>4 piezas</td><td>$ 52.800</td><td>$ 211.200</td><td>—</td></tr>
+                  <tr><td>Colocación</td><td>1 viaje</td><td>$ 186.400</td><td>$ 186.400</td><td>—</td></tr>
+                  <tr class="total"><td>TOTAL PARCIAL</td><td>—</td><td>—</td><td>$ 2.153.000</td><td>…</td></tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="composer">
+      <div class="comp-row">
+        <div class="comp-input placeholder">Presupuesto calculándose — esperá un momento</div>
+        <div class="comp-btns">
+          <button class="icon-btn" disabled><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg></button>
+          <button class="icon-btn primary" disabled><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg></button>
+        </div>
+      </div>
+      <div class="comp-foot">
+        <span>Enter para enviar · Shift+Enter para nueva línea</span>
+        <label class="multi-check"><input type="checkbox"/> multi-pieza</label>
+      </div>
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/docs/mockups/16-chat-calculating-mobile.html
+++ b/docs/mockups/16-chat-calculating-mobile.html
@@ -1,0 +1,192 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Chat · calculando · Mobile 390×844</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:14px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:390px; height:844px; border-radius:38px; border:10px solid #0a0a10; background:var(--bg); overflow:hidden; position:relative; display:flex; flex-direction:column; }
+  .frame::after { content:''; position:absolute; inset:0; pointer-events:none; background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E"); }
+
+  .mobile-topbar { display:flex; align-items:center; gap:12px; padding:12px 16px; background:var(--s1); border-bottom:1px solid var(--b1); flex-shrink:0; }
+  .mobile-topbar .burger { background:transparent; border:none; color:var(--t2); padding:2px; display:flex; }
+  .mobile-topbar .dlogo { width:22px; height:22px; border-radius:6px; background:var(--acc); display:flex; align-items:center; justify-content:center; color:#fff; font-size:10px; font-weight:600; }
+  .mobile-topbar .brand { font-size:13px; font-weight:500; color:var(--t1); }
+
+  .qh-header { padding:12px 16px; border-bottom:1px solid var(--b1); background:var(--s1); flex-shrink:0; }
+  .qh-row { display:flex; align-items:center; gap:10px; }
+  .qh-back { width:30px; height:30px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; flex-shrink:0; }
+  .qh-title-wrap { flex:1; min-width:0; }
+  .qh-title { font-size:14px; font-weight:600; color:var(--t1); max-width:200px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; letter-spacing:-.01em; }
+  .qh-sub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .qh-status { display:inline-flex; align-items:center; gap:4px; padding:2px 7px; border-radius:99px; font-size:9px; font-weight:600; text-transform:uppercase; letter-spacing:.05em; flex-shrink:0; }
+  .qh-status.draft { color:var(--amb); background:var(--amb2); }
+  .qh-status .dot { width:4px; height:4px; border-radius:99px; background:currentColor; }
+
+  .tabs { display:flex; padding-left:16px; border-bottom:1px solid var(--b1); background:var(--s1); flex-shrink:0; }
+  .tab { padding:10px 16px; font-size:12px; font-weight:500; color:var(--t3); background:transparent; border:none; border-bottom:2px solid transparent; opacity:.6; }
+  .tab.active { color:var(--acc); border-bottom-color:var(--acc); opacity:1; }
+  .tab.locked { opacity:.35; }
+
+  .chat-scroll { flex:1; overflow-y:auto; padding:20px 16px 16px; display:flex; flex-direction:column; gap:14px; }
+
+  .msg { display:flex; gap:10px; align-items:flex-start; }
+  .avatar { width:28px; height:28px; border-radius:99px; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:10px; font-weight:600; }
+  .avatar.v { background:var(--acc); color:#fff; }
+
+  /* Confirmation pill */
+  .confirmed-pill {
+    align-self:center; display:inline-flex; align-items:center; gap:6px;
+    padding:6px 12px; border-radius:99px;
+    background:var(--grn2); border:1px solid rgba(48,209,88,.30);
+    color:var(--grn); font-size:11px; font-weight:600;
+    text-transform:uppercase; letter-spacing:.06em;
+  }
+  .confirmed-pill .dot { width:5px; height:5px; border-radius:99px; background:var(--grn); }
+
+  .vwrap { flex:1; border:1px solid var(--b2); border-radius:2px 12px 12px 12px; overflow:hidden; }
+  .blk { padding:12px 14px; background:var(--s2); }
+  .blk + .blk { border-top:1px solid var(--b1); }
+  .blk.thinking { display:flex; flex-direction:column; gap:6px; }
+  .think-line { display:flex; align-items:center; gap:7px; font-size:11px; color:var(--t3); font-style:italic; }
+  .think-dot { width:5px; height:5px; border-radius:99px; background:var(--acc); flex-shrink:0; animation:pulse 1.4s ease-in-out infinite; }
+  .think-dot.d2 { animation-delay:.3s; } .think-dot.d3 { animation-delay:.6s; } .think-dot.d4 { animation-delay:.9s; }
+  .think-dot.ok { background:var(--grn); animation:none; }
+  @keyframes pulse { 0%,100% { opacity:.35; } 50% { opacity:1; } }
+
+  /* Partial table — horizontal scroll */
+  .table-wrap { overflow-x:auto; margin:8px -14px -12px; padding:0 14px 12px; }
+  .partial-table { width:100%; min-width:440px; border-collapse:collapse; font-size:12px; }
+  .partial-table thead th {
+    text-align:left; font-size:9px; font-weight:600; color:var(--t3);
+    text-transform:uppercase; letter-spacing:.08em;
+    padding:8px 10px; border-bottom:1px solid var(--b1);
+  }
+  .partial-table thead th.r { text-align:right; }
+  .partial-table tbody td {
+    padding:8px 10px; border-bottom:1px solid rgba(255,255,255,.04);
+    font-family:var(--font-mono); color:var(--t2);
+  }
+  .partial-table tbody td.r { text-align:right; }
+  .partial-table tbody td.label { font-family:var(--font-sans); color:var(--t1); }
+  .partial-table tr.total td {
+    font-weight:600; color:var(--t1); background:rgba(255,255,255,.04); border-bottom:0;
+  }
+  .table-scroll-hint {
+    font-size:10px; color:var(--t3); font-style:italic; text-align:right;
+    padding-top:6px; padding-right:4px;
+  }
+
+  .composer { border-top:1px solid var(--b1); background:var(--s1); padding:12px 16px; flex-shrink:0; }
+  .comp-row { display:flex; align-items:center; gap:8px; background:var(--s3); border:1px solid var(--b2); border-radius:12px; padding:8px 10px 8px 12px; }
+  .comp-input { flex:1; background:transparent; border:none; outline:none; font-size:13px; color:var(--t4); }
+  .comp-btns { display:flex; gap:5px; flex-shrink:0; }
+  .icon-btn { width:28px; height:28px; border-radius:99px; display:flex; align-items:center; justify-content:center; border:1px solid var(--b1); background:transparent; color:var(--t2); }
+  .icon-btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .comp-hint { font-size:10px; color:var(--t3); margin-top:5px; text-align:right; }
+</style>
+</head>
+<body>
+<span class="frame-label">CHAT · CALCULANDO · MOBILE · 390×844 · /quote/pr-0248</span>
+<div class="frame">
+
+  <div class="mobile-topbar">
+    <button class="burger">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <div class="dlogo">D</div>
+    <span class="brand">D'Angelo</span>
+  </div>
+
+  <header class="qh-header">
+    <div class="qh-row">
+      <button class="qh-back">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><polyline points="15 18 9 12 15 6"/></svg>
+      </button>
+      <div class="qh-title-wrap">
+        <div class="qh-title">Erica Bernardi — Casa Bernardi</div>
+        <div class="qh-sub">#PR-0248 · hace 5 min</div>
+      </div>
+      <span class="qh-status draft"><span class="dot"></span>Borrador</span>
+    </div>
+  </header>
+
+  <div class="tabs">
+    <button class="tab active">Chat</button>
+    <button class="tab locked">Detalle</button>
+  </div>
+
+  <div class="chat-scroll">
+
+    <span class="confirmed-pill"><span class="dot"></span>Dual read confirmado · 5.76 m²</span>
+
+    <div class="msg">
+      <div class="avatar v">V</div>
+      <div class="vwrap">
+        <div class="blk thinking">
+          <div class="think-line"><span class="think-dot ok"></span>Medidas fijadas (5.76 m²)</div>
+          <div class="think-line"><span class="think-dot"></span>Aplicando merma 5% (Puraprima sintético)…</div>
+          <div class="think-line"><span class="think-dot d2"></span>Calculando mano de obra…</div>
+          <div class="think-line"><span class="think-dot d3"></span>Sumando pileta, anafes, flete…</div>
+          <div class="think-line"><span class="think-dot d4"></span>Aplicando IVA 21%…</div>
+        </div>
+
+        <div class="blk">
+          <div class="table-wrap">
+            <table class="partial-table">
+              <thead>
+                <tr>
+                  <th>Concepto</th>
+                  <th class="r">m² / un</th>
+                  <th class="r">USD</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td class="label">Mesada Puraprima</td><td class="r">6.05</td><td class="r">1.210</td></tr>
+                <tr><td class="label">Zócalos (3)</td><td class="r">0.48</td><td class="r">96</td></tr>
+                <tr><td class="label">Pileta doble</td><td class="r">1</td><td class="r">180</td></tr>
+                <tr><td class="label">PEGADOPILETA</td><td class="r">1</td><td class="r">40</td></tr>
+                <tr><td class="label">Anafes (2)</td><td class="r">2</td><td class="r">160</td></tr>
+                <tr class="total"><td class="label">Parcial (sin IVA)</td><td class="r">—</td><td class="r">1.686</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="table-scroll-hint">← desliza →</div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="composer">
+    <div class="comp-row">
+      <span class="comp-input">Enunciado o adjuntar plano…</span>
+      <div class="comp-btns">
+        <button class="icon-btn">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg>
+        </button>
+        <button class="icon-btn primary">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+        </button>
+      </div>
+    </div>
+    <div class="comp-hint">Enter para enviar</div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/17-chat-final-with-pdfs-desktop.html
+++ b/docs/mockups/17-chat-final-with-pdfs-desktop.html
@@ -1,0 +1,247 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Chat · final PDF/Excel/Drive · Desktop 1440×900</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:1440px; height:900px; background:var(--bg); overflow:hidden; position:relative; border:1px solid rgba(255,255,255,.06); border-radius:6px; display:flex; }
+  .sidebar { width:212px; flex-shrink:0; background:var(--s1); border-right:1px solid var(--b1); display:flex; flex-direction:column; padding:18px 10px 20px; }
+  .side-logo { display:flex; align-items:center; gap:10px; padding:2px 8px 20px; }
+  .side-logo-badge { width:26px; height:26px; border-radius:6px; background:var(--acc); color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
+  .side-logo-text { font-size:13px; font-weight:500; letter-spacing:-.02em; }
+  .side-label { font-size:10px; font-weight:500; color:var(--t4); text-transform:uppercase; letter-spacing:.1em; padding:0 8px 4px; }
+  .side-label.mt { margin-top:14px; }
+  .side-item { display:flex; align-items:center; gap:8px; padding:8px; border-radius:6px; font-size:12px; color:var(--t2); border:none; background:transparent; width:100%; text-align:left; cursor:pointer; }
+  .side-item.active { color:var(--acc); background:rgba(79,143,255,.11); }
+  .side-item svg { flex-shrink:0; opacity:.65; }
+  .side-item.active svg { opacity:1; }
+  .side-item .count { margin-left:auto; font-size:10px; font-weight:500; padding:1px 7px; border-radius:99px; background:rgba(255,255,255,.07); color:var(--t3); font-family:var(--font-mono); }
+  .side-item.active .count { background:var(--acc); color:#fff; font-weight:600; }
+  .side-divider { height:1px; background:var(--b1); margin:12px 0; }
+  .side-spacer { flex:1; }
+  .side-new { width:100%; padding:10px 12px; background:var(--acc); color:#fff; font-size:13px; font-weight:500; border:none; border-radius:8px; display:flex; align-items:center; justify-content:center; gap:7px; }
+  .side-logout { width:100%; padding:7px 8px; background:transparent; border:none; color:var(--t3); font-size:11px; display:flex; align-items:center; justify-content:center; gap:6px; margin-top:10px; }
+  .main { flex:1; display:flex; flex-direction:column; min-width:0; }
+
+  .qh-header { padding:14px 28px; border-bottom:1px solid var(--b1); background:var(--s1); display:flex; align-items:center; gap:14px; }
+  .qh-back { width:30px; height:30px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; cursor:pointer; }
+  .qh-title-wrap { min-width:0; flex:1; }
+  .qh-title { font-size:15px; font-weight:600; color:var(--t1); display:flex; align-items:center; gap:10px; }
+  .qh-status { display:inline-flex; align-items:center; gap:5px; padding:2px 8px; border-radius:99px; font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.06em; }
+  .qh-status.valid { color:var(--grn); background:var(--grn2); }
+  .qh-status .dot { width:5px; height:5px; border-radius:99px; background:currentColor; }
+  .qh-sub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .qh-actions { display:flex; gap:8px; align-items:center; }
+  .qh-pill { display:inline-flex; align-items:center; gap:6px; padding:6px 12px; border-radius:6px; font-size:12px; font-weight:500; border:1px solid; text-decoration:none; }
+  .qh-pill.pdf { color:var(--acc); border-color:rgba(79,143,255,.20); background:transparent; }
+  .qh-pill.xls { color:#34d399; border-color:rgba(52,211,153,.20); background:transparent; }
+
+  .tabs { display:flex; padding-left:28px; border-bottom:1px solid var(--b1); background:var(--s1); }
+  .tab { padding:10px 20px; font-size:13px; font-weight:500; color:var(--t3); background:transparent; border:none; cursor:pointer; border-bottom:2px solid transparent; opacity:.6; }
+  .tab.active { color:var(--acc); border-bottom-color:var(--acc); opacity:1; }
+
+  .chat-scroll { flex:1; overflow-y:auto; padding:24px 28px 16px; display:flex; flex-direction:column; gap:14px; background:var(--bg); }
+  .msg { display:flex; gap:12px; align-items:flex-start; }
+  .msg.user { flex-direction:row-reverse; }
+  .avatar { width:30px; height:30px; border-radius:99px; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:11px; font-weight:600; }
+  .avatar.v { background:var(--acc); color:#fff; }
+  .avatar.u { background:var(--s3); color:var(--t2); border:1px solid var(--b2); }
+  .bubble.user { max-width:52%; padding:8px 14px; background:var(--acc2); border:1px solid rgba(79,143,255,.25); border-radius:12px 2px 12px 12px; font-size:13px; line-height:1.55; color:rgba(255,255,255,.55); }
+  .vwrap { flex:1; border:1px solid var(--b2); border-radius:2px 12px 12px 12px; overflow:hidden; }
+  .blk { padding:14px 18px; background:var(--s2); }
+  .blk + .blk { border-top:1px solid var(--b1); }
+  .blk.text { font-size:15px; line-height:1.7; color:var(--t2); }
+  .blk.text h3 { font-size:15px; font-weight:600; color:var(--t1); border-bottom:1px solid var(--b1); padding-bottom:6px; margin-bottom:10px; letter-spacing:-.01em; }
+
+  .verified-ind { text-align:center; font-size:12px; color:var(--grn); font-style:italic; padding:4px 0; }
+
+  .mdtable { margin:6px 0; border-radius:10px; overflow:hidden; border:1px solid var(--b1); background:rgba(255,255,255,.02); }
+  .mdtable table { width:100%; border-collapse:collapse; }
+  .mdtable th { padding:9px 14px; font-size:12px; font-weight:600; color:var(--t1); text-align:left; border-bottom:2px solid rgba(255,255,255,.10); }
+  .mdtable th:not(:first-child), .mdtable td:not(:first-child) { text-align:right; }
+  .mdtable td { padding:8px 14px; font-size:13px; color:var(--t2); border-bottom:1px solid rgba(255,255,255,.06); }
+  .mdtable tr.total td { font-weight:600; color:var(--t1); background:rgba(255,255,255,.06); border-bottom:0; font-size:15px; }
+
+  .action-row { display:flex; gap:8px; margin-left:42px; margin-top:4px; }
+  .act-pill { display:inline-flex; align-items:center; gap:6px; padding:7px 14px; border-radius:8px; font-size:12px; font-weight:500; border:1px solid; background:transparent; cursor:pointer; text-decoration:none; }
+  .act-pill.pdf { color:var(--acc); border-color:rgba(79,143,255,.20); }
+  .act-pill.xls { color:#34d399; border-color:rgba(52,211,153,.20); }
+  .act-pill.drv { color:var(--t2); border-color:var(--b2); }
+
+  /* Small attached cards */
+  .mini-card { margin-left:42px; border:1px solid var(--b1); background:var(--s1); border-radius:12px; overflow:hidden; }
+  .mini-hdr { padding:10px 14px; background:var(--s2); border-bottom:1px solid var(--b1); display:flex; align-items:center; gap:8px; font-size:11px; color:var(--t3); font-weight:600; text-transform:uppercase; letter-spacing:.08em; }
+  .mini-hdr .mini-ts { margin-left:auto; font-family:var(--font-mono); font-size:10px; text-transform:none; letter-spacing:0; color:var(--t4); }
+  .mini-body { padding:12px 14px; font-size:12px; color:var(--t2); line-height:1.55; }
+  .mini-subj { background:var(--s3); border:1px solid var(--b1); border-radius:6px; padding:8px 10px; font-size:12px; color:var(--t1); margin-bottom:8px; font-family:var(--font-mono); }
+  .mini-pre { background:rgba(255,255,255,.03); border:1px solid var(--b1); border-radius:6px; padding:8px 10px; font-size:12px; color:var(--t2); font-family:var(--font-mono); white-space:pre-line; line-height:1.6; }
+  .mini-actions { padding:8px 14px; border-top:1px solid var(--b1); display:flex; gap:6px; }
+  .mini-btn { font-size:11px; padding:4px 10px; border-radius:5px; border:1px solid var(--b1); background:transparent; color:var(--t2); cursor:pointer; }
+  .mini-pill { display:inline-flex; align-items:center; gap:5px; padding:4px 10px; border-radius:5px; font-size:11px; border:1px solid rgba(79,143,255,.20); color:var(--acc); background:transparent; margin-top:6px; }
+
+  .composer { border-top:1px solid var(--b1); background:var(--s1); padding:14px 20px; opacity:.5; pointer-events:none; }
+  .comp-row { display:flex; align-items:flex-end; gap:8px; background:var(--s3); border:1px solid var(--b2); border-radius:12px; padding:10px 10px 10px 16px; }
+  .comp-input { flex:1; background:transparent; border:none; outline:none; font-size:13px; color:var(--t1); line-height:1.5; min-height:20px; padding:2px 0; }
+  .comp-input.placeholder { color:var(--t4); }
+  .comp-btns { display:flex; gap:5px; flex-shrink:0; }
+  .icon-btn { width:32px; height:32px; border-radius:99px; display:flex; align-items:center; justify-content:center; cursor:pointer; border:1px solid var(--b1); background:transparent; color:var(--t2); }
+  .icon-btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .icon-btn:disabled { opacity:.4; cursor:not-allowed; }
+  .comp-foot { display:flex; justify-content:space-between; align-items:center; margin-top:6px; font-size:11px; color:var(--t3); }
+  .multi-check { display:inline-flex; align-items:center; gap:5px; cursor:pointer; }
+</style>
+</head>
+<body>
+<span class="frame-label">CHAT · FINAL · DESKTOP · 1440×900 · /quote/pr-0248</span>
+<div class="frame">
+  <aside class="sidebar">
+    <div class="side-logo"><div class="side-logo-badge">D</div><span class="side-logo-text">D'Angelo</span></div>
+    <div class="side-label">Principal</div>
+    <button class="side-item active">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Presupuestos<span class="count">3</span>
+    </button>
+    <div class="side-label mt">Sistema</div>
+    <button class="side-item"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/></svg>Catálogo</button>
+    <button class="side-item"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><line x1="4" y1="21" x2="4" y2="14"/></svg>Configuración</button>
+    <div class="side-divider"></div>
+    <div class="side-spacer"></div>
+    <button class="side-new"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>Nuevo presupuesto</button>
+    <button class="side-logout">Cerrar sesión</button>
+  </aside>
+
+  <main class="main">
+    <header class="qh-header">
+      <button class="qh-back">←</button>
+      <div class="qh-title-wrap">
+        <div class="qh-title">Erica Bernardi — Casa Bernardi <span class="qh-status valid"><span class="dot"></span>validado</span></div>
+        <div class="qh-sub">#PR-0248 · hace 5 min</div>
+      </div>
+      <div class="qh-actions">
+        <a class="qh-pill pdf">📄 PDF</a>
+        <a class="qh-pill xls">📊 Excel</a>
+      </div>
+    </header>
+
+    <div class="tabs">
+      <button class="tab active">Chat</button>
+      <button class="tab">Detalle</button>
+    </div>
+
+    <div class="chat-scroll">
+      <div class="msg user"><div class="avatar u">EB</div><div class="bubble user">Brief + plano…</div></div>
+      <div class="msg"><div class="avatar v">V</div><div class="vwrap"><div class="blk text" style="padding:10px 18px; font-size:13px;">Contexto + despiece confirmados.</div></div></div>
+      <div class="verified-ind">✅ Medidas verificadas</div>
+
+      <div class="msg">
+        <div class="avatar v">V</div>
+        <div class="vwrap">
+          <div class="blk text">
+            <h3>Material</h3>
+            <div class="mdtable"><table>
+              <thead><tr><th>Producto</th><th>Valor</th></tr></thead>
+              <tbody>
+                <tr><td>Puraprima Onix White Mate 3 cm</td><td>USD 485/m²</td></tr>
+                <tr><td>Merma 10% (sintético)</td><td>+ 0.58 m²</td></tr>
+                <tr><td>m² facturable</td><td>5.81 m²</td></tr>
+                <tr class="total"><td>Subtotal material</td><td>USD 2.818</td></tr>
+              </tbody>
+            </table></div>
+          </div>
+
+          <div class="blk text">
+            <h3>Mano de obra</h3>
+            <div class="mdtable"><table>
+              <thead><tr><th>Operación</th><th>Cant.</th><th>Unit</th><th>Total</th></tr></thead>
+              <tbody>
+                <tr><td>Corte y pulido</td><td>5.81 m²</td><td>$ 32.400</td><td>$ 188.280</td></tr>
+                <tr><td>Pegado piletas (PEGADOPILETA)</td><td>2</td><td>$ 28.600</td><td>$ 57.200</td></tr>
+                <tr><td>Colocación en obra</td><td>1 viaje</td><td>$ 186.400</td><td>$ 186.400</td></tr>
+                <tr><td>Zócalo trasero (7.20 ml)</td><td>7.20 ml</td><td>$ 5.840</td><td>$ 42.040</td></tr>
+                <tr class="total"><td>Subtotal MO</td><td>—</td><td>—</td><td>$ 473.920</td></tr>
+              </tbody>
+            </table></div>
+          </div>
+
+          <div class="blk text">
+            <h3>Resumen del presupuesto</h3>
+            <div class="mdtable"><table>
+              <thead><tr><th>Concepto</th><th>USD</th><th>ARS</th></tr></thead>
+              <tbody>
+                <tr><td>Subtotal material</td><td>USD 2.818</td><td>$ 3.802.000</td></tr>
+                <tr><td>Subtotal MO</td><td>—</td><td>$ 473.920</td></tr>
+                <tr><td>Descuento arquitecta</td><td>0%</td><td>—</td></tr>
+                <tr><td>Flete Rosario (incluido)</td><td>—</td><td>—</td></tr>
+                <tr class="total"><td>TOTAL</td><td>USD 3.180</td><td>$ 4.284.000</td></tr>
+              </tbody>
+            </table></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="action-row">
+        <a class="act-pill pdf">📄 Ver PDF</a>
+        <a class="act-pill xls">📊 Abrir Excel</a>
+        <a class="act-pill drv">☁ Drive — carpeta Bernardi</a>
+      </div>
+
+      <div class="mini-card">
+        <div class="mini-hdr">📑 Resumen de obra · Generado <span class="mini-ts">hace 1 min</span></div>
+        <div class="mini-body">Notas: Cocina U + isla con pileta doble, 2 anafes (gas+eléctrico), zócalo trasero 7 cm en todos los tramos. Colocación incluida.</div>
+        <div class="mini-actions"><a class="mini-pill">☁ Abrir en Drive</a></div>
+      </div>
+
+      <div class="mini-card">
+        <div class="mini-hdr">✉️ Email al cliente · IA · Generado <span class="mini-ts">hace 45 s</span></div>
+        <div class="mini-body">
+          <div class="mini-subj">Asunto: Presupuesto Casa Bernardi — Puraprima Onix White Mate</div>
+          <div class="mini-pre">Hola Erica,
+Te paso el presupuesto para la cocina en U con isla central. Material: Puraprima Onix White Mate 3 cm, con pileta doble y 2 anafes.
+Total USD 3.180 · $ 4.284.000 — contado, colocación y flete a Rosario incluidos.
+Adjunto PDF con el detalle…</div>
+        </div>
+        <div class="mini-actions">
+          <button class="mini-btn">Copiar</button>
+          <button class="mini-btn">Editar</button>
+        </div>
+      </div>
+
+      <div class="mini-card">
+        <div class="mini-hdr">📋 Condiciones · Generado <span class="mini-ts">hace 30 s</span></div>
+        <div class="mini-body">Demora: 30 días hábiles desde seña confirmada. Forma de pago contado. Cotización válida 15 días.</div>
+        <div class="mini-actions"><a class="mini-pill">📄 Descargar PDF</a></div>
+      </div>
+    </div>
+
+    <div class="composer">
+      <div class="comp-row">
+        <div class="comp-input placeholder">Presupuesto cerrado — regenerá para seguir</div>
+        <div class="comp-btns">
+          <button class="icon-btn" disabled><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg></button>
+          <button class="icon-btn primary" disabled><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg></button>
+        </div>
+      </div>
+      <div class="comp-foot">
+        <span>Enter para enviar · Shift+Enter para nueva línea</span>
+        <label class="multi-check"><input type="checkbox"/> multi-pieza</label>
+      </div>
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/docs/mockups/17-chat-final-with-pdfs-mobile.html
+++ b/docs/mockups/17-chat-final-with-pdfs-mobile.html
@@ -1,0 +1,281 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Chat · final con PDFs · Mobile 390×844</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:14px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:390px; height:844px; border-radius:38px; border:10px solid #0a0a10; background:var(--bg); overflow:hidden; position:relative; display:flex; flex-direction:column; }
+  .frame::after { content:''; position:absolute; inset:0; pointer-events:none; background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E"); }
+
+  .mobile-topbar { display:flex; align-items:center; gap:12px; padding:12px 16px; background:var(--s1); border-bottom:1px solid var(--b1); flex-shrink:0; }
+  .mobile-topbar .burger { background:transparent; border:none; color:var(--t2); padding:2px; display:flex; }
+  .mobile-topbar .dlogo { width:22px; height:22px; border-radius:6px; background:var(--acc); display:flex; align-items:center; justify-content:center; color:#fff; font-size:10px; font-weight:600; }
+  .mobile-topbar .brand { font-size:13px; font-weight:500; color:var(--t1); }
+
+  .qh-header { padding:12px 16px; border-bottom:1px solid var(--b1); background:var(--s1); flex-shrink:0; }
+  .qh-row { display:flex; align-items:center; gap:10px; }
+  .qh-back { width:30px; height:30px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; flex-shrink:0; }
+  .qh-title-wrap { flex:1; min-width:0; }
+  .qh-title { font-size:14px; font-weight:600; color:var(--t1); max-width:200px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; letter-spacing:-.01em; }
+  .qh-sub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .qh-status { display:inline-flex; align-items:center; gap:4px; padding:2px 7px; border-radius:99px; font-size:9px; font-weight:600; text-transform:uppercase; letter-spacing:.05em; flex-shrink:0; }
+  .qh-status.valid { color:var(--grn); background:var(--grn2); }
+  .qh-status .dot { width:4px; height:4px; border-radius:99px; background:currentColor; }
+
+  .qh-pills { display:flex; gap:6px; margin-top:8px; }
+  .qh-pill { display:inline-flex; align-items:center; gap:5px; padding:4px 10px; border-radius:6px; font-size:11px; font-weight:500; border:1px solid; text-decoration:none; }
+  .qh-pill.pdf { color:var(--acc); border-color:rgba(79,143,255,.30); background:rgba(79,143,255,.05); }
+  .qh-pill.xls { color:#34d399; border-color:rgba(52,211,153,.30); background:rgba(52,211,153,.05); }
+
+  .tabs { display:flex; padding-left:16px; border-bottom:1px solid var(--b1); background:var(--s1); flex-shrink:0; }
+  .tab { padding:10px 16px; font-size:12px; font-weight:500; color:var(--t3); background:transparent; border:none; border-bottom:2px solid transparent; opacity:.6; }
+  .tab.active { color:var(--acc); border-bottom-color:var(--acc); opacity:1; }
+  .tab.locked { opacity:.6; color:var(--t2); }
+
+  .chat-scroll { flex:1; overflow-y:auto; padding:20px 16px 16px; display:flex; flex-direction:column; gap:16px; }
+
+  .msg { display:flex; gap:10px; align-items:flex-start; }
+  .avatar { width:28px; height:28px; border-radius:99px; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:10px; font-weight:600; }
+  .avatar.v { background:var(--acc); color:#fff; }
+
+  .vwrap { flex:1; border:1px solid var(--b2); border-radius:2px 12px 12px 12px; overflow:hidden; }
+  .blk { padding:12px 14px; background:var(--s2); }
+  .blk + .blk { border-top:1px solid var(--b1); }
+  .blk.text { font-size:13px; line-height:1.65; color:var(--t2); }
+  .blk.text h3 { font-size:13px; font-weight:600; color:var(--t1); border-bottom:1px solid var(--b1); padding-bottom:5px; margin-bottom:8px; letter-spacing:-.01em; }
+  .blk.text strong { color:var(--t1); font-weight:500; }
+
+  /* MO table — horizontal scroll */
+  .table-wrap { overflow-x:auto; margin:6px -14px; padding:0 14px; }
+  .md-table { width:100%; min-width:420px; border-collapse:collapse; font-size:12px; }
+  .md-table th {
+    text-align:left; font-size:9px; font-weight:600; color:var(--t3);
+    text-transform:uppercase; letter-spacing:.08em;
+    padding:7px 10px; border-bottom:1px solid var(--b1); background:rgba(255,255,255,.02);
+  }
+  .md-table th.r, .md-table td.r { text-align:right; }
+  .md-table td { padding:7px 10px; border-bottom:1px solid rgba(255,255,255,.04); color:var(--t2); font-family:var(--font-mono); }
+  .md-table td.label { font-family:var(--font-sans); color:var(--t1); }
+  .md-table tr.total td { font-weight:600; color:var(--t1); background:rgba(255,255,255,.04); border-bottom:0; }
+
+  /* Resumen total big */
+  .resumen-total { padding:14px 16px; background:linear-gradient(180deg, rgba(48,209,88,.08), rgba(48,209,88,.02)); border:1px solid rgba(48,209,88,.25); border-radius:10px; margin:8px 0; }
+  .resumen-total .rt-label { font-size:9px; font-weight:600; text-transform:uppercase; letter-spacing:.1em; color:var(--grn); margin-bottom:6px; }
+  .resumen-total .rt-ars { font-size:24px; font-weight:700; color:var(--t1); font-family:var(--font-mono); letter-spacing:-.02em; }
+  .resumen-total .rt-usd { font-size:13px; color:var(--t2); font-family:var(--font-mono); margin-top:2px; font-weight:600; }
+  .resumen-total .rt-note { font-size:10px; color:var(--t3); margin-top:6px; font-style:italic; }
+
+  /* Action pills — stacked */
+  .action-pills { display:flex; flex-direction:column; gap:6px; margin-top:10px; }
+  .action-pill {
+    display:flex; align-items:center; gap:8px;
+    padding:10px 12px; border-radius:10px; border:1px solid;
+    font-size:12px; font-weight:500; text-decoration:none;
+  }
+  .action-pill.pdf { color:var(--acc); border-color:rgba(79,143,255,.30); background:rgba(79,143,255,.05); }
+  .action-pill.xls { color:#34d399; border-color:rgba(52,211,153,.30); background:rgba(52,211,153,.05); }
+  .action-pill.drive { color:var(--t2); border-color:var(--b2); background:transparent; }
+  .action-pill .ico { font-size:14px; }
+
+  /* Extra cards */
+  .extra-card { border:1px solid var(--b1); border-radius:10px; background:var(--s1); overflow:hidden; }
+  .extra-hdr { padding:10px 12px; background:var(--s2); border-bottom:1px solid var(--b1); font-size:11px; font-weight:600; color:var(--t1); display:flex; align-items:center; gap:8px; }
+  .extra-hdr .tag { font-size:9px; font-weight:600; text-transform:uppercase; letter-spacing:.08em; padding:2px 6px; border-radius:4px; }
+  .extra-hdr .tag.brief { background:var(--acc2); color:var(--acc); border:1px solid rgba(79,143,255,.30); }
+  .extra-hdr .tag.email { background:rgba(245,166,35,.10); color:var(--amb); border:1px solid rgba(245,166,35,.30); }
+  .extra-hdr .tag.cond { background:rgba(255,255,255,.05); color:var(--t3); border:1px solid var(--b2); }
+  .extra-body { padding:12px; font-size:12px; color:var(--t2); line-height:1.55; }
+  .extra-body .kv { display:flex; justify-content:space-between; padding:3px 0; }
+  .extra-body .kv span:last-child { color:var(--t1); font-family:var(--font-mono); }
+  .email-text { background:var(--s3); padding:10px; border-radius:8px; font-size:11px; color:var(--t2); line-height:1.5; border:1px solid var(--b1); }
+  .cond-list { list-style:none; display:flex; flex-direction:column; gap:4px; }
+  .cond-list li { font-size:11px; color:var(--t2); padding-left:12px; position:relative; }
+  .cond-list li::before { content:'•'; position:absolute; left:0; color:var(--t3); }
+
+  .composer { border-top:1px solid var(--b1); background:var(--s1); padding:12px 16px; flex-shrink:0; }
+  .comp-row { display:flex; align-items:center; gap:8px; background:var(--s3); border:1px solid var(--b2); border-radius:12px; padding:8px 10px 8px 12px; }
+  .comp-input { flex:1; background:transparent; border:none; outline:none; font-size:13px; color:var(--t4); }
+  .comp-btns { display:flex; gap:5px; flex-shrink:0; }
+  .icon-btn { width:28px; height:28px; border-radius:99px; display:flex; align-items:center; justify-content:center; border:1px solid var(--b1); background:transparent; color:var(--t2); }
+  .icon-btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .comp-hint { font-size:10px; color:var(--t3); margin-top:5px; text-align:right; }
+</style>
+</head>
+<body>
+<span class="frame-label">CHAT · FINAL · MOBILE · 390×844 · /quote/pr-0248</span>
+<div class="frame">
+
+  <div class="mobile-topbar">
+    <button class="burger">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <div class="dlogo">D</div>
+    <span class="brand">D'Angelo</span>
+  </div>
+
+  <header class="qh-header">
+    <div class="qh-row">
+      <button class="qh-back">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><polyline points="15 18 9 12 15 6"/></svg>
+      </button>
+      <div class="qh-title-wrap">
+        <div class="qh-title">Erica Bernardi — Casa Bernardi</div>
+        <div class="qh-sub">#PR-0248 · hace 9 min</div>
+      </div>
+      <span class="qh-status valid"><span class="dot"></span>Validado</span>
+    </div>
+    <div class="qh-pills">
+      <a class="qh-pill pdf">📄 PDF</a>
+      <a class="qh-pill xls">📊 Excel</a>
+      <a class="qh-pill pdf">☁ Drive</a>
+    </div>
+  </header>
+
+  <div class="tabs">
+    <button class="tab active">Chat</button>
+    <button class="tab locked">Detalle</button>
+  </div>
+
+  <div class="chat-scroll">
+
+    <div class="msg">
+      <div class="avatar v">V</div>
+      <div class="vwrap">
+
+        <!-- Material summary block -->
+        <div class="blk text">
+          <h3>Resumen material</h3>
+          <p><strong>Puraprima Onix White Mate · 3 cm</strong></p>
+          <p>Mesada U + isla · 4 tramos · 5.76 m² + merma 5% = <strong>6.05 m²</strong> a cortar</p>
+          <p style="margin-top:4px">Pileta doble empotrada · PEGADOPILETA · 2 anafes · zóc. trasero 7 cm · colocación incluida</p>
+        </div>
+
+        <!-- MO table -->
+        <div class="blk text">
+          <h3>Mano de obra + accesorios</h3>
+          <div class="table-wrap">
+            <table class="md-table">
+              <thead>
+                <tr><th>Concepto</th><th class="r">Cant.</th><th class="r">USD</th></tr>
+              </thead>
+              <tbody>
+                <tr><td class="label">Mesada Puraprima</td><td class="r">6.05 m²</td><td class="r">1.210</td></tr>
+                <tr><td class="label">Zócalos (3)</td><td class="r">0.48 m²</td><td class="r">96</td></tr>
+                <tr><td class="label">Pileta doble</td><td class="r">1</td><td class="r">180</td></tr>
+                <tr><td class="label">PEGADOPILETA</td><td class="r">1</td><td class="r">40</td></tr>
+                <tr><td class="label">Anafes (2)</td><td class="r">2</td><td class="r">160</td></tr>
+                <tr><td class="label">Colocación</td><td class="r">1</td><td class="r">420</td></tr>
+                <tr><td class="label">Flete Rosario</td><td class="r">1</td><td class="r">120</td></tr>
+                <tr class="total"><td class="label">Subtotal</td><td class="r">—</td><td class="r">2.226</td></tr>
+                <tr class="total"><td class="label">IVA 21% + redondeo</td><td class="r">—</td><td class="r">954</td></tr>
+                <tr class="total"><td class="label">TOTAL</td><td class="r">—</td><td class="r">3.180</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- Resumen total -->
+        <div class="blk">
+          <div class="resumen-total">
+            <div class="rt-label">✓ Total presupuesto</div>
+            <div class="rt-ars">$ 4.284.000</div>
+            <div class="rt-usd">USD 3.180</div>
+            <div class="rt-note">Forma de pago: Contado</div>
+          </div>
+
+          <div class="action-pills">
+            <a class="action-pill pdf"><span class="ico">📄</span>Ver PDF del presupuesto</a>
+            <a class="action-pill xls"><span class="ico">📊</span>Descargar Excel</a>
+            <a class="action-pill drive"><span class="ico">☁</span>Abrir en Drive</a>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- Resumen de obra card -->
+    <div class="msg">
+      <div class="avatar v">V</div>
+      <div style="flex:1; display:flex; flex-direction:column; gap:10px;">
+
+        <div class="extra-card">
+          <div class="extra-hdr">
+            <span class="tag brief">📋 Resumen de obra</span>
+          </div>
+          <div class="extra-body">
+            <div class="kv"><span>Cliente</span><span>E. Bernardi</span></div>
+            <div class="kv"><span>Zona</span><span>Rosario</span></div>
+            <div class="kv"><span>Material</span><span>Puraprima</span></div>
+            <div class="kv"><span>Sectores</span><span>U + isla</span></div>
+            <div class="kv"><span>m² a cortar</span><span>6.05</span></div>
+            <div class="kv"><span>Piezas</span><span>4 + 3 zóc.</span></div>
+          </div>
+        </div>
+
+        <div class="extra-card">
+          <div class="extra-hdr">
+            <span class="tag email">✉ Borrador de email</span>
+          </div>
+          <div class="extra-body">
+            <div class="email-text">
+              Hola Erica,<br>
+              Te paso el presupuesto para la cocina U + isla en Puraprima Onix White Mate. Total <strong>$ 4.284.000</strong> (USD 3.180) contado, con colocación incluida.<br><br>
+              Entrega estimada: 14 días hábiles desde la seña.<br>
+              Abrazo — D'Angelo Marmolería.
+            </div>
+          </div>
+        </div>
+
+        <div class="extra-card">
+          <div class="extra-hdr">
+            <span class="tag cond">⚙ Condiciones</span>
+          </div>
+          <div class="extra-body">
+            <ul class="cond-list">
+              <li>Validez: 7 días</li>
+              <li>Forma de pago: Contado</li>
+              <li>Seña: 50% al aceptar</li>
+              <li>Saldo: contra entrega</li>
+              <li>Entrega: 14 días hábiles</li>
+            </ul>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+  </div>
+
+  <div class="composer">
+    <div class="comp-row">
+      <span class="comp-input">Enunciado o adjuntar plano…</span>
+      <div class="comp-btns">
+        <button class="icon-btn">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg>
+        </button>
+        <button class="icon-btn primary">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+        </button>
+      </div>
+    </div>
+    <div class="comp-hint">Enter para enviar</div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/18-chat-error-retry-desktop.html
+++ b/docs/mockups/18-chat-error-retry-desktop.html
@@ -1,0 +1,179 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Chat · error retry · Desktop 1440×900</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:1440px; height:900px; background:var(--bg); overflow:hidden; position:relative; border:1px solid rgba(255,255,255,.06); border-radius:6px; display:flex; }
+  .sidebar { width:212px; flex-shrink:0; background:var(--s1); border-right:1px solid var(--b1); display:flex; flex-direction:column; padding:18px 10px 20px; }
+  .side-logo { display:flex; align-items:center; gap:10px; padding:2px 8px 20px; }
+  .side-logo-badge { width:26px; height:26px; border-radius:6px; background:var(--acc); color:#fff; font-weight:600; font-size:12px; display:flex; align-items:center; justify-content:center; }
+  .side-logo-text { font-size:13px; font-weight:500; letter-spacing:-.02em; }
+  .side-label { font-size:10px; font-weight:500; color:var(--t4); text-transform:uppercase; letter-spacing:.1em; padding:0 8px 4px; }
+  .side-label.mt { margin-top:14px; }
+  .side-item { display:flex; align-items:center; gap:8px; padding:8px; border-radius:6px; font-size:12px; color:var(--t2); border:none; background:transparent; width:100%; text-align:left; cursor:pointer; }
+  .side-item.active { color:var(--acc); background:rgba(79,143,255,.11); }
+  .side-item svg { flex-shrink:0; opacity:.65; }
+  .side-item.active svg { opacity:1; }
+  .side-item .count { margin-left:auto; font-size:10px; font-weight:500; padding:1px 7px; border-radius:99px; background:rgba(255,255,255,.07); color:var(--t3); font-family:var(--font-mono); }
+  .side-item.active .count { background:var(--acc); color:#fff; font-weight:600; }
+  .side-divider { height:1px; background:var(--b1); margin:12px 0; }
+  .side-spacer { flex:1; }
+  .side-new { width:100%; padding:10px 12px; background:var(--acc); color:#fff; font-size:13px; font-weight:500; border:none; border-radius:8px; display:flex; align-items:center; justify-content:center; gap:7px; }
+  .side-logout { width:100%; padding:7px 8px; background:transparent; border:none; color:var(--t3); font-size:11px; display:flex; align-items:center; justify-content:center; gap:6px; margin-top:10px; }
+  .main { flex:1; display:flex; flex-direction:column; min-width:0; }
+
+  .qh-header { padding:14px 28px; border-bottom:1px solid var(--b1); background:var(--s1); display:flex; align-items:center; gap:14px; }
+  .qh-back { width:30px; height:30px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; cursor:pointer; }
+  .qh-title-wrap { min-width:0; flex:1; }
+  .qh-title { font-size:15px; font-weight:600; color:var(--t1); display:flex; align-items:center; gap:10px; }
+  .qh-status { display:inline-flex; align-items:center; gap:5px; padding:2px 8px; border-radius:99px; font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.06em; }
+  .qh-status.draft { color:var(--amb); background:var(--amb2); }
+  .qh-status .dot { width:5px; height:5px; border-radius:99px; background:currentColor; }
+  .qh-sub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .tabs { display:flex; padding-left:28px; border-bottom:1px solid var(--b1); background:var(--s1); }
+  .tab { padding:10px 20px; font-size:13px; font-weight:500; color:var(--t3); background:transparent; border:none; cursor:pointer; border-bottom:2px solid transparent; opacity:.6; }
+  .tab.active { color:var(--acc); border-bottom-color:var(--acc); opacity:1; }
+  .tab.locked { opacity:.35; cursor:not-allowed; }
+
+  .chat-scroll { flex:1; overflow-y:auto; padding:28px 28px 16px; display:flex; flex-direction:column; gap:20px; background:var(--bg); }
+  .msg { display:flex; gap:12px; align-items:flex-start; }
+  .msg.user { flex-direction:row-reverse; }
+  .avatar { width:30px; height:30px; border-radius:99px; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:11px; font-weight:600; }
+  .avatar.v { background:var(--acc); color:#fff; }
+  .avatar.u { background:var(--s3); color:var(--t2); border:1px solid var(--b2); }
+  .bubble.user { max-width:52%; padding:12px 16px; background:var(--acc2); border:1px solid rgba(79,143,255,.25); border-radius:12px 2px 12px 12px; font-size:15px; line-height:1.65; color:rgba(255,255,255,.78); }
+  .attach-badge { display:inline-flex; align-items:center; gap:5px; padding:4px 8px; border-radius:5px; background:rgba(255,255,255,.08); border:1px solid var(--b1); font-size:11px; color:var(--t2); margin-bottom:7px; }
+  .vwrap { flex:1; border:1px solid var(--b2); border-radius:2px 12px 12px 12px; overflow:hidden; }
+  .blk { padding:14px 18px; background:var(--s2); }
+  .blk + .blk { border-top:1px solid var(--b1); }
+  .blk.thinking { padding:12px 18px; display:flex; flex-direction:column; gap:6px; }
+  .think-line { display:flex; align-items:center; gap:7px; font-size:11px; color:var(--t3); font-style:italic; }
+  .think-dot { width:5px; height:5px; border-radius:99px; background:var(--acc); flex-shrink:0; opacity:.6; }
+  .think-line.err { color:var(--red); font-style:normal; }
+  .think-line.err .think-dot { background:var(--red); opacity:1; }
+
+  .err-card { margin-left:42px; padding:14px 16px; background:rgba(255,69,58,.08); border:1px solid rgba(255,69,58,.30); border-radius:10px; display:flex; align-items:flex-start; gap:12px; }
+  .err-ico { width:24px; height:24px; border-radius:99px; background:rgba(255,69,58,.20); color:var(--red); display:flex; align-items:center; justify-content:center; font-size:14px; flex-shrink:0; }
+  .err-txt { flex:1; font-size:13px; color:var(--t1); line-height:1.55; }
+  .err-actions { display:flex; gap:8px; margin-top:10px; }
+  .btn-primary { padding:8px 14px; border-radius:8px; background:var(--acc); color:#fff; font-size:13px; font-weight:500; border:none; cursor:pointer; }
+  .btn-ghost { padding:8px 14px; border-radius:8px; background:transparent; border:1px solid var(--b1); color:var(--t2); font-size:13px; cursor:pointer; }
+
+  .composer { border-top:1px solid var(--b1); background:var(--s1); padding:14px 20px; }
+  .comp-row { display:flex; align-items:flex-end; gap:8px; background:var(--s3); border:1px solid var(--b2); border-radius:12px; padding:10px 10px 10px 16px; }
+  .comp-input { flex:1; background:transparent; border:none; outline:none; font-size:13px; color:var(--t1); line-height:1.5; min-height:20px; padding:2px 0; }
+  .comp-input.placeholder { color:var(--t4); }
+  .comp-btns { display:flex; gap:5px; flex-shrink:0; }
+  .icon-btn { width:32px; height:32px; border-radius:99px; display:flex; align-items:center; justify-content:center; cursor:pointer; border:1px solid var(--b1); background:transparent; color:var(--t2); }
+  .icon-btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .icon-btn:disabled { opacity:.4; cursor:not-allowed; }
+  .comp-foot { display:flex; justify-content:space-between; align-items:center; margin-top:6px; font-size:11px; color:var(--t3); }
+  .comp-hint { color:var(--t3); font-size:11px; font-style:italic; }
+  .multi-check { display:inline-flex; align-items:center; gap:5px; cursor:pointer; }
+</style>
+</head>
+<body>
+<span class="frame-label">CHAT · ERROR / RETRY · DESKTOP · 1440×900 · /quote/pr-0248</span>
+<div class="frame">
+  <aside class="sidebar">
+    <div class="side-logo"><div class="side-logo-badge">D</div><span class="side-logo-text">D'Angelo</span></div>
+    <div class="side-label">Principal</div>
+    <button class="side-item active">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Presupuestos<span class="count">3</span>
+    </button>
+    <div class="side-label mt">Sistema</div>
+    <button class="side-item"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/></svg>Catálogo</button>
+    <button class="side-item"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><line x1="4" y1="21" x2="4" y2="14"/></svg>Configuración</button>
+    <div class="side-divider"></div>
+    <div class="side-spacer"></div>
+    <button class="side-new"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>Nuevo presupuesto</button>
+    <button class="side-logout">Cerrar sesión</button>
+  </aside>
+
+  <main class="main">
+    <header class="qh-header">
+      <button class="qh-back">←</button>
+      <div class="qh-title-wrap">
+        <div class="qh-title">Erica Bernardi — Casa Bernardi <span class="qh-status draft"><span class="dot"></span>borrador</span></div>
+        <div class="qh-sub">#PR-0248 · hace 2 min</div>
+      </div>
+    </header>
+
+    <div class="tabs">
+      <button class="tab active">Chat</button>
+      <button class="tab locked">Detalle</button>
+    </div>
+
+    <div class="chat-scroll">
+      <div class="msg user">
+        <div class="avatar u">EB</div>
+        <div class="bubble user">
+          Cocina Bernardi — Puraprima Onix White Mate, cocina U + isla, pileta doble, 2 anafes.
+        </div>
+      </div>
+      <div class="msg user">
+        <div class="avatar u">EB</div>
+        <div class="bubble user">
+          <div class="attach-badge">📎 plano-cocina-U-bernardi.pdf · 2.3 MB · 3 páginas</div>
+          Acá va, gracias.
+        </div>
+      </div>
+
+      <div class="msg">
+        <div class="avatar v">V</div>
+        <div class="vwrap">
+          <div class="blk thinking">
+            <div class="think-line"><span class="think-dot"></span>Rasterizando PDF a 300 DPI…</div>
+            <div class="think-line"><span class="think-dot"></span>Extrayendo capa de texto con cotas…</div>
+            <div class="think-line"><span class="think-dot"></span>Identificando topología global (LLM)…</div>
+            <div class="think-line err"><span class="think-dot"></span>❌ Error al rasterizar página 2: timeout (10 s)</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="err-card">
+        <div class="err-ico">⚠</div>
+        <div class="err-txt">
+          No pude leer el plano. Esto suele ser transitorio — reintentar suele arreglarlo. Si persiste, subí otra versión del PDF.
+          <div class="err-actions">
+            <button class="btn-primary">↻ Reintentar dual read</button>
+            <button class="btn-ghost">Subir otro plano</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="composer">
+      <div class="comp-row">
+        <div class="comp-input placeholder">Reintentá o mandame otro plano</div>
+        <div class="comp-btns">
+          <button class="icon-btn"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg></button>
+          <button class="icon-btn primary"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg></button>
+        </div>
+      </div>
+      <div class="comp-foot">
+        <span class="comp-hint">Reintentá o mandame otro plano</span>
+        <label class="multi-check"><input type="checkbox"/> multi-pieza</label>
+      </div>
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/docs/mockups/18-chat-error-retry-mobile.html
+++ b/docs/mockups/18-chat-error-retry-mobile.html
@@ -1,0 +1,196 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Chat · error / retry · Mobile 390×844</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --grn2:rgba(48,209,88,.11);
+    --amb:#f5a623; --amb2:rgba(245,166,35,.10);
+    --red:#ff453a; --red2:rgba(255,69,58,.08);
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:14px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .frame { width:390px; height:844px; border-radius:38px; border:10px solid #0a0a10; background:var(--bg); overflow:hidden; position:relative; display:flex; flex-direction:column; }
+  .frame::after { content:''; position:absolute; inset:0; pointer-events:none; background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E"); }
+
+  .mobile-topbar { display:flex; align-items:center; gap:12px; padding:12px 16px; background:var(--s1); border-bottom:1px solid var(--b1); flex-shrink:0; }
+  .mobile-topbar .burger { background:transparent; border:none; color:var(--t2); padding:2px; display:flex; }
+  .mobile-topbar .dlogo { width:22px; height:22px; border-radius:6px; background:var(--acc); display:flex; align-items:center; justify-content:center; color:#fff; font-size:10px; font-weight:600; }
+  .mobile-topbar .brand { font-size:13px; font-weight:500; color:var(--t1); }
+
+  .qh-header { padding:12px 16px; border-bottom:1px solid var(--b1); background:var(--s1); flex-shrink:0; }
+  .qh-row { display:flex; align-items:center; gap:10px; }
+  .qh-back { width:30px; height:30px; border-radius:6px; border:1px solid var(--b1); background:transparent; color:var(--t2); display:flex; align-items:center; justify-content:center; flex-shrink:0; }
+  .qh-title-wrap { flex:1; min-width:0; }
+  .qh-title { font-size:14px; font-weight:600; color:var(--t1); max-width:200px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; letter-spacing:-.01em; }
+  .qh-sub { font-size:11px; color:var(--t3); margin-top:2px; font-family:var(--font-mono); }
+  .qh-status { display:inline-flex; align-items:center; gap:4px; padding:2px 7px; border-radius:99px; font-size:9px; font-weight:600; text-transform:uppercase; letter-spacing:.05em; flex-shrink:0; }
+  .qh-status.draft { color:var(--amb); background:var(--amb2); }
+  .qh-status .dot { width:4px; height:4px; border-radius:99px; background:currentColor; }
+
+  .tabs { display:flex; padding-left:16px; border-bottom:1px solid var(--b1); background:var(--s1); flex-shrink:0; }
+  .tab { padding:10px 16px; font-size:12px; font-weight:500; color:var(--t3); background:transparent; border:none; border-bottom:2px solid transparent; opacity:.6; }
+  .tab.active { color:var(--acc); border-bottom-color:var(--acc); opacity:1; }
+  .tab.locked { opacity:.35; }
+
+  .chat-scroll { flex:1; overflow-y:auto; padding:20px 16px 16px; display:flex; flex-direction:column; gap:16px; }
+
+  .msg { display:flex; gap:10px; align-items:flex-start; }
+  .avatar { width:28px; height:28px; border-radius:99px; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:10px; font-weight:600; }
+  .avatar.v { background:var(--acc); color:#fff; }
+
+  .vwrap { flex:1; border:1px solid var(--b2); border-radius:2px 12px 12px 12px; overflow:hidden; }
+  .blk { padding:12px 14px; background:var(--s2); }
+  .blk + .blk { border-top:1px solid var(--b1); }
+  .blk.thinking { display:flex; flex-direction:column; gap:6px; }
+  .think-line { display:flex; align-items:center; gap:7px; font-size:11px; color:var(--t3); font-style:italic; }
+  .think-line.err { color:var(--red); font-style:normal; }
+  .think-dot { width:5px; height:5px; border-radius:99px; background:var(--acc); flex-shrink:0; animation:pulse 1.4s ease-in-out infinite; }
+  .think-dot.d2 { animation-delay:.3s; }
+  .think-dot.ok { background:var(--grn); animation:none; }
+  .think-dot.err { background:var(--red); animation:none; }
+  @keyframes pulse { 0%,100% { opacity:.35; } 50% { opacity:1; } }
+
+  /* Error banner */
+  .err-banner {
+    padding:14px; background:var(--red2); border:1px solid rgba(255,69,58,.30);
+    border-radius:12px; display:flex; flex-direction:column; gap:8px;
+  }
+  .err-head { display:flex; align-items:center; gap:8px; }
+  .err-icon {
+    width:32px; height:32px; border-radius:8px; background:rgba(255,69,58,.20);
+    color:var(--red); display:flex; align-items:center; justify-content:center;
+    font-size:16px; flex-shrink:0;
+  }
+  .err-title { font-size:13px; font-weight:600; color:var(--red); }
+  .err-body { font-size:12px; color:var(--t2); line-height:1.5; padding-left:40px; }
+  .err-body code {
+    display:block; margin-top:6px; padding:6px 8px;
+    background:rgba(0,0,0,.3); border:1px solid var(--b1); border-radius:6px;
+    font-family:var(--font-mono); font-size:10px; color:var(--t3);
+  }
+
+  .err-actions { display:flex; flex-direction:column; gap:8px; margin-top:4px; }
+  .btn-retry {
+    padding:10px 14px; background:var(--red); color:#fff;
+    font-size:13px; font-weight:600; border:none; border-radius:10px;
+    display:flex; align-items:center; justify-content:center; gap:6px;
+  }
+  .btn-secondary {
+    padding:10px 14px; background:transparent; color:var(--t2);
+    font-size:12px; font-weight:500; border:1px solid var(--b2); border-radius:10px;
+    display:flex; align-items:center; justify-content:center; gap:6px;
+  }
+
+  .composer { border-top:1px solid var(--b1); background:var(--s1); padding:12px 16px; flex-shrink:0; }
+  .comp-row { display:flex; align-items:center; gap:8px; background:var(--s3); border:1px solid var(--b2); border-radius:12px; padding:8px 10px 8px 12px; }
+  .comp-input { flex:1; background:transparent; border:none; outline:none; font-size:13px; color:var(--t4); }
+  .comp-btns { display:flex; gap:5px; flex-shrink:0; }
+  .icon-btn { width:28px; height:28px; border-radius:99px; display:flex; align-items:center; justify-content:center; border:1px solid var(--b1); background:transparent; color:var(--t2); }
+  .icon-btn.primary { background:var(--acc); color:#fff; border-color:var(--acc); }
+  .comp-hint { font-size:10px; color:var(--t3); margin-top:5px; text-align:right; }
+</style>
+</head>
+<body>
+<span class="frame-label">CHAT · ERROR / RETRY · MOBILE · 390×844 · /quote/pr-0248</span>
+<div class="frame">
+
+  <div class="mobile-topbar">
+    <button class="burger">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <div class="dlogo">D</div>
+    <span class="brand">D'Angelo</span>
+  </div>
+
+  <header class="qh-header">
+    <div class="qh-row">
+      <button class="qh-back">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><polyline points="15 18 9 12 15 6"/></svg>
+      </button>
+      <div class="qh-title-wrap">
+        <div class="qh-title">Erica Bernardi — Casa Bernardi</div>
+        <div class="qh-sub">#PR-0248 · hace 2 min</div>
+      </div>
+      <span class="qh-status draft"><span class="dot"></span>Borrador</span>
+    </div>
+  </header>
+
+  <div class="tabs">
+    <button class="tab active">Chat</button>
+    <button class="tab locked">Detalle</button>
+  </div>
+
+  <div class="chat-scroll">
+
+    <!-- Thinking with failure -->
+    <div class="msg">
+      <div class="avatar v">V</div>
+      <div class="vwrap">
+        <div class="blk thinking">
+          <div class="think-line"><span class="think-dot ok"></span>Rasterizando plano a 300 DPI…</div>
+          <div class="think-line"><span class="think-dot ok"></span>Detectando páginas relevantes…</div>
+          <div class="think-line"><span class="think-dot d2"></span>Ejecutando Dual Read (Sonnet + Opus)…</div>
+          <div class="think-line err"><span class="think-dot err"></span>Opus no respondió — timeout a los 90 s</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Error banner -->
+    <div class="msg">
+      <div class="avatar v">V</div>
+      <div style="flex:1; display:flex; flex-direction:column; gap:10px;">
+
+        <div class="err-banner">
+          <div class="err-head">
+            <div class="err-icon">!</div>
+            <div class="err-title">No pude leer el plano</div>
+          </div>
+          <div class="err-body">
+            Opus no respondió a tiempo y Sonnet no reconoció cotas claras. Puede ser que el plano esté rotado, con baja resolución o que sea una vista 3D sin medidas.
+            <code>dual_read_timeout · 2 retries</code>
+          </div>
+          <div class="err-actions">
+            <button class="btn-retry">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
+              Reintentar lectura
+            </button>
+            <button class="btn-secondary">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+              Subir otro plano
+            </button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+  </div>
+
+  <div class="composer">
+    <div class="comp-row">
+      <span class="comp-input">Enunciado o adjuntar plano…</span>
+      <div class="comp-btns">
+        <button class="icon-btn">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg>
+        </button>
+        <button class="icon-btn primary">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+        </button>
+      </div>
+    </div>
+    <div class="comp-hint">Enter para enviar</div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/20-card-context-analysis.html
+++ b/docs/mockups/20-card-context-analysis.html
@@ -1,0 +1,326 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Card · Context Analysis · 920×auto</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --amb:#f5a623; --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .canvas {
+    background:var(--bg); padding:30px; border-radius:8px; width:920px; position:relative;
+    border:1px solid rgba(255,255,255,.06);
+  }
+  .canvas::after {
+    content:''; position:absolute; inset:0; border-radius:8px;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+    pointer-events:none;
+  }
+
+  /* ── Card ─────────────────────────────────────────────────── */
+  .card {
+    width:100%; border:1px solid var(--b1); background:var(--s1);
+    border-radius:16px; overflow:hidden;
+    box-shadow:0 20px 40px -20px rgba(0,0,0,.5);
+  }
+  .card-header {
+    display:flex; align-items:center; gap:12px;
+    padding:16px 20px; border-bottom:1px solid var(--b1);
+    background:linear-gradient(to bottom, var(--s3), var(--s2));
+  }
+  .badge-primary {
+    font-size:10px; font-weight:600; text-transform:uppercase;
+    letter-spacing:.1em; color:var(--acc);
+    background:var(--acc2); border:1px solid var(--acc3);
+    padding:5px 8px; border-radius:6px;
+  }
+  .card-title {
+    font-size:15px; font-weight:600; color:var(--t1); letter-spacing:-.01em;
+  }
+  .sector-summary {
+    margin-left:auto; font-family:var(--font-mono);
+    font-size:12px; color:var(--t3);
+  }
+  .copy-btn {
+    display:inline-flex; align-items:center; gap:6px;
+    padding:6px 10px; border-radius:6px;
+    font-size:11px; font-weight:500; color:var(--t3);
+    background:transparent; border:1px solid var(--b2);
+    cursor:pointer;
+  }
+  .copy-btn svg { width:12px; height:12px; }
+  .card-body { padding:20px; }
+  .intro-text {
+    font-size:12px; color:var(--t3); line-height:1.55; margin-bottom:18px;
+  }
+  .section { margin-bottom:20px; }
+  .section h4 {
+    font-size:11px; font-weight:600; text-transform:uppercase;
+    letter-spacing:.1em; margin-bottom:8px;
+  }
+  .section h4.grn { color:var(--grn); }
+  .section h4.amb { color:var(--amb); }
+
+  .row {
+    display:grid; grid-template-columns:140px 1fr auto; gap:12px;
+    align-items:start; padding:8px 0;
+    border-top:1px solid rgba(255,255,255,.035);
+  }
+  .row-label {
+    font-size:12px; color:var(--t3); text-transform:uppercase;
+    letter-spacing:.06em;
+  }
+  .row-value { font-size:13px; color:var(--t1); }
+  .row-note {
+    font-size:11px; color:var(--t3); margin-top:3px; font-style:italic;
+    line-height:1.45;
+  }
+
+  .src-badge {
+    font-size:10px; text-transform:uppercase; letter-spacing:.08em;
+    padding:2px 6px; border-radius:4px; border:1px solid transparent;
+    white-space:nowrap;
+  }
+  .src-brief  { background:rgba(79,143,255,.10); color:var(--acc); border-color:rgba(79,143,255,.30); }
+  .src-rule   { background:rgba(245,166,35,.10); color:var(--amb); border-color:rgba(245,166,35,.30); }
+  .src-default{ background:rgba(255,255,255,.05); color:var(--t3); border-color:var(--b1); }
+  .src-inferred{ background:rgba(255,255,255,.05); color:var(--t3); border-color:var(--b1); }
+
+  .status-verified {
+    background:rgba(48,209,88,.15); color:var(--grn);
+    border:1px solid rgba(48,209,88,.40);
+    font-size:10px; text-transform:uppercase; letter-spacing:.08em;
+    padding:2px 6px; border-radius:4px;
+  }
+
+  /* Tech detection row */
+  .tech-row { padding:10px 0; border-top:1px solid rgba(255,255,255,.035); }
+  .tech-head {
+    display:flex; align-items:center; gap:8px; margin-bottom:8px;
+  }
+  .tech-label {
+    font-size:12px; color:var(--t3);
+    text-transform:uppercase; letter-spacing:.06em;
+  }
+  .tech-confidence {
+    margin-left:auto; font-family:var(--font-mono);
+    font-size:10px; color:var(--t3);
+  }
+  .radio-pills { display:flex; flex-wrap:wrap; gap:6px; }
+  .radio-pill {
+    display:inline-flex; align-items:center; gap:6px;
+    font-size:12px; padding:5px 10px; border-radius:6px;
+    border:1px solid var(--b1); background:transparent; color:var(--t2);
+    cursor:pointer;
+  }
+  .radio-pill.selected {
+    border-color:var(--acc);
+    background:rgba(79,143,255,.10);
+    color:var(--t1);
+  }
+  .radio-dot {
+    display:inline-block; width:10px; height:10px; border-radius:50%;
+    border:1.5px solid var(--t3); background:transparent;
+  }
+  .radio-pill.selected .radio-dot {
+    border-color:var(--acc);
+    background:radial-gradient(circle, var(--acc) 40%, transparent 42%);
+  }
+
+  .card-footer {
+    padding:16px 20px; border-top:1px solid var(--b1);
+    background:var(--s2);
+  }
+  .btn-primary {
+    width:100%; padding:10px 16px; border-radius:12px;
+    background:var(--acc); color:#fff; border:none; cursor:pointer;
+    font-size:13px; font-weight:600; letter-spacing:-.005em;
+  }
+  .btn-primary:hover { background:#3d7be6; }
+</style>
+</head>
+<body>
+<span class="frame-label">CARD · CONTEXT ANALYSIS · 920×auto</span>
+<div class="canvas">
+  <div class="card">
+    <!-- Header -->
+    <div class="card-header">
+      <span class="badge-primary">🔍 Análisis de contexto</span>
+      <h3 class="card-title">Paso previo al despiece</h3>
+      <span class="sector-summary">4 mesada(s) en cocina + isla</span>
+      <button class="copy-btn" title="Copiar contexto">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 5h8a2 2 0 012 2v12a2 2 0 01-2 2H8a2 2 0 01-2-2V7a2 2 0 012-2z"/><path d="M16 3H10a2 2 0 00-2 2"/></svg>
+      </button>
+    </div>
+
+    <!-- Body -->
+    <div class="card-body">
+      <p class="intro-text">
+        Antes de medir el plano, validemos lo que sé del trabajo. Corregí lo que esté mal
+        con doble-click y respondé las preguntas bloqueantes.
+      </p>
+
+      <!-- Datos que tengo -->
+      <div class="section">
+        <h4 class="grn">📋 Datos que tengo</h4>
+
+        <div class="row">
+          <div class="row-label">Cliente</div>
+          <div class="row-value">Erica Bernardi</div>
+          <span class="src-badge src-brief">del brief</span>
+        </div>
+        <div class="row">
+          <div class="row-label">Proyecto</div>
+          <div class="row-value">Casa Bernardi</div>
+          <span class="src-badge src-brief">del brief</span>
+        </div>
+        <div class="row">
+          <div class="row-label">Material</div>
+          <div class="row-value">Puraprima Onix White Mate</div>
+          <span class="src-badge src-brief">del brief</span>
+        </div>
+        <div class="row">
+          <div class="row-label">Localidad</div>
+          <div class="row-value">Rosario</div>
+          <span class="src-badge src-brief">del brief</span>
+        </div>
+        <div class="row">
+          <div class="row-label">Tipo de trabajo</div>
+          <div class="row-value">Cocina</div>
+          <span class="src-badge src-brief">del brief</span>
+        </div>
+      </div>
+
+      <!-- Detectado en plano / brief -->
+      <div class="section">
+        <h4 class="grn">🔎 Detectado en plano / brief</h4>
+
+        <div class="tech-row">
+          <div class="tech-head">
+            <span class="tech-label">Isla central</span>
+            <span class="src-badge src-brief">del brief</span>
+            <span class="status-verified">confirmado</span>
+            <span class="tech-confidence">95%</span>
+          </div>
+          <div class="radio-pills">
+            <label class="radio-pill selected"><span class="radio-dot"></span>Sí, hay isla</label>
+            <label class="radio-pill"><span class="radio-dot"></span>No hay isla</label>
+          </div>
+        </div>
+
+        <div class="tech-row">
+          <div class="tech-head">
+            <span class="tech-label">Pileta</span>
+            <span class="src-badge src-brief">del brief</span>
+            <span class="status-verified">confirmado</span>
+            <span class="tech-confidence">95%</span>
+          </div>
+          <div class="radio-pills">
+            <label class="radio-pill"><span class="radio-dot"></span>Simple</label>
+            <label class="radio-pill selected"><span class="radio-dot"></span>Doble (2 bachas)</label>
+            <label class="radio-pill"><span class="radio-dot"></span>No lleva</label>
+          </div>
+        </div>
+
+        <div class="tech-row">
+          <div class="tech-head">
+            <span class="tech-label">Anafe</span>
+            <span class="src-badge src-brief">del brief</span>
+            <span class="status-verified">confirmado</span>
+            <span class="tech-confidence">95%</span>
+          </div>
+          <div class="radio-pills">
+            <label class="radio-pill"><span class="radio-dot"></span>No lleva</label>
+            <label class="radio-pill"><span class="radio-dot"></span>1</label>
+            <label class="radio-pill selected"><span class="radio-dot"></span>2 (gas + eléctrico)</label>
+            <label class="radio-pill"><span class="radio-dot"></span>3+</label>
+          </div>
+        </div>
+      </div>
+
+      <!-- Reglas / defaults -->
+      <div class="section">
+        <h4 class="amb">✨ Reglas / defaults que aplico</h4>
+
+        <div class="row">
+          <div class="row-label">Pileta (montaje)</div>
+          <div class="row-value">
+            Empotrada (PEGADOPILETA)
+            <div class="row-note">
+              Regla D'Angelo: en cocina la pileta siempre va empotrada, nunca apoyo. El operador puede corregir si es excepción.
+            </div>
+          </div>
+          <span class="src-badge src-rule">regla D'Angelo</span>
+        </div>
+
+        <div class="row">
+          <div class="row-label">Zócalos</div>
+          <div class="row-value">
+            Trasero por tramo, 7 cm
+            <div class="row-note">
+              Brief dice "con zócalos". Default 7 cm trasero por tramo del largo real.
+            </div>
+          </div>
+          <span class="src-badge src-rule">brief + regla</span>
+        </div>
+
+        <div class="row">
+          <div class="row-label">Colocación</div>
+          <div class="row-value">Incluye</div>
+          <span class="src-badge src-brief">del brief</span>
+        </div>
+
+        <div class="row">
+          <div class="row-label">Forma de pago</div>
+          <div class="row-value">Contado</div>
+          <span class="src-badge src-brief">del brief</span>
+        </div>
+
+        <div class="row">
+          <div class="row-label">Demora</div>
+          <div class="row-value">30 días</div>
+          <span class="src-badge src-default">default</span>
+        </div>
+
+        <div class="row">
+          <div class="row-label">Tipo</div>
+          <div class="row-value">
+            Particular
+            <div class="row-note">
+              Inferido — si tiene varias unidades/tipologías, corregí a Edificio.
+            </div>
+          </div>
+          <span class="src-badge src-inferred">inferido</span>
+        </div>
+
+        <div class="row">
+          <div class="row-label">Descuento</div>
+          <div class="row-value">
+            No aplica
+            <div class="row-note">
+              Si el cliente tiene descuento (arquitecta u otro), corregí.
+            </div>
+          </div>
+          <span class="src-badge src-default">default</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <div class="card-footer">
+      <button class="btn-primary">Confirmar contexto — seguir al despiece</button>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/mockups/21-card-dual-read.html
+++ b/docs/mockups/21-card-dual-read.html
@@ -1,0 +1,314 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Card · Dual Read (Despiece) · 920×auto</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --amb:#f5a623; --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .canvas {
+    background:var(--bg); padding:30px; border-radius:8px; width:920px; position:relative;
+    border:1px solid rgba(255,255,255,.06);
+  }
+  .canvas::after {
+    content:''; position:absolute; inset:0; border-radius:8px;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+    pointer-events:none;
+  }
+
+  .card {
+    width:100%; border:1px solid var(--b1); background:var(--s1);
+    border-radius:16px; overflow:hidden;
+    box-shadow:0 20px 40px -20px rgba(0,0,0,.5);
+  }
+
+  .card-header {
+    display:flex; align-items:center; gap:10px;
+    padding:16px 20px; border-bottom:1px solid var(--b1);
+    background:linear-gradient(to bottom, var(--s3), var(--s2));
+  }
+  .badge-primary {
+    font-size:10px; font-weight:600; text-transform:uppercase;
+    letter-spacing:.1em; color:var(--acc);
+    background:var(--acc2); border:1px solid var(--acc3);
+    padding:5px 8px; border-radius:6px;
+  }
+  .card-title {
+    font-size:15px; font-weight:600; color:var(--t1); letter-spacing:-.01em;
+  }
+  .chip-mini {
+    font-size:10px; padding:3px 8px; border-radius:999px;
+    font-weight:500; display:inline-flex; align-items:center; gap:5px;
+  }
+  .chip-grn {
+    background:rgba(48,209,88,.10); color:var(--grn);
+    border:1px solid rgba(48,209,88,.30);
+  }
+  .chip-amb {
+    background:rgba(245,166,35,.10); color:var(--amb);
+    border:1px solid rgba(245,166,35,.30);
+  }
+  .chips-cluster { margin-left:auto; display:flex; gap:6px; }
+  .copy-btn {
+    display:inline-flex; align-items:center; gap:6px;
+    padding:6px 8px; border-radius:6px;
+    font-size:11px; font-weight:500; color:var(--t3);
+    background:transparent; border:1px solid var(--b2);
+    cursor:pointer;
+  }
+  .copy-btn svg { width:12px; height:12px; }
+
+  .card-body { padding:16px; }
+
+  /* Sector heading */
+  .sector-head {
+    font-size:13px; font-weight:600; color:var(--t1);
+    padding:8px 0; border-bottom:1px solid var(--b1);
+    margin-bottom:12px;
+  }
+  .sector-head-second { margin-top:18px; }
+
+  /* Tramo card */
+  .tramo-card {
+    background:var(--s2); border:1px solid var(--b1);
+    border-radius:10px; padding:12px; margin-bottom:10px;
+  }
+  .tramo-title {
+    font-size:13px; color:var(--t1); font-weight:600; margin-bottom:10px;
+  }
+  .tramo-grid {
+    display:grid; grid-template-columns:1fr 1fr 1fr 1fr; gap:12px;
+    align-items:start;
+  }
+  .field { display:flex; flex-direction:column; gap:5px; }
+  .field-label {
+    font-size:10px; text-transform:uppercase; letter-spacing:.08em;
+    color:var(--t3); font-weight:600;
+  }
+  .field-input {
+    font-family:var(--font-mono); font-size:12px; color:var(--t1);
+    background:var(--s3); border:1px solid var(--b1);
+    border-radius:6px; padding:5px 8px;
+    display:inline-flex; align-items:center; gap:6px; width:fit-content;
+  }
+  .field-input.amber { border-color:rgba(245,166,35,.6); }
+  .field-input.disabled {
+    color:var(--t2); background:transparent;
+    border-color:transparent; padding-left:0;
+  }
+  .dot {
+    display:inline-block; width:6px; height:6px; border-radius:50%;
+    flex-shrink:0;
+  }
+  .dot-grn { background:var(--grn); box-shadow:0 0 6px rgba(48,209,88,.4); }
+  .dot-amb { background:var(--amb); box-shadow:0 0 6px rgba(245,166,35,.4); }
+
+  .features { margin-top:10px; display:flex; flex-wrap:wrap; gap:6px; }
+  .feat-chip {
+    font-size:10px; padding:2px 8px; border-radius:999px;
+    background:rgba(255,255,255,.03); border:1px solid var(--b1);
+    color:var(--t3);
+  }
+  .feat-chip.acc {
+    background:rgba(79,143,255,.10); color:var(--acc);
+    border-color:rgba(79,143,255,.22);
+  }
+
+  .tramo-note {
+    margin-top:8px; font-size:11px; color:var(--amb); font-style:italic;
+    line-height:1.5;
+  }
+
+  /* Totals row */
+  .totals {
+    background:var(--s3); border-top:1px solid var(--b1);
+    padding:12px 20px;
+  }
+  .total-line {
+    display:flex; justify-content:space-between; align-items:center;
+    font-size:13px;
+  }
+  .total-line + .total-line { margin-top:6px; }
+  .total-label { color:var(--t2); }
+  .total-value {
+    font-family:var(--font-mono); color:var(--t1); font-weight:600;
+    letter-spacing:-.01em;
+  }
+
+  /* Footer */
+  .card-footer {
+    padding:16px 20px; border-top:1px solid var(--b1);
+    background:var(--s2);
+  }
+  .btn-primary {
+    width:100%; padding:10px 16px; border-radius:12px;
+    background:var(--acc); color:#fff; border:none; cursor:pointer;
+    font-size:13px; font-weight:600;
+  }
+</style>
+</head>
+<body>
+<span class="frame-label">CARD · DUAL READ (DESPIECE) · 920×auto</span>
+<div class="canvas">
+  <div class="card">
+    <!-- Header -->
+    <div class="card-header">
+      <span class="badge-primary">📐 Despiece</span>
+      <h3 class="card-title">Medidas verificadas — cocina U + isla</h3>
+      <div class="chips-cluster">
+        <span class="chip-mini chip-grn">● 3 confirmados</span>
+        <span class="chip-mini chip-amb">● 1 dudoso</span>
+      </div>
+      <button class="copy-btn" title="Copiar despiece">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 5h8a2 2 0 012 2v12a2 2 0 01-2 2H8a2 2 0 01-2-2V7a2 2 0 012-2z"/><path d="M16 3H10a2 2 0 00-2 2"/></svg>
+      </button>
+    </div>
+
+    <!-- Body -->
+    <div class="card-body">
+      <!-- Sector 1: Cocina -->
+      <div class="sector-head">Cocina (tipo U) · 3 tramos · 4.32 m²</div>
+
+      <!-- Tramo P1 -->
+      <div class="tramo-card">
+        <div class="tramo-title">P1 · Mesada principal contra pared</div>
+        <div class="tramo-grid">
+          <div class="field">
+            <span class="field-label">Largo</span>
+            <span class="field-input"><span class="dot dot-grn"></span>3.20 m</span>
+          </div>
+          <div class="field">
+            <span class="field-label">Ancho</span>
+            <span class="field-input"><span class="dot dot-grn"></span>0.60 m</span>
+          </div>
+          <div class="field">
+            <span class="field-label">m²</span>
+            <span class="field-input disabled">1.92</span>
+          </div>
+          <div class="field">
+            <span class="field-label">Zóc. trasero</span>
+            <span class="field-input">3.20 ml</span>
+          </div>
+        </div>
+        <div class="features">
+          <span class="feat-chip">🧱 toca pared</span>
+        </div>
+      </div>
+
+      <!-- Tramo P2 -->
+      <div class="tramo-card">
+        <div class="tramo-title">P2 · Ala derecha</div>
+        <div class="tramo-grid">
+          <div class="field">
+            <span class="field-label">Largo</span>
+            <span class="field-input"><span class="dot dot-grn"></span>1.80 m</span>
+          </div>
+          <div class="field">
+            <span class="field-label">Ancho</span>
+            <span class="field-input"><span class="dot dot-grn"></span>0.60 m</span>
+          </div>
+          <div class="field">
+            <span class="field-label">m²</span>
+            <span class="field-input disabled">1.08</span>
+          </div>
+          <div class="field">
+            <span class="field-label">Zóc. trasero</span>
+            <span class="field-input">1.80 ml</span>
+          </div>
+        </div>
+        <div class="features">
+          <span class="feat-chip">🧱 toca pared</span>
+        </div>
+      </div>
+
+      <!-- Tramo P3 -->
+      <div class="tramo-card">
+        <div class="tramo-title">P3 · Ala izquierda con pileta doble</div>
+        <div class="tramo-grid">
+          <div class="field">
+            <span class="field-label">Largo</span>
+            <span class="field-input"><span class="dot dot-grn"></span>2.20 m</span>
+          </div>
+          <div class="field">
+            <span class="field-label">Ancho</span>
+            <span class="field-input"><span class="dot dot-grn"></span>0.60 m</span>
+          </div>
+          <div class="field">
+            <span class="field-label">m²</span>
+            <span class="field-input disabled">1.32</span>
+          </div>
+          <div class="field">
+            <span class="field-label">Zóc. trasero</span>
+            <span class="field-input">2.20 ml</span>
+          </div>
+        </div>
+        <div class="features">
+          <span class="feat-chip acc">🚰 sink_double</span>
+          <span class="feat-chip">🧱 toca pared</span>
+        </div>
+      </div>
+
+      <!-- Sector 2: Isla -->
+      <div class="sector-head sector-head-second">Isla · 1 tramo · 0.96 m²</div>
+
+      <!-- Tramo P4 -->
+      <div class="tramo-card">
+        <div class="tramo-title">P4 · Isla central</div>
+        <div class="tramo-grid">
+          <div class="field">
+            <span class="field-label">Largo</span>
+            <span class="field-input"><span class="dot dot-grn"></span>1.60 m</span>
+          </div>
+          <div class="field">
+            <span class="field-label">Ancho</span>
+            <span class="field-input amber"><span class="dot dot-amb"></span>0.60 m</span>
+          </div>
+          <div class="field">
+            <span class="field-label">m²</span>
+            <span class="field-input disabled">0.96</span>
+          </div>
+          <div class="field">
+            <span class="field-label">Zóc. trasero</span>
+            <span class="field-input disabled">—</span>
+          </div>
+        </div>
+        <div class="features">
+          <span class="feat-chip acc">🏝 isla central</span>
+        </div>
+        <div class="tramo-note">
+          Ancho derivado por default (0.60 m) — confirmá la profundidad real de la isla.
+        </div>
+      </div>
+    </div>
+
+    <!-- Totals -->
+    <div class="totals">
+      <div class="total-line">
+        <span class="total-label">Total m² material</span>
+        <span class="total-value">5.28 m²</span>
+      </div>
+      <div class="total-line">
+        <span class="total-label">Total ml zóc. trasero</span>
+        <span class="total-value">7.20 ml</span>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <div class="card-footer">
+      <button class="btn-primary">Confirmar despiece — calcular presupuesto</button>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/mockups/22-card-zone-selector.html
+++ b/docs/mockups/22-card-zone-selector.html
@@ -1,0 +1,219 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Card · Zone Selector · 920×auto</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --amb:#f5a623; --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .canvas {
+    background:var(--bg); padding:30px; border-radius:8px; width:920px; position:relative;
+    border:1px solid rgba(255,255,255,.06);
+  }
+  .canvas::after {
+    content:''; position:absolute; inset:0; border-radius:8px;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+    pointer-events:none;
+  }
+
+  .card {
+    width:100%; border:1px solid var(--b1); background:var(--s1);
+    border-radius:16px; overflow:hidden;
+    box-shadow:0 20px 40px -20px rgba(0,0,0,.5);
+  }
+
+  .card-header {
+    display:flex; align-items:center; gap:12px;
+    padding:16px 20px; border-bottom:1px solid var(--b1);
+    background:linear-gradient(to bottom, var(--s3), var(--s2));
+  }
+  .badge-primary {
+    font-size:10px; font-weight:600; text-transform:uppercase;
+    letter-spacing:.1em; color:var(--acc);
+    background:var(--acc2); border:1px solid var(--acc3);
+    padding:5px 8px; border-radius:6px;
+  }
+  .card-title {
+    font-size:15px; font-weight:600; color:var(--t1); letter-spacing:-.01em;
+  }
+
+  .card-body { padding:20px; }
+
+  .thumbs {
+    display:grid; grid-template-columns:repeat(3, 1fr); gap:12px;
+  }
+  .thumb {
+    aspect-ratio:3/4; background:var(--s2); border:1px solid var(--b1);
+    border-radius:10px; padding:12px; position:relative; cursor:pointer;
+    display:flex; flex-direction:column;
+    transition:border-color .15s;
+  }
+  .thumb:hover { border-color:var(--b2); }
+  .thumb.selected {
+    border-color:var(--acc);
+    box-shadow:0 0 0 2px rgba(79,143,255,.30);
+  }
+  .page-num {
+    position:absolute; top:8px; left:8px;
+    font-family:var(--font-mono); font-size:10px; color:var(--t3);
+    background:var(--s3); border:1px solid var(--b1);
+    padding:2px 6px; border-radius:4px;
+  }
+  .thumb-preview {
+    flex:1; background:rgba(255,255,255,.02);
+    border:1px dashed rgba(255,255,255,.06);
+    border-radius:6px; margin-top:22px; margin-bottom:10px;
+    position:relative; overflow:hidden;
+  }
+  .thumb-preview svg {
+    width:100%; height:100%; display:block;
+  }
+  .thumb-label {
+    text-align:center; font-size:12px; color:var(--t2);
+  }
+  .thumb.selected .thumb-label { color:var(--t1); font-weight:500; }
+
+  .hint {
+    margin-top:14px; font-size:12px; color:var(--t3);
+    font-style:italic; line-height:1.5;
+  }
+
+  .card-footer {
+    padding:16px 20px; border-top:1px solid var(--b1);
+    background:var(--s2);
+    display:flex; gap:10px;
+  }
+  .btn-primary {
+    flex:1; padding:10px 16px; border-radius:12px;
+    background:var(--acc); color:#fff; border:none; cursor:pointer;
+    font-size:13px; font-weight:600;
+  }
+  .btn-secondary {
+    padding:10px 16px; border-radius:12px;
+    background:transparent; color:var(--t2);
+    border:1px solid var(--b1); cursor:pointer;
+    font-size:13px; font-weight:500;
+  }
+  .btn-secondary:hover { color:var(--t1); border-color:var(--b2); }
+</style>
+</head>
+<body>
+<span class="frame-label">CARD · ZONE SELECTOR · 920×auto</span>
+<div class="canvas">
+  <div class="card">
+    <!-- Header -->
+    <div class="card-header">
+      <span class="badge-primary">🔍 Seleccionar zona</span>
+      <h3 class="card-title">¿Qué página querés medir?</h3>
+    </div>
+
+    <!-- Body -->
+    <div class="card-body">
+      <div class="thumbs">
+        <!-- Page 1 -->
+        <div class="thumb">
+          <span class="page-num">p. 1</span>
+          <div class="thumb-preview">
+            <svg viewBox="0 0 100 130" preserveAspectRatio="none">
+              <defs>
+                <pattern id="grid1" x="0" y="0" width="10" height="10" patternUnits="userSpaceOnUse">
+                  <path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(255,255,255,.05)" stroke-width="0.3"/>
+                </pattern>
+              </defs>
+              <rect width="100" height="130" fill="url(#grid1)"/>
+              <rect x="15" y="20" width="70" height="50" fill="none" stroke="rgba(255,255,255,.15)" stroke-width="0.6"/>
+              <rect x="25" y="30" width="20" height="15" fill="none" stroke="rgba(255,255,255,.12)" stroke-width="0.4"/>
+              <rect x="55" y="30" width="20" height="15" fill="none" stroke="rgba(255,255,255,.12)" stroke-width="0.4"/>
+              <line x1="15" y1="80" x2="85" y2="80" stroke="rgba(255,255,255,.10)" stroke-width="0.4"/>
+              <line x1="15" y1="90" x2="85" y2="90" stroke="rgba(255,255,255,.10)" stroke-width="0.4"/>
+              <line x1="15" y1="100" x2="65" y2="100" stroke="rgba(255,255,255,.10)" stroke-width="0.4"/>
+              <text x="50" y="115" fill="rgba(255,255,255,.12)" font-size="4" text-anchor="middle" font-family="monospace">ROTULO</text>
+            </svg>
+          </div>
+          <div class="thumb-label">Vista general</div>
+        </div>
+
+        <!-- Page 2 - SELECTED -->
+        <div class="thumb selected">
+          <span class="page-num">p. 2</span>
+          <div class="thumb-preview">
+            <svg viewBox="0 0 100 130" preserveAspectRatio="none">
+              <defs>
+                <pattern id="grid2" x="0" y="0" width="10" height="10" patternUnits="userSpaceOnUse">
+                  <path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(79,143,255,.08)" stroke-width="0.3"/>
+                </pattern>
+              </defs>
+              <rect width="100" height="130" fill="url(#grid2)"/>
+              <!-- cocina U -->
+              <path d="M 15 30 L 15 80 L 35 80 L 35 60 L 65 60 L 65 80 L 85 80 L 85 30 Z" fill="none" stroke="rgba(79,143,255,.55)" stroke-width="0.8"/>
+              <!-- pileta -->
+              <rect x="45" y="35" width="10" height="8" fill="none" stroke="rgba(79,143,255,.55)" stroke-width="0.5"/>
+              <rect x="57" y="35" width="10" height="8" fill="none" stroke="rgba(79,143,255,.55)" stroke-width="0.5"/>
+              <!-- anafes -->
+              <circle cx="25" cy="50" r="3" fill="none" stroke="rgba(79,143,255,.45)" stroke-width="0.4"/>
+              <circle cx="75" cy="50" r="3" fill="none" stroke="rgba(79,143,255,.45)" stroke-width="0.4"/>
+              <!-- isla -->
+              <rect x="30" y="95" width="40" height="15" fill="none" stroke="rgba(79,143,255,.55)" stroke-width="0.8"/>
+              <!-- dimension lines -->
+              <line x1="15" y1="115" x2="85" y2="115" stroke="rgba(255,255,255,.20)" stroke-width="0.3"/>
+              <text x="50" y="123" fill="rgba(255,255,255,.25)" font-size="3.5" text-anchor="middle" font-family="monospace">3.20 m</text>
+            </svg>
+          </div>
+          <div class="thumb-label">Planta cocina — U + isla</div>
+        </div>
+
+        <!-- Page 3 -->
+        <div class="thumb">
+          <span class="page-num">p. 3</span>
+          <div class="thumb-preview">
+            <svg viewBox="0 0 100 130" preserveAspectRatio="none">
+              <defs>
+                <pattern id="grid3" x="0" y="0" width="10" height="10" patternUnits="userSpaceOnUse">
+                  <path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(255,255,255,.05)" stroke-width="0.3"/>
+                </pattern>
+              </defs>
+              <rect width="100" height="130" fill="url(#grid3)"/>
+              <!-- elevation cuts -->
+              <line x1="15" y1="40" x2="85" y2="40" stroke="rgba(255,255,255,.18)" stroke-width="0.5"/>
+              <line x1="15" y1="45" x2="85" y2="45" stroke="rgba(255,255,255,.12)" stroke-width="0.4"/>
+              <rect x="20" y="48" width="8" height="18" fill="none" stroke="rgba(255,255,255,.15)" stroke-width="0.4"/>
+              <rect x="32" y="48" width="8" height="18" fill="none" stroke="rgba(255,255,255,.15)" stroke-width="0.4"/>
+              <rect x="44" y="48" width="8" height="18" fill="none" stroke="rgba(255,255,255,.15)" stroke-width="0.4"/>
+              <rect x="56" y="48" width="8" height="18" fill="none" stroke="rgba(255,255,255,.15)" stroke-width="0.4"/>
+              <!-- secondary section -->
+              <line x1="15" y1="85" x2="85" y2="85" stroke="rgba(255,255,255,.18)" stroke-width="0.5"/>
+              <line x1="15" y1="90" x2="85" y2="90" stroke="rgba(255,255,255,.12)" stroke-width="0.4"/>
+              <path d="M 20 95 L 35 95 L 35 108 L 65 108 L 65 95 L 80 95" fill="none" stroke="rgba(255,255,255,.15)" stroke-width="0.5"/>
+              <!-- dimension -->
+              <text x="50" y="120" fill="rgba(255,255,255,.18)" font-size="3.5" text-anchor="middle" font-family="monospace">CORTE A-A</text>
+            </svg>
+          </div>
+          <div class="thumb-label">Cortes y detalles</div>
+        </div>
+      </div>
+
+      <p class="hint">
+        Valentina lee texto y medidas solo de la página elegida — evitá que analice rótulos sueltos.
+      </p>
+    </div>
+
+    <!-- Footer -->
+    <div class="card-footer">
+      <button class="btn-primary">Confirmar zona · página 2</button>
+      <button class="btn-secondary">Subir otro plano</button>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/mockups/23-card-resumen-obra.html
+++ b/docs/mockups/23-card-resumen-obra.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Card · Resumen de Obra · 920×auto</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --amb:#f5a623; --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .canvas {
+    background:var(--bg); padding:30px; border-radius:8px; width:920px; position:relative;
+    border:1px solid rgba(255,255,255,.06);
+  }
+  .canvas::after {
+    content:''; position:absolute; inset:0; border-radius:8px;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+    pointer-events:none;
+  }
+
+  /* Small card (like ResumenObraCard) */
+  .card-small {
+    width:560px; /* narrower than canvas */
+    border:1px solid var(--b1);
+    border-radius:10px; background:rgba(255,255,255,.015);
+  }
+  .card-head {
+    display:flex; align-items:center; justify-content:space-between;
+    padding:12px 16px; border-bottom:1px solid var(--b1);
+  }
+  .head-left { display:flex; align-items:center; gap:8px; }
+  .head-icon { font-size:16px; }
+  .head-label {
+    font-size:11px; font-weight:600;
+    text-transform:uppercase; letter-spacing:.09em;
+    color:var(--t3);
+  }
+  .head-sub {
+    font-size:11px; color:var(--t4); margin-top:2px;
+  }
+
+  .regen-btn {
+    padding:6px 12px; border-radius:6px;
+    background:transparent; border:1px solid var(--b1);
+    color:var(--t2); font-size:11px; font-weight:500;
+    font-family:var(--font-sans); cursor:pointer;
+    transition:border-color .15s;
+  }
+  .regen-btn:hover { color:var(--t1); border-color:var(--b2); }
+
+  .card-body { padding:12px 16px; }
+
+  .notes-label {
+    font-size:10px; font-weight:600; text-transform:uppercase;
+    letter-spacing:.1em; color:var(--t3); margin-bottom:6px;
+  }
+  .notes-text {
+    font-size:13px; color:var(--t2); font-style:italic;
+    line-height:1.6;
+  }
+
+  .links-row {
+    display:flex; flex-wrap:wrap; gap:8px; margin-top:14px;
+  }
+  .link-pill {
+    display:inline-flex; align-items:center; gap:6px;
+    padding:6px 12px; border-radius:6px;
+    background:transparent; border:1px solid var(--b1);
+    color:var(--t2); font-size:12px; font-weight:500;
+    text-decoration:none;
+    transition:border-color .15s, color .15s;
+  }
+  .link-pill:hover { color:var(--t1); border-color:var(--b2); }
+</style>
+</head>
+<body>
+<span class="frame-label">CARD · RESUMEN DE OBRA · 920×auto</span>
+<div class="canvas" style="display:flex; justify-content:center;">
+  <div class="card-small">
+    <!-- Header -->
+    <div class="card-head">
+      <div class="head-left">
+        <span class="head-icon">📑</span>
+        <div>
+          <div class="head-label">Resumen de obra</div>
+          <div class="head-sub">Generado hace 2 min · por Valentina</div>
+        </div>
+      </div>
+      <button class="regen-btn">↻ Regenerar</button>
+    </div>
+
+    <!-- Body -->
+    <div class="card-body">
+      <div class="notes-label">Notas</div>
+      <p class="notes-text">
+        Cocina U + isla central. Puraprima Onix White Mate espesor 3 cm, con zócalo trasero
+        7 cm en todos los tramos. Pileta doble empotrada (regla D'Angelo, sin variante apoyo).
+        2 anafes (1 gas + 1 eléctrico), agujero por unidad. Colocación incluida. Plazo de demora
+        30 días hábiles desde seña.
+      </p>
+
+      <div class="links-row">
+        <a href="#" class="link-pill">☁ Ver en Drive</a>
+        <a href="#" class="link-pill">📄 PDF</a>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/mockups/24-card-email-draft.html
+++ b/docs/mockups/24-card-email-draft.html
@@ -1,0 +1,171 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Card · Email Draft · 920×auto</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --amb:#f5a623; --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .canvas {
+    background:var(--bg); padding:30px; border-radius:8px; width:920px; position:relative;
+    border:1px solid rgba(255,255,255,.06);
+  }
+  .canvas::after {
+    content:''; position:absolute; inset:0; border-radius:8px;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+    pointer-events:none;
+  }
+
+  .card {
+    width:680px; /* narrower than canvas */
+    border:1px solid var(--b1);
+    border-radius:10px; background:rgba(255,255,255,.015);
+  }
+
+  .card-head {
+    display:flex; align-items:center; justify-content:space-between;
+    padding:12px 16px; border-bottom:1px solid var(--b1);
+  }
+  .head-left { display:flex; align-items:center; gap:8px; }
+  .head-icon { font-size:16px; }
+  .label-row { display:flex; align-items:center; gap:6px; }
+  .head-label {
+    font-size:11px; font-weight:600;
+    text-transform:uppercase; letter-spacing:.09em;
+    color:var(--t3);
+  }
+  .ia-badge {
+    font-size:9px; font-weight:600;
+    background:rgba(79,143,255,.15); color:var(--acc);
+    padding:1px 6px; border-radius:3px; letter-spacing:.05em;
+  }
+  .head-sub {
+    font-size:11px; color:var(--t4); margin-top:2px;
+  }
+
+  .regen-btn {
+    padding:6px 12px; border-radius:6px;
+    background:transparent; border:1px solid var(--b1);
+    color:var(--t2); font-size:11px; font-weight:500;
+    font-family:var(--font-sans); cursor:pointer;
+  }
+  .regen-btn:hover { color:var(--t1); border-color:var(--b2); }
+
+  .card-body { padding:12px 16px; }
+
+  /* Subject box */
+  .subject-box {
+    background:rgba(255,255,255,.02); border:1px solid var(--b1);
+    border-radius:8px; padding:10px 12px;
+  }
+  .subject-label {
+    font-size:10px; font-weight:600;
+    text-transform:uppercase; letter-spacing:.1em;
+    color:var(--t3); margin-bottom:2px;
+  }
+  .subject-value {
+    font-size:13px; font-weight:500; color:var(--t1);
+    letter-spacing:-.005em; word-break:break-word;
+  }
+
+  /* Body pre */
+  .body-pre {
+    margin-top:12px;
+    font-family:var(--font-mono); font-size:12px; line-height:1.6;
+    background:rgba(255,255,255,.02); border:1px solid var(--b1);
+    border-radius:8px; padding:12px 14px;
+    color:var(--t1); white-space:pre-wrap;
+    max-height:320px; overflow-y:auto;
+  }
+
+  /* Actions row */
+  .actions {
+    margin-top:12px;
+    display:flex; flex-wrap:wrap; gap:8px; align-items:center;
+  }
+  .btn-primary {
+    display:inline-flex; align-items:center; gap:6px;
+    padding:6px 12px; border-radius:6px;
+    background:var(--acc); color:#fff; border:none; cursor:pointer;
+    font-size:12px; font-weight:500;
+  }
+  .btn-secondary {
+    display:inline-flex; align-items:center; gap:6px;
+    padding:6px 12px; border-radius:6px;
+    background:transparent; color:var(--t2); border:1px solid var(--b1);
+    font-size:12px; font-weight:500; cursor:pointer;
+  }
+  .btn-secondary:hover { color:var(--t1); border-color:var(--b2); }
+  .note-right {
+    margin-left:auto; font-size:10px; color:var(--t4);
+  }
+</style>
+</head>
+<body>
+<span class="frame-label">CARD · EMAIL DRAFT · 920×auto</span>
+<div class="canvas" style="display:flex; justify-content:center;">
+  <div class="card">
+    <!-- Header -->
+    <div class="card-head">
+      <div class="head-left">
+        <span class="head-icon">✉️</span>
+        <div>
+          <div class="label-row">
+            <span class="head-label">Email al cliente</span>
+            <span class="ia-badge">IA</span>
+          </div>
+          <div class="head-sub">Generado 18/04 14:23</div>
+        </div>
+      </div>
+      <button class="regen-btn">↻ Regenerar</button>
+    </div>
+
+    <!-- Body -->
+    <div class="card-body">
+      <div class="subject-box">
+        <div class="subject-label">Asunto</div>
+        <div class="subject-value">Presupuesto Casa Bernardi — Puraprima Onix White Mate 3 cm</div>
+      </div>
+
+      <pre class="body-pre">Hola Erica,
+
+Adjunto presupuesto para la cocina y la isla central en Puraprima
+Onix White Mate (espesor 3 cm).
+
+El despiece considera 4 tramos (mesada U contra pared + ala derecha,
+ala izquierda con pileta doble, e isla central), con zócalo trasero
+de 7 cm en los tres tramos de la U. Pileta doble empotrada y 2
+anafes (gas + eléctrico) con agujero por unidad. Colocación
+incluida.
+
+Total: USD 3.180 — equivalente a $ 4.284.000 al tipo de cambio
+del día. Condición: contado. Demora de entrega: 30 días hábiles
+desde seña.
+
+Si hace falta agregar o sacar algo — armás el detalle y lo ajusto.
+
+Saludos,
+Javier
+D'Angelo Marmolería — Rosario</pre>
+
+      <div class="actions">
+        <button class="btn-primary">📋 Copiar email</button>
+        <button class="btn-secondary">✏ Editar</button>
+        <a class="note-right" href="#">Descargar .eml</a>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/mockups/25-card-condiciones.html
+++ b/docs/mockups/25-card-condiciones.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Card · Condiciones · 920×auto</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --amb:#f5a623; --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .canvas {
+    background:var(--bg); padding:30px; border-radius:8px; width:920px; position:relative;
+    border:1px solid rgba(255,255,255,.06);
+  }
+  .canvas::after {
+    content:''; position:absolute; inset:0; border-radius:8px;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+    pointer-events:none;
+  }
+
+  .card-small {
+    width:520px;
+    border:1px solid var(--b1);
+    border-radius:10px; background:rgba(255,255,255,.015);
+  }
+
+  .card-head {
+    display:flex; align-items:center; justify-content:space-between;
+    padding:12px 16px; border-bottom:1px solid var(--b1);
+  }
+  .head-left { display:flex; align-items:center; gap:8px; }
+  .head-icon { font-size:16px; }
+  .head-label {
+    font-size:11px; font-weight:600;
+    text-transform:uppercase; letter-spacing:.09em;
+    color:var(--t3);
+  }
+  .head-sub {
+    font-size:11px; color:var(--t4); margin-top:2px;
+  }
+
+  .card-body { padding:12px 16px; }
+
+  .cond-line {
+    font-size:12px; color:var(--t3); line-height:1.6;
+  }
+  .cond-line + .cond-line { margin-top:6px; }
+  .cond-label { font-weight:600; color:var(--t3); }
+  .cond-value { color:var(--t2); }
+
+  .links-row {
+    display:flex; flex-wrap:wrap; gap:8px; margin-top:14px;
+  }
+  .link-pill {
+    display:inline-flex; align-items:center; gap:6px;
+    padding:6px 12px; border-radius:6px;
+    background:transparent; border:1px solid var(--b1);
+    color:var(--t2); font-size:12px; font-weight:500;
+    text-decoration:none;
+  }
+  .link-pill:hover { color:var(--t1); border-color:var(--b2); }
+</style>
+</head>
+<body>
+<span class="frame-label">CARD · CONDICIONES · 920×auto</span>
+<div class="canvas" style="display:flex; justify-content:center;">
+  <div class="card-small">
+    <!-- Header -->
+    <div class="card-head">
+      <div class="head-left">
+        <span class="head-icon">📋</span>
+        <div>
+          <div class="head-label">Condiciones</div>
+          <div class="head-sub">Generado hace 2 min</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Body -->
+    <div class="card-body">
+      <div class="cond-line">
+        <span class="cond-label">Plazo de entrega:</span>
+        <span class="cond-value">30 días hábiles desde seña</span>
+      </div>
+      <div class="cond-line">
+        <span class="cond-label">Forma de pago:</span>
+        <span class="cond-value">Contado</span>
+      </div>
+      <div class="cond-line">
+        <span class="cond-label">Validez del presupuesto:</span>
+        <span class="cond-value">15 días corridos</span>
+      </div>
+
+      <div class="links-row">
+        <a href="#" class="link-pill">☁ Drive</a>
+        <a href="#" class="link-pill">📄 PDF</a>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/mockups/26-card-message-bubbles.html
+++ b/docs/mockups/26-card-message-bubbles.html
@@ -1,0 +1,317 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Card · Message Bubble Variants · 720×auto</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --acc-bg:rgba(79,143,255,.08);
+    --acc-hover:rgba(79,143,255,.30);
+    --grn:#30d158; --amb:#f5a623; --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .canvas {
+    background:var(--bg); padding:30px; border-radius:8px; width:720px; position:relative;
+    border:1px solid rgba(255,255,255,.06);
+  }
+  .canvas::after {
+    content:''; position:absolute; inset:0; border-radius:8px;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+    pointer-events:none;
+  }
+
+  .variant-label {
+    font-family:var(--font-mono); font-size:10px;
+    color:rgba(255,255,255,.3); letter-spacing:.04em;
+    text-transform:uppercase;
+    padding-top:14px; padding-bottom:6px;
+    border-top:1px dashed rgba(255,255,255,.08);
+    margin-top:14px;
+  }
+  .variant-label:first-child { margin-top:0; border-top:none; padding-top:0; }
+
+  /* Message row */
+  .msg { display:flex; gap:12px; align-items:flex-start; }
+  .msg.user { flex-direction:row-reverse; }
+  .avatar {
+    width:30px; height:30px; border-radius:50%; flex-shrink:0;
+    display:flex; align-items:center; justify-content:center;
+    font-size:11px; font-weight:600;
+  }
+  .avatar.v { background:var(--acc); color:#fff; }
+  .avatar.op { background:var(--s3); color:var(--t2); border:1px solid var(--b2); }
+
+  /* User bubble */
+  .user-bubble {
+    max-width:70%; padding:10px 16px;
+    background:var(--acc-bg);
+    border:1px solid var(--acc-hover);
+    border-radius:12px 2px 12px 12px;
+    font-size:14px; line-height:1.65; color:rgba(255,255,255,.78);
+  }
+  .attach-chip {
+    display:inline-flex; align-items:center; gap:5px;
+    padding:4px 8px; border-radius:5px;
+    background:rgba(255,255,255,.08); border:1px solid var(--b1);
+    font-size:11px; color:var(--t2); margin-bottom:7px;
+  }
+
+  /* Assistant wrapper */
+  .assist-wrap {
+    flex:1; border:1px solid var(--b2);
+    border-radius:2px 12px 12px 12px;
+    overflow:hidden;
+    max-width:92%;
+  }
+  .block {
+    padding:12px 18px; background:var(--s2);
+  }
+  .block + .block { border-top:1px solid var(--b1); }
+
+  /* Thinking block */
+  .think-block { display:flex; flex-direction:column; gap:6px; }
+  .think-line {
+    display:flex; align-items:center; gap:7px;
+    font-size:11px; color:var(--t3); font-style:italic;
+  }
+  .pulse-dot {
+    width:5px; height:5px; border-radius:50%; background:var(--acc);
+    flex-shrink:0;
+    animation:pulse 1.4s ease-in-out infinite;
+  }
+  @keyframes pulse {
+    0%,100% { opacity:.4; transform:scale(.85); }
+    50% { opacity:1; transform:scale(1); }
+  }
+  .pulse-dot.d2 { animation-delay:.3s; }
+  .pulse-dot.d3 { animation-delay:.6s; }
+
+  /* Text block */
+  .text-block {
+    font-size:15px; line-height:1.7; color:var(--t2);
+  }
+  .text-block h3 {
+    font-size:15px; font-weight:600; color:var(--t1);
+    margin-top:0; margin-bottom:8px;
+    padding-bottom:6px; border-bottom:1px solid var(--b1);
+    letter-spacing:-.01em;
+  }
+  .text-block h3 + p { margin-top:0; }
+  .text-block p { margin-bottom:2px; }
+  .text-block ul { list-style:none; padding:0; }
+  .text-block ul li {
+    margin-bottom:3px; padding-left:12px; position:relative;
+  }
+  .text-block ul li::before {
+    content:"•"; position:absolute; left:0; color:var(--t3);
+  }
+
+  /* Table block */
+  .md-table-wrap {
+    margin:8px 0; border-radius:10px; overflow:hidden;
+    border:1px solid var(--b1); background:rgba(255,255,255,.02);
+  }
+  table.md-table {
+    width:100%; border-collapse:collapse;
+  }
+  .md-table th {
+    padding:8px 14px; font-weight:600; color:var(--t1);
+    font-size:13px; letter-spacing:.01em;
+    border-bottom:2px solid rgba(255,255,255,.10);
+    text-align:left;
+  }
+  .md-table th.num { text-align:right; }
+  .md-table td {
+    padding:10px 14px; font-size:14px; line-height:1.4;
+    color:var(--t2); font-weight:400;
+    border-bottom:1px solid rgba(255,255,255,.06);
+    text-align:left;
+  }
+  .md-table td.num { text-align:right; }
+  .md-table tr.total td {
+    background:rgba(255,255,255,.04);
+    font-weight:600; color:var(--t1); border-bottom:none;
+  }
+
+  /* Streaming cursor */
+  .cursor {
+    display:inline-block; color:var(--acc); font-weight:700;
+    animation:blink 1s steps(2, start) infinite;
+    margin-left:2px;
+  }
+  @keyframes blink { to { visibility:hidden; } }
+</style>
+</head>
+<body>
+<span class="frame-label">CARD · MESSAGE BUBBLES · 720×auto</span>
+<div class="canvas">
+
+  <!-- Variant 1: User with attachment -->
+  <div class="variant-label">User message (role=user, with attachment)</div>
+  <div class="msg user">
+    <div class="avatar op">EB</div>
+    <div class="user-bubble">
+      <div class="attach-chip">📎 plano-cocina-U-bernardi.pdf · 2.3 MB</div>
+      <p>Material Puraprima Onix White Mate. Cocina en U con isla, pileta doble, anafes gas + eléctrico.</p>
+    </div>
+  </div>
+
+  <!-- Variant 2: Thinking only -->
+  <div class="variant-label">Assistant — thinking only (pulsing dots)</div>
+  <div class="msg">
+    <div class="avatar v">V</div>
+    <div class="assist-wrap">
+      <div class="block think-block">
+        <div class="think-line"><span class="pulse-dot"></span>Analizando brief…</div>
+        <div class="think-line"><span class="pulse-dot d2"></span>Identificando material…</div>
+        <div class="think-line"><span class="pulse-dot d3"></span>Detectando sectores…</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Variant 3: Text block (headings + markdown) -->
+  <div class="variant-label">Assistant — text block (headings + markdown)</div>
+  <div class="msg">
+    <div class="avatar v">V</div>
+    <div class="assist-wrap">
+      <div class="block text-block">
+        <h3>Material</h3>
+        <p>Puraprima Onix White Mate, espesor 3 cm. Es un sintético — aplica merma 10%.</p>
+        <h3>Cobertura</h3>
+        <ul>
+          <li>Mesada U — 4.32 m²</li>
+          <li>Isla central — 0.96 m²</li>
+          <li>Total — 5.28 m²</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- Variant 4: Calc table block -->
+  <div class="variant-label">Assistant — calc table block</div>
+  <div class="msg">
+    <div class="avatar v">V</div>
+    <div class="assist-wrap">
+      <div class="block text-block">
+        <div class="md-table-wrap">
+          <table class="md-table">
+            <thead>
+              <tr>
+                <th>Ítem</th>
+                <th class="num">Cantidad</th>
+                <th class="num">Unit</th>
+                <th class="num">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Puraprima Onix White Mate</td>
+                <td class="num">5.81 m²</td>
+                <td class="num">USD 485/m²</td>
+                <td class="num">USD 2.818</td>
+              </tr>
+              <tr>
+                <td>Corte y pulido borde recto</td>
+                <td class="num">7.20 ml</td>
+                <td class="num">$ 6.500</td>
+                <td class="num">$ 46.800</td>
+              </tr>
+              <tr>
+                <td>Pegado pileta empotrada</td>
+                <td class="num">1 un</td>
+                <td class="num">$ 78.000</td>
+                <td class="num">$ 78.000</td>
+              </tr>
+              <tr>
+                <td>Agujero anafe</td>
+                <td class="num">2 un</td>
+                <td class="num">$ 32.000</td>
+                <td class="num">$ 64.000</td>
+              </tr>
+              <tr>
+                <td>Colocación</td>
+                <td class="num">5.28 m²</td>
+                <td class="num">$ 54.000</td>
+                <td class="num">$ 285.120</td>
+              </tr>
+              <tr class="total">
+                <td><strong>TOTAL</strong></td>
+                <td class="num">—</td>
+                <td class="num">—</td>
+                <td class="num"><strong>USD 3.180 / $ 4.284.000</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Variant 5: Multi-block -->
+  <div class="variant-label">Assistant — multi-block (thinking + text + table)</div>
+  <div class="msg">
+    <div class="avatar v">V</div>
+    <div class="assist-wrap">
+      <div class="block think-block">
+        <div class="think-line"><span class="pulse-dot"></span>Aplicando IVA + merma…</div>
+        <div class="think-line"><span class="pulse-dot d2"></span>Calculando colocación…</div>
+      </div>
+      <div class="block text-block">
+        <p>Cálculo listo, revisá la tabla.</p>
+      </div>
+      <div class="block text-block">
+        <div class="md-table-wrap">
+          <table class="md-table">
+            <thead>
+              <tr>
+                <th>Ítem</th>
+                <th class="num">m²</th>
+                <th class="num">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Material + merma</td>
+                <td class="num">5.81</td>
+                <td class="num">USD 2.818</td>
+              </tr>
+              <tr>
+                <td>MO (corte, pegado, agujeros)</td>
+                <td class="num">—</td>
+                <td class="num">$ 188.800</td>
+              </tr>
+              <tr class="total">
+                <td><strong>Total</strong></td>
+                <td class="num">—</td>
+                <td class="num"><strong>USD 3.180</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Variant 6: Streaming cursor -->
+  <div class="variant-label">Assistant — streaming cursor</div>
+  <div class="msg">
+    <div class="avatar v">V</div>
+    <div class="assist-wrap">
+      <div class="block text-block">
+        <p>Listo, ya tengo el despiece. Estoy armando el cálculo de precios ahora<span class="cursor">▋</span></p>
+      </div>
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/27-composer-chat-input.html
+++ b/docs/mockups/27-composer-chat-input.html
@@ -1,0 +1,233 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Card · Composer (ChatInput) · 840×auto</title>
+<style>
+  :root {
+    --bg:#07070e; --s1:#0c0c16; --s2:#101018; --s3:#15151f;
+    --b1:rgba(255,255,255,.07); --b2:rgba(255,255,255,.13); --b3:rgba(255,255,255,.20);
+    --t1:rgba(255,255,255,.96); --t2:rgba(255,255,255,.58); --t3:rgba(255,255,255,.28); --t4:rgba(255,255,255,.14);
+    --acc:#4f8fff; --acc2:rgba(79,143,255,.12); --acc3:rgba(79,143,255,.22);
+    --grn:#30d158; --amb:#f5a623; --red:#ff453a;
+    --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Geist","Inter",system-ui,sans-serif;
+    --font-mono:ui-monospace,"Geist Mono",Menlo,monospace;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  html,body { background:#050508; color:var(--t1); font-family:var(--font-sans); font-size:15px; -webkit-font-smoothing:antialiased; }
+  body { padding:40px 24px; min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:14px; }
+  .frame-label { font-family:var(--font-mono); font-size:11px; color:rgba(255,255,255,.4); letter-spacing:.05em; }
+  .canvas {
+    background:var(--bg); padding:30px; border-radius:8px; width:840px; position:relative;
+    border:1px solid rgba(255,255,255,.06);
+  }
+  .canvas::after {
+    content:''; position:absolute; inset:0; border-radius:8px;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+    pointer-events:none;
+  }
+
+  .variant-label {
+    font-family:var(--font-mono); font-size:10px;
+    color:rgba(255,255,255,.3); letter-spacing:.04em;
+    text-transform:uppercase;
+    margin-top:18px; margin-bottom:6px;
+    padding-top:14px;
+    border-top:1px dashed rgba(255,255,255,.08);
+  }
+  .variant-label:first-child { margin-top:0; border-top:none; padding-top:0; }
+
+  /* Composer shell */
+  .composer {
+    background:var(--s1); border-top:1px solid var(--b1);
+    padding:14px 20px; position:relative;
+    border-radius:8px;
+    border:1px solid var(--b1);
+  }
+
+  /* File chips row */
+  .chips-row {
+    display:flex; flex-wrap:wrap; gap:6px; margin-bottom:8px;
+  }
+  .file-chip {
+    display:inline-flex; align-items:center; gap:6px;
+    padding:5px 10px; border-radius:6px;
+    background:var(--s3); border:1px solid var(--b1);
+    font-size:11px; color:var(--t2);
+  }
+  .file-chip .close {
+    color:var(--t3); cursor:pointer; padding:0 2px;
+  }
+  .file-chip .meta { color:var(--t3); }
+
+  /* Input row */
+  .input-row {
+    display:flex; align-items:flex-end; gap:8px;
+    background:var(--s3); border:1px solid var(--b2);
+    border-radius:12px; padding:10px 10px 10px 16px;
+  }
+  .textarea-like {
+    flex:1; background:transparent; border:none; outline:none;
+    font-size:13px; color:var(--t1); line-height:1.5;
+    padding:0; min-height:18px;
+  }
+  .textarea-like.placeholder { color:var(--t4); }
+
+  .actions { display:flex; align-items:center; gap:5px; flex-shrink:0; }
+  .icon-btn {
+    width:32px; height:32px; border-radius:50%;
+    display:inline-flex; align-items:center; justify-content:center;
+    cursor:pointer;
+    background:transparent; border:1px solid var(--b1);
+    color:var(--t2); transition:all .15s;
+  }
+  .icon-btn:hover { color:var(--t1); border-color:var(--b2); }
+  .icon-btn.primary {
+    background:var(--acc); border-color:var(--acc); color:#fff;
+  }
+  .icon-btn svg { width:13px; height:13px; }
+
+  /* Hint row */
+  .hint-row {
+    display:flex; justify-content:space-between; align-items:center;
+    margin-top:6px;
+    font-size:11px; color:var(--t3);
+  }
+  .hint-checkbox {
+    display:inline-flex; align-items:center; gap:6px;
+    cursor:pointer;
+  }
+  .hint-checkbox input { accent-color:var(--acc); }
+
+  /* Drag overlay */
+  .drag-wrap { position:relative; }
+  .drag-overlay {
+    position:absolute; inset:0; z-index:10;
+    background:rgba(79,143,255,.08);
+    border:2px dashed var(--acc);
+    border-radius:12px;
+    display:flex; flex-direction:column;
+    align-items:center; justify-content:center;
+    gap:8px;
+  }
+  .drag-icon { font-size:40px; }
+  .drag-title {
+    font-size:14px; font-weight:500; color:var(--acc);
+  }
+  .drag-sub {
+    font-size:11px; color:var(--t3);
+  }
+
+  /* Typed text */
+  .textarea-like.typed { color:var(--t1); }
+</style>
+</head>
+<body>
+<span class="frame-label">COMPOSER · CHAT INPUT · 840×auto</span>
+<div class="canvas">
+
+  <!-- Variant 1: Idle empty -->
+  <div class="variant-label">Idle — empty composer</div>
+  <div class="composer">
+    <div class="input-row">
+      <div class="textarea-like placeholder">Escribí el enunciado o arrastrá el plano…</div>
+      <div class="actions">
+        <button class="icon-btn" title="Adjuntar">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+            <path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/>
+          </svg>
+        </button>
+        <button class="icon-btn primary" title="Enviar">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2">
+            <line x1="22" y1="2" x2="11" y2="13"/>
+            <polygon points="22 2 15 22 11 13 2 9 22 2"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div class="hint-row">
+      <span>Enter para enviar · Shift+Enter para nueva línea</span>
+      <label class="hint-checkbox">
+        <input type="checkbox"> multi-pieza
+      </label>
+    </div>
+  </div>
+
+  <!-- Variant 2: With attachments -->
+  <div class="variant-label">With attachments</div>
+  <div class="composer">
+    <div class="chips-row">
+      <div class="file-chip">
+        📎
+        <span>plano-bernardi.pdf</span>
+        <span class="meta">· 2.3 MB</span>
+        <span class="close">×</span>
+      </div>
+      <div class="file-chip">
+        📎
+        <span>enunciado.txt</span>
+        <span class="meta">· 1 KB</span>
+        <span class="close">×</span>
+      </div>
+    </div>
+    <div class="input-row">
+      <div class="textarea-like typed">Cliente Erica Bernardi, casa en Rosario…</div>
+      <div class="actions">
+        <button class="icon-btn" title="Adjuntar">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+            <path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/>
+          </svg>
+        </button>
+        <button class="icon-btn primary" title="Enviar">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2">
+            <line x1="22" y1="2" x2="11" y2="13"/>
+            <polygon points="22 2 15 22 11 13 2 9 22 2"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div class="hint-row">
+      <span>Enter para enviar · Shift+Enter para nueva línea</span>
+      <label class="hint-checkbox">
+        <input type="checkbox"> multi-pieza
+      </label>
+    </div>
+  </div>
+
+  <!-- Variant 3: Drag overlay active -->
+  <div class="variant-label">Drag overlay active</div>
+  <div class="composer">
+    <div class="drag-wrap">
+      <div class="input-row">
+        <div class="textarea-like placeholder">Escribí el enunciado o arrastrá el plano…</div>
+        <div class="actions">
+          <button class="icon-btn" title="Adjuntar">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+              <path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/>
+            </svg>
+          </button>
+          <button class="icon-btn primary" title="Enviar">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2">
+              <line x1="22" y1="2" x2="11" y2="13"/>
+              <polygon points="22 2 15 22 11 13 2 9 22 2"/>
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div class="drag-overlay">
+        <span class="drag-icon">📎</span>
+        <span class="drag-title">Soltá el plano acá</span>
+        <span class="drag-sub">PDF, DWG, JPG — hasta 25 MB</span>
+      </div>
+    </div>
+    <div class="hint-row">
+      <span>Enter para enviar · Shift+Enter para nueva línea</span>
+      <label class="hint-checkbox">
+        <input type="checkbox"> multi-pieza
+      </label>
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -1,0 +1,74 @@
+# Mockups · Estado actual del producto
+
+36 archivos HTML standalone que capturan **cómo luce HOY** la app de Valentina (D'Angelo Marmolería). Se exportaron para pasarlos a Claude Design como referencia y que sobre eso proponga el rediseño.
+
+## Cómo abrirlos
+
+Cada archivo es autocontenido — zero build, zero dependencias. `open docs/mockups/<archivo>.html` en el navegador.
+
+Cada mockup tiene un label arriba indicando el viewport objetivo (`Desktop 1440×900` o `Mobile 390×844`). El marco interno replica exactamente esos píxeles.
+
+## Caso de datos
+
+Todos los mockups usan el caso **Bernardi** (realista, extraído de tickets reales):
+
+- **Cliente:** Erica Bernardi
+- **Proyecto:** Casa Bernardi — Rosario
+- **Material:** Puraprima Onix White Mate (3 cm)
+- **Sectores:** Cocina en U + Isla central (4 tramos)
+- **Pileta:** doble (empotrada por regla D'Angelo)
+- **Anafe:** 2 (gas + eléctrico)
+- **Zócalos:** trasero 7 cm por tramo
+- **Colocación:** sí
+- **Total:** USD 3.180 / $ 4.284.000
+
+En el dashboard hay ~8 presupuestos variados (Bernardi como borrador activo, más casos de otros materiales y estados) para mostrar la grilla llena.
+
+## Index
+
+### Pantallas completas (10 = 5 vistas × desktop/mobile)
+| # | Vista | Desktop | Mobile |
+|---|---|---|---|
+| 01 | Login | `01-login-desktop.html` | `01-login-mobile.html` |
+| 02 | Dashboard con presupuestos | `02-dashboard-populated-desktop.html` | `02-dashboard-populated-mobile.html` |
+| 02b | Dashboard vacío | `02b-dashboard-empty-desktop.html` | `02b-dashboard-empty-mobile.html` |
+| 03 | Detalle de presupuesto (tab Detalle) | `03-quote-detail-desktop.html` | `03-quote-detail-mobile.html` |
+| 04 | Catálogo / Configuración | `04-settings-catalog-desktop.html` | `04-settings-catalog-mobile.html` |
+
+### Estados del chat (18 = 9 estados × desktop/mobile)
+| # | Estado | Desktop | Mobile |
+|---|---|---|---|
+| 10 | Chat vacío (quote recién creado) | `10-chat-empty-desktop.html` | `10-chat-empty-mobile.html` |
+| 11 | Brief enviado, Valentina pensando | `11-chat-brief-sent-desktop.html` | `11-chat-brief-sent-mobile.html` |
+| 12 | Plano procesándose | `12-chat-plano-processing-desktop.html` | `12-chat-plano-processing-mobile.html` |
+| 13 | Zone selector (plano multi-página) | `13-chat-zone-selector-desktop.html` | `13-chat-zone-selector-mobile.html` |
+| 14 | Análisis de contexto | `14-chat-context-analysis-desktop.html` | `14-chat-context-analysis-mobile.html` |
+| 15 | Despiece (dual read) confirmado | `15-chat-dual-read-desktop.html` | `15-chat-dual-read-mobile.html` |
+| 16 | Calculando | `16-chat-calculating-desktop.html` | `16-chat-calculating-mobile.html` |
+| 17 | Final con PDF/Excel/Drive | `17-chat-final-with-pdfs-desktop.html` | `17-chat-final-with-pdfs-mobile.html` |
+| 18 | Error / Retry | `18-chat-error-retry-desktop.html` | `18-chat-error-retry-mobile.html` |
+
+### Cards individuales (8, desktop only ~900px)
+| # | Card | Archivo |
+|---|---|---|
+| 20 | Context Analysis (3 secciones) | `20-card-context-analysis.html` |
+| 21 | Dual Read Result (despiece) | `21-card-dual-read.html` |
+| 22 | Zone Selector | `22-card-zone-selector.html` |
+| 23 | Resumen de Obra | `23-card-resumen-obra.html` |
+| 24 | Email Draft | `24-card-email-draft.html` |
+| 25 | Condiciones | `25-card-condiciones.html` |
+| 26 | Message bubbles (user / thinking / text / calc / tabla) | `26-card-message-bubbles.html` |
+| 27 | Composer / ChatInput (incl. drag&drop overlay) | `27-composer-chat-input.html` |
+
+## Sistema visual actual
+
+- **Fuentes:** Geist Sans (UI), Geist Mono (números), fallback `-apple-system,BlinkMacSystemFont,system-ui`.
+- **Paleta:** dark puro. Fondo `#07070e`, superficies `#0c0c16 / #101018 / #15151f`.
+- **Bordes:** `rgba(255,255,255,.07 / .13 / .20)`.
+- **Tinta:** `rgba(255,255,255,.96 / .58 / .28 / .14)`.
+- **Acento:** azul `#4f8fff` (+ alphas 0.12 / 0.22).
+- **Estado:** verde `#30d158` (validado), amber `#f5a623` (borrador / warning), rojo `#ff453a` (error).
+- **Overlay de ruido:** SVG fractalNoise 0.02 opacity sobre todo el body.
+- **Escrollbar:** 3px en pointer fino, 6px en táctil.
+
+Ver `web/src/app/globals.css` para la fuente canónica de tokens.


### PR DESCRIPTION
## Summary

36 archivos HTML standalone en \`docs/mockups/\` — 1 por vista — para pasárselos a Claude Design como referencia y que arme el rediseño sobre esa base.

**Contenido:**
- **5 pantallas completas × desktop/mobile = 10 archivos**: login, dashboard populado, dashboard vacío, detalle de presupuesto, catálogo.
- **9 estados del chat × desktop/mobile = 18 archivos**: vacío → brief → plano procesando → zone selector → context analysis → dual read → calculando → final con PDF/Excel/Drive → error/retry.
- **8 cards individuales aisladas a ~900px**: context, dual read, zone, resumen obra, email, condiciones, message bubbles (6 variantes), composer (3 estados).

**Datos:** todos usan el caso Bernardi (cocina U + isla, Puraprima Onix White Mate, pileta doble, 2 anafes, USD 3.180 / $ 4.284.000) para ver el producto con datos realistas.

**Tokens:** cada archivo inline el \`:root\` idéntico a \`web/src/app/globals.css\` — zero build, zero dependencies, abre directo con \`open docs/mockups/<archivo>.html\`.

## Test plan

- [ ] Abrir \`docs/mockups/README.md\` y ver el index
- [ ] Abrir 3-4 mockups al azar (ej. \`14-chat-context-analysis-desktop.html\`, \`17-chat-final-with-pdfs-mobile.html\`, \`21-card-dual-read.html\`) y validar que la estética refleje el producto actual
- [ ] Compartir el folder con Claude Design

🤖 Generated with [Claude Code](https://claude.com/claude-code)