### PR TITLE
feat(design): PR B — dashboard aéreo/editorial + bg más oscuro

### DIFF
--- a/docs/pr-g-avatar-animation-spec.md
+++ b/docs/pr-g-avatar-animation-spec.md
@@ -1,0 +1,108 @@
+# PR G — Avatar Valentina animado (breathing ring + shimmer + pulsing core)
+
+Spec provisto por el usuario vía chat. Objetivo: reemplazar el avatar estático de Valentina por una versión con **actividad interna animada** que no mueva la bola (centro fijo), para dar sensación de vida sin distraer.
+
+## 1 · Keyframes (agregar al `<style>` global)
+
+```css
+@keyframes vcore {
+  0%, 100% { opacity: 0.3; transform: scale(0.92); }
+  50%      { opacity: 1;   transform: scale(1.04); }
+}
+@keyframes vring {
+  0%, 100% { opacity: 0.35; transform: scale(0.96); }
+  50%      { opacity: 0.85; transform: scale(1.06); }
+}
+@keyframes vspin {
+  0%   { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+```
+
+## 2 · Componente `VAvatar` (reemplaza el actual)
+
+```tsx
+// Valentina avatar — breathing ring + rotating conic shimmer + pulsing core.
+// No position shift; size/location stay fixed. Pass `still` to freeze
+// (e.g. print/favicon/screenshot).
+function VAvatar({ size = 28, accent = '#a9c1d6', still }) {
+  const id = React.useId();
+  const anim = !still;
+  return (
+    <span style={{
+      display: 'inline-block', position: 'relative',
+      width: size, height: size, flexShrink: 0,
+    }}>
+      {/* outer breathing ring */}
+      {anim && (
+        <span style={{
+          position: 'absolute', inset: -2, borderRadius: '50%',
+          background: `radial-gradient(closest-side, transparent 58%, ${accent} 70%, transparent 88%)`,
+          animation: 'vring 2.4s ease-in-out infinite',
+          pointerEvents: 'none',
+        }} />
+      )}
+      {/* conic shimmer — slow rotation, masked to a ring */}
+      {anim && (
+        <span style={{
+          position: 'absolute', inset: 2, borderRadius: '50%',
+          background: `conic-gradient(from 0deg, transparent 0deg, ${accent} 60deg, transparent 140deg, transparent 360deg)`,
+          opacity: 0.5, mixBlendMode: 'screen',
+          maskImage: 'radial-gradient(circle, black 55%, transparent 80%)',
+          WebkitMaskImage: 'radial-gradient(circle, black 55%, transparent 80%)',
+          animation: 'vspin 5.5s linear infinite',
+          pointerEvents: 'none',
+        }} />
+      )}
+      {/* sphere + pulsing core + specular highlight */}
+      <svg width={size} height={size} viewBox="0 0 40 40" style={{ position: 'relative', display: 'block' }}>
+        <defs>
+          <radialGradient id={`g${id}`} cx="35%" cy="30%" r="70%">
+            <stop offset="0%"   stopColor="oklch(0.88 0.07 200)" />
+            <stop offset="55%"  stopColor={accent} />
+            <stop offset="100%" stopColor="oklch(0.38 0.06 220)" />
+          </radialGradient>
+          <radialGradient id={`core${id}`} cx="40%" cy="38%" r="55%">
+            <stop offset="0%"   stopColor="rgba(255,255,255,0.85)" />
+            <stop offset="55%"  stopColor="rgba(255,255,255,0)" />
+            <stop offset="100%" stopColor="rgba(255,255,255,0)" />
+          </radialGradient>
+        </defs>
+        <circle cx="20" cy="20" r="18" fill={`url(#g${id})`} />
+        <circle cx="20" cy="20" r="15" fill={`url(#core${id})`}
+          style={anim ? { animation: 'vcore 2.4s ease-in-out infinite', transformOrigin: '20px 20px' } : undefined} />
+        <ellipse cx="14" cy="14" rx="6" ry="3" fill="rgba(255,255,255,0.4)" />
+        <ellipse cx="12" cy="12" rx="2" ry="1.2" fill="rgba(255,255,255,0.75)" />
+      </svg>
+    </span>
+  );
+}
+```
+
+## Notas del spec
+
+- 3 ciclos desfasados (**2.4s / 5.5s / 2.4s**) — da sensación de actividad interna sin que la bola se mueva.
+- `mix-blend-mode: screen` en el shimmer — solo funciona bien sobre fondo oscuro; si se pone sobre light mode, cambiar a `overlay` o bajar opacidad.
+- `accent` ahora es prop — pasar el color del sistema (`var(--acc)` = `#5f7da0` en la app). El default del spec es `#a9c1d6` (celeste polvo del design).
+- `still` freeza todo (útil para screenshots, PDF export, favicon).
+
+## Dónde va en el código actual
+
+Hoy **no existe** un `VAvatar` en la app. Los avatares de Valentina en el chat son un simple div Tailwind:
+```tsx
+// web/src/components/chat/MessageBubble.tsx — avatar assistant
+<div className="w-[30px] h-[30px] rounded-full bg-acc text-white text-[11px] font-semibold flex items-center justify-center">V</div>
+```
+
+Plan de implementación cuando llegue el turno:
+
+1. Crear `web/src/components/ui/VAvatar.tsx` con el componente + keyframes inline (via `styled-jsx` o en `globals.css`).
+2. Agregar los 3 keyframes a `globals.css` en la sección `/* Animations */`.
+3. Reemplazar el avatar "V" de `MessageBubble.tsx` (role="assistant") por `<VAvatar size={30} accent="var(--acc)" />`.
+4. En contextos donde no conviene animar (PDF export, condición `prefers-reduced-motion`), pasar `still`. Agregar media query global que active `still` automáticamente con `@media (prefers-reduced-motion: reduce)` si es posible, o escucharlo vía JS hook.
+5. Verificar que el hash `conic-gradient` render correcto en Safari ≥ 13 y Chrome/Firefox modernos.
+6. Screenshot comparativo antes/después.
+
+## Prioridad
+
+Depende del usuario — probablemente post-PR D (chat restyle) para poder integrarlo con el message bubble restyleado.

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -3,15 +3,18 @@
 @tailwind utilities;
 
 :root {
-  /* Paleta "Pizarra & acero" — carbón azulado con acento celeste polvo.
-     Tinta crema fría para reducir glare sobre fondos oscuros. */
-  --bg:    #0f1318;
-  --s1:    #141923;
-  --s2:    #1a1f26;
-  --s3:    #232934;
-  --b1:    rgba(232,237,229,0.07);
-  --b2:    rgba(232,237,229,0.14);
-  --b3:    rgba(232,237,229,0.20);
+  /* Paleta "Pizarra & acero" — carbón azulado muy oscuro (cercano a
+     negro) con acento celeste polvo. La diferencia bg/s1 es mínima
+     (~1% luminance) para que la sidebar no se separe visualmente del
+     main — look editorial. Tinta crema fría para reducir glare sobre
+     fondos oscuros. */
+  --bg:    #070b10;
+  --s1:    #0a0e13;
+  --s2:    #111720;
+  --s3:    #1a2230;
+  --b1:    rgba(232,237,229,0.06);
+  --b2:    rgba(232,237,229,0.12);
+  --b3:    rgba(232,237,229,0.18);
   --t1:    #e8ede5;
   --t2:    rgba(232,237,229,0.66);
   --t3:    rgba(232,237,229,0.42);

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -28,6 +28,20 @@ const BADGE_CLASS: Record<Quote["status"], string> = {
   sent:      "bg-acc-bg text-acc",
 };
 
+// Color del dot inline (editorial — reemplaza al pill en las filas).
+const STATUS_DOT: Record<Quote["status"], string> = {
+  draft:     "var(--amb)",
+  pending:   "#b299ff",
+  validated: "var(--grn)",
+  sent:      "var(--acc)",
+};
+const STATUS_TEXT: Record<Quote["status"], string> = {
+  draft:     "text-amb",
+  pending:   "text-[#b299ff]",
+  validated: "text-grn",
+  sent:      "text-acc",
+};
+
 const STATUS_NEXT: Record<Quote["status"], Quote["status"] | null> = {
   draft: "validated", pending: "validated", validated: "sent", sent: null,
 };
@@ -291,13 +305,18 @@ export default function DashboardPage() {
 
   return (
     <div className="flex flex-col h-full">
-      {/* Header */}
-      <div className="flex items-center justify-between px-4 md:px-7 pt-4 md:pt-5 pb-3 md:pb-[18px] border-b border-b1 shrink-0">
-        <div>
-          <div className="text-base md:text-lg font-medium -tracking-[0.03em]">Presupuestos</div>
-          <div className="text-[11px] text-t3 mt-0.5">
+      {/* Header — editorial: eyebrow mono uppercase + título Fraunces italic gigante */}
+      <div className="flex items-end justify-between px-4 md:px-10 pt-5 md:pt-10 pb-5 md:pb-8 shrink-0 gap-6">
+        <div className="min-w-0">
+          <div className="text-[10px] md:text-[11px] font-medium font-mono text-t4 uppercase tracking-[0.14em] mb-2 md:mb-3">
             {new Date().toLocaleDateString("es-AR", { month: "long", year: "numeric" })} · {quotes.length} registros
+            {quotes.filter(q => !q.is_read).length > 0 && (
+              <> · <span className="text-acc">{quotes.filter(q => !q.is_read).length} sin leer</span></>
+            )}
           </div>
+          <h1 className="font-serif italic text-[34px] md:text-[44px] font-normal -tracking-[0.01em] text-t1 leading-[1.05]">
+            Presupuestos
+          </h1>
         </div>
         <button
           onClick={() => {
@@ -311,19 +330,20 @@ export default function DashboardPage() {
             const a = document.createElement("a"); a.href = URL.createObjectURL(blob);
             a.download = `presupuestos-${new Date().toISOString().slice(0,10)}.csv`; a.click();
           }}
-          className="px-3 py-[7px] rounded-md text-xs font-medium font-sans cursor-pointer border border-b1 bg-transparent text-t2 -tracking-[0.01em] hover:border-b2 hover:text-t1 transition"
+          className="hidden md:inline-flex items-center gap-2 px-3.5 py-[7px] rounded-md text-xs font-medium font-sans cursor-pointer border border-b1 bg-transparent text-t2 -tracking-[0.01em] hover:border-b2 hover:text-t1 transition shrink-0 mb-1"
         >
-          Exportar CSV
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><path d="M12 4v12m0 0l-5-5m5 5l5-5M4 20h16"/></svg>
+          Exportar
         </button>
       </div>
 
-      <div className="flex-1 overflow-y-auto px-4 md:px-7 py-4 md:py-6">
-        {/* Stale drafts banner */}
+      <div className="flex-1 overflow-y-auto">
+        {/* Stale drafts banner — minimal inline, no border lg rounded */}
         {staleDrafts.length > 0 && (
-          <div className="flex items-center gap-2.5 bg-amb/[0.06] border border-amb/[0.16] rounded-lg px-3.5 py-2.5 mb-5 text-xs text-amb">
+          <div className="flex items-center gap-2.5 mx-4 md:mx-10 mt-2 bg-amb/[0.06] border border-amb/[0.14] rounded-md px-4 py-2.5 text-[12px] text-amb">
             <div className="w-1.5 h-1.5 rounded-full bg-amb shrink-0" />
             <span>
-              <strong>{staleDrafts.length} {staleDrafts.length === 1 ? "presupuesto en borrador lleva" : "presupuestos en borrador llevan"} más de 5 días sin acción</strong>
+              <strong className="font-medium">{staleDrafts.length} {staleDrafts.length === 1 ? "borrador lleva" : "borradores llevan"} más de 5 días sin acción</strong>
               {" — "}{staleDrafts.map(q => q.client_name || "Sin nombre").join(" y ")}
             </span>
           </div>
@@ -339,62 +359,70 @@ export default function DashboardPage() {
             </button>
           </div>
         ) : (
-          <div className="bg-s1 border border-b1 rounded-[10px] overflow-hidden">
-            {/* Filter bar */}
-            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-2 px-3 md:px-4 py-2.5 bg-s2 border-b border-b1">
-              <div className="flex gap-1.5 overflow-x-auto pb-1 md:pb-0">
+          <div className="bg-transparent">
+            {/* Filter strip — inline dot + text, estilo editorial */}
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 px-4 md:px-10 py-3 md:py-4 border-b border-b1/60">
+              <div className="flex items-center gap-4 md:gap-6 overflow-x-auto pb-1 md:pb-0">
                 {([
-                  { key: "todos", label: "Todos" },
-                  { key: "draft", label: "Borrador" },
-                  { key: "pending", label: "Pendiente" },
-                  { key: "validated", label: "Validado" },
-                  { key: "sent", label: "Enviado" },
-                  { key: "web", label: "Web" },
-                ] as const).map(f => (
-                  <button
-                    key={f.key}
-                    onClick={() => setStatusFilter(f.key)}
-                    className={clsx(
-                      "flex items-center gap-1.5 px-3 py-[5px] rounded-md text-xs font-medium font-sans cursor-pointer border transition",
-                      statusFilter === f.key
-                        ? "border-acc-hover bg-acc-bg text-acc"
-                        : "border-b1 bg-transparent text-t3 hover:text-t2 hover:border-b2",
-                    )}
-                  >
-                    {f.label}
-                    <span className={clsx(
-                      "text-[10px] px-1.5 py-px rounded-full",
-                      statusFilter === f.key ? "bg-acc/20" : "bg-white/[0.06]",
-                    )}>
-                      {statusCounts[f.key]}
-                    </span>
-                  </button>
-                ))}
+                  { key: "todos", label: "Todos", dot: null },
+                  { key: "draft", label: "Borrador", dot: "var(--amb)" },
+                  { key: "pending", label: "Pendiente", dot: "#b299ff" },
+                  { key: "validated", label: "Validado", dot: "var(--grn)" },
+                  { key: "sent", label: "Enviado", dot: "var(--acc)" },
+                  { key: "web", label: "Web", dot: "#b48fe0" },
+                ] as const).map(f => {
+                  const active = statusFilter === f.key;
+                  return (
+                    <button
+                      key={f.key}
+                      onClick={() => setStatusFilter(f.key)}
+                      className={clsx(
+                        "flex items-center gap-2 py-1 bg-transparent border-none text-[13px] font-sans cursor-pointer transition-colors shrink-0 relative",
+                        active ? "text-t1 font-medium" : "text-t3 hover:text-t2 font-normal",
+                      )}
+                    >
+                      {f.dot && (
+                        <span className="w-[7px] h-[7px] rounded-full shrink-0" style={{ background: f.dot }} />
+                      )}
+                      <span>{f.label}</span>
+                      <span className={clsx(
+                        "text-[11px] font-mono tabular-nums",
+                        active ? "text-t3" : "text-t4",
+                      )}>{statusCounts[f.key]}</span>
+                      {active && (
+                        <span className="absolute -bottom-[13px] left-0 right-0 h-px bg-t1" />
+                      )}
+                    </button>
+                  );
+                })}
               </div>
-              <div className="hidden md:flex items-center gap-2">
-                <input type="date" value={dateFrom} onChange={e => setDateFrom(e.target.value)} className="px-2 py-[5px] rounded-md text-[11px] font-sans border border-b1 bg-s3 text-t2 outline-none w-[120px] [color-scheme:dark]" title="Desde" />
-                <span className="text-t4 text-[10px]">—</span>
-                <input type="date" value={dateTo} onChange={e => setDateTo(e.target.value)} className="px-2 py-[5px] rounded-md text-[11px] font-sans border border-b1 bg-s3 text-t2 outline-none w-[120px] [color-scheme:dark]" title="Hasta" />
-                {(dateFrom || dateTo) && (
-                  <button onClick={() => { setDateFrom(""); setDateTo(""); }} className="text-t3 text-[11px] bg-transparent border-none cursor-pointer hover:text-t2 p-0">✕</button>
-                )}
-              </div>
-              <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-b1 bg-s3 w-full md:w-60">
-                <svg className="text-t3 shrink-0" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                  <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
-                </svg>
-                <input
-                  value={search}
-                  onChange={e => setSearch(e.target.value)}
-                  placeholder="Buscar cliente, material..."
-                  aria-label="Buscar presupuestos"
-                  className="bg-transparent border-none outline-none text-t1 text-xs font-sans w-full placeholder:text-t4"
-                />
-                {search && (
-                  <button onClick={() => setSearch("")} className="bg-transparent border-none text-t3 cursor-pointer text-[11px] p-0 hover:text-t2">
-                    ✕
-                  </button>
-                )}
+              <div className="flex items-center gap-3 md:gap-4 shrink-0">
+                <div className="hidden md:flex items-center gap-2 text-[12px] text-t3">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.4"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18M8 3v4M16 3v4" strokeLinecap="round"/></svg>
+                  <input type="date" value={dateFrom} onChange={e => setDateFrom(e.target.value)} className="px-1 py-0.5 text-[12px] font-sans bg-transparent text-t2 outline-none w-[92px] [color-scheme:dark] border-0 focus:text-t1" title="Desde" />
+                  <span className="text-t4">—</span>
+                  <input type="date" value={dateTo} onChange={e => setDateTo(e.target.value)} className="px-1 py-0.5 text-[12px] font-sans bg-transparent text-t2 outline-none w-[92px] [color-scheme:dark] border-0 focus:text-t1" title="Hasta" />
+                  {(dateFrom || dateTo) && (
+                    <button onClick={() => { setDateFrom(""); setDateTo(""); }} className="text-t3 text-[11px] bg-transparent border-none cursor-pointer hover:text-t2 p-0 ml-1">✕</button>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 px-3 py-1.5 rounded-md border border-b1 bg-transparent w-full md:w-56">
+                  <svg className="text-t3 shrink-0" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+                    <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                  </svg>
+                  <input
+                    value={search}
+                    onChange={e => setSearch(e.target.value)}
+                    placeholder="Buscar cliente, material..."
+                    aria-label="Buscar presupuestos"
+                    className="bg-transparent border-none outline-none text-t1 text-[12px] font-sans w-full placeholder:text-t4"
+                  />
+                  {search && (
+                    <button onClick={() => setSearch("")} className="bg-transparent border-none text-t3 cursor-pointer text-[11px] p-0 hover:text-t2">
+                      ✕
+                    </button>
+                  )}
+                </div>
               </div>
             </div>
 
@@ -436,8 +464,8 @@ export default function DashboardPage() {
               )}
             </div>
 
-            {/* Mobile Cards */}
-            <div className="md:hidden divide-y divide-white/[0.045]">
+            {/* Mobile Cards — editorial: cliente serif, importe serif, status dot+text */}
+            <div className="md:hidden divide-y divide-b1/50">
               {pageQuotes.map(q => {
                 const isUnread = !q.is_read;
                 const isChecked = selectedIds.has(q.id);
@@ -455,9 +483,9 @@ export default function DashboardPage() {
                       }
                     }}
                     className={clsx(
-                      "flex items-center gap-3 px-3 py-3 cursor-pointer active:bg-white/[0.04] transition",
-                      isChecked && "bg-acc/[0.09]",
-                      !isChecked && isUnread && "bg-acc/[0.04]",
+                      "flex items-start gap-3 px-5 py-5 cursor-pointer active:bg-white/[0.03] transition",
+                      isChecked && "bg-acc/[0.08]",
+                      !isChecked && isUnread && "bg-acc/[0.03]",
                       selectionMode && checkboxDisabled && "opacity-45"
                     )}
                   >
@@ -468,50 +496,39 @@ export default function DashboardPage() {
                         disabled={checkboxDisabled}
                         onChange={() => toggleSelect(q.id)}
                         onClick={(e) => e.stopPropagation()}
-                        className="w-4 h-4 accent-acc shrink-0"
+                        className="w-4 h-4 accent-acc shrink-0 mt-1"
                       />
                     )}
                     <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-1.5">
+                      <div className="flex items-baseline gap-2">
                         {isUnread && <span className="w-[6px] h-[6px] rounded-full bg-acc shrink-0" />}
-                        <span className={clsx("text-[13px] truncate", isUnread ? "font-semibold text-t1" : "font-medium text-t1")}>{q.client_name || "Sin nombre"}</span>
-                        {q.source === "web" && <span className="text-[8px] font-semibold px-1 py-px rounded bg-purple-500/15 text-purple-400">WEB</span>}
+                        <span className="font-serif italic text-[17px] text-t1 font-medium -tracking-[0.01em] truncate leading-tight">{q.client_name || "Sin nombre"}</span>
+                        {q.source === "web" && <span className="text-[9px] font-semibold font-mono px-1.5 py-[1px] rounded border border-[#b48fe0]/30 text-[#b48fe0] tracking-wider not-italic">WEB</span>}
                       </div>
-                      <div className="text-[11px] text-t3 truncate mt-0.5">{q.material || "\u2014"}</div>
+                      <div className="text-[12px] text-t3 truncate mt-1 font-sans">{q.material || q.project || "\u2014"}</div>
+                      <div className="flex items-center gap-3 mt-2">
+                        <span className={clsx("inline-flex items-center gap-1.5 text-[12px] font-sans", STATUS_TEXT[q.status])}>
+                          <span className="w-[6px] h-[6px] rounded-full shrink-0" style={{ background: STATUS_DOT[q.status] }} />
+                          {STATUS_LABEL[q.status]}
+                        </span>
+                        <span className="text-[11px] text-t4 font-mono tabular-nums">
+                          {format(new Date(q.created_at), "d MMM", { locale: es })}
+                        </span>
+                      </div>
                     </div>
                     <div className="text-right shrink-0">
-                      <div className="text-[13px] font-mono text-t1">{q.total_ars ? `$${q.total_ars.toLocaleString("es-AR")}` : "\u2014"}</div>
-                      {q.total_usd ? <div className="text-[10px] text-t3">USD {q.total_usd.toLocaleString()}</div> : null}
+                      <div className="font-serif text-[16px] text-t1 -tracking-[0.01em] leading-none whitespace-nowrap">{q.total_ars ? `$\u00A0${q.total_ars.toLocaleString("es-AR")}` : "\u2014"}</div>
+                      {q.total_usd ? <div className="text-[10px] text-t3 mt-1.5 font-mono">USD {q.total_usd.toLocaleString()}</div> : null}
                     </div>
-                    {q.material && (
-                      <button
-                        onClick={(e) => askDerive(e, q.id, q.material || "", q.client_name)}
-                        title="Duplicar con otro material"
-                        className="w-7 h-7 rounded-md border border-b1 bg-transparent text-t3 cursor-pointer flex items-center justify-center text-[10px] shrink-0 transition-all hover:border-acc/50 hover:text-acc"
-                      >
-                        +M
-                      </button>
-                    )}
-                    <span className={clsx("text-[10px] font-medium px-1.5 py-[2px] rounded-full shrink-0", BADGE_CLASS[q.status])}>{STATUS_LABEL[q.status]}</span>
                   </div>
                 );
               })}
             </div>
 
-            {/* Desktop Table */}
+            {/* Desktop Table — editorial: sin header de columnas, filas
+                con cliente serif italic, importe serif, estado como
+                dot+texto, separador sutil. */}
             <table className="w-full border-collapse hidden md:table">
-              <thead className="bg-s2 border-b border-b1">
-                <tr>
-                  <th className="px-3 py-2.5 w-8"></th>
-                  <th className="text-left px-[18px] py-2.5 text-[10px] font-medium text-t3 uppercase tracking-[0.09em] w-[28%]">Cliente</th>
-                  <th className="text-left px-[18px] py-2.5 text-[10px] font-medium text-t3 uppercase tracking-[0.09em]">Material</th>
-                  <th className="text-right px-[18px] py-2.5 text-[10px] font-medium text-t3 uppercase tracking-[0.09em]">Importe</th>
-                  <th className="text-center px-[18px] py-2.5 text-[10px] font-medium text-t3 uppercase tracking-[0.09em]">Estado</th>
-                  <th className="text-right px-[18px] py-2.5 text-[10px] font-medium text-t3 uppercase tracking-[0.09em]">Fecha</th>
-                  <th className="text-right px-[18px] py-2.5 text-[10px] font-medium text-t3 uppercase tracking-[0.09em]">Archivos</th>
-                  <th className="px-[18px] py-2.5 w-10"></th>
-                </tr>
-              </thead>
               <tbody>
                 {pageQuotes.map(q => {
                   const daysOld = (Date.now() - new Date(q.created_at).getTime()) / 86400000;
@@ -531,25 +548,26 @@ export default function DashboardPage() {
                           )
                         ? "Cliente distinto — limpiá la selección para elegir éste, o confirmá manualmente en el siguiente paso"
                         : undefined;
+                  const isBuilding = q.quote_kind === "building_parent" || q.is_building;
                   return (
                     <tr
                       key={q.id}
                       onClick={() => { setSelectedId(q.id); router.push(`/quote/${q.id}`); }}
                       className={clsx(
-                        "border-b border-white/[0.045] cursor-pointer transition-[background] duration-75",
+                        "border-b border-b1/50 cursor-pointer transition-colors duration-75",
                         isChecked
-                          ? "bg-acc/[0.09] border-l-2 border-l-acc"
+                          ? "bg-acc/[0.08]"
                           : checkboxDisabled && selectedIds.size > 0
-                            ? "opacity-45 border-l-2 border-l-transparent hover:bg-white/[0.02]"
+                            ? "opacity-45 hover:bg-white/[0.015]"
                             : isSelected
-                              ? "bg-acc/[0.07] border-l-2 border-l-acc"
+                              ? "bg-acc/[0.05]"
                               : isUnread
-                                ? "bg-acc/[0.04] border-l-2 border-l-transparent hover:bg-acc/[0.07]"
-                                : "border-l-2 border-l-transparent hover:bg-white/[0.035]",
+                                ? "bg-acc/[0.03] hover:bg-acc/[0.05]"
+                                : "hover:bg-white/[0.02]",
                       )}
                     >
                       {/* Checkbox */}
-                      <td className="px-3 py-[13px]" onClick={(e) => e.stopPropagation()}>
+                      <td className="pl-6 pr-2 py-6 w-10" onClick={(e) => e.stopPropagation()}>
                         <input
                           type="checkbox"
                           checked={isChecked}
@@ -559,123 +577,124 @@ export default function DashboardPage() {
                           aria-label={checkboxReason || "Seleccionar presupuesto"}
                           className={clsx(
                             "w-4 h-4 accent-acc cursor-pointer",
-                            checkboxDisabled && "cursor-not-allowed"
+                            checkboxDisabled && "cursor-not-allowed",
+                            !isChecked && "opacity-0 hover:opacity-100 transition-opacity"
                           )}
                         />
                       </td>
-                      {/* Cliente */}
-                      <td className="px-[18px] py-[13px] max-w-[300px]">
-                        <div className="flex items-center">
-                          {isUnread && <span className="w-[7px] h-[7px] rounded-full bg-acc shrink-0 mr-2" />}
+                      {/* Cliente — serif italic grande + sublabel sans */}
+                      <td className="px-4 py-6 max-w-[320px]">
+                        <div className="flex items-baseline gap-2">
+                          {isUnread && <span className="w-[7px] h-[7px] rounded-full bg-acc shrink-0" />}
                           <div className="min-w-0">
-                            <div className={clsx("text-[13px] text-t1 -tracking-[0.01em] truncate", isUnread ? "font-semibold" : "font-medium")}>
-                              {q.client_name || <span className="text-t3 italic">Sin nombre</span>}
+                            <div className="font-serif italic text-[18px] font-medium text-t1 -tracking-[0.01em] truncate leading-tight">
+                              {q.client_name || <span className="text-t3">Sin nombre</span>}
                               {q.source === "web" && (
-                                <span className="ml-1.5 text-[9px] font-semibold px-[5px] py-px rounded bg-purple-500/15 text-purple-400 tracking-wide">WEB</span>
+                                <span className="ml-2 text-[9px] font-semibold font-mono tracking-wider px-1.5 py-[2px] rounded border border-[#b48fe0]/30 text-[#b48fe0] align-middle not-italic">WEB</span>
                               )}
                               {isUnread && (
-                                <span className="ml-1.5 text-[9px] font-semibold px-1.5 py-px rounded bg-acc-bg text-acc tracking-wide">NUEVO</span>
+                                <span className="ml-2 text-[9px] font-semibold font-mono tracking-wider px-1.5 py-[2px] rounded border border-acc/40 text-acc align-middle not-italic">NUEVO</span>
                               )}
                             </div>
-                            <div className="text-[11px] text-t3 mt-px truncate">{q.project}</div>
+                            <div className="text-[12px] text-t3 mt-0.5 truncate font-sans">{q.project}</div>
                           </div>
                         </div>
                       </td>
-                      {/* Material */}
-                      <td className={clsx("px-[18px] py-[13px] text-xs max-w-[250px] truncate", isUnread ? "text-t1 font-medium" : "text-t2")}>
-                        {q.quote_kind === "building_parent" || q.is_building ? (
-                          <span className="flex items-center gap-1.5">
-                            <span className="text-[9px] font-semibold px-1.5 py-px rounded bg-purple-500/15 text-purple-400">OBRA</span>
+                      {/* Material — sans sentence case, chip OBRA outlined */}
+                      <td className="px-4 py-6 text-[13px] max-w-[280px] text-t2">
+                        {isBuilding ? (
+                          <span className="flex items-center gap-2">
+                            <span className="text-[9px] font-semibold font-mono tracking-wider px-1.5 py-[2px] rounded border border-[#b48fe0]/30 text-[#b48fe0]">OBRA</span>
                             <span className="truncate">{q.material || q.project || "Edificio"}</span>
                           </span>
                         ) : (
-                          q.material || "\u2014"
+                          <span className="truncate">{q.material || "\u2014"}</span>
                         )}
                       </td>
-                      {/* Importe */}
-                      <td className="px-[18px] py-[13px] text-right">
-                        <div className="text-[13px] text-t1 font-mono -tracking-[0.02em]">
-                          {q.total_ars ? `$${q.total_ars.toLocaleString("es-AR")}` : "\u2014"}
+                      {/* Importe — ARS Fraunces grande + USD mono chico */}
+                      <td className="px-4 py-6 text-right whitespace-nowrap">
+                        <div className="font-serif text-[18px] text-t1 -tracking-[0.01em] leading-none">
+                          {q.total_ars ? `$\u00A0${q.total_ars.toLocaleString("es-AR")}` : "\u2014"}
                         </div>
                         {q.total_usd ? (
-                          <div className="text-[11px] text-t3 mt-px">USD {q.total_usd.toLocaleString()}</div>
+                          <div className="text-[11px] text-t3 mt-1.5 font-mono tabular-nums">USD {q.total_usd.toLocaleString()}</div>
                         ) : null}
                       </td>
-                      {/* Estado */}
-                      <td className="px-[18px] py-[13px] text-center">
+                      {/* Estado — dot + texto, no pill */}
+                      <td className="px-4 py-6">
                         <button
                           onClick={(e) => toggleStatus(e, q.id, q.status)}
                           title={STATUS_NEXT[q.status] ? `Cambiar a ${STATUS_LABEL[STATUS_NEXT[q.status]!]}` : "Estado final"}
                           className={clsx(
-                            "inline-flex items-center gap-[5px] px-2 py-[3px] rounded-full text-[11px] font-medium border-none font-sans",
-                            STATUS_NEXT[q.status] ? "cursor-pointer" : "cursor-default",
-                            BADGE_CLASS[q.status],
+                            "inline-flex items-center gap-2 bg-transparent border-none text-[13px] font-sans p-0",
+                            STATUS_NEXT[q.status] ? "cursor-pointer hover:opacity-80" : "cursor-default",
+                            STATUS_TEXT[q.status],
                           )}
                         >
-                          <span className="w-[5px] h-[5px] rounded-full bg-current" />
+                          <span className="w-[7px] h-[7px] rounded-full shrink-0" style={{ background: STATUS_DOT[q.status] }} />
                           {STATUS_LABEL[q.status]}
                         </button>
                       </td>
-                      {/* Fecha */}
-                      <td className={clsx("px-[18px] py-[13px] text-[11px] text-right", isStale ? "text-amb" : "text-t3")}>
+                      {/* Fecha — mono chico */}
+                      <td className={clsx("px-4 py-6 text-[12px] font-mono tabular-nums whitespace-nowrap", isStale ? "text-amb" : "text-t3")}>
                         {format(new Date(q.created_at), "d MMM", { locale: es })}
-                        {isStale && ` ·${Math.floor(daysOld)}d`}
+                        {isStale && ` · ${Math.floor(daysOld)}d`}
                       </td>
-                      {/* Archivos */}
-                      <td className="px-[18px] py-[13px]">
-                        <div className="flex gap-1 justify-end" onClick={e => e.stopPropagation()}>
+                      {/* Archivos — pills outline */}
+                      <td className="px-4 py-6">
+                        <div className="flex gap-1.5 justify-end" onClick={e => e.stopPropagation()}>
                           {(q.drive_pdf_url || q.pdf_url) && <FileBtn href={q.drive_pdf_url || q.pdf_url!} emoji="📄" label="PDF" />}
                           {(q.drive_excel_url || q.excel_url) && <FileBtn href={q.drive_excel_url || q.excel_url!} emoji="📊" label="Excel" />}
+                          {!q.drive_pdf_url && !q.pdf_url && !q.drive_excel_url && !q.excel_url && <span className="text-t4 text-[11px] font-mono">—</span>}
                         </div>
                       </td>
-                      {/* Duplicar material */}
-                      <td className="px-1 py-[13px] w-10">
-                        {q.material ? (
+                      {/* Acciones (hover reveal) */}
+                      <td className="pl-2 pr-6 py-6 w-[72px]">
+                        <div className="flex gap-1 opacity-0 hover:opacity-100 transition-opacity" onClick={e => e.stopPropagation()}>
+                          {q.material && (
+                            <button
+                              onClick={(e) => askDerive(e, q.id, q.material || "", q.client_name)}
+                              title="Duplicar con otro material"
+                              className="w-7 h-7 rounded-md border border-b1 bg-transparent text-t3 cursor-pointer flex items-center justify-center text-[10px] font-medium transition-all hover:border-acc/50 hover:text-acc"
+                            >
+                              +M
+                            </button>
+                          )}
                           <button
-                            onClick={(e) => askDerive(e, q.id, q.material || "", q.client_name)}
-                            title="Duplicar con otro material"
-                            className="w-7 h-7 rounded-md border border-b1 bg-transparent text-t3 cursor-pointer flex items-center justify-center text-[10px] font-medium transition-all hover:border-acc/50 hover:text-acc"
+                            onClick={(e) => askDelete(e, q.id, q.client_name)}
+                            title="Eliminar presupuesto"
+                            className="w-7 h-7 rounded-md border border-b1 bg-transparent text-t3 cursor-pointer flex items-center justify-center text-xs transition-all hover:border-err/50 hover:text-err"
                           >
-                            +M
+                            ✕
                           </button>
-                        ) : null}
-                      </td>
-                      {/* Delete */}
-                      <td className="px-2.5 py-[13px] w-10">
-                        <button
-                          onClick={(e) => askDelete(e, q.id, q.client_name)}
-                          title="Eliminar presupuesto"
-                          className="w-7 h-7 rounded-md border border-b1 bg-transparent text-t3 cursor-pointer flex items-center justify-center text-xs transition-all hover:border-err/50 hover:text-err"
-                        >
-                          ✕
-                        </button>
+                        </div>
                       </td>
                     </tr>
                   );
                 })}
               </tbody>
             </table>
-            {/* Pagination bar — solo si hay más de 1 página */}
+            {/* Pagination bar — transparente, minimal */}
             {filteredQuotes.length > 0 && totalPages > 1 && (
-              <div className="flex items-center justify-between px-4 py-2.5 border-t border-b1 bg-s2/80 text-[12px]">
+              <div className="flex items-center justify-between px-6 md:px-10 py-5 text-[12px]">
                 <span className="text-t3 font-mono tabular-nums">
                   {page * pageSize + 1}–{Math.min((page + 1) * pageSize, filteredQuotes.length)} de {filteredQuotes.length}
                 </span>
-                <div className="flex items-center gap-1.5">
+                <div className="flex items-center gap-2">
                   <button
                     disabled={page === 0}
                     onClick={() => setPage(p => p - 1)}
-                    className="px-2.5 py-1 rounded-md text-t2 bg-transparent border border-b1 cursor-pointer disabled:opacity-30 disabled:cursor-default hover:bg-white/[0.04] hover:text-t1 transition text-[11px] font-medium"
+                    className="px-3 py-1.5 rounded-md text-t2 bg-transparent border border-b1 cursor-pointer disabled:opacity-30 disabled:cursor-default hover:bg-white/[0.03] hover:text-t1 transition text-[11px] font-medium"
                   >
                     ← Anterior
                   </button>
                   <span className="px-2 text-t3 font-mono tabular-nums">
-                    {page + 1}/{totalPages}
+                    {page + 1} / {totalPages}
                   </span>
                   <button
                     disabled={page >= totalPages - 1}
                     onClick={() => setPage(p => p + 1)}
-                    className="px-2.5 py-1 rounded-md text-t2 bg-transparent border border-b1 cursor-pointer disabled:opacity-30 disabled:cursor-default hover:bg-white/[0.04] hover:text-t1 transition text-[11px] font-medium"
+                    className="px-3 py-1.5 rounded-md text-t2 bg-transparent border border-b1 cursor-pointer disabled:opacity-30 disabled:cursor-default hover:bg-white/[0.03] hover:text-t1 transition text-[11px] font-medium"
                   >
                     Siguiente →
                   </button>
@@ -684,12 +703,22 @@ export default function DashboardPage() {
             )}
 
             {filteredQuotes.length === 0 && (
-              <div className="flex flex-col items-center justify-center py-16 gap-2 text-t3">
-                <span className="text-2xl">📋</span>
-                <div className="text-[13px]">{quotes.length === 0 ? "No hay presupuestos todavía" : "Sin resultados para los filtros aplicados"}</div>
+              <div className="flex flex-col items-center justify-center py-24 gap-3 text-t3">
+                <svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.2" className="text-acc/60">
+                  <path d="M3 14l2-8h14l2 8" strokeLinejoin="round"/>
+                  <path d="M3 14h6l1 2h4l1-2h6v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4z" strokeLinejoin="round"/>
+                </svg>
+                <div className="font-serif italic text-[18px] text-t2 -tracking-[0.01em]">
+                  {quotes.length === 0 ? "Sin presupuestos todavía" : "Sin resultados para los filtros aplicados"}
+                </div>
+                <div className="text-[12px] text-t4 font-sans max-w-[360px] text-center">
+                  {quotes.length === 0
+                    ? "Subí un plano o dictá un enunciado y Valentina arma el primero."
+                    : "Probá cambiar el filtro o limpiar la búsqueda."}
+                </div>
                 {(search || dateFrom || dateTo || statusFilter !== "todos") && (
                   <button onClick={() => { setSearch(""); setDateFrom(""); setDateTo(""); setStatusFilter("todos"); }}
-                    className="mt-1 text-xs text-acc bg-transparent border-none cursor-pointer font-sans hover:underline">
+                    className="mt-2 text-xs text-acc bg-transparent border-none cursor-pointer font-sans hover:underline">
                     Limpiar filtros
                   </button>
                 )}

--- a/web/src/components/ui/Sidebar.tsx
+++ b/web/src/components/ui/Sidebar.tsx
@@ -24,23 +24,19 @@ export default function Sidebar({ isOpen, onClose }: { isOpen?: boolean; onClose
     router.push(to);
   }
 
+  const unread = quotes.filter(q => !q.is_read).length;
   const sidebarContent = (
-    <nav className="w-[212px] shrink-0 bg-s1 border-r border-b1 flex flex-col px-2.5 pt-[18px] pb-5 h-full">
-      {/* Logo */}
-      <div onClick={() => navigate("/")} className="flex items-center gap-2.5 px-2 pt-0.5 pb-5 cursor-pointer">
-        <div className="w-[26px] h-[26px] rounded-md bg-acc flex items-center justify-center text-xs font-semibold text-white -tracking-[0.5px]">D</div>
-        <span className="text-[13px] font-medium -tracking-[0.02em] text-t1">D&apos;Angelo</span>
+    <nav className="w-[200px] shrink-0 bg-bg flex flex-col px-4 pt-6 pb-6 h-full">
+      {/* Logo — Fraunces italic, badge con acento suave */}
+      <div onClick={() => navigate("/")} className="flex items-center gap-3 pb-8 cursor-pointer group">
+        <div className="w-[34px] h-[34px] rounded-lg bg-gradient-to-br from-acc/90 to-acc-hover flex items-center justify-center text-[13px] font-semibold text-white -tracking-[0.5px] shadow-[0_4px_12px_var(--acc-shadow)]">D</div>
+        <span className="font-serif italic text-[19px] font-medium -tracking-[0.01em] text-t1 leading-none">D&apos;Angelo</span>
       </div>
 
-      {/* Nav */}
-      <span className="text-[10px] font-medium text-t4 uppercase tracking-[0.10em] px-2 pb-1">Principal</span>
-      <NavItem icon={<GridIcon />} label="Presupuestos" badge={String(quotes.length)} unreadCount={quotes.filter(q => !q.is_read).length} active={path === "/"} onClick={() => navigate("/")} />
-
-      <span className="text-[10px] font-medium text-t4 uppercase tracking-[0.10em] px-2 pb-1 mt-3.5">Sistema</span>
-      <NavItem icon={<GearIcon />} label="Catálogo" active={path === "/config"} onClick={() => navigate("/config")} />
-      <NavItem icon={<SettingsIcon />} label="Configuración" active={path === "/settings"} onClick={() => navigate("/settings")} />
-
-      <div className="h-px bg-b1 my-3" />
+      {/* Nav items — sin labels de sección, tipografía editorial */}
+      <NavItem icon={<InboxIcon />} label="Presupuestos" count={quotes.length} unreadCount={unread} active={path === "/"} onClick={() => navigate("/")} />
+      <NavItem icon={<BookIcon />} label="Catálogo" active={path === "/config"} onClick={() => navigate("/config")} />
+      <NavItem icon={<CogIcon />} label="Configuración" active={path === "/settings"} onClick={() => navigate("/settings")} />
 
       <div className="mt-auto">
         <button onClick={handleNew} className="w-full py-2.5 px-3 bg-acc border-none rounded-lg text-white text-[13px] font-medium font-sans cursor-pointer flex items-center justify-center gap-[7px] -tracking-[0.01em] transition-all duration-150 hover:bg-acc-hover hover:-translate-y-px hover:shadow-[0_8px_24px_var(--acc-shadow)]">
@@ -74,48 +70,49 @@ export default function Sidebar({ isOpen, onClose }: { isOpen?: boolean; onClose
 // Mobile top bar component
 export function MobileTopBar({ onMenuClick }: { onMenuClick: () => void }) {
   return (
-    <div className="md:hidden flex items-center gap-3 px-4 py-3 bg-s1 border-b border-b1 shrink-0">
+    <div className="md:hidden flex items-center gap-3 px-4 py-3 bg-bg border-b border-b1 shrink-0">
       <button onClick={onMenuClick} className="bg-transparent border-none text-t2 cursor-pointer p-1">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
           <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
         </svg>
       </button>
-      <div className="w-[22px] h-[22px] rounded-md bg-acc flex items-center justify-center text-[10px] font-semibold text-white">D</div>
-      <span className="text-[13px] font-medium text-t1">D&apos;Angelo</span>
+      <div className="w-[24px] h-[24px] rounded-md bg-gradient-to-br from-acc/90 to-acc-hover flex items-center justify-center text-[11px] font-semibold text-white">D</div>
+      <span className="font-serif italic text-[15px] font-medium text-t1 leading-none">D&apos;Angelo</span>
     </div>
   );
 }
 
-function NavItem({ icon, label, badge, unreadCount, active, onClick }: {
-  icon: React.ReactNode; label: string; badge?: string; unreadCount?: number; active: boolean; onClick: () => void;
+function NavItem({ icon, label, count, unreadCount, active, onClick }: {
+  icon: React.ReactNode; label: string; count?: number; unreadCount?: number; active: boolean; onClick: () => void;
 }) {
   return (
     <button onClick={onClick} className={clsx(
-      "flex items-center gap-2 p-2 rounded-md text-xs font-normal cursor-pointer border-none w-full text-left transition-all duration-100 font-sans",
-      active ? "text-acc bg-acc/[0.11]" : "text-t2 bg-transparent hover:bg-white/[0.04]",
+      "flex items-center gap-3 px-3 py-[9px] rounded-md text-[13px] cursor-pointer border-none w-full text-left transition-colors duration-100 font-sans mb-0.5",
+      active ? "text-t1 bg-white/[0.035]" : "text-t2 bg-transparent hover:bg-white/[0.025]",
     )}>
-      <span className={clsx("shrink-0", active ? "opacity-100" : "opacity-65")}>{icon}</span>
-      {label}
+      <span className={clsx("shrink-0", active ? "text-acc" : "text-t3")}>{icon}</span>
+      <span className={clsx("flex-1", active ? "font-medium" : "font-normal")}>{label}</span>
       {unreadCount ? (
-        <span className="ml-auto text-[10px] font-semibold px-[7px] py-px rounded-full bg-acc text-white font-mono">{unreadCount}</span>
-      ) : badge ? (
-        <span className="ml-auto text-[10px] font-medium px-[7px] py-px rounded-full bg-white/[0.07] text-t3 font-mono">{badge}</span>
+        <span className="text-[10px] font-semibold px-[7px] py-px rounded-full bg-acc text-white font-mono">{unreadCount}</span>
+      ) : count != null ? (
+        <span className="text-[11px] text-t4 font-mono tabular-nums">{count}</span>
       ) : null}
     </button>
   );
 }
 
-function GridIcon() {
-  return <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>;
+// Iconos de trazo fino — estilo editorial, no "blocky".
+function InboxIcon() {
+  return <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"><path d="M3 14l2-8h14l2 8"/><path d="M3 14h6l1 2h4l1-2h6v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4z"/></svg>;
 }
-function GearIcon() {
-  return <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8"><path d="M12.22 2h-.44a2 2 0 00-2 2v.18a2 2 0 01-1 1.73l-.43.25a2 2 0 01-2 0l-.15-.08a2 2 0 00-2.73.73l-.22.38a2 2 0 00.73 2.73l.15.1a2 2 0 011 1.72v.51a2 2 0 01-1 1.74l-.15.09a2 2 0 00-.73 2.73l.22.38a2 2 0 002.73.73l.15-.08a2 2 0 012 0l.43.25a2 2 0 011 1.73V20a2 2 0 002 2h.44a2 2 0 002-2v-.18a2 2 0 011-1.73l.43-.25a2 2 0 012 0l.15.08a2 2 0 002.73-.73l.22-.39a2 2 0 00-.73-2.73l-.15-.08a2 2 0 01-1-1.74v-.5a2 2 0 011-1.74l.15-.09a2 2 0 00.73-2.73l-.22-.38a2 2 0 00-2.73-.73l-.15.08a2 2 0 01-2 0l-.43-.25a2 2 0 01-1-1.73V4a2 2 0 00-2-2z"/><circle cx="12" cy="12" r="3"/></svg>;
+function BookIcon() {
+  return <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"><path d="M4 5a2 2 0 012-2h13v16H6a2 2 0 00-2 2V5zM4 19a2 2 0 012-2h13"/></svg>;
+}
+function CogIcon() {
+  return <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09a1.65 1.65 0 00-1-1.51 1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 11-2.83-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09a1.65 1.65 0 001.51-1 1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 112.83-2.83l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 112.83 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>;
 }
 function PlusIcon() {
   return <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>;
-}
-function SettingsIcon() {
-  return <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>;
 }
 function LogoutIcon() {
   return <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>;

--- a/web/src/lib/design-tokens.ts
+++ b/web/src/lib/design-tokens.ts
@@ -18,15 +18,15 @@
 
 export const COLORS = {
   /* Superficies (dark, "pizarra & acero") */
-  bg: "#0f1318",
-  s1: "#141923",
-  s2: "#1a1f26",
-  s3: "#232934",
+  bg: "#070b10",
+  s1: "#0a0e13",
+  s2: "#111720",
+  s3: "#1a2230",
 
   /* Bordes y líneas sutiles — tint crema fría */
-  b1: "rgba(232,237,229,0.07)",
-  b2: "rgba(232,237,229,0.14)",
-  b3: "rgba(232,237,229,0.20)",
+  b1: "rgba(232,237,229,0.06)",
+  b2: "rgba(232,237,229,0.12)",
+  b3: "rgba(232,237,229,0.18)",
 
   /* Tinta */
   t1: "#e8ede5",


### PR DESCRIPTION
Segundo paso del rediseño UI/UX. **Solo visual, cero impacto funcional.**

## Summary

- **Bg global más oscuro** — \`#0f1318 → #070b10\` (casi negro con tint pizarra). Sidebar \`s1\` queda ~1% más clara que bg → deja de verse separada del main, look editorial.
- **Sidebar restyleada** — brand \"D'Angelo\" en Fraunces italic, sin labels \"Principal/Sistema\", items limpios con iconos de trazo fino, count en mono tabular.
- **Header editorial** — eyebrow mono uppercase \`ABRIL 2026 · 8 REGISTROS · 3 SIN LEER\` + título \"Presupuestos\" en Fraunces italic 44px.
- **Filter strip** — pills con border → **dot + texto inline** estilo editorial. Active state con underline sutil (sin bg).
- **Tabla desktop** — sin thead de columnas, cliente en Fraunces italic 18px, importe ARS en Fraunces 18px + USD mono 11px abajo, estado como **dot + texto coloreado** (no pill), OBRA/WEB/NUEVO como pills outline. Respiro vertical py-6. Checkbox + acciones hover-reveal.
- **Mobile cards** — cliente serif italic + importe serif + status dot inline.
- **Empty state** — icon SVG + título Fraunces italic + copy sans.
- **Pagination + stale banner** — transparentes / minimal.

Spec del futuro **PR G** (VAvatar animado) queda guardado en \`docs/pr-g-avatar-animation-spec.md\` para cuando toque.

## Test plan

- [x] Typecheck limpio
- [x] Preview login renderiza con bg más oscuro
- [ ] **User validation visual** del dashboard logueado vs el diseño target (se espera iteración pixel-perfect en PR B.1)
- [ ] Verificar que filtros + paginación + selección múltiple + modales siguen funcionando idénticos

## Siguientes PRs

B.1 pixel-perfect tune-up (tras feedback visual) · C: login + detalle + catálogo · D: chat · E: Home \"Buen día\" · G: avatar animado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)