### PR TITLE
feat(design): PR C — login + detalle + catálogo restyleados

### DIFF
--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -41,15 +41,15 @@ export default function LoginPage() {
       <div className="hidden md:block fixed w-[600px] h-[600px] top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none bg-[radial-gradient(circle,rgba(95,125,160,0.06)_0%,transparent_70%)]" />
 
       <div className="relative z-[1] w-full max-w-[400px] mx-4 bg-s1 border border-b1 rounded-2xl px-5 md:px-9 pt-8 md:pt-10 pb-7 md:pb-9 shadow-[0_24px_80px_rgba(0,0,0,0.5),0_0_0_1px_rgba(255,255,255,0.03)_inset]">
-        {/* Branding */}
-        <div className="text-center mb-8">
-          <div className="inline-flex items-center justify-center w-11 h-11 bg-acc-bg border border-acc/20 rounded-xl text-xl font-bold text-acc mb-4 -tracking-[0.02em]">
+        {/* Branding — badge con gradient + brand serif italic */}
+        <div className="text-center mb-9">
+          <div className="inline-flex items-center justify-center w-12 h-12 bg-gradient-to-br from-acc/90 to-acc-hover rounded-xl text-[22px] font-semibold text-white mb-5 -tracking-[0.02em] shadow-[0_6px_20px_var(--acc-shadow)]">
             D
           </div>
-          <div className="text-lg font-semibold text-t1 -tracking-[0.03em]">
+          <div className="font-serif italic text-[22px] font-medium text-t1 -tracking-[0.01em] leading-tight">
             D&apos;Angelo Marmoleria
           </div>
-          <div className="text-xs text-t3 mt-1 tracking-wide">
+          <div className="text-[11px] text-t3 mt-2 tracking-[0.14em] uppercase font-mono">
             Sistema de presupuestos
           </div>
         </div>

--- a/web/src/components/catalog/CatalogToolbar.tsx
+++ b/web/src/components/catalog/CatalogToolbar.tsx
@@ -43,19 +43,19 @@ export default function CatalogToolbar({
   const disableSave = !validation?.valid || saving || !hasChanges;
 
   return (
-    <div className="flex flex-wrap md:flex-nowrap items-center justify-between px-3 md:px-5 py-2.5 md:py-3 border-b border-b1 bg-s1 shrink-0 gap-2 md:gap-3">
-      {/* Left: back + title */}
-      <div className="flex items-center gap-3 shrink-0">
+    <div className="flex flex-wrap md:flex-nowrap items-center justify-between px-4 md:px-8 py-3 md:py-4 border-b border-b1 bg-bg shrink-0 gap-2 md:gap-3">
+      {/* Left: back + title (Fraunces italic editorial) */}
+      <div className="flex items-center gap-4 shrink-0">
         <button
           onClick={onBack}
-          className="w-[30px] h-[30px] rounded-md border border-b1 bg-transparent text-t2 cursor-pointer flex items-center justify-center transition hover:border-b2 hover:text-t1"
+          className="w-[32px] h-[32px] rounded-md border border-b1 bg-transparent text-t2 cursor-pointer flex items-center justify-center transition hover:border-b2 hover:text-t1"
           aria-label="Volver"
         >
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="15 18 9 12 15 6"/></svg>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
         </button>
         <div>
-          <div className="text-[15px] font-medium text-t1 -tracking-[0.02em]">Catalogo</div>
-          <div className="text-[10px] text-t3 mt-0.5">Validacion IA antes de guardar</div>
+          <div className="font-serif italic text-[20px] font-medium text-t1 -tracking-[0.01em] leading-none">Catálogo</div>
+          <div className="text-[10px] text-t4 mt-1.5 uppercase tracking-[0.14em] font-mono">Validación IA antes de guardar</div>
         </div>
       </div>
 

--- a/web/src/components/quote/PricingSummary.tsx
+++ b/web/src/components/quote/PricingSummary.tsx
@@ -9,20 +9,39 @@ export default function PricingSummary({ totalArs, totalUsd }: Props) {
   if (!totalArs && !totalUsd) return null;
   return (
     <div style={{
-      marginTop: 20, padding: "16px 20px", borderRadius: 10,
-      background: "var(--s3)", border: "1px solid var(--b2)",
-      display: "flex", justifyContent: "space-between", alignItems: "center",
+      marginTop: 24, padding: "22px 28px", borderRadius: 12,
+      background: "var(--s2)", border: "1px solid var(--b1)",
+      display: "flex", justifyContent: "space-between", alignItems: "flex-end",
     }}>
-      <span style={{ fontSize: 14, fontWeight: 600, color: "var(--t1)" }}>PRESUPUESTO TOTAL</span>
+      <div>
+        <div style={{
+          fontSize: 10, fontFamily: "var(--font-mono)", fontWeight: 500,
+          color: "var(--t4)", letterSpacing: "0.14em", textTransform: "uppercase",
+          marginBottom: 8,
+        }}>Presupuesto total</div>
+        <div style={{
+          fontFamily: "var(--font-serif), Georgia, serif", fontStyle: "italic",
+          fontSize: 15, color: "var(--t3)", fontWeight: 400,
+          letterSpacing: "-0.01em",
+        }}>Contado · 30 días demora</div>
+      </div>
       <div style={{ textAlign: "right" }}>
         {totalArs && (
-          <div style={{ fontSize: 18, fontWeight: 700, color: "var(--t1)" }}>
-            {fmtARS(totalArs)} <span style={{ color: "var(--t3)", fontWeight: 400, fontSize: 13 }}>mano de obra</span>
+          <div style={{
+            fontFamily: "var(--font-serif), Georgia, serif",
+            fontSize: 28, fontWeight: 500, color: "var(--t1)",
+            letterSpacing: "-0.02em", lineHeight: 1, marginBottom: 2,
+          }}>
+            {fmtARS(totalArs)}
           </div>
         )}
         {totalUsd && (
-          <div style={{ fontSize: 15, fontWeight: 600, color: "var(--acc)", marginTop: 2 }}>
-            + {fmtUSD(totalUsd)} <span style={{ color: "var(--t3)", fontWeight: 400, fontSize: 13 }}>material</span>
+          <div style={{
+            fontSize: 13, fontWeight: 500, color: "var(--acc)",
+            marginTop: 6, fontFamily: "var(--font-mono)",
+            letterSpacing: "-0.01em",
+          }}>
+            {fmtUSD(totalUsd)}
           </div>
         )}
       </div>

--- a/web/src/components/quote/QuoteHeader.tsx
+++ b/web/src/components/quote/QuoteHeader.tsx
@@ -17,30 +17,55 @@ export default function QuoteHeader({ quote, onBack }: Props) {
       display: "flex", alignItems: isMobile ? "flex-start" : "center",
       flexDirection: isMobile ? "column" : "row",
       justifyContent: "space-between",
-      padding: isMobile ? "10px 14px" : "14px 28px",
+      padding: isMobile ? "12px 18px" : "18px 36px",
       borderBottom: "1px solid var(--b1)",
-      flexShrink: 0, background: "var(--s1)",
+      flexShrink: 0, background: "var(--bg)",
       gap: isMobile ? 10 : 0,
     }}>
-      <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
-        <button onClick={onBack} style={backBtnStyle}>
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="15 18 9 12 15 6" /></svg>
+      <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+        <button onClick={onBack} style={backBtnStyle} aria-label="Volver al listado">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6" /></svg>
         </button>
         <div>
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <span style={{ fontSize: 16, fontWeight: 600, color: "var(--t1)" }}>{quote?.client_name || "Nuevo presupuesto"}</span>
-            <span style={{ ...badgeStyle, background: st.bg, color: st.color }}>● {st.label}</span>
-            {quote?.source === "web" && <span style={{ ...badgeStyle, background: "rgba(138,43,226,.15)", color: "#a855f7" }}>WEB</span>}
+          <div style={{ display: "flex", alignItems: "baseline", gap: 10 }}>
+            <span style={{
+              fontFamily: "var(--font-serif), Georgia, serif",
+              fontStyle: "italic",
+              fontSize: isMobile ? 18 : 22,
+              fontWeight: 500,
+              color: "var(--t1)",
+              letterSpacing: "-0.01em",
+              lineHeight: 1.15,
+            }}>{quote?.client_name || "Nuevo presupuesto"}</span>
+            <span style={{
+              display: "inline-flex", alignItems: "center", gap: 6,
+              fontSize: 12, color: st.color, fontFamily: "var(--font-sans)",
+            }}>
+              <span style={{ width: 7, height: 7, borderRadius: 999, background: st.color }} />
+              {st.label}
+            </span>
+            {quote?.source === "web" && (
+              <span style={{
+                fontSize: 9, fontFamily: "var(--font-mono)",
+                fontWeight: 600, letterSpacing: "0.08em",
+                padding: "2px 6px", borderRadius: 4,
+                border: "1px solid rgba(180,143,224,0.3)",
+                color: "#b48fe0",
+              }}>WEB</span>
+            )}
           </div>
-          <div style={{ fontSize: 12, color: "var(--t3)", marginTop: 2 }}>
+          <div style={{
+            fontSize: 12, color: "var(--t3)", marginTop: 3,
+            fontFamily: "var(--font-sans)",
+          }}>
             {quote?.project}{quote?.material ? ` ${DOT} ${quote.material}` : ""}
           </div>
         </div>
       </div>
       <div style={{ display: "flex", gap: 8 }}>
         {quote?.drive_pdf_url && <FileLink href={quote.drive_pdf_url} label="PDF Drive" color="var(--acc)" />}
-        {quote?.drive_excel_url && <FileLink href={quote.drive_excel_url} label="Excel Drive" color="#34d399" />}
-        {!quote?.drive_pdf_url && quote?.pdf_url && <FileLink href={quote.pdf_url} label="PDF" color="#ff6b63" />}
+        {quote?.drive_excel_url && <FileLink href={quote.drive_excel_url} label="Excel Drive" color="#5cb38f" />}
+        {!quote?.drive_pdf_url && quote?.pdf_url && <FileLink href={quote.pdf_url} label="PDF" color="#d46b60" />}
       </div>
     </div>
   );

--- a/web/src/components/quote/Section.tsx
+++ b/web/src/components/quote/Section.tsx
@@ -9,13 +9,15 @@ interface Props {
 export default function Section({ title, children, style: extraStyle }: Props) {
   return (
     <div style={{
-      background: "var(--s1)", border: "1px solid var(--b1)",
-      borderRadius: 12, padding: "18px 22px", ...extraStyle,
+      background: "transparent", border: "none",
+      padding: "6px 0 24px", ...extraStyle,
     }}>
       <div style={{
-        fontSize: 13, fontWeight: 600, color: "var(--t1)",
-        textTransform: "uppercase", letterSpacing: "0.06em",
-        marginBottom: 14, paddingBottom: 8, borderBottom: "1px solid var(--b1)",
+        fontFamily: "var(--font-serif), Georgia, serif",
+        fontStyle: "italic",
+        fontSize: 20, fontWeight: 500, color: "var(--t1)",
+        letterSpacing: "-0.01em",
+        marginBottom: 18, paddingBottom: 10, borderBottom: "1px solid var(--b1)",
       }}>
         {title}
       </div>


### PR DESCRIPTION
Tercer paso del rediseño UI/UX. Visual-only.

- **Login** — badge gradient, brand Fraunces italic 22px, subtítulo mono uppercase.
- **QuoteHeader** — cliente Fraunces italic, status dot+texto (sin pill), badge WEB outline.
- **Section** (detalle) — contenedor transparente, heading Fraunces italic 20px.
- **PricingSummary** — split editorial: eyebrow + hint serif | ARS Fraunces 28px + USD mono acento.
- **CatalogToolbar** — título Fraunces italic 20px, subtítulo mono uppercase.

Parte de la secuencia B → C → D → E → G. 🤖 Claude Code