### PR TITLE
feat(context): preguntar alto de patas de la isla

### DIFF
--- a/api/app/modules/quote_engine/pending_questions.py
+++ b/api/app/modules/quote_engine/pending_questions.py
@@ -250,6 +250,46 @@ def _detect_isla_patas_question(
     }
 
 
+def _detect_isla_patas_alto_question(
+    brief: str, dual_result: dict, *, force: bool = False,
+) -> dict | None:
+    """Isla con patas → preguntar el alto (piso a mesada). Default 0.90m es
+    razonable pero NO silencioso — el operador lo confirma. Skip si brief ya
+    da el valor explícito (raro).
+
+    Frontend oculta esta pregunta cuando la respuesta a `isla_patas` es "no"
+    (cascada isla_presence → isla_patas → isla_patas_alto).
+    """
+    has_isla = (
+        force
+        or _has_sector_type(dual_result, "isla")
+        or _brief_mentions_isla(brief)
+    )
+    if not has_isla:
+        return None
+    if brief:
+        if re.search(r"\balto\s+(de\s+)?patas?\s*[=:]?\s*\d", brief, re.IGNORECASE):
+            return None
+        if re.search(r"\bpatas?\s+(de\s+)?\d+[,.]\d\s*m\b", brief, re.IGNORECASE):
+            return None
+    return {
+        "id": "isla_patas_alto",
+        "label": "Alto de las patas",
+        "question": (
+            "¿De qué alto son las patas? Es la distancia del piso al borde "
+            "inferior de la mesada."
+        ),
+        "type": "radio_with_detail",
+        "options": [
+            {"value": "0.90", "label": "0.90 m (estándar — piso a mesada)"},
+            {"value": "0.85", "label": "0.85 m"},
+            {"value": "0.80", "label": "0.80 m"},
+            {"value": "custom", "label": "Otra medida (detallar)"},
+        ],
+        "detail_placeholder": "Ej: 0.75",
+    }
+
+
 def _detect_colocacion_question(brief: str, dual_result: dict) -> dict | None:
     """Colocación: si el brief no menciona, preguntar. Default comercial suele
     ser 'con colocación' pero no lo asumimos silencioso."""
@@ -454,6 +494,9 @@ def detect_pending_questions(
         q_isla_patas = _detect_isla_patas_question(brief, dual_result, force=True)
         if q_isla_patas:
             questions.append(q_isla_patas)
+        q_isla_patas_alto = _detect_isla_patas_alto_question(brief, dual_result, force=True)
+        if q_isla_patas_alto:
+            questions.append(q_isla_patas_alto)
 
     q_zoc = _detect_zocalos_question(brief, dual_result)
     if q_zoc:
@@ -624,6 +667,36 @@ def apply_isla_patas_answer(dual_result: dict, answer: dict) -> dict:
     return dual_result
 
 
+def apply_isla_patas_alto_answer(dual_result: dict, answer: dict) -> dict:
+    """Setea el alto de las patas de la isla. Convive con apply_isla_patas_answer:
+    patas sets sides+default alto, este pisa alto con el valor real.
+
+    Idempotente — si la sección `patas` no existía (patas=no), no hace nada."""
+    if not isinstance(answer, dict):
+        return dual_result
+    value = answer.get("value")
+    if value in ("0.90", "0.85", "0.80"):
+        alto = float(value)
+    elif value == "custom":
+        try:
+            alto = float(answer.get("detail") or 0)
+        except (TypeError, ValueError):
+            return dual_result
+    else:
+        return dual_result
+    if alto <= 0 or alto > 5:
+        return dual_result
+    for sector in dual_result.get("sectores") or []:
+        if (sector.get("tipo") or "").lower() != "isla":
+            continue
+        patas = sector.get("patas")
+        if not patas or not patas.get("sides"):
+            continue  # no lleva patas → alto no aplica
+        patas["alto_m"] = alto
+        patas["alto_source"] = "operator"
+    return dual_result
+
+
 def apply_colocacion_answer(dual_result: dict, answer: dict) -> dict:
     if not isinstance(answer, dict):
         return dual_result
@@ -707,6 +780,8 @@ def apply_answers(dual_result: dict, answers: list[dict]) -> dict:
             apply_isla_presence_answer(dual_result, ans)
         elif qid == "isla_profundidad":
             apply_isla_profundidad_answer(dual_result, ans)
+        elif qid == "isla_patas_alto":
+            apply_isla_patas_alto_answer(dual_result, ans)
         elif qid == "isla_patas":
             apply_isla_patas_answer(dual_result, ans)
         elif qid == "colocacion":

--- a/web/src/components/chat/ContextAnalysis.tsx
+++ b/web/src/components/chat/ContextAnalysis.tsx
@@ -98,15 +98,25 @@ export default function ContextAnalysis({ data, onConfirm }: Props) {
 
   const questions = data.pending_questions || [];
 
-  // Preguntas dependientes de isla: si el operador dijo "no" a isla_presence,
-  // las preguntas de profundidad + patas quedan no-aplicables. Las marcamos
-  // como auto-respondidas para no bloquear Confirmar, y las ocultamos.
+  // Preguntas dependientes de isla (cascada):
+  //  - isla_presence=no  → oculto profundidad, patas, patas_alto
+  //  - isla_patas=no     → oculto patas_alto (la alto no aplica sin patas)
   const islaPresenceValue = answers["isla_presence"]?.value;
   const islaNotApplicable = islaPresenceValue === "no";
-  const hiddenIfNoIsla = new Set(["isla_profundidad", "isla_patas"]);
+  const hiddenIfNoIsla = new Set(["isla_profundidad", "isla_patas", "isla_patas_alto"]);
+
+  const islaPatasValue = answers["isla_patas"]?.value;
+  const patasNotApplicable = islaPatasValue === "no";
+  const hiddenIfNoPatas = new Set(["isla_patas_alto"]);
+
+  const isHidden = (id: string): boolean => {
+    if (islaNotApplicable && hiddenIfNoIsla.has(id)) return true;
+    if (patasNotApplicable && hiddenIfNoPatas.has(id)) return true;
+    return false;
+  };
 
   const allAnswered = questions.every(q => {
-    if (islaNotApplicable && hiddenIfNoIsla.has(q.id)) return true;
+    if (isHidden(q.id)) return true;
     return answers[q.id]?.value;
   });
 


### PR DESCRIPTION
Cuando el operador confirma 'Sí — frontal + ambos laterales' (u otro valor con patas), hasta ahora el alto se guardaba silenciosamente en 0.90 m. Faltaba preguntarlo.

- Nueva pregunta bloqueante `isla_patas_alto` con opciones 0.90 (estándar) / 0.85 / 0.80 / custom.
- Aparece en cascada: sólo si `isla_presence != no` Y `isla_patas != no`.
- Frontend extendido para ocultar esta pregunta cuando patas=no (chain de dependencias).
- Applier `apply_isla_patas_alto_answer` pisa `sector.patas.alto_m` (si existe).

58/58 tests pass. 🤖 Claude Code