### PR TITLE
fix(api+web): root cause del 'Failed to fetch' — 307 redirect sobre http://

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -4,6 +4,7 @@ import os
 import time
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from contextlib import asynccontextmanager
 
 from fastapi import Depends
@@ -96,6 +97,17 @@ app = FastAPI(
     version="1.0.0",
     lifespan=lifespan,
 )
+
+# ProxyHeadersMiddleware — cuando FastAPI corre detrás de un proxy/LB que
+# termina TLS (Railway, Vercel, nginx, Cloudflare), las requests entran
+# como HTTP al contenedor. Sin este middleware, cualquier redirect que
+# genere FastAPI (ej: trailing-slash: /api/catalog → /api/catalog/) arma
+# la Location header con scheme http://, que el browser bloquea por
+# Mixed Content desde una página https. Este middleware lee
+# X-Forwarded-Proto y reescribe el request scope para que los redirects
+# salgan como https://. `trusted_hosts="*"` es OK porque Railway no
+# expone el puerto interno a internet — sólo el proxy frontal.
+app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
 
 app.add_middleware(
     CORSMiddleware,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -598,7 +598,14 @@ export async function* streamChat(
 // ── Catalog ───────────────────────────────────────────────────────────────────
 
 export async function fetchCatalogs() {
-  const res = await apiFetch(`${API_BASE}/api/catalog`, { credentials: "include" });
+  // Trailing slash obligatorio: el FastAPI router monta "/" en el root,
+  // así que sin slash se dispara un 307 redirect a /api/catalog/. En
+  // Railway la Location header del redirect sale con scheme http://
+  // (uvicorn no sabe que la request original fue https porque no está
+  // configurado para leer X-Forwarded-Proto). El browser bloquea esa
+  // redirect por Mixed Content desde la página https de Vercel y el
+  // fetch falla. Con slash vamos directo al handler, zero redirects.
+  const res = await apiFetch(`${API_BASE}/api/catalog/`, { credentials: "include" });
   handleAuthError(res);
   if (!res.ok) throw new Error("Error al cargar catálogos");
   return res.json();


### PR DESCRIPTION
## Cadena del bug

1. Frontend llama `/api/catalog` (sin trailing slash)
2. Next.js rewrite: → `https://railway.app/api/catalog`
3. FastAPI router tiene el endpoint en `/` → 307 redirect a `/api/catalog/`
4. Railway termina TLS antes de uvicorn → uvicorn ve la request como http:// → Location header sale como `http://railway.app/api/catalog/`
5. Browser intenta seguir el redirect → **Mixed Content blocked** desde página https de Vercel → fetch falla

## Fix doble (defensa en profundidad)

**Frontend**: `fetchCatalogs()` ahora llama con trailing slash. Skip redirect.

**Backend**: agrego `ProxyHeadersMiddleware` de uvicorn — lee `X-Forwarded-Proto` + `X-Forwarded-Host` que Railway inyecta, reescribe el request scope para que FastAPI arme redirects con `https://`. Cualquier endpoint futuro con mismatch queda blindado.

## Test plan

- [ ] Deploy a Vercel + Railway
- [ ] Entrar al catálogo → sin "Failed to fetch"
- [ ] Network tab: verificar que `/api/catalog/` devuelve 200 directo (0 redirects)
- [ ] Otros endpoints con mismatch de trailing slash: quedan cubiertos por el backend middleware

🤖 Claude Code