### PR TITLE
fix(web): skipTrailingSlashRedirect para evitar redirect cross-origin

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -40,6 +40,16 @@ function normalizeApiUrl(raw) {
 const API_URL = normalizeApiUrl(process.env.NEXT_PUBLIC_API_URL);
 
 const nextConfig = {
+  // skipTrailingSlashRedirect: sin esto, Next.js (Vercel) auto-redirige
+  // `/api/catalog/` → `/api/catalog` con 308. Cuando ese redirect se
+  // combina con el 307 del backend (de `/api/catalog` → `/api/catalog/`),
+  // el browser termina siguiendo la cadena hasta el ORIGEN del backend
+  // (railway.app) y pierde la cookie de sesión (que está seteada para
+  // .vercel.app) → 401. Desactivando el redirect de Next, la URL se
+  // mantiene como el browser la pidió y el rewrite proxy funciona sin
+  // saltar de origen.
+  skipTrailingSlashRedirect: true,
+
   async rewrites() {
     return [
       {


### PR DESCRIPTION
## Root cause verdadero

1. Browser → `vercel.app/api/catalog/` (con slash)
2. **Next.js 308 → `/api/catalog`** (sin slash, trailingSlash:false por default)
3. Browser sigue redirect
4. Vercel rewrite → `railway.app/api/catalog`
5. **FastAPI 307 → `/api/catalog/`** (con slash)
6. Browser sigue redirect → **ahora está en origen railway.app, perdió la cookie de .vercel.app** → 401

## Fix

`skipTrailingSlashRedirect: true` en `next.config.mjs`. Sin el 308 de Next, el path que el browser pidió viaja intacto hasta el rewrite que proxyea server-to-server. El browser NUNCA salta de origen, la cookie viaja, el backend autentica.

El ProxyHeadersMiddleware del PR #316 queda como defensa general (redirects futuros siguen saliendo con https).

## Test

- `curl -sI https://ia-agent-quote-marble-operator.vercel.app/api/catalog/` no debe responder 308
- Browser en /config debe cargar el catálogo sin 401

🤖 Claude Code