### PR TITLE
fix(api+web): restore ProxyHeadersMiddleware + hydration errors

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -4,6 +4,7 @@ import os
 import time
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from contextlib import asynccontextmanager
 
 from fastapi import Depends
@@ -103,6 +104,15 @@ app = FastAPI(
 # auth — si no, un 401 de auth sale SIN los headers CORS, el browser
 # lo bloquea, y la UI ve un error genérico en vez del 401 real.
 app.middleware("http")(auth_middleware)
+
+# ProxyHeadersMiddleware — Railway termina TLS antes de llegar a uvicorn.
+# Sin esto, cualquier redirect que FastAPI genere (ej. trailing-slash:
+# /api/catalog → /api/catalog/) sale con `Location: http://...` porque
+# uvicorn cree que la request llegó por HTTP. El browser bloquea ese
+# redirect por Mixed Content desde la página https de Vercel.
+# Con este middleware, uvicorn lee X-Forwarded-Proto y arma los
+# redirects con scheme correcto (https).
+app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
 
 app.add_middleware(
     CORSMiddleware,

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -304,12 +304,15 @@ export default function DashboardPage() {
   }
 
   // ── Formatters — matching dash-airy.jsx exact ──────────────────────────
-  const fmtMes = () => {
-    // Eyebrow formato "ABRIL 2029" (sin "DE"). letterSpacing 1px uppercase.
+  // Mes/año en eyebrow "ABRIL 2029". Se calcula solo del lado client (en
+  // mount) para evitar hydration mismatch — SSR y client pueden tener
+  // timezones distintos y producir meses distintos en el boundary.
+  const [mesHeader, setMesHeader] = useState("");
+  useEffect(() => {
     const d = new Date();
     const mes = d.toLocaleDateString("es-AR", { month: "long" }).toUpperCase();
-    return `${mes} ${d.getFullYear()}`;
-  };
+    setMesHeader(`${mes} ${d.getFullYear()}`);
+  }, []);
   const fmtARS = (n: number | null | undefined) => n == null ? "\u2014" : `$\u00A0${n.toLocaleString("es-AR")}`;
   const fmtUSD = (n: number | null | undefined) => n == null ? null : `USD\u00A0${n.toLocaleString("en-US")}`;
   const fmtDia = (iso: string) => format(new Date(iso), "d MMM", { locale: es });
@@ -352,7 +355,7 @@ export default function DashboardPage() {
               letterSpacing: "1px", marginBottom: 6, fontWeight: 600,
             }}
           >
-            {fmtMes()} · {quotes.length} registros
+            {mesHeader} · {quotes.length} registros
             {quotes.filter(q => !q.is_read).length > 0 && (
               <> · <span style={{ color: "var(--acc)" }}>{quotes.filter(q => !q.is_read).length} sin leer</span></>
             )}
@@ -398,7 +401,7 @@ export default function DashboardPage() {
       <div className="md:hidden flex items-end justify-between shrink-0" style={{ padding: "20px 16px 14px" }}>
         <div className="min-w-0">
           <div className="font-mono uppercase" style={{ fontSize: 10, color: "var(--t3)", letterSpacing: "1px", marginBottom: 4, fontWeight: 600 }}>
-            {fmtMes()} · {quotes.length}
+            {mesHeader} · {quotes.length}
           </div>
           <h1 className="font-serif italic" style={{ fontSize: 28, color: "var(--t1)", letterSpacing: "-0.5px", lineHeight: 1.1, fontWeight: 400 }}>Presupuestos</h1>
         </div>

--- a/web/src/components/chat/HomeHero.tsx
+++ b/web/src/components/chat/HomeHero.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useState } from "react";
 import { getCurrentUsername, prettyFirstName } from "@/lib/auth";
 import VAvatar from "@/components/ui/VAvatar";
 
@@ -28,8 +28,15 @@ function greeting(): string {
  * (docs/BACKLOG.md) para clonar quote con otro material.
  */
 export default function HomeHero({ onPickFile, onFocusText }: Props) {
-  const name = useMemo(() => prettyFirstName(getCurrentUsername()), []);
-  const greet = useMemo(() => greeting(), []);
+  // Ambas se calculan post-mount para evitar hydration mismatch:
+  // - `name` viene de localStorage (no existe en SSR)
+  // - `greet` depende de la hora del cliente (timezone-dependent)
+  const [name, setName] = useState("");
+  const [greet, setGreet] = useState("Hola");
+  useEffect(() => {
+    setName(prettyFirstName(getCurrentUsername()));
+    setGreet(greeting());
+  }, []);
 
   return (
     <div className="flex-1 flex flex-col items-center justify-center px-6 pb-20">

--- a/web/src/components/ui/Sidebar.tsx
+++ b/web/src/components/ui/Sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { logout, getCurrentUsername, prettyFirstName } from "@/lib/auth";
 import { useQuotes } from "@/lib/quotes-context";
@@ -20,7 +21,14 @@ export default function Sidebar({ isOpen, onClose }: { isOpen?: boolean; onClose
     router.push(to);
   }
 
-  const name = prettyFirstName(getCurrentUsername()) || "Operador";
+  // getCurrentUsername() lee localStorage — NO se puede llamar en render
+  // porque el SSR no tiene window → hidratación mismatch (React error #418/#425).
+  // Lo leemos después del mount. Fallback "Operador" mientras tanto.
+  const [name, setName] = useState("Operador");
+  useEffect(() => {
+    const n = prettyFirstName(getCurrentUsername());
+    if (n) setName(n);
+  }, []);
 
   const sidebarContent = (
     <nav


### PR DESCRIPTION
## Dos fixes para cerrar el roto del listado + catálogo

**1. ProxyHeadersMiddleware (api/main.py):**
Lo saqué por error en PR #318 (revert). El Mixed Content `http://railway.app/...` volvió porque FastAPI genera redirects con scheme http:// cuando no lee X-Forwarded-Proto. Lo restauro. Ahora los redirects salen con https:// y el browser no los bloquea.

**2. Hydration errors #418/#423/#425 (web):**
3 componentes llamaban APIs con resultado distinto entre SSR y client:
- `page.tsx fmtMes()` → `new Date()` (timezone distinto)
- `Sidebar.tsx name` → localStorage (SSR no tiene)
- `HomeHero.tsx` → localStorage + `new Date().getHours()`

Migré los 3 a `useState` + `useEffect` con valor inicial sensato ("", "Operador", "Hola") que matchea en SSR y client. Post-mount, se actualizan al valor real. Sin mismatch.

Typecheck limpio, sin errores en preview. 🤖 Claude Code