### PR TITLE
fix(web): catálogo cierra sesión — re-aplicar trailing slash + skipTrailingSlashRedirect

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -40,6 +40,16 @@ function normalizeApiUrl(raw) {
 const API_URL = normalizeApiUrl(process.env.NEXT_PUBLIC_API_URL);
 
 const nextConfig = {
+  // skipTrailingSlashRedirect: sin esto, Next.js (Vercel) auto-redirige
+  // `/api/catalog/` → `/api/catalog` con 308. Pero el endpoint real del
+  // backend FastAPI vive en `/api/catalog/` (con slash). Al quitarlo,
+  // FastAPI responde 307 devolviendo el slash → el browser sigue el
+  // redirect cross-origin a Railway → cookie con SameSite=Lax no viaja
+  // → 401 → handleAuthError redirige a /login.
+  // Con este flag el path original se mantiene intacto hasta el rewrite
+  // proxy, todo pasa same-origin, la cookie viaja.
+  skipTrailingSlashRedirect: true,
+
   async rewrites() {
     return [
       {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -598,7 +598,17 @@ export async function* streamChat(
 // ── Catalog ───────────────────────────────────────────────────────────────────
 
 export async function fetchCatalogs() {
-  const res = await apiFetch(`${API_BASE}/api/catalog`, { credentials: "include" });
+  // Trailing slash obligatorio: el endpoint FastAPI está registrado como
+  // `@router.get("/")` con prefix `/catalog`, así que la ruta real es
+  // `/api/catalog/` (con slash). Sin slash, FastAPI responde 307 con
+  // `Location: .../api/catalog/`. El browser sigue el redirect, y si
+  // Vercel lo procesa como redirect cross-origin (no proxy), terminamos
+  // en origen Railway donde la cookie SameSite=Lax no viaja → 401 →
+  // handleAuthError redirige a /login → usuario ve "sesión cerrada".
+  //
+  // Con el slash vamos directo al handler — zero redirects, zero jumps
+  // cross-origin, cookie viaja.
+  const res = await apiFetch(`${API_BASE}/api/catalog/`, { credentials: "include" });
   handleAuthError(res);
   if (!res.ok) throw new Error("Error al cargar catálogos");
   return res.json();


### PR DESCRIPTION
## Síntoma
Usuario va a /config y se cierra la sesión (redirect a /login).

## Causa
`fetchCatalogs()` llama sin trailing slash → FastAPI 307 → Vercel forwardea al browser → browser sigue cross-origin a railway.app → cookie SameSite=Lax no viaja → 401 → handleAuthError redirige a /login.

## Fix
Dos cambios que se habían aplicado en PRs #316/#317 y se revirtieron en #318 por error de contexto. Ahora con CORS + ProxyHeaders + SameSite=None ya en su lugar, estos traen el cierre:

1. `next.config.mjs` → `skipTrailingSlashRedirect: true`
2. `fetchCatalogs()` → usa `/api/catalog/` con slash

Con los dos: zero redirects, zero cross-origin jumps, same-origin via Vercel proxy.

Typecheck limpio, preview sin errores. 🤖 Claude Code