### PR TITLE
fix(api): frontend llama DIRECTO a Railway (cross-origin) — fix definitivo del 401

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,5 +1,24 @@
-// Use relative URLs to go through Next.js rewrite proxy (avoids CORS)
-const API_BASE = "";
+// Llamamos DIRECTO al backend (cross-origin) en vez de pasar por el
+// rewrite de Next.js. Motivo: el rewrite con destino externo en Vercel
+// a veces proxyea y a veces redirige (depende del endpoint, headers,
+// etc.) — ingobernable. Con cross-origin explícito + CORS configurado
+// en el backend + SameSite=None en el cookie, todo flow es predecible:
+//   POST /api/auth/login desde vercel.app → railway.app
+//   → Set-Cookie con domain=railway.app, SameSite=None
+//   → subsecuentes fetches desde vercel.app con credentials:"include"
+//     y SameSite=None → cookie viaja → 200
+//
+// `NEXT_PUBLIC_API_URL` debe apuntar a la URL completa del backend
+// (ej: https://ia-agent-quote-marble-operator-production.up.railway.app).
+// En dev lo resolvemos a localhost:8000.
+function resolveApiBase(): string {
+  if (typeof process !== "undefined" && process.env.NEXT_PUBLIC_API_URL) {
+    return process.env.NEXT_PUBLIC_API_URL.replace(/\/+$/, "");
+  }
+  return "http://localhost:8000";
+}
+
+const API_BASE = resolveApiBase();
 
 /**
  * Antes: cualquier 401 redirigía automáticamente a /login. Problema: si

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,4 +1,12 @@
-const API_BASE = "";
+// Ver lib/api.ts para explicación completa — llamamos DIRECTO a Railway.
+function resolveApiBase(): string {
+  if (typeof process !== "undefined" && process.env.NEXT_PUBLIC_API_URL) {
+    return process.env.NEXT_PUBLIC_API_URL.replace(/\/+$/, "");
+  }
+  return "http://localhost:8000";
+}
+
+const API_BASE = resolveApiBase();
 const STORAGE_KEY = "dangelo:username";
 
 export async function login(username: string, password: string): Promise<{ ok: boolean; username: string }> {


### PR DESCRIPTION
## Por qué no andaba

El rewrite de Next.js con destino externo `https://railway.app/api/*` tiene comportamiento **inconsistente** en Vercel prod: algunos endpoints se proxean (same-origin desde el browser), otros se redirigen (el browser termina en origen Railway). Es ingobernable.

Cuando Vercel redirige, la cookie (atada a vercel.app por el proxy del login) NO viaja a railway.app → 401 → "sesión cerrada".

Los parches anteriores (trailing slash, ProxyHeadersMiddleware, SameSite=None, skipTrailingSlashRedirect, CORS order, handleAuthError no-op) cubrían capas individuales pero la raíz seguía.

## Fix definitivo

Frontend llama DIRECTO a `${NEXT_PUBLIC_API_URL}/api/...` (URL completa de Railway). Bypasea el rewrite. Todo es cross-origin explícito:
- Cookie de login se setea con `Domain=railway.app` + `SameSite=None` + `Secure`
- CORS headers del backend ya permiten origen Vercel
- `credentials: 'include'` manda la cookie cross-origin

Los rewrites de Next quedan para `/files/*` (PDFs descargables).

## Lo que tenés que hacer

1. Esperar deploy Vercel (~1 min)
2. **Logout + login** (regenerar cookie con Domain=railway.app)
3. Navegar libre

🤖 Claude Code