### PR TITLE
fix(auth): default APP_ENV=production → cookie SameSite=None+Secure siempre

### DIFF
--- a/api/app/core/auth.py
+++ b/api/app/core/auth.py
@@ -116,10 +116,11 @@ def set_auth_cookie(response: Response, token: str):
 
     SameSite: en dev usamos "lax" (mismo origen), en prod "none" porque
     el frontend (vercel.app) y el backend (railway.app) están en dominios
-    distintos y los rewrites de Next.js a URLs externas pueden comportarse
-    como redirect cross-origin — con "lax" el cookie NO viajaría y todo
-    queda en 401 sin posibilidad de recuperar. "none" requiere Secure=True,
-    que ya tenemos en prod.
+    distintos → la cookie NECESITA SameSite=None para viajar cross-origin.
+    Requiere Secure=True (Chrome lo obliga), que ya tenemos en prod.
+
+    Default de APP_ENV es "production" (ver config.py), así que aunque
+    Railway no tenga la env var seteada, la cookie sale correcta.
     """
     is_prod = settings.APP_ENV != "development"
     response.set_cookie(
@@ -130,6 +131,10 @@ def set_auth_cookie(response: Response, token: str):
         samesite="none" if is_prod else "lax",
         max_age=TOKEN_EXPIRY_HOURS * 3600,
         path="/",
+    )
+    logger.info(
+        f"Set auth cookie — APP_ENV={settings.APP_ENV!r}, "
+        f"secure={is_prod}, samesite={'none' if is_prod else 'lax'}"
     )
 
 

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -10,7 +10,10 @@ class Settings(BaseSettings):
     ANTHROPIC_MODEL: str = "claude-sonnet-4-5-20250514"
     GOOGLE_SERVICE_ACCOUNT_FILE: str = "service-account.json"
     GOOGLE_DRIVE_FOLDER_ID: str
-    APP_ENV: str = "development"
+    # Default PRODUCTION: safer for deploys que olvidan setear la env
+    # (ej. Railway sin APP_ENV explícita). En dev local, el `.env` lo
+    # override a "development" y el cookie sale SameSite=Lax + no Secure.
+    APP_ENV: str = "production"
     CORS_ORIGINS: List[str] = ["http://localhost:3000"]
     SECRET_KEY: str
     QUOTE_API_KEY: str = ""


### PR DESCRIPTION
## Root cause del 401 persistente

`config.py` default era `APP_ENV: str = 'development'`. Si Railway no tenía `APP_ENV=production` seteada explícita (que no la tenía), caía al default → cookie con `SameSite=Lax` → NO viaja cross-origin → **todas las requests a railway.app sin cookie** → 401.

Todos los parches anteriores eran correctos pero el cookie NUNCA llegaba al backend.

## Fix

- Default `APP_ENV='production'` (seguro para deploys que olvidan setear env)
- Log en `set_auth_cookie` con los atributos del cookie (debug futuro)

Dev local sigue con `.env` → "development" → Lax + sin Secure para localhost.

## Pasos después del deploy

1. Railway redeploya (~1 min)
2. Logout completo (DevTools → Clear site data)
3. Login fresco
4. Debería andar el catálogo sin 401

🤖 Claude Code