### PR TITLE
fix(chat): ocultar pseudo-mensajes [CONTEXT_CONFIRMED] y [SYSTEM_TRIGGER] del UI

### DIFF
--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -595,6 +595,13 @@ export default function QuotePage() {
               const isShortConfirm = msg.role === "user" && /^(confirmo|sí|si|dale|ok|listo)$/i.test(msg.content.trim());
               // Hide DUAL_READ_CONFIRMED raw JSON — show green pill instead
               const isDualConfirm = msg.role === "user" && msg.content.startsWith("[DUAL_READ_CONFIRMED]");
+              // Idem CONTEXT_CONFIRMED: pseudo-mensaje que manda la card de
+              // contexto al confirmar — muestra pill en vez del JSON crudo.
+              const isContextConfirm = msg.role === "user" && msg.content.startsWith("[CONTEXT_CONFIRMED]");
+              // SYSTEM_TRIGGER (ej: zone_confirmed) — ocultar entero, no
+              // muestra ni pill, es ruido puramente interno.
+              const isSystemTriggerMsg = msg.role === "user" && msg.content.startsWith("[SYSTEM_TRIGGER");
+              if (isSystemTriggerMsg) return null;
 
               // Hide ghost messages (dots from sanitization)
               const isDot = msg.content.trim() === "." || msg.content.trim() === "..";
@@ -606,6 +613,12 @@ export default function QuotePage() {
                     <div className="flex justify-end">
                       <span className="px-3 py-1 rounded-full text-[11px] font-medium bg-grn/20 text-grn border border-grn/30">
                         Medidas verificadas {"\u2705"}
+                      </span>
+                    </div>
+                  ) : isContextConfirm ? (
+                    <div className="flex justify-end">
+                      <span className="px-3 py-1 rounded-full text-[11px] font-medium bg-grn/20 text-grn border border-grn/30">
+                        Contexto confirmado {"\u2705"}
                       </span>
                     </div>
                   ) : isShortConfirm ? (


### PR DESCRIPTION
El JSON crudo `[CONTEXT_CONFIRMED]{...}` que la card de contexto le manda al backend se mostraba como burbuja en el chat. Mismo tratamiento que `[DUAL_READ_CONFIRMED]`:

- `[CONTEXT_CONFIRMED]` → pill verde "Contexto confirmado ✅" (oculta el JSON)
- `[SYSTEM_TRIGGER...`` → oculto por completo (ruido interno, ej. zone_confirmed)

Revisé los 3 `send()` con pseudo-markers en la UI — los 3 están cubiertos ahora:
- `[DUAL_READ_CONFIRMED]` → pill "Medidas verificadas" (pre-existing)
- `[CONTEXT_CONFIRMED]` → pill "Contexto confirmado" (nuevo)
- `[SYSTEM_TRIGGER:*]` → hidden (nuevo)

🤖 Claude Code