### PR TITLE
fix(isla): applier de profundidad busca tramos 'isla' también en sectores cocina (caso Bernardi)

### DIFF
--- a/api/app/modules/quote_engine/pending_questions.py
+++ b/api/app/modules/quote_engine/pending_questions.py
@@ -602,11 +602,22 @@ def apply_pileta_type_answer(dual_result: dict, answer: dict) -> dict:
 
 
 def apply_isla_profundidad_answer(dual_result: dict, answer: dict) -> dict:
-    """Setea ancho_m del tramo de isla con la profundidad elegida."""
+    """Setea ancho_m del tramo de isla con la profundidad elegida.
+
+    Busca tramos de isla en 2 lugares (en este orden):
+      1. Sectores con `tipo == "isla"` (caso canónico).
+      2. Tramos cuya descripción contenga "isla" dentro de cualquier
+         sector (común en cocinas L + isla donde el dual_read lumps
+         todo en un solo sector tipo "L" / "cocina").
+
+    Antes sólo miraba (1) — si el plano no tenía un sector isla
+    separado, el 0.60 que respondía el operador no se aplicaba y el
+    despiece quedaba con la medida original (1.20 u otro valor).
+    """
     if not isinstance(answer, dict):
         return dual_result
     value = answer.get("value")
-    if value in ("0.60", "0.70"):
+    if value in ("0.60", "0.70", "0.80", "0.90", "1.00"):
         prof = float(value)
     elif value == "custom":
         try:
@@ -614,21 +625,49 @@ def apply_isla_profundidad_answer(dual_result: dict, answer: dict) -> dict:
         except (TypeError, ValueError):
             return dual_result
     else:
-        return dual_result
+        try:
+            prof = float(value)  # last resort: si el value es un número crudo
+        except (TypeError, ValueError):
+            return dual_result
     if prof <= 0 or prof > 5:
         return dual_result
+
+    def _update_tramo(tramo: dict) -> None:
+        tramo.setdefault("ancho_m", {})
+        tramo["ancho_m"]["valor"] = prof
+        tramo["ancho_m"]["status"] = "CONFIRMADO"
+        tramo["ancho_m"]["source"] = "brief_rule"
+        largo = (tramo.get("largo_m") or {}).get("valor") or 0
+        tramo.setdefault("m2", {})
+        tramo["m2"]["valor"] = round(float(largo) * prof, 2)
+        tramo["m2"]["status"] = "CONFIRMADO"
+
+    updated_any = False
     for sector in dual_result.get("sectores") or []:
-        if (sector.get("tipo") or "").lower() != "isla":
-            continue
-        for tramo in sector.get("tramos") or []:
-            tramo.setdefault("ancho_m", {})
-            tramo["ancho_m"]["valor"] = prof
-            tramo["ancho_m"]["status"] = "CONFIRMADO"
-            tramo["ancho_m"]["source"] = "brief_rule"
-            largo = (tramo.get("largo_m") or {}).get("valor") or 0
-            tramo.setdefault("m2", {})
-            tramo["m2"]["valor"] = round(float(largo) * prof, 2)
-            tramo["m2"]["status"] = "CONFIRMADO"
+        if (sector.get("tipo") or "").lower() == "isla":
+            for tramo in sector.get("tramos") or []:
+                _update_tramo(tramo)
+                updated_any = True
+
+    # Fallback: buscar tramos "isla" en sectores non-isla (cocina L + isla
+    # lumped juntos). Solo si no actualizamos nada en el loop anterior —
+    # para no pisar dos veces si el plano tiene ambos formatos.
+    if not updated_any:
+        for sector in dual_result.get("sectores") or []:
+            if (sector.get("tipo") or "").lower() == "isla":
+                continue
+            for tramo in sector.get("tramos") or []:
+                desc = (tramo.get("descripcion") or "").lower()
+                feats = tramo.get("features") or {}
+                is_isla_tramo = (
+                    "isla" in desc
+                    or feats.get("is_island")
+                    or feats.get("isla")
+                )
+                if is_isla_tramo:
+                    _update_tramo(tramo)
+                    updated_any = True
+
     return dual_result
 
 

--- a/api/tests/test_pending_questions.py
+++ b/api/tests/test_pending_questions.py
@@ -329,6 +329,75 @@ class TestApplyIslaProfundidad:
         # Valor original preservado
         assert result["sectores"][1]["tramos"][0]["ancho_m"]["valor"] == 2.35
 
+    def test_isla_lumped_in_cocina_sector_gets_updated(self):
+        """Caso real Bernardi: el dual_read puso el tramo de isla dentro del
+        sector "L" (cocina), no en un sector tipo="isla" separado. El applier
+        debe encontrar el tramo por su descripcion ("isla central") y
+        actualizar su ancho y m² igual.
+        """
+        result = {
+            "sectores": [{
+                "id": "s1",
+                "tipo": "L",  # cocina L — NO "isla"
+                "tramos": [
+                    {"id": "t1", "descripcion": "Mesada principal horizontal",
+                     "largo_m": {"valor": 2.95, "status": "CONFIRMADO"},
+                     "ancho_m": {"valor": 0.60, "status": "CONFIRMADO"},
+                     "m2": {"valor": 1.77, "status": "CONFIRMADO"},
+                     "zocalos": []},
+                    {"id": "t2", "descripcion": "Retorno vertical",
+                     "largo_m": {"valor": 2.15, "status": "CONFIRMADO"},
+                     "ancho_m": {"valor": 0.60, "status": "CONFIRMADO"},
+                     "m2": {"valor": 1.29, "status": "CONFIRMADO"},
+                     "zocalos": []},
+                    {"id": "t3", "descripcion": "Isla central",
+                     "largo_m": {"valor": 1.60, "status": "CONFIRMADO"},
+                     "ancho_m": {"valor": 1.20, "status": "DUDOSO"},  # valor inicial del plano
+                     "m2": {"valor": 1.92, "status": "DUDOSO"},
+                     "zocalos": []},
+                ],
+            }],
+        }
+        apply_answers(result, [{"id": "isla_profundidad", "value": "0.60"}])
+        tramos = result["sectores"][0]["tramos"]
+        # Los dos primeros quedan intactos
+        assert tramos[0]["ancho_m"]["valor"] == 0.60
+        assert tramos[0]["m2"]["valor"] == 1.77
+        assert tramos[1]["ancho_m"]["valor"] == 0.60
+        # El tramo "isla central" SE actualiza
+        assert tramos[2]["ancho_m"]["valor"] == 0.60
+        assert tramos[2]["ancho_m"]["status"] == "CONFIRMADO"
+        assert tramos[2]["m2"]["valor"] == round(1.60 * 0.60, 2)  # 0.96
+
+    def test_only_canonical_isla_sector_when_both_present(self):
+        """Si hay sector tipo="isla" Y tramos con "isla" en cocina,
+        actualizamos SOLO el sector isla (evitamos doble update)."""
+        result = {
+            "sectores": [
+                {
+                    "id": "s1", "tipo": "cocina",
+                    "tramos": [
+                        {"id": "t1", "descripcion": "Tramo con Isla en el nombre",
+                         "largo_m": {"valor": 1.00}, "ancho_m": {"valor": 0.90},
+                         "m2": {"valor": 0.90}, "zocalos": []},
+                    ],
+                },
+                {
+                    "id": "s2", "tipo": "isla",
+                    "tramos": [
+                        {"id": "t2", "descripcion": "isla real",
+                         "largo_m": {"valor": 2.00}, "ancho_m": {"valor": 1.20, "status": "DUDOSO"},
+                         "m2": {"valor": 2.40}, "zocalos": []},
+                    ],
+                },
+            ],
+        }
+        apply_answers(result, [{"id": "isla_profundidad", "value": "0.60"}])
+        # Sector isla — actualizado
+        assert result["sectores"][1]["tramos"][0]["ancho_m"]["valor"] == 0.60
+        # Sector cocina con "isla" en descripción — NO tocado
+        assert result["sectores"][0]["tramos"][0]["ancho_m"]["valor"] == 0.90
+
 
 class TestDetectIslaPatas:
     def test_always_emits_when_isla_present(self):


### PR DESCRIPTION
## Bug real

Operador responde `isla_profundidad=0.60` pero despiece muestra `1.60 × 1.20 = 1.92 m²`. **El 0.60 nunca se aplicaba** — m² duplicado, material casi el doble.

## Causa

`apply_isla_profundidad_answer` filtraba `sector.tipo == 'isla'`. Pero cuando la cocina es L + isla en un solo ambiente, el dual_read suele agrupar todo en un sector tipo="L" con los tramos juntos (mesada principal + retorno + isla central). Sin sector isla separado → applier no encontraba nada → respuesta perdida.

## Fix

Fallback: si no hay sector isla canónico, buscar tramos con `isla` en descripción dentro de cualquier sector. Updatea solo ESOS tramos.

Además expandí los valores aceptables (antes solo 0.60/0.70 — si elegías 0.80 desde UI se ignoraba silenciosamente).

2 tests nuevos cubren el caso Bernardi + el caso mixto (si hay ambos formatos, solo actualiza el canónico). 60/60 tests pass.

🤖 Claude Code