### PR TITLE
fix(plan-reader): anchoring más estricto — Valentina no inventa medidas

### DIFF
--- a/api/app/modules/quote_engine/dual_reader.py
+++ b/api/app/modules/quote_engine/dual_reader.py
@@ -124,9 +124,19 @@ async def _call_vision(
             "text": (
                 cotas_text
                 + "\n\n"
-                + "⚠️ REGLA CRÍTICA: usá SOLO los valores numéricos listados arriba. "
-                + "NO inventes otros números. Tu tarea es asignar cada cota a su rol "
-                + "geométrico (largo, ancho, zócalo, etc.) según su posición (x, y)."
+                + "⚠️ REGLA CRÍTICA (sin excepciones): TODO valor numérico que "
+                + "devuelvas en el JSON (largo_m, ancho_m, zócalos) DEBE coincidir "
+                + "EXACTAMENTE con uno de los valores numéricos listados arriba.\n"
+                + "- Si una medida del plano no aparece en esta lista, NO la uses. "
+                + "Marcala con `status: \"DUDOSO\"` y dejá `valor: null`, en vez de "
+                + "estimar visualmente.\n"
+                + "- NO redondees, NO promedies, NO infieras desde el dibujo sin cota. "
+                + "Mejor un `null` honesto que un número inventado.\n"
+                + "- Si ves varias cotas candidatas para el mismo rol (ej. pared-a-pared "
+                + "vs muro-a-muro), elegí la INTERNA (pared-a-pared) y anotá tu elección "
+                + "en `ambiguedades`.\n"
+                + "Tu tarea es ASIGNAR cada cota listada a su rol geométrico usando la "
+                + "posición (x, y) — no generar números nuevos."
             ),
         })
     user_text_blocks.append({

--- a/api/app/modules/quote_engine/plan_anchor_validator.py
+++ b/api/app/modules/quote_engine/plan_anchor_validator.py
@@ -16,18 +16,28 @@ from __future__ import annotations
 from typing import Iterable
 
 
-TOLERANCE = 0.02  # metros — margen para error de redondeo o rotación OCR
+TOLERANCE = 0.01  # metros — 1cm. Apretado desde 2cm tras caso real donde
+# Valentina leyó 2.15m en vez de 2.05m en un plano con cota explícita de 2.05:
+# con tol=0.02 la diferencia de 10cm igual se detectaba (|2.15-2.05|=0.10 > 0.02),
+# pero nunca llegó acá porque el reconciliador Opus/Sonnet (±5%) aceptó ambos
+# modelos coincidiendo en 2.15. Bajar a 1cm reduce falsos positivos en cotas
+# cercanas como 0.60/0.62 y fuerza el anchor real contra el text layer.
+
+
+_FP_EPSILON = 1e-6  # evita falsos UNANCHORED por ruido de floating point
 
 
 def _matches_any(value: float, reference: Iterable[float], tol: float = TOLERANCE) -> bool:
-    """True si `value` está dentro de `tol` metros de algún valor de referencia."""
+    """True si `value` está dentro de `tol` metros de algún valor de referencia.
+    Agrega epsilon chico para evitar que `abs(2.94 - 2.95) = 0.01000...231` sea
+    rechazado por un tol="0.01" exacto."""
     if value is None:
         return True  # valores null no se validan (el frontend los renderiza como edit inputs)
     try:
         v = float(value)
     except (TypeError, ValueError):
         return True
-    return any(abs(v - float(r)) <= tol for r in reference if r is not None)
+    return any(abs(v - float(r)) <= tol + _FP_EPSILON for r in reference if r is not None)
 
 
 def annotate_anchoring(result: dict, extracted_values: list[float]) -> dict:

--- a/api/catalog/config.json
+++ b/api/catalog/config.json
@@ -126,6 +126,7 @@
     "rotate_plan_images": false,
     "max_examples": 1,
     "dual_read_enabled": true,
+    "multi_crop_enabled": true,
     "plan_rasterization_dpi": 300
   },
   "zone_aliases": {


### PR DESCRIPTION
Reduce errores de lectura tipo caso Bernardi (leyó 2.15m en un plano con cota 2.05m).

**3 cambios:**
1. `plan_anchor_validator.py` tolerance **2cm → 1cm** (+ epsilon FP)
2. `config.json` multi_crop_enabled **false → true** (valida per-región con cotas locales; skip LLM si <2 cotas → DUDOSO automático)
3. `dual_reader.py` prompt **endurecido**: "TODO número DEBE estar en las cotas listadas. Si no, null + DUDOSO, no estimes visualmente"

1103/1103 tests pass. 🤖 Claude Code