### PR TITLE
fix(cleanup): no borrar drafts con plano/mensajes — causa raíz del 'vuelve al listado' tras confirmar despiece

### DIFF
--- a/api/app/core/database.py
+++ b/api/app/core/database.py
@@ -151,13 +151,41 @@ async def get_db():
 
 
 async def cleanup_empty_drafts():
-    """Delete draft quotes older than 1 hour that lack client + material.
-    Drafts with real data (client_name AND material set) are preserved."""
+    """Delete draft quotes that are truly abandoned placeholders.
+
+    "Abandoned" means: inactive for >1h AND nothing real attached —
+    no client_name, no plano adjunto, no historial de chat. Un quote
+    con cualquiera de esos es trabajo en curso y NO se toca.
+
+    Causa raíz del bug que arregla esta función (ver regresión en
+    tests/test_cleanup_drafts.py): antes borrábamos cualquier draft con
+    `material IS NULL` más de 1h de antigüedad. Pero `material` se setea
+    recién en Paso 2 (tras confirmar el despiece), así que durante todo
+    el Paso 1 — brief, plano, Dual Read, revisar medidas — material
+    queda NULL. Si el operador tardaba >1h (esperar a Opus, corregir,
+    revisar con cliente) y otro tab disparaba `POST /quotes` (que lanza
+    cleanup fire-and-forget), o Railway hacía cold-start, el quote se
+    borraba en pleno flow y `[DUAL_READ_CONFIRMED]` volvía 404 → el
+    frontend redirigía al listado perdiendo todo el trabajo.
+
+    Fix:
+    - Usar `updated_at` en vez de `created_at` — actividad reciente
+      preserva la quote aunque sea vieja.
+    - Sacar el check de `material IS NULL` — material null es estado
+      normal en Paso 1.
+    - Preservar cualquier quote con source_files (plano pegado) o con
+      mensajes en el historial.
+    """
     if settings.APP_ENV == "test":
         return  # Skip cleanup in test environment
 
+    await _cleanup_empty_drafts_impl()
+
+
+async def _cleanup_empty_drafts_impl():
+    """Implementation sin el guard de APP_ENV=test para poder testear."""
     from datetime import datetime, timedelta, timezone
-    from sqlalchemy import delete
+    from sqlalchemy import delete, cast, String
     from app.models.quote import Quote
 
     cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
@@ -165,9 +193,21 @@ async def cleanup_empty_drafts():
         result = await db.execute(
             delete(Quote).where(
                 Quote.status == "draft",
-                Quote.created_at < cutoff,
-                # Only delete if missing client OR material (incomplete)
-                (Quote.client_name == "") | (Quote.client_name.is_(None)) | (Quote.material.is_(None)),
+                # "Idle for >1h" — updated_at refleja la última edición,
+                # not created_at. Un quote activo se actualiza en cada turno
+                # de chat (messages, quote_breakdown, source_files), así que
+                # nunca llega al cutoff mientras el operador esté laburando.
+                Quote.updated_at < cutoff,
+                # Empty placeholder: sin cliente asignado.
+                (Quote.client_name == "") | (Quote.client_name.is_(None)),
+                # Nunca borrar si hay plano adjunto (es trabajo real).
+                # source_files arranca como NULL; al subir el primer plano
+                # pasa a una lista con 1+ items.
+                (Quote.source_files.is_(None)) | (cast(Quote.source_files, String).in_(("null", "[]"))),
+                # Nunca borrar si hay historial de chat.
+                # messages arranca como [] (default=list), pasa a >1 item
+                # apenas Valentina responde.
+                cast(Quote.messages, String).in_(("null", "[]")),
                 # Never delete web-originated quotes — they may be in progress
                 (Quote.source != "web") | (Quote.source.is_(None)),
             )

--- a/api/tests/test_cleanup_drafts.py
+++ b/api/tests/test_cleanup_drafts.py
@@ -1,0 +1,183 @@
+"""Regresión: cleanup_empty_drafts NO debe borrar quotes en curso.
+
+Bug histórico: el cleanup borraba cualquier draft con `material IS NULL`
+y `created_at < hace 1h`. Pero durante todo el Paso 1 (brief + plano +
+Dual Read + despiece) el `material` queda NULL — se setea recién en
+Paso 2. Resultado: si el operador tardaba >1h, otro tab disparaba
+`POST /quotes` (que lanza cleanup fire-and-forget), y el quote se
+borraba en plena confirmación del despiece → frontend veía 404 →
+redirect al listado → trabajo perdido.
+
+Estos tests fijan el contrato nuevo:
+- No borrar quotes con `source_files` (plano adjunto)
+- No borrar quotes con `messages` (historial de chat)
+- Usar `updated_at` en vez de `created_at` (actividad reciente = viva)
+- material NULL ya no es señal de abandono
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.models.quote import Quote, QuoteStatus
+
+
+# Los helpers necesitan AsyncSessionLocal apuntando al db de test, que
+# el fixture `client` ya configura via conftest.py. Por eso dependemos
+# de `client` aunque no lo usemos para HTTP — solo para el side-effect
+# del binding de AsyncSessionLocal.
+
+
+async def _insert_quote(db_session, **fields):
+    q = Quote(
+        id=str(uuid.uuid4()),
+        client_name=fields.pop("client_name", ""),
+        project=fields.pop("project", ""),
+        messages=fields.pop("messages", []),
+        status=fields.pop("status", QuoteStatus.DRAFT),
+        **fields,
+    )
+    db_session.add(q)
+    await db_session.commit()
+    return q
+
+
+async def _force_timestamps(db_session, quote_id: str, *, updated_at, created_at=None):
+    """Setea timestamps manualmente — los defaults de SQLAlchemy ponen NOW,
+    y no podemos bypassar func.now() salvo actualizando después del insert."""
+    from sqlalchemy import update as sql_update
+    values = {"updated_at": updated_at}
+    if created_at is not None:
+        values["created_at"] = created_at
+    await db_session.execute(
+        sql_update(Quote).where(Quote.id == quote_id).values(**values)
+    )
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_preserves_draft_with_plano_attached(client, db_session):
+    """Un draft con plano adjunto + material=None NO debe ser borrado,
+    aunque lleve >1h. Este es el escenario del bug original."""
+    from app.core.database import _cleanup_empty_drafts_impl
+
+    old = datetime.now(timezone.utc) - timedelta(hours=3)
+    q = await _insert_quote(
+        db_session,
+        client_name="",  # Valentina todavía no extrajo
+        material=None,  # Paso 2 no ejecutado
+        source_files=[{"filename": "plano.pdf", "size": 12345}],  # ← plano adjunto
+    )
+    await _force_timestamps(db_session, q.id, updated_at=old, created_at=old)
+
+    await _cleanup_empty_drafts_impl()
+
+    # La quote debe seguir viva.
+    result = await db_session.execute(select(Quote).where(Quote.id == q.id))
+    assert result.scalar_one_or_none() is not None, "Cleanup borró un draft con plano adjunto"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_preserves_draft_with_chat_history(client, db_session):
+    """Un draft con mensajes en el historial NO debe borrarse — es trabajo real."""
+    from app.core.database import _cleanup_empty_drafts_impl
+
+    old = datetime.now(timezone.utc) - timedelta(hours=3)
+    q = await _insert_quote(
+        db_session,
+        client_name="",
+        material=None,
+        messages=[
+            {"role": "user", "content": "Cocina en L con isla"},
+            {"role": "assistant", "content": "Dale, ¿me pasás el plano?"},
+        ],
+    )
+    await _force_timestamps(db_session, q.id, updated_at=old, created_at=old)
+
+    await _cleanup_empty_drafts_impl()
+
+    result = await db_session.execute(select(Quote).where(Quote.id == q.id))
+    assert result.scalar_one_or_none() is not None, "Cleanup borró un draft con historial de chat"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_preserves_draft_with_recent_activity(client, db_session):
+    """Un draft con updated_at reciente NO debe borrarse, aunque sea viejo
+    de created_at. Este es el fix del filtro created_at→updated_at."""
+    from app.core.database import _cleanup_empty_drafts_impl
+
+    old_created = datetime.now(timezone.utc) - timedelta(hours=5)
+    recent_update = datetime.now(timezone.utc) - timedelta(minutes=2)
+    q = await _insert_quote(db_session, client_name="")
+    await _force_timestamps(
+        db_session, q.id, created_at=old_created, updated_at=recent_update
+    )
+
+    await _cleanup_empty_drafts_impl()
+
+    result = await db_session.execute(select(Quote).where(Quote.id == q.id))
+    assert result.scalar_one_or_none() is not None, "Cleanup borró un draft con actividad reciente"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_deletes_truly_empty_placeholder(client, db_session):
+    """El caso legítimo: un placeholder vacío (sin cliente, sin plano,
+    sin mensajes) creado hace >1h. ESE sí debe borrarse."""
+    from app.core.database import _cleanup_empty_drafts_impl
+
+    old = datetime.now(timezone.utc) - timedelta(hours=3)
+    q = await _insert_quote(db_session, client_name="")
+    await _force_timestamps(db_session, q.id, updated_at=old, created_at=old)
+
+    await _cleanup_empty_drafts_impl()
+
+    result = await db_session.execute(select(Quote).where(Quote.id == q.id))
+    assert result.scalar_one_or_none() is None, "Cleanup no borró un placeholder vacío"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_preserves_draft_with_client_name(client, db_session):
+    """Un draft con client_name seteado NO debe borrarse, aun sin plano."""
+    from app.core.database import _cleanup_empty_drafts_impl
+
+    old = datetime.now(timezone.utc) - timedelta(hours=3)
+    q = await _insert_quote(db_session, client_name="Juan Pérez")
+    await _force_timestamps(db_session, q.id, updated_at=old, created_at=old)
+
+    await _cleanup_empty_drafts_impl()
+
+    result = await db_session.execute(select(Quote).where(Quote.id == q.id))
+    assert result.scalar_one_or_none() is not None, "Cleanup borró un draft con cliente asignado"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_preserves_non_draft_status(client, db_session):
+    """Quotes en pending/validated/sent nunca deben tocarse."""
+    from app.core.database import _cleanup_empty_drafts_impl
+
+    old = datetime.now(timezone.utc) - timedelta(hours=3)
+    q = await _insert_quote(db_session, client_name="", status=QuoteStatus.PENDING)
+    await _force_timestamps(db_session, q.id, updated_at=old, created_at=old)
+
+    await _cleanup_empty_drafts_impl()
+
+    result = await db_session.execute(select(Quote).where(Quote.id == q.id))
+    assert result.scalar_one_or_none() is not None, "Cleanup borró un quote no-draft"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_preserves_web_source_quotes(client, db_session):
+    """Quotes con source='web' nunca se tocan — pueden estar en progreso."""
+    from app.core.database import _cleanup_empty_drafts_impl
+
+    old = datetime.now(timezone.utc) - timedelta(hours=3)
+    q = await _insert_quote(db_session, client_name="", source="web")
+    await _force_timestamps(db_session, q.id, updated_at=old, created_at=old)
+
+    await _cleanup_empty_drafts_impl()
+
+    result = await db_session.execute(select(Quote).where(Quote.id == q.id))
+    assert result.scalar_one_or_none() is not None, "Cleanup borró un quote source=web"


### PR DESCRIPTION
## Causa raíz

Al confirmar el despiece del Dual Read, el frontend volvía al dashboard — aparentando abortar el flow.

El culpable: `cleanup_empty_drafts()` borraba cualquier draft con `material IS NULL` y `created_at` > 1h. Pero `material` se setea **recién en Paso 2** (tras confirmar el despiece) — durante todo Paso 1 (brief, plano, Dual Read, revisar medidas) queda NULL.

Escenario del bug:
1. Operador arranca quote a las 10am, pega plano, chatea con Valentina.
2. A las 11:05am está revisando el despiece (material aún NULL).
3. Otro tab dispara `POST /quotes` → cleanup fire-and-forget **borra la quote viva**.
4. Operador hace click en "Confirmar medidas" → 404 → `router.replace("/")`.

Peor aún: el `lifespan` de FastAPI corre cleanup al bootear, así que cualquier cold-start de Railway hacía lo mismo.

## Fix

En `api/app/core/database.py`:

- **`updated_at < cutoff`** en vez de `created_at` — actividad reciente preserva la quote.
- **Sacar `Quote.material.is_(None)`** — material null es estado normal en Paso 1.
- **Preservar quotes con `source_files`** (plano pegado) o **`messages`** no vacíos (historial de chat).

## Por qué no lo agarraban los tests

No había ninguno. El nuevo `tests/test_cleanup_drafts.py` cubre 7 escenarios:
- ✅ Draft con plano adjunto + `material=None` + >1h → **NO se borra** (el bug exacto)
- ✅ Draft con historial de chat → **NO se borra**
- ✅ Draft con actividad reciente (`updated_at` < cutoff) → **NO se borra**
- ✅ Placeholder vacío viejo → **sí se borra** (comportamiento legítimo)
- ✅ Draft con `client_name` → **NO se borra**
- ✅ Quotes no-draft (pending/validated/sent) → **NO se borran**
- ✅ Quotes con `source="web"` → **NO se borran**

## Test plan

- [x] `pytest tests/test_cleanup_drafts.py -v` → 7/7 green
- [x] Suite completa (`pytest --ignore=tests/evaluation`) → 1131 passed (1 pre-existente roto de `test_edificio_render` que no relaciona)
- [ ] Repro manual: dejar una quote abierta con plano + material NULL, esperar que el cleanup no la mate

🤖 Generated with [Claude Code](https://claude.com/claude-code)