### PR TITLE
revert(multi-crop): quitar global_fallback — inventaba medidas swappeadas entre sectores

### DIFF
--- a/api/app/modules/quote_engine/multi_crop_reader.py
+++ b/api/app/modules/quote_engine/multi_crop_reader.py
@@ -252,20 +252,20 @@ async def _measure_region(
     if x2 - x < 10 or y2 - y < 10:
         return {"error": "region_bbox_too_small", "region_id": region.get("id")}
 
-    # Filtrar cotas candidatas ANTES de croppear. Escalada de niveles:
-    #   L1 (local): cotas dentro del bbox + padding estándar. Caso ideal —
-    #       2+ cotas ancladas a la región → LLM + status CONFIRMADO/DUDOSO
-    #       según sanity checks post.
-    #   L2 (expanded): si L1 da <2, expandimos el área de búsqueda de cotas
-    #       300px más allá del bbox (solo para el filtro de cotas; el CROP
-    #       visual sigue siendo el bbox original). Cubre el caso típico: la
-    #       cota está DIBUJADA justo fuera del bbox detectado por el topology
-    #       LLM, pero obviamente pertenece a esta mesada.
-    #   L3 (global_fallback): si L2 sigue dando <2, pasamos TODAS las cotas
-    #       candidatas del plano. El LLM se apoya en el crop visual para
-    #       discriminar. Siempre marcamos suspicious_reasons post → status
-    #       queda DUDOSO aunque el LLM "acierte", para que el operador
-    #       revise (no ancladas = no confirmables).
+    # Filtrar cotas candidatas ANTES de croppear. Dos niveles:
+    #   L1 (local): cotas dentro del bbox + padding estándar.
+    #   L2 (expanded): si L1 <2, expandimos +300px SOLO el filtro de cotas
+    #       (el crop visual sigue siendo bbox original). Cubre el caso típico:
+    #       la cota está dibujada justo al borde del bbox del topology LLM,
+    #       pero claramente pertenece a esta región.
+    #
+    # Lo que NO hacemos: pasar TODAS las cotas del plano al LLM cuando el
+    # bbox queda lejos. Ese fallback global hacía que el LLM eligiera cotas
+    # de OTROS sectores e inventara medidas plausibles pero incorrectas
+    # (ej: caso Bernardi — R2 recibió 13 cotas globales, eligió 4.15 que
+    # era una cota de perímetro de la isla, no del tramo de cocina).
+    # Prefiero "— × —" honesto antes que un número swappeado que el
+    # operador pueda confirmar por error.
     local_cotas: list[Cota] = [c for c in candidate_cotas if x <= c.x <= x2 and y <= c.y <= y2]
 
     MIN_LOCAL_COTAS = 2
@@ -291,13 +291,17 @@ async def _measure_region(
                 f"— retry con pool expandido"
             )
         else:
-            cotas_for_llm = list(candidate_cotas)
-            cotas_mode = "global_fallback"
             logger.info(
                 f"[multi-crop] region {region.get('id')}: {len(local_cotas)} local / "
-                f"{len(expanded_cotas)} expanded — fallback a pool global "
-                f"({len(candidate_cotas)} cotas). Marcará DUDOSO post-LLM."
+                f"{len(expanded_cotas)} expanded cotas (<{MIN_LOCAL_COTAS}) — "
+                f"skip LLM, return DUDOSO (no inventamos medidas con pool global)"
             )
+            return {
+                "error": "insufficient_local_cotas",
+                "region_id": region.get("id"),
+                "local_cotas_count": len(local_cotas),
+                "expanded_cotas_count": len(expanded_cotas),
+            }
 
     # Crop la imagen con PIL
     try:
@@ -318,13 +322,6 @@ async def _measure_region(
         "expanded": (
             "COTAS CERCANAS (dentro del bbox expandido — algunas pueden "
             "pertenecer a regiones vecinas, descartá las que no correspondan):"
-        ),
-        "global_fallback": (
-            "COTAS DEL PLANO COMPLETO (FALLBACK — no hay cotas propias en el "
-            "bbox de esta región). Usá el CROP VISUAL para elegir las que "
-            "correspondan a ESTA mesada. Si no podés anclar ninguna con "
-            "certeza, devolvé largo_m=null / ancho_m=null y explicalo en "
-            "rejected_candidates. NO inventes medidas."
         ),
     }[cotas_mode]
     meta_txt = (

--- a/api/tests/test_multi_crop_reader.py
+++ b/api/tests/test_multi_crop_reader.py
@@ -288,34 +288,31 @@ class TestReadPlanMultiCrop:
         assert result.get("_cotas_mode") == "expanded"
 
     @pytest.mark.asyncio
-    async def test_measure_region_global_fallback_when_still_insufficient(self):
-        """Si NI siquiera expandiendo hay 2 cotas, caemos al pool global. El
-        LLM recibe todas las cotas del plano + prompt explícito: "estas cotas
-        son del plano completo — usá el crop visual para discriminar".
-        Siempre DUDOSO."""
+    async def test_measure_region_no_global_fallback_when_no_cotas_near_bbox(self):
+        """Si NI siquiera expandiendo hay 2 cotas cerca del bbox, devolvemos
+        DUDOSO sin llamar al LLM. NO inventamos medidas con pool global.
+
+        Motivación (caso Bernardi, abril 2026): el global_fallback hacía que
+        el LLM eligiera cotas de OTROS sectores, devolviendo medidas
+        plausibles pero incorrectas. Preferimos DUDOSO honesto que el
+        operador ve como "— × —" y completa manual.
+        """
         image = _make_image_bytes(1000, 800)
-        # bbox chico en esquina — lejos de las cotas
         region = {"id": "R2", "bbox_rel": {"x": 0.7, "y": 0.7, "w": 0.1, "h": 0.1}}
-        # Todas las cotas están en la otra punta del plano
         cotas = [
             _make_cota(2.35, x=100, y=100),
             _make_cota(0.60, x=120, y=120),
             _make_cota(1.20, x=150, y=150),
         ]
-        mock_response = type("R", (), {
-            "content": [type("B", (), {"text": '{"largo_m": 2.35, "ancho_m": 0.60}'})()]
-        })()
         with patch(
             "app.modules.quote_engine.multi_crop_reader.anthropic.AsyncAnthropic"
         ) as mock_anth:
-            mock_anth.return_value.messages.create = AsyncMock(return_value=mock_response)
             result = await _measure_region(image, (1000, 800), region, cotas, model="test")
-        assert result.get("error") is None
-        assert result.get("largo_m") == 2.35
-        assert result.get("_cotas_mode") == "global_fallback"
-        # Suspicious flag garantiza status DUDOSO
-        assert "suspicious_reasons" in result
-        assert any("fallback global" in s for s in result["suspicious_reasons"])
+            # NO debe haberse llamado al LLM
+            mock_anth.assert_not_called()
+        assert result.get("error") == "insufficient_local_cotas"
+        assert result.get("local_cotas_count") == 0
+        assert result.get("expanded_cotas_count") == 0
 
     @pytest.mark.asyncio
     async def test_measure_region_detects_unanchored_values(self):
@@ -364,16 +361,20 @@ class TestReadPlanMultiCrop:
         assert any("largo == ancho" in s for s in result["suspicious_reasons"])
 
     @pytest.mark.asyncio
-    async def test_bernardi_control_r2_gets_fallback_cotas(self):
-        """Regresión del caso real: plano de Bernardi, 2 regiones del topology
-        LLM, R2 (cocina con pileta) caía en zona sin cotas locales → antes del
-        fix se devolvía insufficient_local_cotas → frontend mostraba "— × —".
+    async def test_bernardi_control_r2_stays_dudoso_without_inventing(self):
+        """Regresión del caso real Bernardi (abril 2026): 2 regiones en el
+        topology, R2 (cocina) en zona del plano sin cotas locales.
 
-        Con el fallback escalonado, R2 ahora recibe las cotas globales para
-        que el LLM las discrimine visualmente. Status final = DUDOSO (no
-        CONFIRMADO) porque no hubo anchoring local — el operador revisa.
+        CONTRATO ACTUAL (post-revert del global_fallback): R2 devuelve
+        `insufficient_local_cotas` → aggregator emite largo/ancho=null con
+        status DUDOSO → UI muestra "— × —". El operador completa a mano.
 
-        Coordenadas de cotas tomadas del PDF real
+        Lo que NO hacemos: pasar las cotas globales al LLM para que invente
+        una medida. Ese fallback hacía que el LLM eligiera cotas de otros
+        sectores, devolviendo medidas swappeadas con look-confiado que
+        podían confirmarse por error.
+
+        Coordenadas tomadas del PDF real
         `tests/fixtures/bernardi_erica_mesadas_cocina.pdf` con
         `extract_cotas_from_drawing` a 300 DPI.
         """
@@ -443,13 +444,14 @@ class TestReadPlanMultiCrop:
             result = await read_plan_multi_crop(image, cotas, brief_text="Bernardi — Puraprima")
 
         assert result.get("error") is None
-        # Ambas regiones devolvieron medidas (ninguna con "— × —").
         isla = next(s for s in result["sectores"] if s["tipo"] == "isla")
         cocina = next(s for s in result["sectores"] if s["tipo"] == "cocina")
+        # R1 (isla) tiene cotas locales → mide
         assert isla["tramos"][0]["largo_m"]["valor"] is not None
-        assert cocina["tramos"][0]["largo_m"]["valor"] is not None, \
-            "R2 volvió a tirar null — el fallback no se activó"
-        # R2 queda DUDOSO porque fue fallback, no CONFIRMADO.
+        # R2 (cocina) sin cotas cercanas → valor null + status DUDOSO.
+        # NO debe inventar una medida global que confunda al operador.
+        assert cocina["tramos"][0]["largo_m"]["valor"] is None, \
+            "R2 tiene valor no-null — está inventando desde pool global"
         assert cocina["tramos"][0]["largo_m"]["status"] == "DUDOSO"
         assert result["requires_human_review"] is True
 


### PR DESCRIPTION
## PR 0 — revert de daño inmediato

Rollback parcial de [PR #332](https://github.com/javi10823/ia-agent-quote-marble-operator/pull/332). El nivel L3 "global_fallback" hacía que el LLM eligiera cotas de OTROS sectores cuando el bbox no tenía cotas cercanas — devolvía medidas swappeadas con confianza plena.

### Caso Bernardi (abril 2026)

Plano con L + isla. Medidas reales:
- Isla: 1.60 × 0.60 m
- L tramo 1: 2.35 × 0.60 m
- L tramo 2: 2.05 × 0.60 m
- **Total correcto: 3.60 m²**

Con el bug del global_fallback:
- "Isla con anafe" → 2.35 × 0.60 (era el tramo L)
- "Cocina 1" → 4.15 × 0.60 (cota de **perímetro**, no de mesada)
- "Cocina con pileta" → 2.95 × 0.60 (cota de otra zona)
- **Total reportado: 5.67 m² — 60% de error**

Con badge DUDOSO el operador podía confirmar esas medidas por error. Peor regresión que la que el PR intentaba arreglar.

## Comportamiento post-revert

| Nivel | Comportamiento |
|---|---|
| **L1 "local"** | bbox + 80px padding — igual que siempre |
| **L2 "expanded"** | bbox + 300px sólo para cota-search — SE MANTIENE (seguro: solo agrega cotas geográficamente cercanas) |
| **L3 global_fallback** | ❌ **ELIMINADO** |

Región sin cotas en bbox+expanded → `insufficient_local_cotas` → tramo con `valor=null` + status DUDOSO → UI muestra "— × —" → operador completa manual. Vuelve al comportamiento pre-#332.

## Tests

- `test_measure_region_no_global_fallback_when_no_cotas_near_bbox` — verifica que NO se llama al LLM si bbox+expanded <2 cotas.
- `test_bernardi_control_r2_stays_dudoso_without_inventing` — fixture con cotas reales del plano de Erica Bernardi, garantiza que R2 queda con `valor=null` (no número inventado).
- Suite: 1133 passed, 1 deselected.

## Lo que NO arregla este PR

El **topology LLM sigue clasificando mal** en el plano de Bernardi (detecta 2 regiones cuando hay 3, etiqueta "isla con anafe" a un tramo L). Eso se ataca en PRs separados:

- **PR siguiente (1):** logging estructurado del topology response.
- **PR posterior (2):** iteración del prompt + heurísticas post-topology con el plano de Bernardi como fixture E2E.

## Test plan

- [ ] Subir plano de Bernardi en prod → las regiones sin cotas locales muestran "— × —" (antes mostraban números inventados).
- [ ] Operador puede editar las medidas inline con doble-click.
- [ ] Confirmar despiece sin crashear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)