### PR TITLE
feat(multi-crop): region-aware cota ranking and measurement guardrails

### DIFF
--- a/api/app/modules/quote_engine/multi_crop_reader.py
+++ b/api/app/modules/quote_engine/multi_crop_reader.py
@@ -295,6 +295,10 @@ Reglas:
 - NO confundas cotas del perímetro del ambiente (típicamente > 3m y
   alineadas con el borde exterior del dibujo) con cotas de la mesada.
 
+Las cotas candidatas vienen RANKEADAS por compatibilidad geométrica con
+la región. Elegir una cota DÉBIL o POCO PROBABLE requiere justificación
+visual explícita del crop. NO elegir una EXCLUIDA.
+
 Devolvé SOLO JSON:
 {
   "largo_m": 2.95,
@@ -306,6 +310,414 @@ Devolvé SOLO JSON:
   ]
 }
 """
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PR 2b — Region-aware cota ranking + guardrails
+#
+# Objetivo: que el VLM elija 2.35 en vez de 2.95 para el tramo vertical de
+# Bernardi. El bug es de matching de cotas en pool expanded, no de perímetro.
+# 4 capas:
+#   1. Hard filter (perímetro + absurdos).
+#   2. Ranking SEPARADO para largo y ancho.
+#   3. Prompt estructurado (buckets, sin sugerir valores).
+#   4. Guardrails post-LLM que bajan confidence cuando ignora el ranking.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Valores por fuera de este rango casi nunca corresponden a mesada residencial
+_ABSURD_MIN_M = 0.10
+_ABSURD_MAX_M = 6.0
+
+# Perímetro probable: valor alto + lejos del bbox de la región
+_PERIMETER_VALUE_THRESHOLD_M = 3.0
+_PERIMETER_DISTANCE_THRESHOLD_NORM = 0.20  # suma de distancias x+y normalizadas
+
+# Rangos típicos para cocinas residenciales
+_LENGTH_TYPICAL_RANGE = (1.0, 4.0)
+_DEPTH_TYPICAL_RANGE = (0.40, 0.80)
+_DEPTH_ANCHO_REFERENCE_RANGE = (0.3, 0.8)  # usamos 0.60 y similares como escala
+
+# Umbrales de bucket (score sumatorio 0..100)
+_BUCKET_PREFERRED = 60
+_BUCKET_WEAK = 40
+_BUCKET_UNLIKELY = 20
+
+
+def _bbox_to_px(bbox: dict, image_size: tuple[int, int]) -> dict:
+    """Convierte bbox_rel {x,y,w,h} 0..1 → coords absolutas px."""
+    img_w, img_h = image_size
+    x = int((bbox.get("x") or 0) * img_w)
+    y = int((bbox.get("y") or 0) * img_h)
+    w = int((bbox.get("w") or 0) * img_w)
+    h = int((bbox.get("h") or 0) * img_h)
+    return {"x": x, "y": y, "x2": x + w, "y2": y + h, "w": w, "h": h}
+
+
+def _cota_in_bbox(
+    cota: Cota, bbox_px: dict, *, padding_px: int = 0,
+) -> bool:
+    x, y, x2, y2 = bbox_px["x"], bbox_px["y"], bbox_px["x2"], bbox_px["y2"]
+    return (
+        x - padding_px <= cota.x <= x2 + padding_px
+        and y - padding_px <= cota.y <= y2 + padding_px
+    )
+
+
+def _is_probable_perimeter(
+    cota: Cota, region_bbox_px: dict, image_size: tuple[int, int],
+) -> bool:
+    """Perímetro = valor grande (>3m) + posición fuera del bbox de la región.
+
+    Dos señales combinadas:
+    - value > 3m (cotas de ambiente típicamente son más grandes que mesadas).
+    - Posición: la cota está fuera del bbox tight de la región. NO importa
+      si está pegada o lejos — si el valor es grande y no cae dentro del
+      bbox inmediato, es muy probable que sea cota de perímetro del
+      ambiente arrastrada visualmente.
+
+    Contraejemplo que la regla NO rompe: una cota 2.50 en la isla que
+    estará fuera del bbox de la isla chica — no es perímetro porque su
+    valor <3m. El umbral de 3m captura específicamente las cotas de
+    perímetro del ambiente (> 3m típicamente).
+
+    Contraejemplo que SÍ se contempla: una cota 3.50 DENTRO del bbox
+    tight → no es perímetro, puede ser una mesada larga.
+    """
+    if cota.value <= _PERIMETER_VALUE_THRESHOLD_M:
+        return False
+    # Fuera del bbox tight (sin padding) → probable perímetro
+    if not _cota_in_bbox(cota, region_bbox_px, padding_px=0):
+        return True
+    return False
+
+
+def _tramo_orientation(region_bbox_px: dict) -> str:
+    """'vertical' si h > w, sino 'horizontal'. Determina qué cotas son
+    candidatas a largo vs ancho."""
+    return "vertical" if region_bbox_px["h"] > region_bbox_px["w"] else "horizontal"
+
+
+def _cota_aligned_with_long_axis(
+    cota: Cota, region_bbox_px: dict, orientation: str,
+) -> bool:
+    """True si la cota está posicionada a lo largo del eje largo del tramo.
+
+    Para un tramo vertical: la cota de largo se escribe típicamente al
+    costado (fuera del rango x del bbox) pero alineada con el rango y.
+    Para horizontal: al revés.
+
+    Usamos rango ± 30% de tolerancia para capturar cotas escritas
+    ligeramente fuera del bbox estricto.
+    """
+    if orientation == "vertical":
+        y_tol = 0.30 * region_bbox_px["h"]
+        return (
+            region_bbox_px["y"] - y_tol <= cota.y <= region_bbox_px["y2"] + y_tol
+        )
+    else:
+        x_tol = 0.30 * region_bbox_px["w"]
+        return (
+            region_bbox_px["x"] - x_tol <= cota.x <= region_bbox_px["x2"] + x_tol
+        )
+
+
+def _estimate_plan_scale(
+    regions: list[dict], all_cotas: list[Cota], image_size: tuple[int, int],
+) -> Optional[float]:
+    """Estima `px_per_m` del plano usando pares (region_bbox, cota chica
+    local). Señal DÉBIL — solo se usa para penalizar outliers groseros,
+    no para decidir entre cotas plausibles.
+
+    Requiere ≥2 pares confiables para que la mediana tenga sentido.
+    Devuelve None si no hay suficiente evidencia.
+    """
+    candidates: list[float] = []
+    for region in regions:
+        bbox_px = _bbox_to_px(region.get("bbox_rel") or {}, image_size)
+        if bbox_px["w"] < 10 or bbox_px["h"] < 10:
+            continue
+        # Cotas dentro del bbox que caen en el rango de "ancho de mesada"
+        local = [
+            c for c in all_cotas
+            if _cota_in_bbox(c, bbox_px, padding_px=80)
+            and _DEPTH_ANCHO_REFERENCE_RANGE[0] <= c.value <= _DEPTH_ANCHO_REFERENCE_RANGE[1]
+        ]
+        if not local:
+            continue
+        # Usar la dimensión CORTA del bbox como referencia del ancho
+        short_px = min(bbox_px["w"], bbox_px["h"])
+        for c in local:
+            if c.value > 0:
+                candidates.append(short_px / c.value)
+    if len(candidates) < 2:
+        return None
+    candidates.sort()
+    return candidates[len(candidates) // 2]  # mediana
+
+
+def _score_cota(
+    cota: Cota,
+    region_bbox_px: dict,
+    orientation: str,
+    scale: Optional[float],
+    *,
+    candidate_for: str,  # "length" | "depth"
+) -> dict:
+    """Score sumatorio 0..100 + bucket + razones.
+
+    `candidate_for`: rankeamos por separado para largo y ancho — una cota
+    de 0.60 debe ganar como ancho y perder como largo; 2.35 al revés.
+    """
+    score = 0
+    reasons: list[str] = []
+
+    # ── Proximidad al bbox ─────────────────────────────────────────────
+    if _cota_in_bbox(cota, region_bbox_px, padding_px=80):
+        score += 40
+        reasons.append("inside_tight_bbox")
+    elif _cota_in_bbox(cota, region_bbox_px, padding_px=380):
+        score += 15
+        reasons.append("inside_expanded_bbox")
+    else:
+        reasons.append("outside_expanded_bbox")
+
+    # ── Rango de valor típico según rol ───────────────────────────────
+    if candidate_for == "length":
+        lo, hi = _LENGTH_TYPICAL_RANGE
+        if lo <= cota.value <= hi:
+            score += 15
+            reasons.append("value_in_length_range")
+        else:
+            score -= 10
+            reasons.append("value_outside_length_range")
+    else:  # depth
+        lo, hi = _DEPTH_TYPICAL_RANGE
+        if lo <= cota.value <= hi:
+            score += 35
+            reasons.append("value_in_depth_range")
+        else:
+            score -= 20
+            reasons.append("value_outside_depth_range")
+
+    # ── Orientación vs eje ────────────────────────────────────────────
+    if candidate_for == "length":
+        if _cota_aligned_with_long_axis(cota, region_bbox_px, orientation):
+            score += 25
+            reasons.append(f"aligned_with_{orientation}_long_axis")
+        else:
+            score -= 10
+            reasons.append("not_aligned_with_long_axis")
+    # Para depth la alineación importa menos — el ancho se escribe típico
+    # en cualquier lado.
+
+    # ── Span plausibility (señal DÉBIL — solo si hay scale) ──────────
+    if scale and candidate_for == "length":
+        bbox_long_px = max(region_bbox_px["w"], region_bbox_px["h"])
+        expected_m = bbox_long_px / scale
+        if expected_m > 0.5:
+            deviation = abs(cota.value - expected_m) / expected_m
+            if deviation > 0.40:
+                # Señal débil — no dominante. 20 puntos de castigo.
+                score -= 20
+                reasons.append(f"span_mismatch_{int(deviation * 100)}pct")
+            elif deviation < 0.15:
+                score += 10
+                reasons.append("span_matches")
+
+    # ── Clamp + bucket ─────────────────────────────────────────────────
+    score = max(0, min(100, score))
+    if score >= _BUCKET_PREFERRED:
+        bucket = "preferred"
+    elif score >= _BUCKET_WEAK:
+        bucket = "weak"
+    elif score >= _BUCKET_UNLIKELY:
+        bucket = "unlikely"
+    else:
+        bucket = "excluded_soft"
+    return {
+        "value": cota.value,
+        "score": score,
+        "bucket": bucket,
+        "reasons": reasons,
+    }
+
+
+def _rank_cotas_for_region(
+    cotas: list[Cota],
+    region: dict,
+    image_size: tuple[int, int],
+    scale: Optional[float],
+) -> dict:
+    """Genera dos rankings (length + depth) + lista de excluidas duras.
+
+    Excluidas duras:
+    - Perímetro probable (valor >3m + lejos del bbox).
+    - Valor absurdo (<0.1m o >6m).
+
+    Nada más se excluye duro — el resto va a preferred/weak/unlikely
+    según score.
+    """
+    region_bbox_px = _bbox_to_px(region.get("bbox_rel") or {}, image_size)
+    orientation = _tramo_orientation(region_bbox_px)
+
+    length_ranking: list[dict] = []
+    depth_ranking: list[dict] = []
+    excluded_hard: list[dict] = []
+
+    for cota in cotas:
+        # Hard exclusions
+        if cota.value < _ABSURD_MIN_M or cota.value > _ABSURD_MAX_M:
+            excluded_hard.append({
+                "value": cota.value,
+                "reason": "absurd_value",
+            })
+            continue
+        if _is_probable_perimeter(cota, region_bbox_px, image_size):
+            excluded_hard.append({
+                "value": cota.value,
+                "reason": "probable_perimeter",
+            })
+            continue
+        # Score para ambos roles
+        length_ranking.append(
+            _score_cota(cota, region_bbox_px, orientation, scale, candidate_for="length")
+        )
+        depth_ranking.append(
+            _score_cota(cota, region_bbox_px, orientation, scale, candidate_for="depth")
+        )
+
+    # Ordenar desc por score
+    length_ranking.sort(key=lambda r: r["score"], reverse=True)
+    depth_ranking.sort(key=lambda r: r["score"], reverse=True)
+
+    return {
+        "length": length_ranking,
+        "depth": depth_ranking,
+        "excluded_hard": excluded_hard,
+        "orientation": orientation,
+        "scale_px_per_m": scale,
+    }
+
+
+def _format_ranking_for_prompt(ranking: dict) -> str:
+    """Prompt estructurado — sin sugerir valores específicos."""
+    lines: list[str] = []
+
+    def _bucket_label(bucket: str) -> str:
+        return {
+            "preferred": "PREFERIDAS",
+            "weak": "DÉBILES",
+            "unlikely": "POCO PROBABLES",
+            "excluded_soft": "POCO PROBABLES",  # collapse para el prompt
+        }.get(bucket, "POCO PROBABLES")
+
+    def _format_section(title: str, rows: list[dict]) -> list[str]:
+        out = [f"{title}:"]
+        if not rows:
+            out.append("  (ninguna)")
+            return out
+        by_bucket: dict[str, list[dict]] = {}
+        for r in rows:
+            by_bucket.setdefault(r["bucket"], []).append(r)
+        # Orden fijo
+        for bk in ("preferred", "weak", "unlikely", "excluded_soft"):
+            entries = by_bucket.get(bk) or []
+            if not entries:
+                continue
+            out.append(f"  {_bucket_label(bk)}:")
+            for e in entries[:6]:  # top 6 por bucket
+                reasons = ", ".join(e["reasons"][:3])
+                out.append(
+                    f"    - {e['value']:.2f}m (score {e['score']}) — {reasons}"
+                )
+        return out
+
+    lines.append(f"Orientación del tramo: {ranking['orientation']}")
+    if ranking.get("scale_px_per_m"):
+        lines.append("(escala del plano estimada desde cotas locales)")
+    lines.append("")
+    lines.extend(_format_section("CANDIDATAS PARA LARGO", ranking["length"]))
+    lines.append("")
+    lines.extend(_format_section("CANDIDATAS PARA ANCHO", ranking["depth"]))
+
+    hard = ranking.get("excluded_hard") or []
+    if hard:
+        lines.append("")
+        lines.append("EXCLUIDAS (no usar):")
+        for h in hard[:6]:
+            lines.append(f"  - {h['value']:.2f}m — {h['reason']}")
+
+    lines.append("")
+    lines.append(
+        "Usá el ranking como prior. Elegir una DÉBIL o POCO PROBABLE "
+        "requiere justificación visual explícita del crop."
+    )
+    return "\n".join(lines)
+
+
+def _apply_guardrails(
+    vlm_output: dict, ranking: dict,
+) -> dict:
+    """Post-LLM: si el VLM eligió weak/unlikely habiendo preferred
+    disponible, baja confidence y agrega suspicious_reasons.
+
+    Importante: el guardrail se apoya en el RANKING (determinístico), NO
+    en el `reasoning` del VLM (puede sonar convincente y ser falso).
+
+    Si el VLM elige weak PERO no hay preferred disponible, no castigamos
+    — puede ser lo mejor disponible en ese crop.
+    """
+    largo = vlm_output.get("largo_m")
+    ancho = vlm_output.get("ancho_m")
+    confidence = vlm_output.get("confidence", 0.5)
+    try:
+        confidence = float(confidence)
+    except (TypeError, ValueError):
+        confidence = 0.5
+    suspicious: list[str] = list(vlm_output.get("suspicious_reasons") or [])
+
+    def _find_match(value, rank_list):
+        if value is None:
+            return None
+        for r in rank_list:
+            if abs(r["value"] - float(value)) <= 0.02:
+                return r
+        return None
+
+    for field_name, value, rank_list in [
+        ("largo", largo, ranking.get("length") or []),
+        ("ancho", ancho, ranking.get("depth") or []),
+    ]:
+        if value is None:
+            continue
+        chosen = _find_match(value, rank_list)
+        if chosen is None:
+            # Valor no está en el ranking — halucinado o fuera de scope
+            suspicious.append(
+                f"{field_name} {value}m no está en el ranking de candidatas"
+            )
+            confidence = min(confidence, 0.3)
+            continue
+        if chosen["bucket"] in ("weak", "unlikely", "excluded_soft"):
+            # ¿Había una preferred disponible?
+            top_preferred = next(
+                (r for r in rank_list if r["bucket"] == "preferred"),
+                None,
+            )
+            if top_preferred and abs(top_preferred["value"] - float(value)) > 0.02:
+                suspicious.append(
+                    f"VLM eligió {field_name} {chosen['value']}m (bucket "
+                    f"{chosen['bucket']}, score {chosen['score']}) habiendo "
+                    f"preferred {top_preferred['value']}m (score "
+                    f"{top_preferred['score']}) disponible"
+                )
+                confidence = min(confidence, 0.5)
+            # Si no hay preferred, weak puede ser lo mejor — no castigamos
+
+    vlm_output["confidence"] = confidence
+    if suspicious:
+        vlm_output["suspicious_reasons"] = suspicious
+    return vlm_output
 
 
 async def _measure_region(
@@ -402,14 +814,14 @@ async def _measure_region(
         return {"error": f"crop_failed: {e}", "region_id": region.get("id")}
 
     client = anthropic.AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY)
-    cotas_txt = format_cotas_for_prompt(cotas_for_llm) if cotas_for_llm else "(sin cotas extraídas)"
-    cotas_header = {
-        "local": "COTAS LOCALES (dentro del bbox de esta región):",
-        "expanded": (
-            "COTAS CERCANAS (dentro del bbox expandido — algunas pueden "
-            "pertenecer a regiones vecinas, descartá las que no correspondan):"
-        ),
-    }[cotas_mode]
+
+    # PR 2b — Ranking determinístico ANTES del VLM.
+    # Scale estimation pasa TODAS las candidatas (no solo cotas_for_llm)
+    # para obtener más evidencia si otras regiones tienen cotas locales.
+    plan_scale = _estimate_plan_scale([region], candidate_cotas, image_size)
+    ranking = _rank_cotas_for_region(cotas_for_llm, region, image_size, plan_scale)
+    ranking_txt = _format_ranking_for_prompt(ranking)
+
     meta_txt = (
         f"Sector: {region.get('sector') or 'cocina'}\n"
         f"Toca paredes: {region.get('touches_walls')}\n"
@@ -425,7 +837,7 @@ async def _measure_region(
         },
         {
             "type": "text",
-            "text": f"{cotas_header}\n{cotas_txt}",
+            "text": ranking_txt,
         },
     ]
     if brief_text and brief_text.strip():
@@ -487,56 +899,32 @@ async def _measure_region(
     parsed["region_id"] = region.get("id")
     parsed["_local_cotas_count"] = len(local_cotas)
     parsed["_cotas_mode"] = cotas_mode
+    parsed["_cota_ranking"] = ranking  # expuesto al log [region-detail]
 
-    # Sanity checks post-LLM: marcamos suspicious_reasons para que el
-    # aggregator emita DUDOSO en vez de CONFIRMADO. Regla: no aceptar
-    # output del VLM con "cara de confiado" cuando la evidencia no cierra.
-    largo = parsed.get("largo_m")
-    ancho = parsed.get("ancho_m")
-    suspicious: list[str] = []
-    # Anclamos contra TODAS las cotas que le pasamos al LLM (no solo las
-    # estrictamente locales): si usamos el pool expanded/global y el LLM
-    # eligió una cota real, el valor está anclado — aceptable aunque no
-    # sea "local". El nivel de confianza viene del flag cotas_mode, no
-    # de si la cota vino del bbox estricto.
-    cota_values = [c.value for c in cotas_for_llm]
+    # PR 2b — Guardrails post-LLM apoyados en el RANKING determinístico
+    # (no en el reasoning del VLM que puede sonar convincente y ser falso).
+    parsed = _apply_guardrails(parsed, ranking)
 
-    def _anchored(v) -> bool:
-        if v is None or not isinstance(v, (int, float)):
-            return False
-        return any(abs(float(v) - cv) <= 0.02 for cv in cota_values)
-
-    if cotas_for_llm:
-        if largo is not None and not _anchored(largo):
-            suspicious.append(f"largo {largo}m no está en las cotas candidatas ({cotas_mode})")
-        if ancho is not None and not _anchored(ancho):
-            suspicious.append(f"ancho {ancho}m no está en las cotas candidatas ({cotas_mode})")
-
-    # Cuando caímos a fallback expanded o global, el resultado NUNCA es
-    # CONFIRMADO aunque los números sean plausibles — el operador tiene
-    # que revisar porque el anchoring no fue estricto. Esto es la línea
-    # roja de "fail-loud": mostramos número (útil para arrancar), pero
-    # con badge DUDOSO para que se revise.
+    # Cuando caímos a fallback expanded, el resultado NUNCA es CONFIRMADO
+    # aunque los números sean plausibles — el operador tiene que revisar
+    # porque el anchoring no fue estricto.
     if cotas_mode == "expanded":
-        suspicious.append(
-            "medida tomada con pool de cotas expandido (no estricto a esta región)"
-        )
-    elif cotas_mode == "global_fallback":
-        suspicious.append(
-            "medida tomada con fallback global (no había cotas cercanas a esta región) — revisar"
-        )
+        _susp = list(parsed.get("suspicious_reasons") or [])
+        _susp.append("medida tomada con pool de cotas expandido (no estricto a esta región)")
+        parsed["suspicious_reasons"] = _susp
 
     # Fallback silencioso típico: el modelo devuelve L==A cuando no puede
     # elegir → usualmente agarra 0.60 (el ancho estándar) dos veces.
+    largo = parsed.get("largo_m")
+    ancho = parsed.get("ancho_m")
     if (
         isinstance(largo, (int, float))
         and isinstance(ancho, (int, float))
         and abs(float(largo) - float(ancho)) < 0.01
     ):
-        suspicious.append(f"largo == ancho ({largo}m) — probable fallback silencioso del VLM")
-
-    if suspicious:
-        parsed["suspicious_reasons"] = suspicious
+        _susp = list(parsed.get("suspicious_reasons") or [])
+        _susp.append(f"largo == ancho ({largo}m) — probable fallback silencioso del VLM")
+        parsed["suspicious_reasons"] = _susp
 
     return parsed
 

--- a/api/tests/test_multi_crop_reader.py
+++ b/api/tests/test_multi_crop_reader.py
@@ -16,10 +16,17 @@ from PIL import Image
 from app.modules.quote_engine.cotas_extractor import Cota
 from app.modules.quote_engine.multi_crop_reader import (
     _aggregate,
+    _apply_guardrails,
+    _bbox_to_px,
     _call_global_topology,
+    _estimate_plan_scale,
+    _format_ranking_for_prompt,
     _GLOBAL_SYSTEM_PROMPT,
     _infer_expected_region_count,
+    _is_probable_perimeter,
     _measure_region,
+    _rank_cotas_for_region,
+    _score_cota,
     read_plan_multi_crop,
 )
 
@@ -619,3 +626,298 @@ class TestTopologyCallInjectsHint:
         # Pero NO hay frase de count inferido
         assert "tramos rectos cotizables" not in joined
         assert "fusionaste" not in joined
+
+
+# ── PR 2b: cota ranking + guardrails ─────────────────────────────────────────
+
+class TestPerimeterFilter:
+    """Perímetro = valor grande (>3m) Y lejos del bbox. Ambas señales
+    requeridas — una cota de 4m cercana al bbox puede ser una mesada larga."""
+
+    def test_large_value_far_from_bbox_is_perimeter(self):
+        img_size = (1000, 800)
+        # bbox en la esquina sup-izq; cota en la otra esquina
+        bbox = {"x": 100, "y": 100, "x2": 200, "y2": 200, "w": 100, "h": 100}
+        cota = Cota(text="4.15", value=4.15, x=900, y=700, width=20, height=10)
+        assert _is_probable_perimeter(cota, bbox, img_size) is True
+
+    def test_large_value_close_to_bbox_is_not_perimeter(self):
+        img_size = (1000, 800)
+        bbox = {"x": 100, "y": 100, "x2": 500, "y2": 200, "w": 400, "h": 100}
+        cota = Cota(text="4.15", value=4.15, x=300, y=150, width=20, height=10)
+        assert _is_probable_perimeter(cota, bbox, img_size) is False
+
+    def test_small_value_far_from_bbox_is_not_perimeter(self):
+        # Cota chica lejos NO es perímetro (podría ser ancho de otra región).
+        img_size = (1000, 800)
+        bbox = {"x": 100, "y": 100, "x2": 200, "y2": 200, "w": 100, "h": 100}
+        cota = Cota(text="0.60", value=0.60, x=900, y=700, width=20, height=10)
+        assert _is_probable_perimeter(cota, bbox, img_size) is False
+
+
+class TestEstimatePlanScale:
+    """Scale estimation — señal débil. Requiere ≥2 pares para mediana."""
+
+    def test_scale_from_multiple_regions_with_local_depth_cotas(self):
+        img_size = (4000, 3000)
+        regions = [
+            {"bbox_rel": {"x": 0.1, "y": 0.1, "w": 0.05, "h": 0.3}},  # bbox corto ~200px
+            {"bbox_rel": {"x": 0.4, "y": 0.4, "w": 0.05, "h": 0.3}},  # idem
+        ]
+        # Cotas 0.60 dentro de cada bbox → short_px / 0.60 = 200 / 0.60 ≈ 333
+        cotas = [
+            Cota(text="0.60", value=0.60, x=500, y=450, width=20, height=10),  # dentro region 1
+            Cota(text="0.60", value=0.60, x=1700, y=1350, width=20, height=10),  # dentro region 2
+        ]
+        scale = _estimate_plan_scale(regions, cotas, img_size)
+        assert scale is not None
+        assert 300 <= scale <= 400  # ~333 px/m
+
+    def test_scale_returns_none_without_enough_evidence(self):
+        img_size = (4000, 3000)
+        regions = [{"bbox_rel": {"x": 0.1, "y": 0.1, "w": 0.05, "h": 0.3}}]
+        cotas = [Cota(text="0.60", value=0.60, x=500, y=450, width=20, height=10)]
+        # Solo 1 par → mediana no confiable → None
+        assert _estimate_plan_scale(regions, cotas, img_size) is None
+
+    def test_scale_ignores_cotas_outside_reference_range(self):
+        """Solo cotas chicas (0.30-0.80) cuentan como referencia de ancho."""
+        img_size = (4000, 3000)
+        regions = [
+            {"bbox_rel": {"x": 0.1, "y": 0.1, "w": 0.05, "h": 0.3}},
+            {"bbox_rel": {"x": 0.4, "y": 0.4, "w": 0.05, "h": 0.3}},
+        ]
+        cotas = [
+            Cota(text="2.35", value=2.35, x=500, y=450, width=20, height=10),
+            Cota(text="2.05", value=2.05, x=1700, y=1350, width=20, height=10),
+        ]
+        # Ninguna en rango 0.30-0.80 → None
+        assert _estimate_plan_scale(regions, cotas, img_size) is None
+
+
+class TestScoreCota:
+    """Score sumatorio 0..100. Cota de largo debe preferir alineación con
+    eje largo; cota de ancho debe preferir valor típico (0.40-0.80)."""
+
+    def test_length_cota_aligned_with_vertical_tramo_scores_high(self):
+        # Bbox vertical: 100x500 en posición (200, 200)
+        region_bbox_px = {"x": 200, "y": 200, "x2": 300, "y2": 700, "w": 100, "h": 500}
+        # Cota a la derecha del bbox, alineada en y, valor típico de largo
+        cota = Cota(text="2.35", value=2.35, x=340, y=450, width=20, height=10)
+        result = _score_cota(
+            cota, region_bbox_px, orientation="vertical", scale=None,
+            candidate_for="length",
+        )
+        assert result["score"] >= 60
+        assert result["bucket"] == "preferred"
+
+    def test_length_cota_misaligned_scores_lower(self):
+        region_bbox_px = {"x": 200, "y": 200, "x2": 300, "y2": 700, "w": 100, "h": 500}
+        # Cota MUY arriba del bbox, no alineada en y
+        cota = Cota(text="2.35", value=2.35, x=250, y=50, width=20, height=10)
+        result = _score_cota(
+            cota, region_bbox_px, orientation="vertical", scale=None,
+            candidate_for="length",
+        )
+        # No "inside_tight_bbox" y no alineada con eje → score bajo
+        assert result["score"] < 60
+
+    def test_depth_cota_prefers_small_typical_values(self):
+        region_bbox_px = {"x": 200, "y": 200, "x2": 300, "y2": 700, "w": 100, "h": 500}
+        # 0.60 dentro del bbox
+        cota_chica = Cota(text="0.60", value=0.60, x=250, y=400, width=20, height=10)
+        cota_grande = Cota(text="2.35", value=2.35, x=250, y=400, width=20, height=10)
+        score_chica = _score_cota(
+            cota_chica, region_bbox_px, orientation="vertical", scale=None,
+            candidate_for="depth",
+        )
+        score_grande = _score_cota(
+            cota_grande, region_bbox_px, orientation="vertical", scale=None,
+            candidate_for="depth",
+        )
+        assert score_chica["score"] > score_grande["score"]
+        assert score_chica["bucket"] == "preferred"
+        assert score_grande["bucket"] in ("weak", "unlikely", "excluded_soft")
+
+
+class TestBernardiRankingR2:
+    """Test central del PR. Usa las 7 cotas REALES extraídas del PDF de
+    Erica Bernardi (via `extract_cotas_from_drawing`) + el bbox de R2 tal
+    cual lo devolvió el topology LLM en prod (logs del 2026-04-19):
+    `x:0.64, y:0.28, w:0.08, h:0.32`.
+
+    El 2.95 que el VLM eligió en prod viene de otra ruta de extracción
+    (da 13 cotas) y no tenemos sus coordenadas exactas — no lo inventamos.
+
+    Valida el contrato del ranking contra los datos verificables:
+    - 2.35 aparece en length (es la medida correcta)
+    - 4.15 queda en excluded_hard como perímetro probable
+    - 0.60 aparece en depth preferred
+    - Ninguna de las cotas ajenas (2.75, 1.60, 2.05) supera al 2.35 en length
+    """
+
+    def test_r2_ranking_prefers_2_35_for_length(self):
+        image_size = (4963, 3509)
+        region = {"bbox_rel": {"x": 0.64, "y": 0.28, "w": 0.08, "h": 0.32}}
+        cotas = [
+            Cota(text="0.60", value=0.60, x=3028, y=957, width=20, height=10),
+            Cota(text="1.60", value=1.60, x=2119, y=1267, width=20, height=10),
+            Cota(text="4.15", value=4.15, x=3663, y=1339, width=20, height=10),
+            Cota(text="2.75", value=2.75, x=1577, y=1340, width=20, height=10),
+            Cota(text="2.35", value=2.35, x=2836, y=1458, width=20, height=10),
+            Cota(text="2.05", value=2.05, x=2506, y=1875, width=20, height=10),
+            Cota(text="0.60", value=0.60, x=1941, y=2039, width=20, height=10),
+        ]
+        ranking = _rank_cotas_for_region(cotas, region, image_size, scale=None)
+
+        # 4.15 debe estar en excluded_hard como perímetro (valor >3m fuera del bbox)
+        hard_values = [h["value"] for h in ranking["excluded_hard"]]
+        assert 4.15 in hard_values, (
+            f"4.15 debería ser perímetro; excluded_hard={ranking['excluded_hard']}"
+        )
+
+        # 2.35 debe estar en length
+        v235 = next(
+            (r for r in ranking["length"] if abs(r["value"] - 2.35) < 0.02),
+            None,
+        )
+        assert v235 is not None, (
+            f"2.35 debe estar en length; got values={[(r['value'], r['bucket']) for r in ranking['length']]}"
+        )
+
+        # Ninguna otra cota de largo (2.75, 1.60, 2.05) debe rankear por
+        # encima del 2.35 — el 2.35 es la respuesta correcta para R2.
+        for other_value in (2.75, 1.60, 2.05):
+            other = next(
+                (r for r in ranking["length"] if abs(r["value"] - other_value) < 0.02),
+                None,
+            )
+            if other is None:
+                continue  # puede haber sido filtrada por razones válidas
+            assert v235["score"] >= other["score"], (
+                f"2.35 (score {v235['score']}) debe rankear ≥ {other_value} "
+                f"(score {other['score']}). Ranking actual: "
+                f"{[(r['value'], r['score']) for r in ranking['length']]}"
+            )
+
+        # 0.60 debe aparecer en depth (ancho estándar). No exigimos "preferred"
+        # porque en el plano real de Bernardi las 0.60 quedan cerca del bbox
+        # expandido pero no dentro del tight — el bbox del tramo vertical es
+        # angosto y las cotas 0.60 se escriben arriba/abajo del tramo.
+        # Exigimos al menos que NO quede en "excluded_soft" o "unlikely" todas.
+        depth_matches = [r for r in ranking["depth"] if abs(r["value"] - 0.60) < 0.02]
+        assert len(depth_matches) >= 1
+        best_depth_060 = max(depth_matches, key=lambda r: r["score"])
+        assert best_depth_060["bucket"] in ("preferred", "weak"), (
+            f"Al menos una 0.60 debe ser depth preferred/weak; "
+            f"got {[(r['value'], r['bucket'], r['score']) for r in depth_matches]}"
+        )
+        # Ninguna cota grande (2.35, 1.60, 2.75) debe ranker preferido en depth
+        for v in (2.35, 1.60, 2.75):
+            bad = next(
+                (r for r in ranking["depth"] if abs(r["value"] - v) < 0.02), None,
+            )
+            if bad:
+                assert bad["bucket"] != "preferred", (
+                    f"{v} NO debe ser depth preferred (valor fuera de rango depth)"
+                )
+
+
+class TestGuardrails:
+    """Post-LLM: si VLM elige weak/unlikely habiendo preferred, baja
+    confidence + suspicious. Si no había preferred, no castigamos."""
+
+    def test_guardrail_lowers_confidence_on_weak_choice_vs_preferred(self):
+        ranking = {
+            "length": [
+                {"value": 2.35, "score": 80, "bucket": "preferred", "reasons": []},
+                {"value": 2.95, "score": 45, "bucket": "weak", "reasons": []},
+            ],
+            "depth": [
+                {"value": 0.60, "score": 75, "bucket": "preferred", "reasons": []},
+            ],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 2.95,  # eligió weak
+            "ancho_m": 0.60,
+            "confidence": 0.85,
+            "reasoning": "me pareció mejor",
+        }
+        result = _apply_guardrails(vlm_output, ranking)
+        assert result["confidence"] <= 0.5
+        assert "suspicious_reasons" in result
+        assert any("2.95" in s and "2.35" in s for s in result["suspicious_reasons"])
+
+    def test_guardrail_does_not_punish_weak_choice_when_no_preferred(self):
+        """Si solo hay weak disponible, no castigamos — puede ser lo mejor."""
+        ranking = {
+            "length": [
+                {"value": 2.95, "score": 45, "bucket": "weak", "reasons": []},
+                {"value": 2.05, "score": 38, "bucket": "weak", "reasons": []},
+            ],
+            "depth": [
+                {"value": 0.60, "score": 75, "bucket": "preferred", "reasons": []},
+            ],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 2.95,
+            "ancho_m": 0.60,
+            "confidence": 0.80,
+        }
+        result = _apply_guardrails(vlm_output, ranking)
+        # Confidence NO bajó a 0.5 — no había preferred que perder
+        assert result["confidence"] == 0.80
+        # No suspicious del guardrail tampoco
+        reasons = result.get("suspicious_reasons") or []
+        assert not any("preferred" in r for r in reasons)
+
+    def test_guardrail_flags_hallucinated_value_not_in_ranking(self):
+        ranking = {
+            "length": [
+                {"value": 2.35, "score": 80, "bucket": "preferred", "reasons": []},
+            ],
+            "depth": [
+                {"value": 0.60, "score": 75, "bucket": "preferred", "reasons": []},
+            ],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 7.42,  # valor que no está en el ranking
+            "ancho_m": 0.60,
+            "confidence": 0.90,
+        }
+        result = _apply_guardrails(vlm_output, ranking)
+        assert result["confidence"] <= 0.3
+        assert any("no está en el ranking" in s for s in result["suspicious_reasons"])
+
+
+class TestRankingPromptFormat:
+    """El prompt estructurado NO debe sugerir valores específicos que
+    contaminen la elección del VLM."""
+
+    def test_prompt_has_buckets_without_suggesting_values(self):
+        ranking = {
+            "length": [
+                {"value": 2.35, "score": 80, "bucket": "preferred", "reasons": ["aligned"]},
+                {"value": 2.95, "score": 45, "bucket": "weak", "reasons": ["far"]},
+            ],
+            "depth": [
+                {"value": 0.60, "score": 75, "bucket": "preferred", "reasons": ["depth_range"]},
+            ],
+            "excluded_hard": [{"value": 4.15, "reason": "probable_perimeter"}],
+            "orientation": "vertical",
+            "scale_px_per_m": None,
+        }
+        prompt = _format_ranking_for_prompt(ranking)
+        # Buckets presentes
+        assert "PREFERIDAS" in prompt
+        assert "DÉBILES" in prompt
+        # Sección "EXCLUIDAS" presente
+        assert "EXCLUIDAS" in prompt
+        # Orientación informada
+        assert "vertical" in prompt.lower()
+        # NO debe haber frases tipo "2.35m estimado" ni "respuesta sugerida"
+        assert "estimado" not in prompt.lower()
+        assert "respuesta" not in prompt.lower()


### PR DESCRIPTION
## PR 2b — Ranking determinístico + guardrails

**Objetivo:** arreglar el caso Bernardi donde R2 (tramo vertical) eligió `2.95` en vez de `2.35`. El bug no era el filtro de perímetro (el VLM ya rechazaba 4.15 bien); era que al VLM se le pasaba una **lista plana de cotas** en el pool expanded y elegía con razonamiento cualitativo — sin orden geométrico.

## 4 capas nuevas

### 1. Hard filter — `_is_probable_perimeter`

Cota con valor >3m + posición fuera del bbox tight de la región → se excluye antes del VLM. En Bernardi saca la 4.15 que estaba a 90px del borde del bbox R2 (cerca pero fuera del tight).

### 2. Scale estimation — `_estimate_plan_scale`

Mediana de `(bbox_short_px / cota_ancho_local)` sobre pares confiables. **Señal débil** — solo penaliza outliers groseros vía span-check, no decide entre cotas plausibles. Si no hay ≥2 pares confiables devuelve `None` y el scoring ignora span-check.

### 3. Ranking separado por rol — `_rank_cotas_for_region`

Rankings **independientes** para `length` y `depth` (una 0.60 debe ganar como ancho y perder como largo; una 2.35 al revés).

Señales del scoring:
- Proximidad al bbox (tight +40 / expanded +15 / fuera 0).
- Orientación vs eje del tramo (largo alineado con eje largo → +25).
- Rango típico según rol (largo 1.0-4.0m, ancho 0.40-0.80m).
- Span plausibility si hay scale (±20 según deviation).

**4 buckets:**
- `preferred` ≥60
- `weak` 40-59
- `unlikely` 20-39
- `excluded_soft` <20
- `excluded_hard`: solo perímetro probable + valores absurdos (<0.1m, >6m)

### 4. Prompt estructurado — `_format_ranking_for_prompt`

Bloques PREFERIDAS / DÉBILES / POCO PROBABLES / EXCLUIDAS con razones geométricas. **Sin** sugerir valores específicos (evitado el anti-patrón "2.35m estimado" que contamina).

### 5. Guardrails post-LLM — `_apply_guardrails`

- VLM elige **weak/unlikely habiendo preferred disponible** → `confidence ≤ 0.5` + `suspicious_reasons` con el detalle del swap.
- VLM elige valor que **no está en el ranking** (halucinado) → `confidence ≤ 0.3`.
- VLM elige weak **pero no había preferred** → sin castigo (puede ser lo mejor disponible).

**Crítico:** el guardrail se apoya en el ranking determinístico, **NO en el `reasoning` del VLM** (puede sonar convincente y ser falso).

## Tests — 14 nuevos

- `TestPerimeterFilter` (3) — dos señales combinadas (valor + distancia).
- `TestEstimatePlanScale` (3) — mediana con ≥2 pares; None con <2; ignora fuera de rango.
- `TestScoreCota` (3) — alineación, rango, rol.
- **`TestBernardiRankingR2` (1)** — fixture con las 7 cotas reales del PDF + bbox R2 del log de prod. Verifica que 4.15 va a excluded_hard, 2.35 aparece en length y ninguna cota ajena la supera, 0.60 en depth, y las grandes no son depth preferred.
- `TestGuardrails` (3) — weak vs preferred → confidence baja; weak sin preferred → sin castigo; halucinado → 0.3.
- `TestRankingPromptFormat` (1) — prompt tiene buckets sin frases contaminantes.

Suite: **1168 passed** (+14), 1 deselected (pre-existente roto en main).

## Expectativa en prod

**Caso bueno:** VLM respeta el ranking → R2 mide 2.35 → total 3.60 correcto. 🍦 queda servido si pasa esto.

**Caso pesimista:** VLM ignora el ranking → elige 2.95 igual → **confidence baja automáticamente** a ≤0.5 + suspicious_reasons populado. El operador ve badge DUDOSO claro, no número con look-confiado. El log `[region-detail]` muestra el ranking completo para diagnóstico.

## Logs nuevos

El `_cota_ranking` queda expuesto en el output de `_measure_region`, entonces el log `[multi-crop/region-detail]` (PR #334) lo incluye automáticamente. Vamos a ver el ranking completo por región en prod.

## Lo que NO toca este PR

- Topology (`_GLOBAL_SYSTEM_PROMPT`) — queda como PR 2a.
- Aggregator — intacto.
- Frontend — intacto.
- 2c (cross-check con brief para "isla con anafe") — PR separado.
- 2d (fast-path vectorial) — opcional al final.

## Test plan

- [ ] Subir plano de Bernardi en prod (brief: "cocina en L + isla, con pileta").
- [ ] Revisar `[multi-crop/region-detail]` — ¿qué eligió el VLM por region? ¿Respetó el ranking?
- [ ] Si R2 → 2.35: 🍦 ganado.
- [ ] Si R2 → 2.95 pero con `confidence ≤0.5` + `suspicious_reasons`: el guardrail actuó; operador ve DUDOSO claro.
- [ ] Si R2 → 2.95 con `confidence alto` y sin suspicious: bug en el guardrail, itero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)