### PR TITLE
feat(multi-crop): R3 hardening + expanded cap + inferred_default (PR 2b.1)

### DIFF
--- a/api/app/modules/quote_engine/multi_crop_reader.py
+++ b/api/app/modules/quote_engine/multi_crop_reader.py
@@ -472,6 +472,10 @@ def _score_cota(
     reasons: list[str] = []
 
     # ── Proximidad al bbox ─────────────────────────────────────────────
+    # Tres niveles discretos + ajuste continuo cuando está afuera.
+    # El continuo es clave para diferenciar dos cotas ambas "fuera del
+    # expanded": si una está más cerca del bbox, se nota en el score.
+    # Sin esto, 2.35 y 2.05 quedaban empatadas en R3 de Bernardi.
     if _cota_in_bbox(cota, region_bbox_px, padding_px=80):
         score += 40
         reasons.append("inside_tight_bbox")
@@ -479,7 +483,18 @@ def _score_cota(
         score += 15
         reasons.append("inside_expanded_bbox")
     else:
-        reasons.append("outside_expanded_bbox")
+        # Castigo continuo — más lejos del bbox, más resta.
+        dist_x = max(
+            0, region_bbox_px["x"] - cota.x, cota.x - region_bbox_px["x2"]
+        )
+        dist_y = max(
+            0, region_bbox_px["y"] - cota.y, cota.y - region_bbox_px["y2"]
+        )
+        # Restamos 1 punto cada 100px fuera del bbox expandido, cap 30.
+        dist_px = dist_x + dist_y
+        dist_penalty = min(30, dist_px // 100)
+        score -= int(dist_penalty)
+        reasons.append(f"outside_expanded_bbox_dist{int(dist_px)}px")
 
     # ── Rango de valor típico según rol ───────────────────────────────
     if candidate_for == "length":
@@ -510,17 +525,25 @@ def _score_cota(
     # Para depth la alineación importa menos — el ancho se escribe típico
     # en cualquier lado.
 
-    # ── Span plausibility (señal DÉBIL — solo si hay scale) ──────────
+    # ── Span plausibility — penalización escalonada ──────────────────
+    # Solo aplica si hay scale confiable. Señal secundaria al valor +
+    # orientación, pero más fuerte que antes: deviations groseras empujan
+    # a bucket unlikely, no quedan weak "por cercanía".
     if scale and candidate_for == "length":
         bbox_long_px = max(region_bbox_px["w"], region_bbox_px["h"])
         expected_m = bbox_long_px / scale
         if expected_m > 0.5:
             deviation = abs(cota.value - expected_m) / expected_m
-            if deviation > 0.40:
-                # Señal débil — no dominante. 20 puntos de castigo.
-                score -= 20
+            if deviation > 0.50:
+                score -= 50
+                reasons.append(f"severe_span_mismatch_{int(deviation * 100)}pct")
+            elif deviation > 0.30:
+                score -= 30
                 reasons.append(f"span_mismatch_{int(deviation * 100)}pct")
-            elif deviation < 0.15:
+            elif deviation > 0.15:
+                score -= 20
+                reasons.append(f"span_deviation_{int(deviation * 100)}pct")
+            else:
                 score += 10
                 reasons.append("span_matches")
 
@@ -542,6 +565,72 @@ def _score_cota(
     }
 
 
+def _filter_length_by_geometry(
+    length_ranking: list[dict],
+    all_candidate_cotas: list[Cota],
+    region_bbox_px: dict,
+    scale: Optional[float],
+    excluded_hard: list[dict],
+) -> list[dict]:
+    """Post-filtro del ranking de largo: mueve a `excluded_hard` cotas
+    claramente incompatibles con el span geométrico del tramo, priorizando
+    preservar alternativas válidas.
+
+    Dos reglas. Si alguna dispara, la cota se excluye. Si ambas disparan,
+    se guardan las DOS razones (lista) para logs y tests.
+
+    Regla A — valor alto con alternativas disponibles:
+      - value > 4.0m (proxy para cota de perímetro del ambiente).
+      - existe al menos 1 alternativa en rango típico [1.0, 4.0] en el pool.
+      - Caso Bernardi R3: el topology agarró 4.15 adentro del bbox tight
+        del tramo vertical; había 2.35/2.05 en expanded — las mantenemos,
+        la 4.15 se excluye.
+
+    Regla B — severa incompatibilidad con span estimado:
+      - scale confiable disponible.
+      - deviation entre cota y span esperado > 60%.
+      - Caso: bbox de tramo chico (~1m esperado) con cota 3.50m → excluir.
+
+    Safety: si el pool total NO tiene alternativas en [1.0, 4.0] (caso
+    edificio con todas las mesadas largas), NO se excluye nada por Regla A
+    — puede ser una mesada legítimamente de >4m.
+    """
+    has_valid_alternative = any(
+        _LENGTH_TYPICAL_RANGE[0] <= c.value <= _LENGTH_TYPICAL_RANGE[1]
+        for c in all_candidate_cotas
+    )
+
+    bbox_long_px = max(region_bbox_px["w"], region_bbox_px["h"])
+    expected_m = (bbox_long_px / scale) if (scale and scale > 0) else None
+
+    keep: list[dict] = []
+    for entry in length_ranking:
+        value = entry["value"]
+        reasons: list[str] = []
+
+        # Regla A
+        if has_valid_alternative and value > 4.0:
+            reasons.append("value_over_4m_with_alternatives_available")
+
+        # Regla B
+        if expected_m and expected_m > 0.5:
+            deviation = abs(value - expected_m) / expected_m
+            if deviation > 0.60:
+                reasons.append(
+                    f"severe_span_incompatibility_{int(deviation * 100)}pct"
+                )
+
+        if reasons:
+            excluded_hard.append({
+                "value": value,
+                "reason": "; ".join(reasons),
+            })
+        else:
+            keep.append(entry)
+
+    return keep
+
+
 def _rank_cotas_for_region(
     cotas: list[Cota],
     region: dict,
@@ -550,12 +639,15 @@ def _rank_cotas_for_region(
 ) -> dict:
     """Genera dos rankings (length + depth) + lista de excluidas duras.
 
-    Excluidas duras:
-    - Perímetro probable (valor >3m + lejos del bbox).
+    Excluidas duras (pre-scoring):
+    - Perímetro probable por posición (valor >3m + fuera del bbox tight).
     - Valor absurdo (<0.1m o >6m).
 
-    Nada más se excluye duro — el resto va a preferred/weak/unlikely
-    según score.
+    Excluidas duras (post-scoring, solo para length):
+    - Incompatibilidad geométrica o valor >4m con alternativas disponibles
+      (ver `_filter_length_by_geometry`).
+
+    El resto va a preferred/weak/unlikely según score.
     """
     region_bbox_px = _bbox_to_px(region.get("bbox_rel") or {}, image_size)
     orientation = _tramo_orientation(region_bbox_px)
@@ -563,9 +655,10 @@ def _rank_cotas_for_region(
     length_ranking: list[dict] = []
     depth_ranking: list[dict] = []
     excluded_hard: list[dict] = []
+    surviving_cotas: list[Cota] = []  # para el filtro geométrico
 
     for cota in cotas:
-        # Hard exclusions
+        # Hard exclusions pre-scoring
         if cota.value < _ABSURD_MIN_M or cota.value > _ABSURD_MAX_M:
             excluded_hard.append({
                 "value": cota.value,
@@ -578,6 +671,7 @@ def _rank_cotas_for_region(
                 "reason": "probable_perimeter",
             })
             continue
+        surviving_cotas.append(cota)
         # Score para ambos roles
         length_ranking.append(
             _score_cota(cota, region_bbox_px, orientation, scale, candidate_for="length")
@@ -585,6 +679,11 @@ def _rank_cotas_for_region(
         depth_ranking.append(
             _score_cota(cota, region_bbox_px, orientation, scale, candidate_for="depth")
         )
+
+    # Post-filtro: exclusión geométrica para length (solo).
+    length_ranking = _filter_length_by_geometry(
+        length_ranking, surviving_cotas, region_bbox_px, scale, excluded_hard,
+    )
 
     # Ordenar desc por score
     length_ranking.sort(key=lambda r: r["score"], reverse=True)
@@ -656,16 +755,27 @@ def _format_ranking_for_prompt(ranking: dict) -> str:
 
 
 def _apply_guardrails(
-    vlm_output: dict, ranking: dict,
+    vlm_output: dict, ranking: dict, cotas_mode: str = "local",
 ) -> dict:
-    """Post-LLM: si el VLM eligió weak/unlikely habiendo preferred
-    disponible, baja confidence y agrega suspicious_reasons.
+    """Post-LLM: valida elección del VLM contra el ranking determinístico
+    y baja confidence cuando la elección es sospechosa.
 
-    Importante: el guardrail se apoya en el RANKING (determinístico), NO
-    en el `reasoning` del VLM (puede sonar convincente y ser falso).
+    Se apoya en el RANKING (geométrico/determinístico), NO en el
+    `reasoning` del VLM (puede sonar convincente y ser falso).
 
-    Si el VLM elige weak PERO no hay preferred disponible, no castigamos
-    — puede ser lo mejor disponible en ese crop.
+    Capas:
+    1. Valor no en ranking:
+       - Si cae en rango típico del rol (0.60 para depth, 2.xx para
+         length) → `inferred_default`, cap 0.6 (no 0.3). El VLM infirió
+         un valor estándar razonable sin cota explícita — aceptable.
+       - Fuera del rango típico → halucinación dura, cap 0.3.
+    2. Valor en ranking pero bucket weak/unlikely habiendo preferred →
+       cap 0.5, suspicious con detalle.
+    3. cotas_mode == "expanded":
+       - Cap duro de confidence 0.65 (evidencia ambigua por naturaleza).
+       - Si además eligió valor distinto al top-ranked para largo **O**
+         ancho (cada campo evaluado por separado, no se exige AND) →
+         cap 0.5.
     """
     largo = vlm_output.get("largo_m")
     ancho = vlm_output.get("ancho_m")
@@ -684,22 +794,38 @@ def _apply_guardrails(
                 return r
         return None
 
-    for field_name, value, rank_list in [
-        ("largo", largo, ranking.get("length") or []),
-        ("ancho", ancho, ranking.get("depth") or []),
+    length_ranking = ranking.get("length") or []
+    depth_ranking = ranking.get("depth") or []
+
+    for field_name, value, rank_list, typical_range in [
+        ("largo", largo, length_ranking, _LENGTH_TYPICAL_RANGE),
+        ("ancho", ancho, depth_ranking, _DEPTH_TYPICAL_RANGE),
     ]:
         if value is None:
             continue
         chosen = _find_match(value, rank_list)
         if chosen is None:
-            # Valor no está en el ranking — halucinado o fuera de scope
-            suspicious.append(
-                f"{field_name} {value}m no está en el ranking de candidatas"
-            )
-            confidence = min(confidence, 0.3)
+            # Valor no está en el ranking. ¿Cae en rango típico?
+            lo, hi = typical_range
+            try:
+                value_float = float(value)
+            except (TypeError, ValueError):
+                value_float = None
+            if value_float is not None and lo <= value_float <= hi:
+                # Inferred default razonable — VLM usó valor estándar sin
+                # cota explícita (ej: 0.60 para ancho). No castigo duro.
+                suspicious.append(
+                    f"{field_name} {value}m inferred (valor típico, no en ranking)"
+                )
+                confidence = min(confidence, 0.6)
+            else:
+                # Fuera de rango típico + no en ranking → halucinación
+                suspicious.append(
+                    f"{field_name} {value}m no está en ranking ni rango típico"
+                )
+                confidence = min(confidence, 0.3)
             continue
         if chosen["bucket"] in ("weak", "unlikely", "excluded_soft"):
-            # ¿Había una preferred disponible?
             top_preferred = next(
                 (r for r in rank_list if r["bucket"] == "preferred"),
                 None,
@@ -713,6 +839,37 @@ def _apply_guardrails(
                 )
                 confidence = min(confidence, 0.5)
             # Si no hay preferred, weak puede ser lo mejor — no castigamos
+
+    # ── Cap duro por cotas_mode=expanded ─────────────────────────────
+    # Evidencia ambigua por naturaleza. Dos niveles:
+    #   1. Cap base 0.65 siempre que sea expanded.
+    #   2. Si además el VLM no eligió el top del ranking en largo O ancho
+    #      (cada campo evaluado por separado), cap 0.5.
+    # El segundo se evalúa por OR — no se exige AND. Un ancho 0.60
+    # inferred_default NO distorsiona el cap del largo.
+    if cotas_mode == "expanded":
+        if confidence > 0.65:
+            confidence = 0.65
+            suspicious.append("cotas_mode=expanded → cap confidence 0.65")
+        for field_name, value, rank_list in [
+            ("largo", largo, length_ranking),
+            ("ancho", ancho, depth_ranking),
+        ]:
+            if value is None or not rank_list:
+                continue
+            chosen = _find_match(value, rank_list)
+            if chosen is None:
+                # inferred_default — no computa para este check
+                continue
+            top = rank_list[0]
+            if top and abs(top["value"] - float(value)) > 0.02:
+                if confidence > 0.5:
+                    confidence = 0.5
+                    suspicious.append(
+                        f"expanded + {field_name}={value}m no es top "
+                        f"({top['value']}m score {top['score']}) → cap 0.5"
+                    )
+                break  # con que uno dispare alcanza
 
     vlm_output["confidence"] = confidence
     if suspicious:
@@ -903,7 +1060,8 @@ async def _measure_region(
 
     # PR 2b — Guardrails post-LLM apoyados en el RANKING determinístico
     # (no en el reasoning del VLM que puede sonar convincente y ser falso).
-    parsed = _apply_guardrails(parsed, ranking)
+    # PR 2b.1 — además, cap duro de confidence cuando cotas_mode=expanded.
+    parsed = _apply_guardrails(parsed, ranking, cotas_mode=cotas_mode)
 
     # Cuando caímos a fallback expanded, el resultado NUNCA es CONFIRMADO
     # aunque los números sean plausibles — el operador tiene que revisar
@@ -1175,6 +1333,7 @@ async def read_plan_multi_crop(
     try:
         _region_summary = []
         for r in region_results:
+            _ranking = r.get("_cota_ranking") or {}
             _region_summary.append({
                 "region_id": r.get("region_id"),
                 "error": r.get("error"),
@@ -1189,6 +1348,25 @@ async def read_plan_multi_crop(
                     {"v": c.get("value"), "why": (c.get("reason") or "")[:60]}
                     for c in (r.get("rejected_candidates") or [])[:3]
                 ],
+                # PR 2b.1 — ranking determinístico completo, para diagnóstico.
+                # Sin esto estamos ciegos: no sabemos si falla el filtro, el
+                # scoring o el guardrail.
+                "ranking": {
+                    "orientation": _ranking.get("orientation"),
+                    "scale_px_per_m": _ranking.get("scale_px_per_m"),
+                    "length_top": [
+                        {"v": e["value"], "s": e["score"], "b": e["bucket"]}
+                        for e in (_ranking.get("length") or [])[:4]
+                    ],
+                    "depth_top": [
+                        {"v": e["value"], "s": e["score"], "b": e["bucket"]}
+                        for e in (_ranking.get("depth") or [])[:4]
+                    ],
+                    "excluded_hard": [
+                        {"v": h["value"], "why": (h.get("reason") or "")[:60]}
+                        for h in (_ranking.get("excluded_hard") or [])
+                    ],
+                } if _ranking else None,
             })
         logger.info(f"[multi-crop/region-detail] {json.dumps(_region_summary, ensure_ascii=False)}")
     except Exception as _e_log:

--- a/api/tests/test_multi_crop_reader.py
+++ b/api/tests/test_multi_crop_reader.py
@@ -890,7 +890,11 @@ class TestGuardrails:
         }
         result = _apply_guardrails(vlm_output, ranking)
         assert result["confidence"] <= 0.3
-        assert any("no está en el ranking" in s for s in result["suspicious_reasons"])
+        # Wording actualizado en PR 2b.1 — texto "no está en ranking ni rango típico"
+        assert any(
+            ("no está en ranking" in s) or ("no está en el ranking" in s)
+            for s in result["suspicious_reasons"]
+        )
 
 
 class TestRankingPromptFormat:
@@ -921,3 +925,236 @@ class TestRankingPromptFormat:
         # NO debe haber frases tipo "2.35m estimado" ni "respuesta sugerida"
         assert "estimado" not in prompt.lower()
         assert "respuesta" not in prompt.lower()
+
+
+# ── PR 2b.1: R3 hardening + expanded confidence cap + inferred_default ────
+
+class TestR3VerticalBernardi:
+    """Test central de PR 2b.1: R3 vertical derecha del caso Bernardi
+    cuando el topology puso el bbox tan a la derecha que la 4.15 cayó
+    dentro del bbox tight. La regla de exclusión por incompatibilidad
+    geométrica + alternativas debe:
+
+    - excluir 4.15 del length ranking (regla A: >4m con alternativas).
+    - mantener 2.35 y 2.05 en length.
+    - **rankear 2.35 por encima de 2.05** (2.35 está más cerca del bbox
+      de R3 en x → penalización por distancia menor).
+
+    Sin la prioridad de 2.35 sobre 2.05, el VLM puede seguir eligiendo
+    mal y el caso central no queda resuelto.
+    """
+
+    def test_r3_excludes_4_15_and_prefers_2_35_over_2_05(self):
+        image_size = (4963, 3509)
+        # bbox R3 real del log de prod
+        region = {"bbox_rel": {"x": 0.73, "y": 0.26, "w": 0.09, "h": 0.37}}
+        # 7 cotas reales + el 4.15 duplicado que cae dentro del bbox tight
+        cotas = [
+            Cota(text="0.60", value=0.60, x=3028, y=957, width=20, height=10),
+            Cota(text="1.60", value=1.60, x=2119, y=1267, width=20, height=10),
+            Cota(text="4.15", value=4.15, x=3663, y=1339, width=20, height=10),
+            Cota(text="4.15", value=4.15, x=3700, y=1400, width=20, height=10),
+            Cota(text="2.75", value=2.75, x=1577, y=1340, width=20, height=10),
+            Cota(text="2.35", value=2.35, x=2836, y=1458, width=20, height=10),
+            Cota(text="2.05", value=2.05, x=2506, y=1875, width=20, height=10),
+        ]
+        ranking = _rank_cotas_for_region(cotas, region, image_size, scale=None)
+
+        # 4.15 debe estar en excluded_hard, NUNCA en length
+        length_values = [r["value"] for r in ranking["length"]]
+        assert 4.15 not in length_values, (
+            f"4.15 no debe estar en length después del filtro geométrico. "
+            f"Ranking length: {[(r['value'], r['score'], r['bucket']) for r in ranking['length']]}"
+        )
+        # Al menos una 4.15 debe aparecer como excluded_hard con razón reconocible
+        hard_entries = ranking["excluded_hard"]
+        assert any(
+            abs(h["value"] - 4.15) < 0.02
+            and ("alternatives" in h["reason"] or "over_4m" in h["reason"] or "perimeter" in h["reason"])
+            for h in hard_entries
+        ), f"4.15 debe estar en excluded_hard con razón geométrica; got {hard_entries}"
+
+        # 2.35 y 2.05 deben mantenerse en length
+        v235 = next(
+            (r for r in ranking["length"] if abs(r["value"] - 2.35) < 0.02), None,
+        )
+        v205 = next(
+            (r for r in ranking["length"] if abs(r["value"] - 2.05) < 0.02), None,
+        )
+        assert v235 is not None, "2.35 debe estar en length ranking"
+        assert v205 is not None, "2.05 debe estar en length ranking"
+
+        # Requisito central del PR: 2.35 rankea por encima de 2.05
+        # (2.35 está más cerca del bbox de R3 en x: 787px vs 1117px → menos penalty).
+        assert v235["score"] > v205["score"], (
+            f"Para el bbox vertical R3, 2.35 debe rankear > 2.05. "
+            f"Got 2.35=score {v235['score']} ({v235['bucket']}), "
+            f"2.05=score {v205['score']} ({v205['bucket']}). "
+            f"Sin esto el caso central no queda resuelto."
+        )
+
+
+class TestExpandedConfidenceCap:
+    """PR 2b.1 — cap duro de confidence cuando cotas_mode=expanded."""
+
+    def test_confidence_capped_at_065_in_expanded_mode(self):
+        """cotas_mode=expanded + VLM eligió el top-ranked → cap 0.65."""
+        ranking = {
+            "length": [
+                {"value": 2.35, "score": 55, "bucket": "weak", "reasons": []},
+            ],
+            "depth": [
+                {"value": 0.60, "score": 75, "bucket": "preferred", "reasons": []},
+            ],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 2.35,  # eligió el top
+            "ancho_m": 0.60,
+            "confidence": 0.85,
+        }
+        result = _apply_guardrails(vlm_output, ranking, cotas_mode="expanded")
+        assert result["confidence"] == 0.65, (
+            f"Expected 0.65 cap, got {result['confidence']}"
+        )
+        assert any(
+            "expanded" in s and "cap" in s
+            for s in result["suspicious_reasons"]
+        )
+
+    def test_confidence_capped_at_05_when_expanded_and_not_top(self):
+        """cotas_mode=expanded + VLM eligió no-top en algún campo → cap 0.5."""
+        ranking = {
+            "length": [
+                {"value": 2.35, "score": 55, "bucket": "weak", "reasons": []},
+                {"value": 2.05, "score": 40, "bucket": "weak", "reasons": []},
+            ],
+            "depth": [
+                {"value": 0.60, "score": 75, "bucket": "preferred", "reasons": []},
+            ],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 2.05,  # NO es el top (2.35 es)
+            "ancho_m": 0.60,  # top
+            "confidence": 0.85,
+        }
+        result = _apply_guardrails(vlm_output, ranking, cotas_mode="expanded")
+        assert result["confidence"] == 0.5, (
+            f"Expected 0.5 cap, got {result['confidence']}"
+        )
+
+    def test_confidence_not_capped_in_local_mode(self):
+        """cotas_mode=local no dispara los caps de expanded."""
+        ranking = {
+            "length": [
+                {"value": 2.35, "score": 80, "bucket": "preferred", "reasons": []},
+            ],
+            "depth": [
+                {"value": 0.60, "score": 75, "bucket": "preferred", "reasons": []},
+            ],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 2.35,
+            "ancho_m": 0.60,
+            "confidence": 0.90,
+        }
+        result = _apply_guardrails(vlm_output, ranking, cotas_mode="local")
+        assert result["confidence"] == 0.90
+
+    def test_expanded_cap_05_fires_on_largo_even_if_ancho_is_inferred(self):
+        """Check 3 — el cap 0.5 se evalúa por campo (OR, no AND).
+        Si ancho es inferred_default (no en ranking), no debe impedir que
+        el largo dispare el cap."""
+        ranking = {
+            "length": [
+                {"value": 2.35, "score": 55, "bucket": "weak", "reasons": []},
+                {"value": 2.05, "score": 40, "bucket": "weak", "reasons": []},
+            ],
+            "depth": [],  # ningún candidato de depth en el ranking
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 2.05,  # no es el top (2.35 lo es)
+            "ancho_m": 0.60,  # inferred_default — no está en depth ranking
+            "confidence": 0.85,
+        }
+        result = _apply_guardrails(vlm_output, ranking, cotas_mode="expanded")
+        # El ancho inferred no cuenta para el cap de no-top; pero el largo sí.
+        assert result["confidence"] == 0.5
+
+
+class TestInferredDefaultGuardrail:
+    """PR 2b.1 — cuando el VLM elige un valor no-en-ranking pero dentro
+    del rango típico del rol (ej: 0.60 para ancho de mesada), es un
+    inferred_default razonable. Cap suave 0.6, no 0.3 duro."""
+
+    def test_inferred_default_for_ancho_060_caps_at_06(self):
+        """Arregla el falso positivo de R1 en Bernardi: midió 1.60×0.60
+        correcto, pero 0.60 no estaba en el ranking local → confidence
+        bajó a 0.3 injustamente."""
+        ranking = {
+            "length": [
+                {"value": 1.60, "score": 70, "bucket": "preferred", "reasons": []},
+            ],
+            "depth": [],  # sin candidatos de ancho en el ranking
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 1.60,
+            "ancho_m": 0.60,  # inferred — no está en el ranking
+            "confidence": 0.80,
+        }
+        result = _apply_guardrails(vlm_output, ranking, cotas_mode="local")
+        assert result["confidence"] == 0.60, (
+            f"0.60 es default razonable de ancho → cap 0.6, no 0.3. "
+            f"Got {result['confidence']}"
+        )
+        # Suspicious explicativo pero no alarmante
+        assert any(
+            "inferred" in s for s in result["suspicious_reasons"]
+        )
+
+    def test_out_of_range_value_not_in_ranking_hits_03_cap(self):
+        """Valor fuera de rango típico AND no en ranking → halucinación
+        dura, confidence 0.3."""
+        ranking = {
+            "length": [
+                {"value": 2.35, "score": 80, "bucket": "preferred", "reasons": []},
+            ],
+            "depth": [
+                {"value": 0.60, "score": 75, "bucket": "preferred", "reasons": []},
+            ],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 7.42,  # fuera del rango 1.0-4.0 AND no en ranking
+            "ancho_m": 0.60,
+            "confidence": 0.90,
+        }
+        result = _apply_guardrails(vlm_output, ranking, cotas_mode="local")
+        assert result["confidence"] <= 0.3
+
+
+class TestSevereSpanMismatch:
+    """PR 2b.1 — penalty escalonada. Deviation grande debe empujar a
+    buckets bajos (no solo quedar como "weak por cercanía")."""
+
+    def test_severe_span_mismatch_penalized_heavily(self):
+        """Cota 4.15 con span esperado ~2.35m (deviation ~77%) → -50 puntos."""
+        # bbox vertical con ~400px de alto (~2.35m con scale ~170 px/m)
+        region_bbox_px = {"x": 100, "y": 100, "x2": 200, "y2": 500, "w": 100, "h": 400}
+        # Cota cerca del bbox con valor 4.15
+        cota = Cota(text="4.15", value=4.15, x=150, y=300, width=20, height=10)
+        # scale=170 px/m → expected = 400/170 ≈ 2.35
+        result = _score_cota(
+            cota, region_bbox_px, orientation="vertical", scale=170.0,
+            candidate_for="length",
+        )
+        # Confirmar que la razón de severe span mismatch está presente
+        assert any("severe_span_mismatch" in r for r in result["reasons"]), (
+            f"Expected severe_span_mismatch reason, got {result['reasons']}"
+        )
+        # Bucket weak o inferior (no preferred)
+        assert result["bucket"] in ("weak", "unlikely", "excluded_soft")


### PR DESCRIPTION
## PR 2b.1 — blindar R3 contra 4.15

**Incendio dominante post-2b:** en el caso Bernardi, R3 (tramo vertical derecha) eligió 4.15 como largo porque el topology LLM puso el bbox tan a la derecha que la 4.15 (cota de perímetro del ambiente) cayó DENTRO del bbox tight — única cota local, ranked alta, el VLM la tomó. PR 2b solo excluía perímetro si estaba fuera del bbox tight; no alcanzó.

Segunda opinión externa (GPT) identificó 4 problemas concretos y los ataco quirúrgicos.

## 5 cambios

### 1. Filtro geométrico post-ranking para length

Nueva función `_filter_length_by_geometry()`:

**Regla A** — value > 4.0m **Y** existe alternativa en [1.0, 4.0] en el pool → `excluded_hard`.

**Regla B** — scale confiable **Y** deviation > 60% del span esperado → `excluded_hard`.

Si ambas disparan, se guardan las dos razones (lista joined), no se pisa — útil para logs y tests.

**Safety:** si el pool solo tiene >4m (edificio con mesadas largas), NO se excluye — el valor puede ser legítimo sin alternativa razonable.

### 2. `_cota_ranking` en el log `[region-detail]`

Agrego top-4 length + top-4 depth + excluded_hard completo. **Sin esto estábamos ciegos.** El log de la prueba anterior de Javi no mostraba el ranking — solo rejected_candidates. Ahora el diagnóstico es completo.

### 3. Cap duro de confidence en expanded

- `cotas_mode=expanded` → confidence máx `0.65`.
- Si además VLM eligió no-top en largo **O** ancho (evaluado por separado, no AND) → cap `0.5`.
- Un ancho `0.60` inferred (no en ranking) **NO cuenta** para el check — no distorsiona el cap del largo (microajuste de Javi).

### 4. Span_mismatch escalonado + distance penalty continuo

- deviation >50% → -50 pts (empuja a unlikely)
- 30-50% → -30
- 15-30% → -20
- <15% → +10

Más: castigo continuo por distancia cuando la cota está fuera del expanded (1 pt cada 100px, cap 30). Necesario para diferenciar cotas ambas "fuera del expanded" — antes empataban en score.

### 5. `inferred_default` para guardrail

Si VLM elige valor no-en-ranking PERO en rango típico del rol → `inferred`, cap suave `0.6` en vez de duro `0.3`.

**Arregla R1 en Bernardi:** midió 1.60×0.60 correcto pero confidence bajó a 0.3 solo porque `0.60` no estaba en el ranking local. Es un default razonable que el VLM infirió.

## Test clave — `test_r3_excludes_4_15_and_prefers_2_35_over_2_05`

Fixture con el bbox R3 real del log de prod + las 7 cotas del PDF + 4.15 duplicada dentro del bbox tight. Verifica **tres invariantes**:

1. 4.15 **nunca** está en length ranking (regla A disparó).
2. 4.15 está en `excluded_hard` con razón documentada.
3. **2.35 rankea por encima de 2.05** — requisito central: sin esto el caso no queda resuelto aunque 4.15 se excluya (microajuste de Javi).

Más 7 tests adicionales de expanded cap, inferred_default, severe_span_mismatch.

**Suite:** 1176 passed (+8 nuevos), 1 deselected (pre-existente).

## Expectativa en prod

| Region | Hoy (con 2b) | Post-2b.1 esperado |
|---|---|---|
| R1 isla | 1.60×0.60, conf 0.3 (falso bajo) | 1.60×0.60, conf 0.6 (inferred_default) |
| R2 horiz | 2.05×0.60, conf 0.85 | 2.05×0.60, conf ≤0.65 (expanded cap) |
| R3 vert | 4.15×0.60 ❌ | **2.35×0.60 ✅** (4.15 excluida, 2.35 rankea > 2.05) |
| **Total** | **4.68 (30% err)** | **3.60 (0% err)** 🍦 |

**Caso pesimista:** si el topology vuelve a poner bbox raro y el VLM elige algo distinto a 2.35, el confidence queda ≤0.5 con suspicious claro + ranking completo en logs → operador ve DUDOSO y puede editar.

## Test plan manual

- [ ] Subir Bernardi con brief *"cocina en L + isla, con pileta, SIN anafe en isla"*.
- [ ] Revisar `[multi-crop/region-detail]` — debe incluir el bloque `ranking` completo.
- [ ] R3 debe reportar `largo_m: 2.35` (ideal) o bien un valor ≠ 4.15 con confidence ≤0.5 + suspicious poblado.
- [ ] R1 confidence > 0.5 (antes 0.3 falso positivo).
- [ ] Total despiece ≈ 3.60 m² → 🍦.

🤖 Generated with [Claude Code](https://claude.com/claude-code)