### PR TITLE
feat(multi-crop): brief vs features contradiction — mínimo (PR 2c)

### DIFF
--- a/api/app/modules/quote_engine/multi_crop_reader.py
+++ b/api/app/modules/quote_engine/multi_crop_reader.py
@@ -1141,8 +1141,103 @@ def _derive_description(region: dict) -> str:
     return base
 
 
-def _aggregate(topology: dict, region_results: list[dict]) -> dict:
-    """Combina topología global + medidas por región en el schema dual_read."""
+# ─────────────────────────────────────────────────────────────────────────────
+# PR 2c — Brief vs features cross-check (mínimo)
+#
+# Detecta contradicciones obvias entre lo que clasificó el topology LLM y
+# lo que dice el brief del operador. Alcance inicial: SOLO isla + anafe
+# no confirmado por brief. Atacar otros tipos de contradicción en PRs
+# separados si hace falta.
+#
+# Principio: NO mutamos las features del topology — respetamos el output
+# del VLM. Solo HACEMOS VISIBLE la duda vía ambigüedad en el sector +
+# sufijo "a confirmar" en la descripción del tramo.
+# ─────────────────────────────────────────────────────────────────────────────
+
+_BRIEF_MENTIONS_ANAFE = re.compile(
+    r"\b(anafes?|hornallas?|cooktop)\b",
+    re.IGNORECASE,
+)
+_BRIEF_ANAFE_IN_ISLA = re.compile(
+    r"\b(anafes?|hornallas?|cooktop).{0,30}isla|"
+    r"isla.{0,30}(anafes?|hornallas?|cooktop)",
+    re.IGNORECASE | re.DOTALL,
+)
+# Amplía a cooktop / hornallas, no solo "anafe" — el operador puede usar
+# cualquiera de las tres palabras para negarlo.
+_BRIEF_ANAFE_NEGATED = re.compile(
+    r"\b(sin\s+(anafes?|hornallas?|cooktop)|"
+    r"no\s+(lleva|tiene|va|hay)\s+(anafes?|hornallas?|cooktop))\b",
+    re.IGNORECASE,
+)
+
+
+def _detect_region_brief_contradictions(region: dict, brief_text: str) -> list[str]:
+    """Detecta contradicciones entre features del topology y brief.
+
+    Alcance mínimo (PR 2c): isla con anafe no confirmada por el brief.
+
+    Orden de evaluación (importante):
+    1. `brief_places_in_isla` — si el brief asocia anafe con isla explícito,
+       NO hay contradicción aunque haya cooktop_groups. Se chequea PRIMERO
+       para evitar caer en rama genérica cuando el brief sí asocia los dos.
+    2. `brief_negates_anafe` — brief dice "sin anafe" / "sin hornallas":
+       topology se equivocó, contradicción fuerte.
+    3. `brief_has_anafe` pero NO en isla — topology ubica en isla pero
+       brief no asocia isla con anafe: ambiguo.
+    4. Brief no menciona anafe — contradicción suave, confirmar.
+
+    Retorna lista de strings (puede ser vacía). NO muta `region`.
+    """
+    contradictions: list[str] = []
+    features = region.get("features") or {}
+    touches_wall = features.get("touches_wall")
+    cooktop = features.get("cooktop_groups") or 0
+
+    if not (touches_wall is False and cooktop > 0):
+        return contradictions  # no hay escenario isla+anafe para chequear
+
+    brief = brief_text or ""
+    brief_places_in_isla = bool(_BRIEF_ANAFE_IN_ISLA.search(brief))
+    if brief_places_in_isla:
+        return contradictions  # brief confirma isla+anafe, sin contradicción
+
+    brief_negates_anafe = bool(_BRIEF_ANAFE_NEGATED.search(brief))
+    if brief_negates_anafe:
+        contradictions.append(
+            "topology detectó anafe en isla pero el brief dice explícitamente "
+            "que NO lleva anafe — revisar"
+        )
+        return contradictions
+
+    brief_has_anafe = bool(_BRIEF_MENTIONS_ANAFE.search(brief))
+    if brief_has_anafe:
+        contradictions.append(
+            "topology ubica anafe en isla pero el brief no asocia anafe "
+            "con isla — revisar si va en isla o en cocina"
+        )
+    else:
+        contradictions.append(
+            "topology detectó anafe en isla pero el brief no lo menciona "
+            "— puede ser confusión visual (símbolo en cocina contigua), "
+            "confirmar con el operador"
+        )
+    return contradictions
+
+
+def _aggregate(
+    topology: dict,
+    region_results: list[dict],
+    brief_text: str = "",
+) -> dict:
+    """Combina topología global + medidas por región en el schema dual_read.
+
+    PR 2c: `brief_text` se usa para detectar contradicciones obvias entre
+    features del topology y lo que dice el operador (ej: topology marca
+    anafe en isla pero brief no lo confirma). La contradicción se agrega
+    como ambigüedad del sector + sufijo "a confirmar" en la descripción
+    del tramo. NO se muta `region.features` — el output del VLM se respeta.
+    """
     # Agrupar regiones por sector derivado de features (o legacy `sector`).
     # Regiones clasificadas como "descarte" (alacenas superiores) se filtran.
     by_sector: dict[str, list[dict]] = {}
@@ -1179,14 +1274,24 @@ def _aggregate(topology: dict, region_results: list[dict]) -> dict:
             else:
                 status = "CONFIRMADO"
 
+            # PR 2c: contradicciones brief vs features (no mutamos features).
+            contradictions = _detect_region_brief_contradictions(region, brief_text)
+
             # Descripción: deriva de `features` de la región (contrato PR E).
             # No inventamos artefactos — solo los que están en features.
             base_desc = _derive_description(region)
             n = len(tramos) + 1
             if base_desc == "Mesada":
-                desc = f"Mesada {n}" + (" — revisar" if status != "CONFIRMADO" else "")
+                desc = f"Mesada {n}"
             else:
-                desc = base_desc + (" — revisar" if status != "CONFIRMADO" else "")
+                desc = base_desc
+            # Sufijo "— revisar" por status no-CONFIRMADO (preexistente).
+            if status != "CONFIRMADO":
+                desc = f"{desc} — revisar"
+            # PR 2c: sufijo "— a confirmar" por contradicción brief/features.
+            # Si ya dice "— revisar", no duplicamos; si no, lo agregamos.
+            if contradictions and "a confirmar" not in desc and "revisar" not in desc:
+                desc = f"{desc} — a confirmar"
 
             tramo = {
                 "id": rid or f"t{n}",
@@ -1199,6 +1304,8 @@ def _aggregate(topology: dict, region_results: list[dict]) -> dict:
                 "regrueso": [],
                 "features": region.get("features") or {},
             }
+            if contradictions:
+                tramo["_contradictions"] = contradictions
             tramos.append(tramo)
 
             if error:
@@ -1210,6 +1317,13 @@ def _aggregate(topology: dict, region_results: list[dict]) -> dict:
                 all_ambiguedades.append({
                     "tipo": "REVISION",
                     "texto": f"Región {rid}: medida dudosa ({'; '.join(suspicious)[:120]})",
+                })
+
+            # PR 2c: cada contradicción va como bullet REVISION independiente
+            for c_text in contradictions:
+                all_ambiguedades.append({
+                    "tipo": "REVISION",
+                    "texto": f"Región {rid}: {c_text}",
                 })
 
         sectores.append({
@@ -1372,4 +1486,4 @@ async def read_plan_multi_crop(
     except Exception as _e_log:
         logger.warning(f"[multi-crop] region detail log failed: {_e_log}")
 
-    return _aggregate(topology, region_results)
+    return _aggregate(topology, region_results, brief_text=brief_text)

--- a/api/tests/test_multi_crop_reader.py
+++ b/api/tests/test_multi_crop_reader.py
@@ -19,6 +19,7 @@ from app.modules.quote_engine.multi_crop_reader import (
     _apply_guardrails,
     _bbox_to_px,
     _call_global_topology,
+    _detect_region_brief_contradictions,
     _estimate_plan_scale,
     _format_ranking_for_prompt,
     _GLOBAL_SYSTEM_PROMPT,
@@ -1158,3 +1159,179 @@ class TestSevereSpanMismatch:
         )
         # Bucket weak o inferior (no preferred)
         assert result["bucket"] in ("weak", "unlikely", "excluded_soft")
+
+
+# ── PR 2c: brief vs features contradiction detection ─────────────────────
+
+def _isla_region_with_anafe() -> dict:
+    """Fixture: topology región tipo isla con anafe detectado por VLM."""
+    return {
+        "id": "R1",
+        "bbox_rel": {"x": 0.35, "y": 0.35, "w": 0.25, "h": 0.08},
+        "features": {
+            "touches_wall": False,
+            "cooktop_groups": 1,
+            "sink_simple": False,
+            "sink_double": False,
+            "stools_adjacent": False,
+            "non_counter_upper": False,
+        },
+        "evidence": "isla con 4 círculos agrupados (anafe a gas)",
+    }
+
+
+class TestBriefFeatureContradiction:
+    """PR 2c — detección mínima de contradicción isla+anafe."""
+
+    def test_contradiction_bernardi_brief_silent_on_anafe(self):
+        """Caso Bernardi: topology R1 isla con cooktop=1 + brief sin mencionar
+        anafe → contradicción suave ("no lo menciona, confirmar")."""
+        region = _isla_region_with_anafe()
+        brief = (
+            "nuevo presupuesto material en pura prima onix white mate "
+            "Cliente: Erica Bernardi SIN zocalos en rosario con colocacion"
+        )
+        contradictions = _detect_region_brief_contradictions(region, brief)
+        assert len(contradictions) == 1
+        assert "no lo menciona" in contradictions[0]
+
+    def test_no_contradiction_when_brief_places_anafe_in_isla(self):
+        """Brief asocia anafe con isla explícito → SIN contradicción."""
+        region = _isla_region_with_anafe()
+        assert _detect_region_brief_contradictions(
+            region, "cocina con anafe en isla, pileta simple"
+        ) == []
+        assert _detect_region_brief_contradictions(
+            region, "isla central con cooktop eléctrico"
+        ) == []
+        assert _detect_region_brief_contradictions(
+            region, "lleva hornallas en la isla"
+        ) == []
+
+    def test_negated_anafe_triggers_strong_contradiction(self):
+        """Brief dice 'sin anafe' → contradicción fuerte."""
+        region = _isla_region_with_anafe()
+        for brief in [
+            "cocina completa SIN anafe, con pileta doble",
+            "presupuesto sin hornallas, pileta simple",
+            "cocina no lleva cooktop — solo pileta",
+            "no tiene anafe",
+        ]:
+            c = _detect_region_brief_contradictions(region, brief)
+            assert len(c) == 1, f"brief {brief!r} debería dar 1 contradicción"
+            assert "NO lleva anafe" in c[0] or "NO" in c[0]
+
+    def test_anafe_mentioned_without_isla_triggers_ambiguous(self):
+        """Brief menciona anafe pero NO asocia con isla → ambigüedad
+        (topology ubica en isla, brief sugiere otra cosa)."""
+        region = _isla_region_with_anafe()
+        c = _detect_region_brief_contradictions(
+            region, "cocina en L, con anafe empotrado, pileta simple"
+        )
+        assert len(c) == 1
+        assert "no asocia anafe con isla" in c[0]
+
+    def test_no_contradiction_when_cooktop_in_cocina_not_isla(self):
+        """Region con touches_wall=True (cocina) + cooktop → ESPERABLE,
+        sin contradicción aunque el brief no lo mencione."""
+        region = {
+            "id": "R2",
+            "bbox_rel": {"x": 0.5, "y": 0.5, "w": 0.2, "h": 0.1},
+            "features": {
+                "touches_wall": True,  # ← cocina contra pared
+                "cooktop_groups": 1,
+                "sink_simple": False,
+                "sink_double": False,
+            },
+        }
+        # Brief sin anafe — topology lo detecta en cocina: OK, esperable
+        assert _detect_region_brief_contradictions(region, "presupuesto") == []
+        # Brief con "sin anafe" — ahora SÍ sería contradicción pero este
+        # PR solo cubre isla, no cocina. Se trabajará en iteración futura.
+        # (contrato actual: detector solo dispara si touches_wall=False)
+
+    def test_no_contradiction_when_region_has_no_cooktop(self):
+        """Sin cooktop en features → nada que chequear."""
+        region = {
+            "id": "R3",
+            "features": {
+                "touches_wall": False,
+                "cooktop_groups": 0,
+                "sink_simple": True,
+            },
+        }
+        assert _detect_region_brief_contradictions(region, "") == []
+        assert _detect_region_brief_contradictions(region, "sin anafe") == []
+
+
+class TestAggregateAppliesBriefContradictions:
+    """PR 2c — verifica que `_aggregate` propague la contradicción:
+    1) como ambigüedad REVISION del sector,
+    2) como sufijo ' — a confirmar' en la descripción del tramo."""
+
+    def test_aggregate_marks_contradiction_in_sector_ambiguedades(self):
+        topology = {
+            "regions": [_isla_region_with_anafe()],
+        }
+        results = [
+            {"region_id": "R1", "largo_m": 1.60, "ancho_m": 0.60},
+        ]
+        out = _aggregate(
+            topology, results,
+            brief_text="cocina con pileta, sin mencionar anafe",
+        )
+        isla = next(s for s in out["sectores"] if s["tipo"] == "isla")
+        textos = [a["texto"] for a in isla["ambiguedades"]]
+        assert any("anafe" in t.lower() for t in textos), (
+            f"Esperaba ambigüedad de anafe, got: {textos}"
+        )
+        # Tramo marcado con "a confirmar" o similar (status CONFIRMADO →
+        # NO lleva el " — revisar" preexistente, queda espacio para el nuevo)
+        tramo = isla["tramos"][0]
+        assert "a confirmar" in tramo["descripcion"].lower() or \
+               "revisar" in tramo["descripcion"].lower(), (
+            f"Esperaba sufijo 'a confirmar' o 'revisar', got: {tramo['descripcion']!r}"
+        )
+        # _contradictions preservado en el tramo para debugging
+        assert tramo.get("_contradictions")
+
+    def test_aggregate_no_suffix_when_brief_confirms_isla_anafe(self):
+        """Si brief confirma anafe en isla → sin contradicción → descripción
+        sin sufijo 'a confirmar'."""
+        topology = {
+            "regions": [_isla_region_with_anafe()],
+        }
+        results = [
+            {"region_id": "R1", "largo_m": 1.60, "ancho_m": 0.60},
+        ]
+        out = _aggregate(
+            topology, results,
+            brief_text="cocina en L con isla con anafe empotrado",
+        )
+        isla = next(s for s in out["sectores"] if s["tipo"] == "isla")
+        tramo = isla["tramos"][0]
+        assert "a confirmar" not in tramo["descripcion"].lower()
+        # No hay _contradictions tampoco
+        assert not tramo.get("_contradictions")
+        # Ambigüedades del sector no incluyen anafe (status CONFIRMADO)
+        textos = [a["texto"] for a in isla["ambiguedades"]]
+        assert not any("anafe" in t.lower() for t in textos)
+
+    def test_aggregate_backcompat_without_brief_text(self):
+        """Llamada sin `brief_text` (default "") — comportamiento igual
+        que antes del PR 2c, sin contradicciones. Retrocompat con callers
+        que todavía no pasan brief."""
+        topology = {
+            "regions": [_isla_region_with_anafe()],
+        }
+        results = [
+            {"region_id": "R1", "largo_m": 1.60, "ancho_m": 0.60},
+        ]
+        out = _aggregate(topology, results)  # sin brief_text
+        isla = next(s for s in out["sectores"] if s["tipo"] == "isla")
+        tramo = isla["tramos"][0]
+        # Brief vacío → no hay "anafe en isla" ni mención explícita → regla
+        # "brief no menciona anafe" dispara igual. Este es comportamiento
+        # esperado: sin brief, topology detectó anafe en isla y nosotros
+        # no tenemos forma de validarlo → flaguear por conservador.
+        assert tramo.get("_contradictions") is not None


### PR DESCRIPTION
## PR 2c — cross-check brief vs features, solo isla+anafe

Limpia el error semántico residual del caso Bernardi: topology sigue detectando *"isla con 1 anafe a gas"* aunque la isla real no lleva anafe, y el despiece termina mostrando esa descripción sin señal de duda. Eso ensucia UX, pending_questions y confianza del operador, aunque no rompa el cálculo.

## Alcance estricto (chico y quirúrgico)

**Una sola contradicción atacada:** `touches_wall=false` + `cooktop_groups > 0` + brief no asocia anafe con isla.

Otros tipos (pileta en isla ausente, features contradictorias) quedan para iteraciones futuras.

## Principio — NO mutamos features

El output del VLM se respeta. Solo **hacemos visible la duda**:
1. Ambigüedad tipo REVISION al sector → bullet "Revisar en plano".
2. Sufijo `" — a confirmar"` en la descripción del tramo.

El operador puede editar inline si corresponde sacar el anafe.

## 4 ramas del detector (orden importante)

1. **`brief_places_in_isla`** — regex captura *"anafe... isla"* o *"isla... anafe"* (ventana 30 chars). Si matchea → sin contradicción, early return. Chequeado **primero** (microajuste pedido) para evitar caer en rama genérica cuando el brief sí asocia ambos.
2. **`brief_negates_anafe`** — regex amplia: *"sin anafe|hornallas|cooktop"* + *"no lleva/tiene/va/hay anafe|hornallas|cooktop"* (microajuste #1 pedido: no solo "anafe"). Contradicción fuerte.
3. **`brief_has_anafe`** sin asociar isla → ambigua.
4. Brief silent on anafe → suave ("puede ser confusión visual").

## Integración

`_aggregate` toma nuevo arg `brief_text: str = ""` (retrocompat). `read_plan_multi_crop` lo pasa desde el brief del operador.

Por región con contradicción:
- `tramo["_contradictions"]` = lista de strings (debug + tests).
- Descripción: `"Mesada (con 1 anafe)" → "Mesada (con 1 anafe) — a confirmar"`.
- Sector: bullet REVISION por cada contradicción.

## Tests (9 nuevos)

- **`TestBriefFeatureContradiction` (6):**
  - Bernardi silent on anafe → contradicción suave ✅
  - "anafe en isla" / "isla con cooktop" → sin contradicción ✅
  - "sin anafe/hornallas/cooktop" → fuerte ✅
  - Menciona anafe sin asociar isla → ambigua ✅
  - `touches_wall=true` (cocina) + cooktop → sin (esperable) ✅
  - Sin cooktop → sin (nada que chequear) ✅
- **`TestAggregateAppliesBriefContradictions` (3):**
  - Aggregator marca ambigüedad + sufijo en descripción ✅
  - Brief confirma isla+anafe → sin sufijo ✅
  - Retrocompat sin `brief_text` ✅

**Suite: 1185 passed** (+9), 1 deselected (pre-existente).

## Expectativa en Bernardi

| Antes | Después |
|---|---|
| *"Mesada (con 1 anafe)"* sin señal | *"Mesada (con 1 anafe) — a confirmar"* |
| Ambigüedades del sector: (ninguna de anafe) | Bullet: *"R1: topology detectó anafe en isla pero el brief no lo menciona..."* |

**Medidas idénticas** — 1.60 × 0.60 × 3.60 m² total. Solo cambia la narrativa visible.

## Lo que NO toca

- Features del topology (no mutación).
- Pending_questions (infra existente, no duplicamos).
- Medición / ranking / guardrails.
- Frontend.

## Test plan manual

- [ ] Subir Bernardi en prod.
- [ ] Despiece R1 isla: descripción termina en "— a confirmar".
- [ ] Sección "Revisar en plano": bullet mencionando anafe en isla + brief.
- [ ] Medidas: las mismas de antes (1.60, 2.35, 2.05).
- [ ] Editar R1 inline para sacar el anafe — debe funcionar como siempre.

Después del merge: E2E de Bernardi (Paso 2 cálculo + PDF/Excel) para cerrar el ciclo que Javi propuso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)