### PR TITLE
fix(multi-crop): anti-fallback silencioso del VLM — largo <1m inválido (PR 2b.2)

### DIFF
--- a/api/app/modules/quote_engine/multi_crop_reader.py
+++ b/api/app/modules/quote_engine/multi_crop_reader.py
@@ -751,6 +751,20 @@ def _format_ranking_for_prompt(ranking: dict) -> str:
         "Usá el ranking como prior. Elegir una DÉBIL o POCO PROBABLE "
         "requiere justificación visual explícita del crop."
     )
+
+    # PR 2b.2 — Instrucción explícita cuando no hay candidatas válidas para
+    # largo. Sin esto, el VLM tiende a "completar" con el valor del ancho
+    # (0.60) o algún default, generando basura tipo 0.60 × 0.60. Mejor null
+    # honesto → operador ve DUDOSO y completa manual.
+    if not ranking.get("length"):
+        lines.append("")
+        lines.append(
+            "**NO hay candidatas válidas para LARGO** (todas fueron excluidas "
+            "por ser perímetro del ambiente o estar fuera de rango razonable). "
+            "En este caso devolvé `largo_m: null` en el JSON. NO uses el ancho "
+            "como largo. NO uses un default estándar. NO inventes: devolvé "
+            "`null` honestamente."
+        )
     return "\n".join(lines)
 
 
@@ -785,6 +799,23 @@ def _apply_guardrails(
     except (TypeError, ValueError):
         confidence = 0.5
     suspicious: list[str] = list(vlm_output.get("suspicious_reasons") or [])
+
+    # PR 2b.2 — Regla dura defensiva contra fallback silencioso del VLM.
+    # Cuando el ranking queda vacío (ej: todas las cotas fueron excluidas
+    # como perímetro), el VLM tiende a "completar" con un valor razonable
+    # — típicamente agarra el ancho 0.60 y lo reporta como largo también.
+    # Eso es basura: un tramo de mesada no tiene largo < 1m.
+    # Preferimos None honesto que número falso con apariencia válida.
+    try:
+        if largo is not None and float(largo) < 1.0:
+            suspicious.append(
+                f"largo {largo}m < 1.0m — implausible como largo de tramo, invalidado"
+            )
+            vlm_output["largo_m"] = None
+            largo = None
+            confidence = min(confidence, 0.2)
+    except (TypeError, ValueError):
+        pass
 
     def _find_match(value, rank_list):
         if value is None:

--- a/api/tests/test_multi_crop_reader.py
+++ b/api/tests/test_multi_crop_reader.py
@@ -368,8 +368,15 @@ class TestReadPlanMultiCrop:
             mock_client_instance = mock_anth.return_value
             mock_client_instance.messages.create = AsyncMock(return_value=mock_response)
             result = await _measure_region(image, (1000, 800), region, cotas, model="test")
+        # PR 2b.2 — la regla dura defensiva invalida largo < 1.0m ANTES
+        # que llegue al check "largo == ancho". El valor queda en None
+        # (honesto) con suspicious poblado.
         assert "suspicious_reasons" in result
-        assert any("largo == ancho" in s for s in result["suspicious_reasons"])
+        assert result.get("largo_m") is None
+        assert any(
+            "implausible" in s and "largo" in s.lower()
+            for s in result["suspicious_reasons"]
+        )
 
     @pytest.mark.asyncio
     async def test_bernardi_control_r2_stays_dudoso_without_inventing(self):
@@ -1335,3 +1342,106 @@ class TestAggregateAppliesBriefContradictions:
         # esperado: sin brief, topology detectó anafe en isla y nosotros
         # no tenemos forma de validarlo → flaguear por conservador.
         assert tramo.get("_contradictions") is not None
+
+
+# ── PR 2b.2: anti-fallback silencioso del VLM ────────────────────────────
+
+class TestLargoSubMetroInvalidation:
+    """PR 2b.2 — largo <1.0m es implausible para mesada. La regla dura
+    invalida el valor a None antes de ser aceptado.
+
+    Motivación: VLM hace fallback silencioso a 0.60 (el ancho estándar)
+    cuando no puede medir. En el caso Bernardi R3 el operador veía
+    '0.60 × 0.60' con aire de medida válida. Mejor None honesto →
+    UI muestra '— × —' y el operador edita."""
+
+    def test_largo_below_1m_invalidated_to_none(self):
+        """VLM devolvió 0.60 como largo → invalidar a None con confidence 0.2."""
+        ranking = {
+            "length": [],
+            "depth": [],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 0.60,
+            "ancho_m": 0.60,
+            "confidence": 0.85,
+        }
+        result = _apply_guardrails(vlm_output, ranking, cotas_mode="local")
+        assert result["largo_m"] is None, (
+            f"largo 0.60 debería invalidarse a None; got {result['largo_m']}"
+        )
+        assert result["confidence"] <= 0.2
+        assert any(
+            "implausible" in s and "largo" in s.lower()
+            for s in result["suspicious_reasons"]
+        )
+
+    def test_largo_exactly_1m_is_valid(self):
+        """El umbral es <1.0 estricto: 1.0m justo NO se invalida."""
+        ranking = {
+            "length": [{"value": 1.0, "score": 60, "bucket": "preferred", "reasons": []}],
+            "depth": [{"value": 0.60, "score": 75, "bucket": "preferred", "reasons": []}],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 1.0,
+            "ancho_m": 0.60,
+            "confidence": 0.80,
+        }
+        result = _apply_guardrails(vlm_output, ranking, cotas_mode="local")
+        assert result["largo_m"] == 1.0
+
+    def test_largo_valid_above_1m_preserved(self):
+        """Largos típicos (1.60, 2.35, etc.) no se invalidan."""
+        ranking = {
+            "length": [{"value": 1.60, "score": 80, "bucket": "preferred", "reasons": []}],
+            "depth": [{"value": 0.60, "score": 75, "bucket": "preferred", "reasons": []}],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 1.60,
+            "ancho_m": 0.60,
+            "confidence": 0.85,
+        }
+        result = _apply_guardrails(vlm_output, ranking, cotas_mode="local")
+        assert result["largo_m"] == 1.60
+        assert result["confidence"] == 0.85
+
+
+class TestPromptNullWhenEmptyLengthRanking:
+    """PR 2b.2 — cuando length_top queda vacío, el prompt debe instruir
+    explícitamente al VLM a devolver `largo_m: null` y NO inventar."""
+
+    def test_prompt_shows_null_instruction_when_length_empty(self):
+        ranking = {
+            "length": [],
+            "depth": [{"value": 0.60, "score": 75, "bucket": "preferred", "reasons": []}],
+            "excluded_hard": [{"value": 4.15, "reason": "probable_perimeter"}],
+            "orientation": "vertical",
+            "scale_px_per_m": None,
+        }
+        prompt = _format_ranking_for_prompt(ranking)
+        # Instrucción null presente
+        assert "null" in prompt.lower()
+        assert "no uses el ancho" in prompt.lower() or \
+               "no inventes" in prompt.lower()
+        # El prompt debe decir claramente que devolver null
+        assert any(
+            phrase in prompt.lower()
+            for phrase in ("largo_m: null", "largo_m=null", "null honestamente")
+        )
+
+    def test_prompt_no_null_instruction_when_length_has_candidates(self):
+        """Con length_top poblado, NO se inyecta la instrucción null
+        (habría ruido innecesario)."""
+        ranking = {
+            "length": [{"value": 2.35, "score": 80, "bucket": "preferred", "reasons": []}],
+            "depth": [{"value": 0.60, "score": 75, "bucket": "preferred", "reasons": []}],
+            "excluded_hard": [],
+            "orientation": "vertical",
+            "scale_px_per_m": None,
+        }
+        prompt = _format_ranking_for_prompt(ranking)
+        assert "null honestamente" not in prompt.lower()
+        assert "no inventes: devolvé" not in prompt.lower()


### PR DESCRIPTION
## PR 2b.2 — parche defensivo chiquito contra número basura

En la corrida de Bernardi de anoche, R3 devolvió `0.60 × 0.60` con aire de medida válida porque el ranking había quedado vacío (sus cotas locales eran solo 4.15, correctamente excluidas como perímetro). El VLM "completó" agarrando el ancho estándar como largo — fallback silencioso clásico.

Guidance de GPT: "si length_top queda vacío, no aceptar largo 0.60; devolver None/DUDOSO."

Dos cambios chicos, todos defensivos. **NO toco prompts existentes ni topology.**

### Cambio 1 — Regla dura en `_apply_guardrails`

```python
if largo is not None and float(largo) < 1.0:
    suspicious.append(f"largo {largo}m < 1.0m — implausible como largo de tramo, invalidado")
    vlm_output["largo_m"] = None
    confidence = min(confidence, 0.2)
```

Mensaje neutro (microajuste: no "residencial", dejé "tramo" para no hardcodear el contexto por si el pipeline se toca a otros casos).

### Cambio 2 — Instrucción explícita cuando ranking vacío

En `_format_ranking_for_prompt`, si `length` está vacío:

> **NO hay candidatas válidas para LARGO** (todas fueron excluidas como perímetro o fuera de rango razonable). Devolvé `largo_m: null`. NO uses el ancho como largo. NO inventes.

Complementa el Cambio 1: reduce la tasa de fallback en origen.

## Tests — 5 nuevos + 1 actualizado

- `TestLargoSubMetroInvalidation` (3): 0.60 → None con 0.2; 1.0 exacto → válido; 1.60 → preservado.
- `TestPromptNullWhenEmptyLengthRanking` (2): ranking vacío inyecta instrucción null; ranking poblado no inyecta ruido.
- `test_measure_region_detects_silent_fallback` — cambió expectativa porque ahora la regla dura invalida el 0.60 ANTES de llegar al check "largo == ancho". El nuevo assertion verifica `largo_m is None` + suspicious "implausible".

**Suite:** 1190 passed (+5), 1 deselected.

## Lo que NO toca este PR

- **Topology estocástico** — mismo plano, bboxes distintos entre corridas. Eso va a 2d después de medir el ratio vectorial/scan real de los planos de Javi.
- Prompts del topology ni per-region.
- Scoring, ranking, filtros geométricos (PRs 2b/2b.1).

## Expectativa en R3 de Bernardi

| Antes | Después |
|---|---|
| `largo_m: 0.60, ancho_m: 0.60, conf: 0.3` — UI muestra "0.60 × 0.60" | `largo_m: null, ancho_m: 0.60, conf: 0.2` — UI muestra "— × 0.60" con DUDOSO y bullet "implausible" |

**No arregla el total** (R1 puede seguir mal por estocasticidad del topology). Solo arregla que el operador nunca vea un número basura con apariencia confiable.

## Próximos pasos

1. Merge de 2b.2.
2. Javi corre Bernardi **3 veces más** → evidencia definitiva de no-determinismo del topology.
3. Yo preparo en paralelo script para medir ratio vectorial/scan de los planos reales.
4. Con los 3 logs + el ratio, decidimos si 2d vectorial vale (>60% vectorial) o buscamos otra estrategia (retry/ensemble/fail-loud).

🤖 Generated with [Claude Code](https://claude.com/claude-code)