### PR TITLE
feat(admin): endpoint /admin/analyze-plans-vectorality — sin secrets locales

### DIFF
--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -1145,6 +1145,68 @@ async def create_quote(
     return {"id": quote.id}
 
 
+# ── ADMIN: Analyze plans vectorality ──────────────────────────────────────────
+
+@router.post("/admin/analyze-plans-vectorality")
+async def analyze_plans_vectorality(
+    limit: int = Query(default=200, ge=1, le=1000),
+    db: AsyncSession = Depends(get_db),
+):
+    """Analiza las últimas N quotes y clasifica cada `source_file` como
+    `vectorial_clean` / `vectorial_and_raster` / `raster_only` / `unknown`.
+
+    Usado para decidir si vale la inversión del fast-path vectorial (2d).
+    Criterios idénticos al pipeline real (agent.py vision detection).
+
+    Autenticado por el middleware JWT global — no requiere rol extra.
+    Lee los archivos desde disco local (OUTPUT_DIR), sin descarga HTTP.
+
+    Respuesta:
+    ```
+    {
+      "total_analyzed": 150,
+      "counts": {"vectorial_clean": 95, "raster_only": 35, ...},
+      "percentages": {"vectorial_clean": 63.3, ...},
+      "recommend_2d": true
+    }
+    ```
+    """
+    from pathlib import Path
+    from app.core.static import OUTPUT_DIR
+    from app.modules.analytics.plans_vectorality import analyze_source_files
+
+    # Últimas N quotes con source_files no vacío
+    result = await db.execute(
+        select(Quote)
+        .where(Quote.source_files.isnot(None))
+        .order_by(Quote.created_at.desc())
+        .limit(limit)
+    )
+    quotes = result.scalars().all()
+
+    items: list[tuple[str, dict]] = []
+    for q in quotes:
+        for sf in (q.source_files or []):
+            items.append((q.id, sf))
+
+    def _fetch_from_disk(quote_id: str, source_file: dict) -> bytes | None:
+        """Intenta leer el PDF del disco local. Archivos viven en
+        `OUTPUT_DIR/{quote_id}/sources/{filename}`."""
+        filename = source_file.get("filename")
+        if not filename:
+            return None
+        path = Path(OUTPUT_DIR) / quote_id / "sources" / filename
+        try:
+            if path.exists() and path.is_file():
+                return path.read_bytes()
+        except Exception:
+            return None
+        return None
+
+    summary = analyze_source_files(items, _fetch_from_disk)
+    return summary
+
+
 # ── ADMIN: Backfill Drive URLs for existing quotes ───────────────────────────
 
 @router.post("/admin/backfill-drive")

--- a/api/app/modules/analytics/plans_vectorality.py
+++ b/api/app/modules/analytics/plans_vectorality.py
@@ -1,0 +1,138 @@
+"""Helper compartido: clasifica source_files por vectorialidad vs raster.
+
+Usado desde:
+- `scripts/analyze_plans_vectorality.py` (CLI, baja archivos vía HTTP)
+- `POST /api/admin/analyze-plans-vectorality` (backend, lee archivos del disco)
+
+Criterios idénticos al pipeline real en `agent.py` (vision detection).
+NO persiste nada. NO tiene UI. Solo devuelve un JSON resumen.
+"""
+from __future__ import annotations
+
+import io
+from collections import Counter
+from typing import Callable, Optional
+
+import pdfplumber
+
+# Umbrales idénticos a los de `agent.py` (líneas 2480-2508).
+VECTOR_LINES_THRESHOLD = 20
+VECTOR_RECTS_THRESHOLD = 10
+VECTOR_CURVES_THRESHOLD = 20
+RASTER_MIN_DIMENSION = 200  # px — imágenes más chicas no cuentan como scan
+
+# Umbral de decisión para recommend_2d: ratio usable ≥ 60%.
+_USABLE_FOR_2D_THRESHOLD = 0.60
+
+
+def classify_pdf(pdf_bytes: bytes) -> dict:
+    """Analiza un PDF con pdfplumber y devuelve qué tiene.
+
+    - has_raster: True si alguna página tiene imagen > 200x200 (scan).
+    - has_vectors: True si alguna página supera umbrales de primitives.
+    - error: str si falló el parse.
+    """
+    try:
+        with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+            has_raster = False
+            has_vectors = False
+            for page in pdf.pages:
+                for img in (page.images or []):
+                    w = img.get("width", 0) or (img.get("x1", 0) - img.get("x0", 0))
+                    h = img.get("height", 0) or (img.get("top", 0) - img.get("bottom", 0))
+                    if abs(w) > RASTER_MIN_DIMENSION and abs(h) > RASTER_MIN_DIMENSION:
+                        has_raster = True
+                        break
+                n_lines = len(page.lines or [])
+                n_rects = len(page.rects or [])
+                n_curves = len(page.curves or [])
+                if (
+                    n_lines > VECTOR_LINES_THRESHOLD
+                    or n_rects > VECTOR_RECTS_THRESHOLD
+                    or n_curves > VECTOR_CURVES_THRESHOLD
+                ):
+                    has_vectors = True
+            return {"has_raster": has_raster, "has_vectors": has_vectors}
+    except Exception as e:
+        return {"error": f"pdf_parse_failed: {e}"}
+
+
+def classify_source_file(source_file: dict, pdf_bytes: Optional[bytes]) -> str:
+    """Categoría final según mime + resultado del parse PDF.
+
+    Categorías:
+    - `raster_only`: imagen pura (jpg/png/webp) o PDF scan sin vectors.
+    - `vectorial_clean`: PDF con vectors + sin raster grande.
+    - `vectorial_and_raster`: PDF con ambos.
+    - `unknown`: no pudimos bajar o parsear.
+    """
+    mime = (source_file.get("type") or "").lower()
+    filename = (source_file.get("filename") or "").lower()
+
+    if mime.startswith("image/") or filename.endswith((".jpg", ".jpeg", ".png", ".webp")):
+        return "raster_only"
+
+    if not pdf_bytes:
+        return "unknown"
+
+    info = classify_pdf(pdf_bytes)
+    if info.get("error"):
+        return "unknown"
+
+    if info["has_vectors"] and info["has_raster"]:
+        return "vectorial_and_raster"
+    if info["has_vectors"]:
+        return "vectorial_clean"
+    return "raster_only"
+
+
+def format_summary(categories: list[str]) -> dict:
+    """Shape exacto de respuesta:
+
+    {
+      "total_analyzed": 150,
+      "counts": {"vectorial_clean": 95, "raster_only": 35, ...},
+      "percentages": {"vectorial_clean": 63.3, ...},
+      "recommend_2d": true
+    }
+    """
+    counts = Counter(categories)
+    total = len(categories)
+    percentages = {
+        k: round(100 * v / total, 1) if total else 0.0
+        for k, v in counts.items()
+    }
+    # recommend_2d: ≥60% usable (vectorial_clean + vectorial_and_raster).
+    usable = counts.get("vectorial_clean", 0) + counts.get("vectorial_and_raster", 0)
+    ratio_usable = (usable / total) if total else 0.0
+    return {
+        "total_analyzed": total,
+        "counts": dict(counts),
+        "percentages": percentages,
+        "recommend_2d": ratio_usable >= _USABLE_FOR_2D_THRESHOLD,
+    }
+
+
+def analyze_source_files(
+    items: list[tuple[str, dict]],
+    fetch_pdf_bytes: Callable[[str, dict], Optional[bytes]],
+) -> dict:
+    """Itera los source_files y devuelve el resumen.
+
+    `items` = lista de `(quote_id, source_file_dict)`.
+    `fetch_pdf_bytes(quote_id, source_file)` → bytes del PDF o None si falla.
+
+    No descarga nada por sí misma — el caller decide cómo obtener bytes
+    (HTTP para CLI, lectura de disco para endpoint admin).
+    """
+    categories: list[str] = []
+    for quote_id, sf in items:
+        mime = (sf.get("type") or "").lower()
+        filename = (sf.get("filename") or "").lower()
+        # Short-circuit: imagen pura no necesita descarga.
+        if mime.startswith("image/") or filename.endswith((".jpg", ".jpeg", ".png", ".webp")):
+            categories.append("raster_only")
+            continue
+        pdf_bytes = fetch_pdf_bytes(quote_id, sf)
+        categories.append(classify_source_file(sf, pdf_bytes))
+    return format_summary(categories)

--- a/api/scripts/analyze_plans_vectorality.py
+++ b/api/scripts/analyze_plans_vectorality.py
@@ -1,47 +1,28 @@
 #!/usr/bin/env python3
-"""Analiza los planos subidos en quotes recientes y clasifica cada uno
-como "vectorial limpio" vs "raster/scan" vs "desconocido".
+"""CLI wrapper del helper `app.modules.analytics.plans_vectorality`.
 
-Este script existe para decidir si vale la pena invertir en un fast-path
-vectorial (PR 2d). Si la mayoría de los planos reales son PDFs con
-vectores limpios, 2d resuelve estructuralmente el problema de
-estocasticidad del topology LLM. Si la mayoría son scans/fotos, 2d
-ayuda poco.
-
-**Criterios de clasificación** — idénticos a los que usa el pipeline
-en `agent.py` (vision detection, líneas 2480-2508):
-
-- `raster_only`: PDF con imagen raster > 200x200 (scan embebido) SIN
-  vectors limpios, o archivo imagen pura (jpg/png/webp).
-- `vectorial_clean`: PDF con `lines > 20` o `rects > 10` o
-  `curves > 20` en al menos 1 página (CAD/arquitectónico).
-- `vectorial_and_raster`: ambos — PDF con scan + vectors.
-- `unknown`: no pudimos abrir el PDF, o quedó sin señales claras.
+Útil para correr el análisis sin levantar el backend — pero requiere
+DATABASE_URL + env vars de settings. Si peleas con eso, usá el endpoint
+admin POST /api/admin/analyze-plans-vectorality que hace lo mismo sin
+secrets locales.
 
 **Uso:**
 
     python scripts/analyze_plans_vectorality.py              # últimas 50
-    python scripts/analyze_plans_vectorality.py --limit 200  # últimas 200
-    python scripts/analyze_plans_vectorality.py --json       # output JSON
-
-Requiere DATABASE_URL + acceso HTTP a los `url` del source_files. Si
-los archivos están en `/files/...` locales de Railway, correr el
-script desde el mismo contenedor (o bajar los archivos primero).
+    python scripts/analyze_plans_vectorality.py --limit 200
+    python scripts/analyze_plans_vectorality.py --json
 """
 
 from __future__ import annotations
 
 import argparse
 import asyncio
-import io
 import json
 import os
 import sys
-from collections import Counter
 from pathlib import Path
 from typing import Optional
 
-import pdfplumber
 import requests
 
 SCRIPT_DIR = Path(__file__).parent
@@ -49,126 +30,7 @@ API_DIR = SCRIPT_DIR.parent
 sys.path.insert(0, str(API_DIR))
 
 
-# Umbrales idénticos a los de `agent.py` — si cambian allí, cambiar acá.
-VECTOR_LINES_THRESHOLD = 20
-VECTOR_RECTS_THRESHOLD = 10
-VECTOR_CURVES_THRESHOLD = 20
-RASTER_MIN_DIMENSION = 200  # px — imágenes < esto no cuentan como scan
-
-
-def _classify_pdf(pdf_bytes: bytes) -> dict:
-    """Analiza un PDF con pdfplumber y devuelve métricas agregadas.
-
-    Devuelve dict con:
-    - has_raster: True si hay imagen raster > 200x200 en alguna página.
-    - has_vectors: True si alguna página supera umbrales de lines/rects/curves.
-    - pages: int
-    - raster_details: list of (w, h) por página.
-    - vector_details: list of (lines, rects, curves) por página.
-    - error: str si falló el parse.
-    """
-    try:
-        with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
-            pages = pdf.pages
-            has_raster = False
-            has_vectors = False
-            raster_details = []
-            vector_details = []
-            for page in pages:
-                # Raster
-                page_raster = False
-                for img in (page.images or []):
-                    w = img.get("width", 0) or (img.get("x1", 0) - img.get("x0", 0))
-                    h = img.get("height", 0) or (img.get("top", 0) - img.get("bottom", 0))
-                    if abs(w) > RASTER_MIN_DIMENSION and abs(h) > RASTER_MIN_DIMENSION:
-                        page_raster = True
-                        raster_details.append((abs(w), abs(h)))
-                if page_raster:
-                    has_raster = True
-
-                # Vectors
-                n_lines = len(page.lines or [])
-                n_rects = len(page.rects or [])
-                n_curves = len(page.curves or [])
-                vector_details.append((n_lines, n_rects, n_curves))
-                if (
-                    n_lines > VECTOR_LINES_THRESHOLD
-                    or n_rects > VECTOR_RECTS_THRESHOLD
-                    or n_curves > VECTOR_CURVES_THRESHOLD
-                ):
-                    has_vectors = True
-
-            return {
-                "has_raster": has_raster,
-                "has_vectors": has_vectors,
-                "pages": len(pages),
-                "raster_details": raster_details,
-                "vector_details": vector_details,
-            }
-    except Exception as e:
-        return {"error": f"pdf_parse_failed: {e}"}
-
-
-def _classify_category(source_file: dict, pdf_bytes: Optional[bytes]) -> str:
-    """Devuelve la categoría final:
-    - "raster_only" — imagen pura (jpg/png/webp) o PDF scan sin vectors.
-    - "vectorial_clean" — PDF con vectors + sin raster grande.
-    - "vectorial_and_raster" — PDF con ambos.
-    - "unknown" — no pudimos leer.
-    """
-    mime = (source_file.get("type") or "").lower()
-    filename = (source_file.get("filename") or "").lower()
-
-    # Archivos imagen: raster por definición
-    if mime.startswith("image/") or filename.endswith((".jpg", ".jpeg", ".png", ".webp")):
-        return "raster_only"
-
-    if not pdf_bytes:
-        return "unknown"
-
-    info = _classify_pdf(pdf_bytes)
-    if info.get("error"):
-        return "unknown"
-
-    has_raster = info["has_raster"]
-    has_vectors = info["has_vectors"]
-    if has_vectors and has_raster:
-        return "vectorial_and_raster"
-    if has_vectors:
-        return "vectorial_clean"
-    return "raster_only"  # PDF sin vectors + con o sin raster — lo tratamos como scan
-
-
-def _fetch_pdf_bytes(source_file: dict, base_url: str) -> Optional[bytes]:
-    """Intenta bajar el PDF. Orden:
-    1. drive_download_url (si existe).
-    2. drive_url (si existe).
-    3. url relativo (prepend base_url).
-
-    Devuelve bytes o None si falla.
-    """
-    candidates = []
-    for key in ("drive_download_url", "drive_url", "url"):
-        u = source_file.get(key)
-        if not u:
-            continue
-        if u.startswith("/"):
-            u = base_url.rstrip("/") + u
-        candidates.append(u)
-
-    for url in candidates:
-        try:
-            r = requests.get(url, timeout=30, allow_redirects=True)
-            if r.status_code == 200 and r.content:
-                return r.content
-        except Exception:
-            continue
-    return None
-
-
 async def _collect_source_files(limit: int) -> list[tuple[str, dict]]:
-    """Trae los últimos N source_files de la DB, ordenados por created_at desc.
-    Devuelve lista de (quote_id, source_file_dict)."""
     from app.core.database import AsyncSessionLocal
     from app.models.quote import Quote
     from sqlalchemy import select
@@ -185,89 +47,63 @@ async def _collect_source_files(limit: int) -> list[tuple[str, dict]]:
         return out
 
 
-def _format_summary(results: list[dict]) -> dict:
-    by_category = Counter(r["category"] for r in results)
-    total = len(results)
-    ratios = {k: round(v / total, 3) if total else 0 for k, v in by_category.items()}
-    return {
-        "total_files": total,
-        "by_category": dict(by_category),
-        "ratios": ratios,
-        "categories_explained": {
-            "raster_only": (
-                "imagen pura o PDF scan sin vectors — 2d NO ayuda acá, "
-                "seguimos dependiendo del VLM"
-            ),
-            "vectorial_clean": (
-                "PDF con primitives limpias (lines/rects/curves) — "
-                "2d puede extraer bboxes determinísticos"
-            ),
-            "vectorial_and_raster": (
-                "ambos — 2d puede aprovechar los vectors, combinar con "
-                "el raster si es necesario"
-            ),
-            "unknown": "no pudimos leer el archivo (link muerto, parse failed, etc)",
-        },
-    }
+def _make_http_fetcher(base_url: str):
+    def _fetch(quote_id: str, source_file: dict) -> Optional[bytes]:
+        candidates = []
+        for key in ("drive_download_url", "drive_url", "url"):
+            u = source_file.get(key)
+            if not u:
+                continue
+            if u.startswith("/") and base_url:
+                u = base_url.rstrip("/") + u
+            candidates.append(u)
+        for url in candidates:
+            try:
+                r = requests.get(url, timeout=30, allow_redirects=True)
+                if r.status_code == 200 and r.content:
+                    return r.content
+            except Exception:
+                continue
+        return None
+    return _fetch
 
 
 async def main():
+    from app.modules.analytics.plans_vectorality import analyze_source_files
+
     parser = argparse.ArgumentParser()
-    parser.add_argument("--limit", type=int, default=50, help="cantidad de quotes a analizar (default 50)")
-    parser.add_argument("--json", action="store_true", help="output JSON (default: tabla legible)")
+    parser.add_argument("--limit", type=int, default=50)
+    parser.add_argument("--json", action="store_true")
     parser.add_argument(
         "--base-url", default=os.environ.get("FILES_BASE_URL", ""),
-        help="URL base para source_file.url relativos (ej: https://xxx.railway.app)",
     )
     args = parser.parse_args()
 
-    print(f"→ Trayendo últimas {args.limit} quotes con source_files...", file=sys.stderr)
+    print(f"→ Trayendo últimas {args.limit} quotes...", file=sys.stderr)
     items = await _collect_source_files(args.limit)
     print(f"  {len(items)} source_files encontrados.", file=sys.stderr)
 
-    results: list[dict] = []
-    for i, (quote_id, sf) in enumerate(items, 1):
-        mime = sf.get("type") or ""
-        filename = sf.get("filename") or "<sin nombre>"
-        if mime.startswith("image/") or filename.lower().endswith((".jpg", ".jpeg", ".png", ".webp")):
-            # No intentamos descargar — sabemos que es raster por tipo
-            cat = _classify_category(sf, None)
-            results.append({"quote_id": quote_id, "filename": filename, "mime": mime, "category": cat})
-            continue
-        print(f"  [{i}/{len(items)}] {filename[:50]}... ", file=sys.stderr, end="")
-        pdf_bytes = _fetch_pdf_bytes(sf, args.base_url) if args.base_url or sf.get("drive_download_url") else None
-        cat = _classify_category(sf, pdf_bytes)
-        print(cat, file=sys.stderr)
-        results.append({"quote_id": quote_id, "filename": filename, "mime": mime, "category": cat})
-
-    summary = _format_summary(results)
+    fetcher = _make_http_fetcher(args.base_url) if args.base_url else (
+        lambda q, sf: None
+    )
+    summary = analyze_source_files(items, fetcher)
 
     if args.json:
-        print(json.dumps({"summary": summary, "files": results}, ensure_ascii=False, indent=2))
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
         return
 
-    # Output legible
     print()
     print("=" * 60)
     print("RESUMEN — ratio vectorial vs scan")
     print("=" * 60)
-    print(f"Total analizados: {summary['total_files']}")
+    print(f"Total analizados: {summary['total_analyzed']}")
     print()
-    for cat, count in summary["by_category"].items():
-        pct = int(summary["ratios"][cat] * 100)
+    for cat, count in summary["counts"].items():
+        pct = summary["percentages"][cat]
         print(f"  {cat:22s}: {count:4d}  ({pct}%)")
     print()
-    print("Decisión sobre PR 2d (fast-path vectorial):")
-    v_clean = summary["by_category"].get("vectorial_clean", 0)
-    v_both = summary["by_category"].get("vectorial_and_raster", 0)
-    total = max(summary["total_files"], 1)
-    usable_for_2d = (v_clean + v_both) / total
-    if usable_for_2d >= 0.6:
-        print(f"  ✅ {int(usable_for_2d*100)}% usable para 2d → vale la inversión")
-    elif usable_for_2d >= 0.3:
-        print(f"  ⚠️  {int(usable_for_2d*100)}% usable — decisión mixta")
-    else:
-        print(f"  ❌ solo {int(usable_for_2d*100)}% usable — 2d ayuda poco, buscar otra estrategia")
+    rec = summary["recommend_2d"]
+    print(f"recommend_2d: {rec}")
 
 
 if __name__ == "__main__":

--- a/api/tests/test_plans_vectorality.py
+++ b/api/tests/test_plans_vectorality.py
@@ -1,0 +1,156 @@
+"""Tests del helper compartido `app.modules.analytics.plans_vectorality`.
+
+Cubre:
+- Clasificación de source_files según mime / bytes.
+- Resumen formateado con recommend_2d boolean.
+- Integración end-to-end con el PDF real de Bernardi (fixture).
+"""
+import io
+from pathlib import Path
+
+from PIL import Image
+
+from app.modules.analytics.plans_vectorality import (
+    analyze_source_files,
+    classify_pdf,
+    classify_source_file,
+    format_summary,
+)
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class TestClassifySourceFile:
+    def test_jpg_classified_as_raster(self):
+        sf = {"type": "image/jpeg", "filename": "foto.jpg"}
+        assert classify_source_file(sf, None) == "raster_only"
+
+    def test_png_classified_as_raster(self):
+        sf = {"type": "image/png", "filename": "scan.png"}
+        assert classify_source_file(sf, None) == "raster_only"
+
+    def test_webp_classified_as_raster_by_filename(self):
+        sf = {"type": "", "filename": "foto.webp"}
+        assert classify_source_file(sf, None) == "raster_only"
+
+    def test_pdf_without_bytes_is_unknown(self):
+        sf = {"type": "application/pdf", "filename": "plano.pdf"}
+        assert classify_source_file(sf, None) == "unknown"
+
+    def test_bernardi_pdf_classified_as_vectorial_clean(self):
+        """Fixture del caso real: PDF vectorial limpio de Bernardi.
+        lines=133, curves=873 según pdfplumber → vectorial_clean."""
+        pdf_bytes = (FIXTURES / "bernardi_erica_mesadas_cocina.pdf").read_bytes()
+        sf = {"type": "application/pdf", "filename": "bernardi.pdf"}
+        assert classify_source_file(sf, pdf_bytes) == "vectorial_clean"
+
+
+class TestClassifyPdf:
+    def test_bernardi_has_vectors_no_raster(self):
+        pdf_bytes = (FIXTURES / "bernardi_erica_mesadas_cocina.pdf").read_bytes()
+        result = classify_pdf(pdf_bytes)
+        assert result.get("error") is None
+        assert result["has_vectors"] is True
+        assert result["has_raster"] is False
+
+    def test_corrupt_bytes_returns_error(self):
+        result = classify_pdf(b"not a pdf")
+        assert "error" in result
+
+
+class TestFormatSummary:
+    def test_shape_matches_spec(self):
+        """Shape exacto: total_analyzed, counts, percentages, recommend_2d."""
+        categories = ["vectorial_clean"] * 6 + ["raster_only"] * 3 + ["unknown"] * 1
+        summary = format_summary(categories)
+        assert set(summary.keys()) == {
+            "total_analyzed", "counts", "percentages", "recommend_2d",
+        }
+        assert summary["total_analyzed"] == 10
+        assert summary["counts"]["vectorial_clean"] == 6
+        assert summary["percentages"]["vectorial_clean"] == 60.0
+        # 60% usable → recommend_2d True (umbral es 60%)
+        assert summary["recommend_2d"] is True
+
+    def test_recommend_2d_false_when_below_threshold(self):
+        categories = ["vectorial_clean"] * 4 + ["raster_only"] * 6
+        summary = format_summary(categories)
+        # 40% < 60% → no vale 2d
+        assert summary["recommend_2d"] is False
+
+    def test_recommend_2d_true_when_combined_vectorial_over_threshold(self):
+        """vectorial_clean + vectorial_and_raster deben sumar juntos."""
+        categories = (
+            ["vectorial_clean"] * 5
+            + ["vectorial_and_raster"] * 2
+            + ["raster_only"] * 3
+        )
+        summary = format_summary(categories)
+        # 7/10 = 70% usable → recommend_2d True
+        assert summary["recommend_2d"] is True
+
+    def test_empty_categories_returns_zero_and_false(self):
+        summary = format_summary([])
+        assert summary["total_analyzed"] == 0
+        assert summary["counts"] == {}
+        assert summary["recommend_2d"] is False
+
+
+class TestEndpoint:
+    """Smoke test del endpoint admin."""
+
+    import pytest
+
+    @pytest.mark.asyncio
+    async def test_endpoint_returns_summary_shape_on_empty_db(self, client):
+        """Con DB vacía, el endpoint responde 200 + shape correcto."""
+        resp = await client.post("/api/admin/analyze-plans-vectorality?limit=50")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert set(data.keys()) == {
+            "total_analyzed", "counts", "percentages", "recommend_2d",
+        }
+        assert data["total_analyzed"] == 0
+        assert data["counts"] == {}
+        assert data["recommend_2d"] is False
+
+    @pytest.mark.asyncio
+    async def test_endpoint_respects_limit_bounds(self, client):
+        """Query param `limit` tiene bounds 1..1000."""
+        # Fuera de rango → 422
+        resp = await client.post("/api/admin/analyze-plans-vectorality?limit=0")
+        assert resp.status_code == 422
+        resp = await client.post("/api/admin/analyze-plans-vectorality?limit=2000")
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_endpoint_requires_auth(self, client_no_auth):
+        """Sin cookie → 401."""
+        resp = await client_no_auth.post(
+            "/api/admin/analyze-plans-vectorality?limit=50"
+        )
+        assert resp.status_code == 401
+
+
+class TestAnalyzeSourceFiles:
+    def test_end_to_end_with_mixed_types(self):
+        """Itera items heterogéneos + fetch fake, devuelve summary completo."""
+        pdf_bytes = (FIXTURES / "bernardi_erica_mesadas_cocina.pdf").read_bytes()
+        items = [
+            ("q1", {"type": "image/jpeg", "filename": "foto.jpg"}),
+            ("q2", {"type": "application/pdf", "filename": "bernardi.pdf"}),
+            ("q3", {"type": "application/pdf", "filename": "otro.pdf"}),
+            ("q4", {"type": "image/png", "filename": "scan.png"}),
+        ]
+        # Solo devuelve bytes para "bernardi.pdf"; el resto queda unknown.
+        def _fetch(qid, sf):
+            if sf.get("filename") == "bernardi.pdf":
+                return pdf_bytes
+            return None
+
+        summary = analyze_source_files(items, _fetch)
+        assert summary["total_analyzed"] == 4
+        assert summary["counts"]["raster_only"] == 2  # jpg + png
+        assert summary["counts"]["vectorial_clean"] == 1  # bernardi
+        assert summary["counts"]["unknown"] == 1  # otro.pdf sin bytes


### PR DESCRIPTION
## PR chico y temporal — endpoint admin de análisis

Pelearse con DATABASE_URL local + pydantic-settings + `.env` era demasiada fricción para un análisis que necesitamos ya. Endpoint admin resuelve.

## Alcance

- \`POST /api/admin/analyze-plans-vectorality?limit=200\`
- Bounds 1..1000. Default 200.
- Protegido por JWT middleware global (igual que \`/admin/backfill-drive\`).
- Lee archivos del disco local (\`OUTPUT_DIR\`). No baja por HTTP.
- **Sin UI, sin persistencia, sin dashboard.** Solo JSON.

## Shape de respuesta (spec)

\`\`\`json
{
  "total_analyzed": 150,
  "counts": {
    "vectorial_clean": 95,
    "raster_only": 35,
    "vectorial_and_raster": 15,
    "unknown": 5
  },
  "percentages": {
    "vectorial_clean": 63.3,
    "raster_only": 23.3,
    "vectorial_and_raster": 10.0,
    "unknown": 3.3
  },
  "recommend_2d": true
}
\`\`\`

\`recommend_2d\` = \`(vectorial_clean + vectorial_and_raster) / total ≥ 0.60\`.

## Refactor — helper compartido

Moví la lógica de clasificación + resumen del script CLI a \`app.modules.analytics.plans_vectorality\`. El script sigue existiendo (wrapper con HTTP fetch) pero ahora comparte código con el endpoint. Un solo criterio, dos interfaces.

## Uso

Desde tu browser con sesión activa:
\`\`\`
fetch('/api/admin/analyze-plans-vectorality?limit=200', {method:'POST', credentials:'include'}).then(r=>r.json()).then(console.log)
\`\`\`

O curl con cookie:
\`\`\`
curl -X POST "https://ia-agent-quote-marble-operator-production.up.railway.app/api/admin/analyze-plans-vectorality?limit=200" \\
  -H "Cookie: auth_token=<tu_token>"
\`\`\`

## Tests (15 nuevos)

- Clasificación por mime/bytes (jpg/png/webp/pdf/sin-bytes).
- \`classify_pdf\` del PDF real de Bernardi → \`vectorial_clean\`.
- \`format_summary\` con recommend_2d en límites (60% umbral exacto).
- Endpoint: shape con DB vacía, validación de bounds (0 → 422, 2000 → 422), requiere auth (sin cookie → 401).

**Suite:** 1205 passed (+15), 1 deselected (pre-existente).

## Lo que NO toca

- UI (cero cambios de frontend).
- Otros módulos del pipeline.
- Persistencia.
- El script CLI sigue funcionando si preferís correrlo así.

🤖 Generated with [Claude Code](https://claude.com/claude-code)