### PR TITLE
feat(context-analyzer): reconciliación brief↔dual_read con observabilidad (PR #347)

### DIFF
--- a/api/app/modules/quote_engine/context_analyzer.py
+++ b/api/app/modules/quote_engine/context_analyzer.py
@@ -29,11 +29,123 @@ logger = logging.getLogger(__name__)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# PR #347 — Reconciliación brief ↔ dual_read con observabilidad explícita
+#
+# El brief_analyzer extrae SOLO lo que dice el texto (contrato limpio:
+# extractor textual puro). La reconciliación con el topology/dual_read
+# la hace ESTE módulo vía _detect_* + _reconcile_*.
+#
+# Criterio crítico: cuando brief y dual_read tienen ambos un valor
+# válido pero distintos, NO hacer merge silencioso. Loggear explícitamente
+# `divergent=True` y dejar que el operador lo vea (vía UI fields con
+# source="brief"/"dual_read" + confidence). Esto evita el anti-patrón
+# "el sistema eligió uno de los dos sin avisar".
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _log_reconcile(
+    field: str,
+    brief_value,
+    dual_read_value,
+    final,
+    source: str,  # "brief" | "dual_read" | "default" | "merged"
+    confidence: float | None = None,
+    divergent: bool = False,
+) -> None:
+    """Log estructurado de la decisión de reconciliación brief↔dual_read.
+
+    Formato key=value grep-friendly. `divergent=True` cuando ambas fuentes
+    tenían valores no-null y distintos — señal de inconsistencia real
+    que el operador puede tener que resolver visualmente. No se silencia
+    el merge: se muestra qué ganó y qué se descartó.
+
+    Se emite SIEMPRE, incluso cuando no hay divergencia, para dejar
+    trazabilidad completa de cómo se construyó la card de contexto.
+    """
+    conf_str = f"{confidence:.2f}" if isinstance(confidence, (int, float)) else "None"
+    logger.info(
+        "[context-reconcile] field=%s brief_value=%s dual_read_value=%s "
+        "final=%s source=%s confidence=%s divergent=%s",
+        field, brief_value, dual_read_value, final, source, conf_str, divergent,
+    )
+
+
+def _reconcile_work_types(analysis: dict, dual_result: dict) -> dict:
+    """Merge de work_types: brief textual primero, dual_read.sectores
+    como fallback.
+
+    Caso Bernardi real: brief dice "nuevo presupuesto material en pura
+    prima onix white mate Cliente: Erica Bernardi SIN zocalos en rosario
+    con colocacion" — no menciona "cocina" explícito → analysis.work_types=[].
+    Pero dual_result.sectores tiene ["cocina", "isla"]. Sin este merge
+    "Tipo de trabajo" no aparecía en `data_known`.
+
+    Devuelve dict con: final (list[str]), source (brief|dual_read|default),
+    brief_value, dual_read_value, divergent (set-equality).
+    """
+    brief_wt = list(analysis.get("work_types") or [])
+
+    # Normalizar tipos de sectores a canonical set.
+    _NON_COCINA = {"baño", "banio", "isla", "lavadero"}
+    dr_types: list[str] = []
+    for s in dual_result.get("sectores") or []:
+        t = (s.get("tipo") or "").lower().strip()
+        pretty = t if t in _NON_COCINA else ("cocina" if t else None)
+        if pretty and pretty not in dr_types:
+            dr_types.append(pretty)
+
+    if brief_wt:
+        final = brief_wt
+        source = "brief"
+    elif dr_types:
+        final = dr_types
+        source = "dual_read"
+    else:
+        final = []
+        source = "default"
+
+    # Divergent: ambos no-vacíos Y conjuntos distintos.
+    # Normalizar "banio"→"baño" para comparación canonical.
+    def _canon(lst: list[str]) -> set[str]:
+        return {("baño" if x == "banio" else x) for x in lst}
+    divergent = (
+        bool(brief_wt) and bool(dr_types) and _canon(brief_wt) != _canon(dr_types)
+    )
+
+    _log_reconcile(
+        "work_types",
+        brief_value=brief_wt,
+        dual_read_value=dr_types,
+        final=final,
+        source=source,
+        confidence=None,
+        divergent=divergent,
+    )
+    return {
+        "final": final,
+        "source": source,
+        "brief_value": brief_wt,
+        "dual_read_value": dr_types,
+        "divergent": divergent,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Section builders — usan data extraída por brief_analyzer
 # ─────────────────────────────────────────────────────────────────────────────
 
-def _build_data_known(analysis: dict, quote: dict | None) -> list[dict]:
-    """Datos ciertos del brief/quote. Cada row lleva source explícito."""
+def _build_data_known(
+    analysis: dict,
+    quote: dict | None,
+    dual_result: dict | None = None,
+) -> list[dict]:
+    """Datos ciertos del brief/quote/plano. Cada row lleva source explícito.
+
+    PR #347: `dual_result` es ahora input — permite inferir
+    "Tipo de trabajo" desde los sectores del plano cuando el brief no los
+    menciona textualmente (caso Bernardi: brief sin "cocina", plano con
+    cocina+isla). Default `None` para retrocompat de callers legacy.
+    """
     known: list[dict] = []
 
     # Cliente
@@ -60,11 +172,21 @@ def _build_data_known(analysis: dict, quote: dict | None) -> list[dict]:
         source = "quote" if (quote or {}).get("localidad") else "brief"
         known.append({"field": "Localidad", "value": loc, "source": source})
 
-    # Tipos de trabajo detectados
-    work = analysis.get("work_types") or []
+    # Tipos de trabajo — merge brief ↔ dual_read.sectores.
+    # Antes: solo brief → "Tipo de trabajo" desaparecía cuando brief no
+    # mencionaba explícito. Ahora cae al dual_read. El source del row
+    # refleja de dónde salió (brief|dual_read|brief+dual_read si divergen).
+    reconcile = _reconcile_work_types(analysis, dual_result or {})
+    work = reconcile["final"]
     if work:
         pretty = ", ".join(w.capitalize() for w in work)
-        known.append({"field": "Tipo de trabajo", "value": pretty, "source": "brief"})
+        # Si hubo divergencia, marcar source combinada para trazabilidad
+        # en la card. El log [context-reconcile] ya dice qué ganó.
+        if reconcile["divergent"]:
+            src = "brief+dual_read"
+        else:
+            src = reconcile["source"]
+        known.append({"field": "Tipo de trabajo", "value": pretty, "source": src})
 
     # Descuento si se mencionó
     if analysis.get("descuento_mentioned"):
@@ -313,48 +435,154 @@ _ANAFE_OPTIONS = [
 
 
 def _detect_pileta(analysis: dict, feats: dict) -> dict | None:
-    # Brief explícito domina sobre dual_read
-    if analysis.get("pileta_simple_doble") in ("simple", "doble"):
-        v = analysis["pileta_simple_doble"]
-        return _mk("pileta_simple_doble", "Pileta", v, f"{v.capitalize()} (1 bacha)" if v == "simple" else "Doble (2 bachas)",
-                   _PILETA_OPTIONS, "brief", 0.95)
-    if analysis.get("pileta_mentioned") is False and _has_explicit_no_pileta(analysis):
-        return _mk("pileta_simple_doble", "Pileta", "no", "No lleva", _PILETA_OPTIONS, "brief", 0.95)
-    # Dual_read features
+    # Valor del brief y del dual_read, evaluados antes de decidir para
+    # poder loggear la reconciliación incluyendo divergent flag.
+    brief_v = analysis.get("pileta_simple_doble")  # "simple"|"doble"|None
+    # dual_read_v canónico: "doble" si sink_double, "simple" si sink_simple,
+    # "?" si has_pileta pero sin tipo, None si nada.
     if feats["sink_double"]:
-        return _mk("pileta_simple_doble", "Pileta", "doble", "Doble (2 bachas) — detectada en plano",
-                   _PILETA_OPTIONS, "dual_read", 0.80)
-    if feats["sink_simple"]:
-        return _mk("pileta_simple_doble", "Pileta", "simple", "Simple (1 bacha) — detectada en plano",
-                   _PILETA_OPTIONS, "dual_read", 0.75)
-    if feats["has_pileta"]:
-        # sabemos que hay pileta pero no el tipo
-        return _mk("pileta_simple_doble", "Pileta", None, "Presente — tipo a confirmar",
-                   _PILETA_OPTIONS, "dual_read", 0.55)
-    return None
+        dr_v = "doble"
+    elif feats["sink_simple"]:
+        dr_v = "simple"
+    elif feats["has_pileta"]:
+        dr_v = "present_unknown"
+    else:
+        dr_v = None
+
+    # Caso especial: brief dice "no pileta" explícito.
+    brief_explicit_no = (
+        analysis.get("pileta_mentioned") is False
+        and _has_explicit_no_pileta(analysis)
+    )
+
+    # Divergencia real: ambos con valor válido Y distintos. "present_unknown"
+    # NO se considera divergent contra "simple"/"doble" del brief (el dual_read
+    # confirma presencia sin desmentir el tipo).
+    divergent = False
+    if brief_v in ("simple", "doble") and dr_v in ("simple", "doble"):
+        divergent = brief_v != dr_v
+    elif brief_explicit_no and dr_v in ("simple", "doble", "present_unknown"):
+        divergent = True  # brief dice no, plano detecta → inconsistencia
+
+    # Decisión (precedencia brief > dual_read, como siempre).
+    result: dict | None
+    if brief_v in ("simple", "doble"):
+        final, source, conf = brief_v, "brief", 0.95
+        display = "Simple (1 bacha)" if brief_v == "simple" else "Doble (2 bachas)"
+        result = _mk("pileta_simple_doble", "Pileta", brief_v, display,
+                     _PILETA_OPTIONS, source, conf)
+    elif brief_explicit_no:
+        final, source, conf = "no", "brief", 0.95
+        result = _mk("pileta_simple_doble", "Pileta", "no", "No lleva",
+                     _PILETA_OPTIONS, source, conf)
+    elif dr_v == "doble":
+        final, source, conf = "doble", "dual_read", 0.80
+        result = _mk("pileta_simple_doble", "Pileta", "doble",
+                     "Doble (2 bachas) — detectada en plano",
+                     _PILETA_OPTIONS, source, conf)
+    elif dr_v == "simple":
+        final, source, conf = "simple", "dual_read", 0.75
+        result = _mk("pileta_simple_doble", "Pileta", "simple",
+                     "Simple (1 bacha) — detectada en plano",
+                     _PILETA_OPTIONS, source, conf)
+    elif dr_v == "present_unknown":
+        final, source, conf = None, "dual_read", 0.55
+        result = _mk("pileta_simple_doble", "Pileta", None,
+                     "Presente — tipo a confirmar",
+                     _PILETA_OPTIONS, source, conf)
+    else:
+        final, source, conf = None, "default", None
+        result = None
+
+    _log_reconcile(
+        "pileta_simple_doble",
+        brief_value=brief_v if brief_v is not None else (
+            "explicit_no" if brief_explicit_no else None
+        ),
+        dual_read_value=dr_v,
+        final=final,
+        source=source,
+        confidence=conf,
+        divergent=divergent,
+    )
+    return result
 
 
 def _detect_isla(analysis: dict, feats: dict) -> dict | None:
-    if analysis.get("isla_mentioned"):
-        return _mk("isla_presence", "Isla central", "yes", "Sí — del brief", _ISLA_OPTIONS, "brief", 0.95)
-    if feats["has_isla"]:
-        return _mk("isla_presence", "Isla central", "yes", "Sí — detectada en plano",
-                   _ISLA_OPTIONS, "dual_read", 0.85)
-    return None
+    brief_v = bool(analysis.get("isla_mentioned"))
+    dr_v = bool(feats["has_isla"])
+
+    # Divergent: SOLO cuando brief afirma (isla_mentioned=True) Y plano
+    # niega (has_isla=False). brief=False es "no mencionó", no "dijo que
+    # no hay" — caso habitual (Bernardi) → brief silencio + plano detecta
+    # es fallback natural, no divergencia. Consistente con anafe/pileta.
+    divergent = brief_v is True and dr_v is False
+
+    if brief_v:
+        final, source, conf = True, "brief", 0.95
+        result = _mk("isla_presence", "Isla central", "yes", "Sí — del brief",
+                     _ISLA_OPTIONS, source, conf)
+    elif dr_v:
+        final, source, conf = True, "dual_read", 0.85
+        result = _mk("isla_presence", "Isla central", "yes",
+                     "Sí — detectada en plano", _ISLA_OPTIONS, source, conf)
+    else:
+        final, source, conf = False, "default", None
+        result = None
+
+    _log_reconcile(
+        "isla_presence",
+        brief_value=brief_v,
+        dual_read_value=dr_v,
+        final=final,
+        source=source,
+        confidence=conf,
+        divergent=divergent,
+    )
+    return result
 
 
 def _detect_anafe(analysis: dict, feats: dict) -> dict | None:
-    # Brief explícito primero
     ac = analysis.get("anafe_count")
-    if isinstance(ac, int) and ac >= 0:
-        disp = f"{ac}" if ac != 2 else "2 (gas + eléctrico)" if analysis.get("anafe_gas_y_electrico") else "2"
-        return _mk("anafe_count", "Anafe", str(ac), disp, _ANAFE_OPTIONS, "brief", 0.95)
-    # Dual_read cooktop_groups
     cg = feats["cooktop_groups"]
-    if cg > 0:
-        return _mk("anafe_count", "Anafe", str(cg), f"{cg} — detectado en plano",
-                   _ANAFE_OPTIONS, "dual_read", 0.70)
-    return None
+
+    brief_v = ac if isinstance(ac, int) and ac >= 0 else None
+    dr_v = int(cg) if cg > 0 else None
+
+    # Divergent: brief explícito Y dual_read también Y distintos.
+    # brief=0 y dr>0 también es divergencia (brief dice que no hay).
+    divergent = (
+        brief_v is not None and dr_v is not None and brief_v != dr_v
+    )
+
+    if brief_v is not None:
+        disp = (
+            "2 (gas + eléctrico)"
+            if brief_v == 2 and analysis.get("anafe_gas_y_electrico")
+            else f"{brief_v}"
+        )
+        final, source, conf = brief_v, "brief", 0.95
+        result = _mk("anafe_count", "Anafe", str(brief_v), disp,
+                     _ANAFE_OPTIONS, source, conf)
+    elif dr_v is not None:
+        final, source, conf = dr_v, "dual_read", 0.70
+        result = _mk("anafe_count", "Anafe", str(dr_v),
+                     f"{dr_v} — detectado en plano",
+                     _ANAFE_OPTIONS, source, conf)
+    else:
+        final, source, conf = None, "default", None
+        result = None
+
+    _log_reconcile(
+        "anafe_count",
+        brief_value=brief_v,
+        dual_read_value=dr_v,
+        final=final,
+        source=source,
+        confidence=conf,
+        divergent=divergent,
+    )
+    return result
 
 
 def _has_explicit_no_pileta(analysis: dict) -> bool:
@@ -412,7 +640,7 @@ async def build_context_analysis(
     config_defaults = config_defaults or {}
     analysis = await analyze_brief(brief or "")
 
-    data = _build_data_known(analysis, quote)
+    data = _build_data_known(analysis, quote, dual_result)
     assumptions = _build_assumptions(analysis, quote, dual_result, config_defaults)
     tech_detections = _extract_tech_detections(analysis, dual_result)
 

--- a/api/tests/test_context_analyzer.py
+++ b/api/tests/test_context_analyzer.py
@@ -3,12 +3,20 @@
 Patcheamos `analyze_brief` (el LLM call) con el regex fallback determinístico
 para que los tests corran sin pegar a Anthropic y sean reproducibles.
 """
+import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from app.modules.quote_engine.brief_analyzer import EMPTY_SCHEMA, _analyze_regex_fallback
-from app.modules.quote_engine.context_analyzer import build_context_analysis_sync as build_context_analysis
+from app.modules.quote_engine.context_analyzer import (
+    _build_data_known,
+    _detect_anafe,
+    _detect_isla,
+    _detect_pileta,
+    _reconcile_work_types,
+    build_context_analysis_sync as build_context_analysis,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -339,3 +347,400 @@ class TestContextConfirmationRoundTrip:
         assert isla["tramos"][0]["ancho_m"]["valor"] == 0.60
         assert isla["patas"]["sides"] == ["frontal", "lateral_izq", "lateral_der"]
         assert "pending_questions" not in dual
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PR #347 — Reconciliación brief ↔ dual_read + observabilidad + Tipo de trabajo
+#
+# Scope: inferir work_types desde dual_result.sectores cuando el brief no
+# los trae, y loggear explícitamente la decisión de reconciliación por
+# campo crítico (isla, anafe, pileta, work_types). Criterio: NO merge
+# silencioso — cuando brief y dual_read divergen, `divergent=True` en
+# el log.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _dual_with_sectores(tipos: list[str]) -> dict:
+    """Build a dual_result con los tipos de sectores pedidos. Cada sector
+    es un placeholder mínimo válido."""
+    return {
+        "sectores": [
+            {
+                "id": f"s{i}",
+                "tipo": t,
+                "tramos": [],
+                "ambiguedades": [],
+            }
+            for i, t in enumerate(tipos, 1)
+        ],
+        "source": "MULTI_CROP",
+    }
+
+
+class TestReconcileWorkTypes:
+    """_reconcile_work_types merge brief ↔ dual_result.sectores."""
+
+    def test_brief_empty_falls_back_to_dual_read(self, caplog):
+        """Caso Bernardi real: brief no menciona 'cocina'/'isla' → brief
+        analysis devuelve work_types=[]. El dual_result sí tiene sectores
+        cocina + isla. Merge debe devolver los del dual_read."""
+        analysis = {"work_types": []}
+        dual = _dual_with_sectores(["cocina", "isla"])
+        with caplog.at_level(logging.INFO):
+            out = _reconcile_work_types(analysis, dual)
+        assert out["final"] == ["cocina", "isla"]
+        assert out["source"] == "dual_read"
+        assert out["divergent"] is False
+        assert any("[context-reconcile]" in r.message and "field=work_types" in r.message
+                   for r in caplog.records)
+
+    def test_brief_wins_when_both_agree(self, caplog):
+        analysis = {"work_types": ["cocina"]}
+        dual = _dual_with_sectores(["cocina"])
+        out = _reconcile_work_types(analysis, dual)
+        assert out["final"] == ["cocina"]
+        assert out["source"] == "brief"
+        assert out["divergent"] is False
+
+    def test_divergent_when_brief_and_dual_read_have_different_sets(self, caplog):
+        """brief=['baño'] vs dual=['cocina'] → divergent=True, brief gana
+        por precedencia pero el log deja constancia de la inconsistencia."""
+        analysis = {"work_types": ["baño"]}
+        dual = _dual_with_sectores(["cocina"])
+        with caplog.at_level(logging.INFO):
+            out = _reconcile_work_types(analysis, dual)
+        assert out["final"] == ["baño"]
+        assert out["source"] == "brief"
+        assert out["divergent"] is True
+        log = next(r.message for r in caplog.records
+                   if "[context-reconcile]" in r.message and "field=work_types" in r.message)
+        assert "divergent=True" in log
+
+    def test_divergent_when_brief_subset_of_dual_read(self, caplog):
+        """brief=['cocina'] vs dual=['cocina','isla'] → divergent=True,
+        brief gana pero log lo muestra."""
+        analysis = {"work_types": ["cocina"]}
+        dual = _dual_with_sectores(["cocina", "isla"])
+        out = _reconcile_work_types(analysis, dual)
+        assert out["divergent"] is True
+        assert out["source"] == "brief"
+
+    def test_banio_and_bano_normalized_as_equal(self, caplog):
+        """Brief usa 'baño' unicode, dual_result puede traer 'banio' (ASCII)
+        — no son divergentes en canonical form."""
+        analysis = {"work_types": ["baño"]}
+        dual = _dual_with_sectores(["banio"])
+        out = _reconcile_work_types(analysis, dual)
+        assert out["divergent"] is False
+
+    def test_both_empty_is_not_divergent(self, caplog):
+        analysis = {"work_types": []}
+        dual = _dual_with_sectores([])
+        out = _reconcile_work_types(analysis, dual)
+        assert out["final"] == []
+        assert out["source"] == "default"
+        assert out["divergent"] is False
+
+
+class TestDetectIslaReconciliation:
+    """_detect_isla ahora loguea [context-reconcile] siempre + marca
+    divergent cuando brief y dual_read no coinciden y al menos uno es True."""
+
+    def test_brief_true_dual_false_is_divergent(self, caplog):
+        """Brief dice 'isla' pero plano no la detecta — divergencia real."""
+        analysis = {"isla_mentioned": True}
+        feats = {"has_isla": False, "sink_double": False, "sink_simple": False,
+                 "has_pileta": False, "cooktop_groups": 0}
+        with caplog.at_level(logging.INFO):
+            _detect_isla(analysis, feats)
+        log = next(r.message for r in caplog.records
+                   if "[context-reconcile]" in r.message and "field=isla_presence" in r.message)
+        assert "divergent=True" in log
+        assert "source=brief" in log
+
+    def test_brief_false_dual_true_not_divergent(self, caplog):
+        """Brief no menciona (isla_mentioned=False) pero plano detecta.
+        NO es divergent: brief=False es "no mencionó", no "dijo que NO".
+        Fallback natural al dual_read, consistente con anafe/pileta."""
+        analysis = {"isla_mentioned": False}
+        feats = {"has_isla": True, "sink_double": False, "sink_simple": False,
+                 "has_pileta": False, "cooktop_groups": 0}
+        with caplog.at_level(logging.INFO):
+            _detect_isla(analysis, feats)
+        log = next(r.message for r in caplog.records
+                   if "[context-reconcile]" in r.message and "field=isla_presence" in r.message)
+        assert "divergent=False" in log
+        assert "source=dual_read" in log
+
+    def test_both_false_no_divergence(self, caplog):
+        """Ni brief ni plano mencionan isla → no hay card, no divergent."""
+        analysis = {"isla_mentioned": False}
+        feats = {"has_isla": False, "sink_double": False, "sink_simple": False,
+                 "has_pileta": False, "cooktop_groups": 0}
+        with caplog.at_level(logging.INFO):
+            result = _detect_isla(analysis, feats)
+        assert result is None
+        log = next(r.message for r in caplog.records
+                   if "[context-reconcile]" in r.message and "field=isla_presence" in r.message)
+        assert "divergent=False" in log
+
+    def test_both_true_no_divergence(self, caplog):
+        analysis = {"isla_mentioned": True}
+        feats = {"has_isla": True, "sink_double": False, "sink_simple": False,
+                 "has_pileta": False, "cooktop_groups": 0}
+        with caplog.at_level(logging.INFO):
+            _detect_isla(analysis, feats)
+        log = next(r.message for r in caplog.records
+                   if "[context-reconcile]" in r.message and "field=isla_presence" in r.message)
+        assert "divergent=False" in log
+        assert "source=brief" in log  # brief siempre gana cuando ambos true
+
+
+class TestDetectAnafeReconciliation:
+    def test_brief_count_differs_from_dual_is_divergent(self, caplog):
+        """brief dice 2 anafes, plano detecta 1 → divergencia. Brief gana
+        por precedencia, pero log deja constancia."""
+        analysis = {"anafe_count": 2, "anafe_gas_y_electrico": True}
+        feats = {"has_isla": False, "sink_double": False, "sink_simple": False,
+                 "has_pileta": False, "cooktop_groups": 1}
+        with caplog.at_level(logging.INFO):
+            result = _detect_anafe(analysis, feats)
+        assert result["value"] == "2"
+        log = next(r.message for r in caplog.records
+                   if "[context-reconcile]" in r.message and "field=anafe_count" in r.message)
+        assert "divergent=True" in log
+        assert "source=brief" in log
+
+    def test_brief_none_dual_positive_not_divergent(self, caplog):
+        """Brief sin anafe_count (null), plano con cooktop_groups → fallback
+        dual_read, NO divergent (brief no dijo nada)."""
+        analysis = {"anafe_count": None}
+        feats = {"has_isla": False, "sink_double": False, "sink_simple": False,
+                 "has_pileta": False, "cooktop_groups": 1}
+        with caplog.at_level(logging.INFO):
+            _detect_anafe(analysis, feats)
+        log = next(r.message for r in caplog.records
+                   if "[context-reconcile]" in r.message and "field=anafe_count" in r.message)
+        assert "divergent=False" in log
+        assert "source=dual_read" in log
+
+    def test_brief_zero_dual_positive_is_divergent(self, caplog):
+        """Brief explícito '0 anafes', plano detecta anafe → divergencia
+        real (brief afirma que no hay, plano dice que sí)."""
+        analysis = {"anafe_count": 0}
+        feats = {"has_isla": False, "sink_double": False, "sink_simple": False,
+                 "has_pileta": False, "cooktop_groups": 1}
+        with caplog.at_level(logging.INFO):
+            _detect_anafe(analysis, feats)
+        log = next(r.message for r in caplog.records
+                   if "[context-reconcile]" in r.message and "field=anafe_count" in r.message)
+        assert "divergent=True" in log
+        assert "source=brief" in log
+
+    def test_both_equal_not_divergent(self, caplog):
+        analysis = {"anafe_count": 1}
+        feats = {"has_isla": False, "sink_double": False, "sink_simple": False,
+                 "has_pileta": False, "cooktop_groups": 1}
+        with caplog.at_level(logging.INFO):
+            _detect_anafe(analysis, feats)
+        log = next(r.message for r in caplog.records
+                   if "[context-reconcile]" in r.message and "field=anafe_count" in r.message)
+        assert "divergent=False" in log
+
+
+class TestDetectPiletaReconciliation:
+    def test_brief_simple_dual_double_is_divergent(self, caplog):
+        analysis = {"pileta_simple_doble": "simple", "pileta_mentioned": True}
+        feats = {"has_isla": False, "sink_double": True, "sink_simple": False,
+                 "has_pileta": True, "cooktop_groups": 0}
+        with caplog.at_level(logging.INFO):
+            result = _detect_pileta(analysis, feats)
+        assert result["value"] == "simple"  # brief gana
+        log = next(r.message for r in caplog.records
+                   if "[context-reconcile]" in r.message and "field=pileta_simple_doble" in r.message)
+        assert "divergent=True" in log
+        assert "source=brief" in log
+
+    def test_brief_none_dual_simple_not_divergent(self, caplog):
+        analysis = {"pileta_simple_doble": None, "pileta_mentioned": False,
+                    "raw_notes": ""}
+        feats = {"has_isla": False, "sink_double": False, "sink_simple": True,
+                 "has_pileta": True, "cooktop_groups": 0}
+        with caplog.at_level(logging.INFO):
+            result = _detect_pileta(analysis, feats)
+        assert result["value"] == "simple"
+        log = next(r.message for r in caplog.records
+                   if "[context-reconcile]" in r.message and "field=pileta_simple_doble" in r.message)
+        assert "divergent=False" in log
+        assert "source=dual_read" in log
+
+    def test_brief_explicit_no_vs_dual_detected_is_divergent(self, caplog):
+        """Brief dice 'sin pileta' explícito Y plano detecta pileta → divergencia."""
+        analysis = {"pileta_simple_doble": None, "pileta_mentioned": False,
+                    "raw_notes": "sin pileta en la cocina"}
+        feats = {"has_isla": False, "sink_double": False, "sink_simple": True,
+                 "has_pileta": True, "cooktop_groups": 0}
+        with caplog.at_level(logging.INFO):
+            result = _detect_pileta(analysis, feats)
+        assert result["value"] == "no"  # brief gana
+        log = next(r.message for r in caplog.records
+                   if "[context-reconcile]" in r.message and "field=pileta_simple_doble" in r.message)
+        assert "divergent=True" in log
+        assert "source=brief" in log
+
+    def test_brief_simple_dual_present_unknown_not_divergent(self, caplog):
+        """Brief=simple + plano detecta presencia pero sin tipo → NO es
+        divergent (el plano no contradice, solo es menos específico)."""
+        analysis = {"pileta_simple_doble": "simple", "pileta_mentioned": True}
+        feats = {"has_isla": False, "sink_double": False, "sink_simple": False,
+                 "has_pileta": True, "cooktop_groups": 0}
+        with caplog.at_level(logging.INFO):
+            _detect_pileta(analysis, feats)
+        log = next(r.message for r in caplog.records
+                   if "[context-reconcile]" in r.message and "field=pileta_simple_doble" in r.message)
+        assert "divergent=False" in log
+
+
+class TestBuildDataKnownTipoTrabajo:
+    """_build_data_known debe agregar 'Tipo de trabajo' usando el merge
+    brief ↔ dual_read (el bug visible de Bernardi real)."""
+
+    def test_tipo_trabajo_from_dual_read_when_brief_empty(self):
+        analysis = dict(EMPTY_SCHEMA)  # sin work_types
+        dual = _dual_with_sectores(["cocina", "isla"])
+        known = _build_data_known(analysis, quote=None, dual_result=dual)
+        tipo_row = next((r for r in known if r["field"] == "Tipo de trabajo"), None)
+        assert tipo_row is not None
+        assert "Cocina" in tipo_row["value"]
+        assert "Isla" in tipo_row["value"]
+        assert tipo_row["source"] == "dual_read"
+
+    def test_tipo_trabajo_from_brief_when_brief_has_types(self):
+        analysis = dict(EMPTY_SCHEMA)
+        analysis["work_types"] = ["cocina"]
+        dual = _dual_with_sectores(["cocina"])
+        known = _build_data_known(analysis, quote=None, dual_result=dual)
+        tipo_row = next((r for r in known if r["field"] == "Tipo de trabajo"), None)
+        assert tipo_row is not None
+        assert tipo_row["source"] == "brief"
+
+    def test_tipo_trabajo_marked_divergent_when_brief_and_dual_diverge(self):
+        """Brief=cocina, dual=cocina+isla → source="brief+dual_read" para
+        que la card refleje que hubo merge con divergencia."""
+        analysis = dict(EMPTY_SCHEMA)
+        analysis["work_types"] = ["cocina"]
+        dual = _dual_with_sectores(["cocina", "isla"])
+        known = _build_data_known(analysis, quote=None, dual_result=dual)
+        tipo_row = next((r for r in known if r["field"] == "Tipo de trabajo"), None)
+        assert tipo_row is not None
+        assert tipo_row["source"] == "brief+dual_read"
+
+    def test_no_tipo_trabajo_when_both_empty(self):
+        analysis = dict(EMPTY_SCHEMA)
+        dual = _dual_with_sectores([])
+        known = _build_data_known(analysis, quote=None, dual_result=dual)
+        tipo_row = next((r for r in known if r["field"] == "Tipo de trabajo"), None)
+        assert tipo_row is None
+
+    def test_backwards_compat_without_dual_result(self):
+        """Caller legacy sin dual_result → comportamiento anterior (solo brief)."""
+        analysis = dict(EMPTY_SCHEMA)
+        analysis["work_types"] = ["cocina"]
+        known = _build_data_known(analysis, quote=None)  # sin dual_result
+        tipo_row = next((r for r in known if r["field"] == "Tipo de trabajo"), None)
+        assert tipo_row is not None
+        assert tipo_row["source"] == "brief"
+
+
+class TestBernardiE2ELogging:
+    """E2E con brief real de Bernardi + dual_result Bernardi-like.
+    Valida que los 4 logs [context-reconcile] aparecen con los datos
+    esperados — auditoría de que la observabilidad está completa."""
+
+    def test_bernardi_brief_plus_dual_emits_four_reconcile_logs(self, caplog):
+        brief = (
+            "nuevo presupuesto material en pura prima onix white mate "
+            "Cliente: Erica Bernardi SIN zocalos en rosario con colocacion"
+        )
+        # dual_result Bernardi-like: cocina con pileta simple + anafe,
+        # más sector isla. R1 tiene cooktop + sink_simple.
+        dual = {
+            "sectores": [
+                {
+                    "id": "s_cocina",
+                    "tipo": "cocina",
+                    "tramos": [{
+                        "id": "R1",
+                        "descripcion": "Mesada",
+                        "largo_m": {"valor": None, "status": "DUDOSO"},
+                        "ancho_m": {"valor": 0.6, "status": "DUDOSO"},
+                        "m2": {"valor": None, "status": "DUDOSO"},
+                        "features": {
+                            "sink_simple": True,
+                            "sink_double": False,
+                            "has_pileta": True,
+                            "cooktop_groups": 1,
+                        },
+                        "zocalos": [], "frentin": [], "regrueso": [],
+                    }],
+                    "ambiguedades": [],
+                },
+                {
+                    "id": "s_isla",
+                    "tipo": "isla",
+                    "tramos": [{
+                        "id": "R3",
+                        "descripcion": "Mesada",
+                        "largo_m": {"valor": 2.05, "status": "CONFIRMADO"},
+                        "ancho_m": {"valor": 0.6, "status": "CONFIRMADO"},
+                        "m2": {"valor": 1.23, "status": "CONFIRMADO"},
+                        "features": {},
+                        "zocalos": [], "frentin": [], "regrueso": [],
+                    }],
+                    "ambiguedades": [],
+                },
+            ],
+            "source": "MULTI_CROP",
+        }
+        with caplog.at_level(logging.INFO):
+            out = build_context_analysis(brief, None, dual)
+
+        # Verificamos que los 4 logs aparecen
+        fields_logged = set()
+        for r in caplog.records:
+            if "[context-reconcile]" in r.message:
+                for f in ("work_types", "isla_presence",
+                          "pileta_simple_doble", "anafe_count"):
+                    if f"field={f}" in r.message:
+                        fields_logged.add(f)
+        assert fields_logged == {
+            "work_types", "isla_presence",
+            "pileta_simple_doble", "anafe_count",
+        }, f"Missing reconcile logs for: {{'work_types','isla_presence','pileta_simple_doble','anafe_count'}} - {fields_logged}"
+
+        # Y el known tiene "Tipo de trabajo" con cocina + isla (source=dual_read,
+        # brief vacío de work_types).
+        tipo_row = next(
+            (r for r in out["data_known"] if r["field"] == "Tipo de trabajo"),
+            None,
+        )
+        assert tipo_row is not None
+        assert "Cocina" in tipo_row["value"]
+        assert "Isla" in tipo_row["value"]
+        assert tipo_row["source"] == "dual_read"
+
+
+class TestReconcileLogFormat:
+    """Formato del log debe ser grep-friendly (key=value)."""
+
+    def test_log_format_contains_all_expected_keys(self, caplog):
+        analysis = {"isla_mentioned": True}
+        feats = {"has_isla": False, "sink_double": False, "sink_simple": False,
+                 "has_pileta": False, "cooktop_groups": 0}
+        with caplog.at_level(logging.INFO):
+            _detect_isla(analysis, feats)
+        log = next(r.message for r in caplog.records
+                   if "[context-reconcile]" in r.message)
+        for key in ("field=", "brief_value=", "dual_read_value=", "final=",
+                    "source=", "confidence=", "divergent="):
+            assert key in log, f"Missing key '{key}' in log: {log}"


### PR DESCRIPTION
## Contexto

En corrida real de Bernardi post-#346, la card de contexto mostró que falta "Tipo de trabajo" en "Datos que tengo" aunque el plano tiene cocina+isla. El brief no menciona "cocina" explícito → `analysis.work_types=[]` → el campo desaparecía. Y no había observabilidad estructurada de cómo se reconciliaban brief↔dual_read para isla/anafe/pileta.

## Diagnóstico clave

Al explorar el código descubrí que **la reconciliación brief↔dual_read ya existe** en `_detect_isla`, `_detect_anafe`, `_detect_pileta` — la UI sí muestra "Isla: Sí (dual_read, 85%)" etc. El brief_analyzer correctamente extrae **solo lo que dice el texto** (contrato limpio de extractor textual).

**El bug visible real es más chico que lo asumido:**
1. `_build_data_known` solo miraba brief para work_types — ignoraba dual_result.
2. Faltaba log estructurado de la decisión de reconciliación (grep-friendly para diagnóstico en prod).

**NO tocamos `brief_analyzer.py`** — su contrato textual puro se preserva.

## Cambios

1. **Helper `_log_reconcile(field, brief_value, dual_read_value, final, source, confidence, divergent)`** — emite log key=value siempre.

2. **Helper `_reconcile_work_types(analysis, dual_result)`** — merge con normalización canonical (baño/banio).

3. **`_detect_isla/anafe/pileta`** emiten `[context-reconcile]` con `divergent` flag.

4. **`_build_data_known(analysis, quote, dual_result=None)`** — nueva signature con dual_result. Agrega "Tipo de trabajo" usando el merge, source="brief" | "dual_read" | "brief+dual_read".

## Criterio: NO merge silencioso

`divergent=True` SOLO cuando ambas fuentes tienen valor afirmativo Y distintos:
- \`brief=isla_mentioned=True\` + \`dual=False\` → divergent.
- \`brief=anafe=2\` + \`dual_cooktop=1\` → divergent.
- \`brief=pileta=simple\` + \`dual.sink_double=True\` → divergent.
- \`brief=work_types=[\"baño\"]\` + \`dual=[\"cocina\"]\` → divergent.
- \`brief=anafe=0\` (explícito) + \`dual_cooktop=1\` → divergent.

`brief=False/None/[]` (no mencionó) **no** es divergent → fallback natural al dual_read.

Brief siempre gana por precedencia, pero `divergent=True` + `source=brief+dual_read` en la card dejan constancia.

## Tests (25 nuevos)

- **TestReconcileWorkTypes** (6): empty/wins/divergent sets/subset-divergent/canonical-banio/both-empty.
- **TestDetectIslaReconciliation** (4): divergent cases + consistency fix.
- **TestDetectAnafeReconciliation** (4): count mismatch, zero explicit, brief-none fallback.
- **TestDetectPiletaReconciliation** (4): simple/doble divergent, explicit-no vs detected, present-unknown NOT divergent.
- **TestBuildDataKnownTipoTrabajo** (5): from-dual-when-empty, from-brief, marked-divergent, no-tipo, backwards-compat.
- **TestBernardiE2ELogging** (1): brief real Bernardi + dual Bernardi-like → 4 logs + Tipo de trabajo en known.
- **TestReconcileLogFormat** (1): formato key=value.

**Suite: 1602 passed (+25)**. 16 failed son pre-existentes en main.

## Impacto en Bernardi real post-merge

**Card \"Datos que tengo\":**
```
Cliente: Erica Bernardi (brief)
Material: Puraprima Onix White Mate (brief)
Localidad: Rosario (brief)
Tipo de trabajo: Cocina, Isla (dual_read)   ← NUEVO
```

**Logs nuevos en Railway por quote:**
```
[context-reconcile] field=work_types       brief_value=[] dual_read_value=['cocina','isla'] final=['cocina','isla'] source=dual_read confidence=None divergent=False
[context-reconcile] field=isla_presence    brief_value=False dual_read_value=True final=True source=dual_read confidence=0.85 divergent=False
[context-reconcile] field=pileta_simple_doble brief_value=None dual_read_value=simple final=simple source=dual_read confidence=0.75 divergent=False
[context-reconcile] field=anafe_count      brief_value=None dual_read_value=1 final=1 source=dual_read confidence=0.70 divergent=False
```

Cuando haya `divergent=True` en algún campo → señal clara de inconsistencia brief↔plano para revisar.

## NO toca (scope explícito)
- `brief_analyzer.py` — extractor textual puro, contrato preservado.
- topology-cache, rescue, aggregator, frontend.

## Test plan

- [x] 25 tests nuevos pasan.
- [x] Suite completa sin regresión (1602 passed vs 1577 baseline).
- [x] `git diff --stat origin/main..HEAD` = 673+/40- en 2 archivos.
- [ ] CI verde.
- [ ] Post-merge: verificar en Bernardi real que los 4 logs aparecen y \"Tipo de trabajo\" se muestra en la card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)