### PR TITLE
feat(multi-crop): sanity checks semánticos post-measure (PR #349)

### DIFF
--- a/api/app/modules/quote_engine/multi_crop_reader.py
+++ b/api/app/modules/quote_engine/multi_crop_reader.py
@@ -1693,6 +1693,95 @@ def _detect_region_brief_contradictions(region: dict, brief_text: str) -> list[s
     return contradictions
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# PR #349 — Sanity checks semánticos post-measure
+#
+# Motivación: Bernardi R3 midió 2.05 como sector=isla con confidence 0.65
+# → sistema lo promociona a CONFIRMADO. Pero una isla de 2.05m es rara
+# (islas típicas 1.0-1.8m). Sin check semántico, el error "creíble"
+# pasa inadvertido — peor operativamente que un null honesto, porque
+# el operador puede confirmarlo sin revisar.
+#
+# Diseño:
+# - Reglas MÍNIMAS, bien acotadas (solo isla + cocina con pileta+anafe).
+# - NO cambian valor ni confidence. Solo agregan suspicious_reasons.
+# - El aggregator convierte cualquier suspicious_reasons → DUDOSO
+#   automáticamente (lógica preexistente línea ~1740).
+# - Umbrales son configurables como constantes módulo-level; revisar
+#   con data de prod si aparecen falsos positivos sistemáticos.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Islas residenciales típicas 1.0-1.8m. >1.8m es raro y probable error
+# de asignación bbox↔cota (caso Bernardi: R3 isla midió 2.05 que era
+# cota del tramo L vertical).
+_ISLA_LARGO_TIPICO_MAX = 1.80
+
+# Cocina con pileta + anafe necesita espacio físico — tramo corto <1.5m
+# no puede alojar ambos artefactos + ancho útil. Probable mal matching.
+_COCINA_CON_ANAFE_PILETA_LARGO_MIN = 1.50
+
+
+def _semantic_sanity_checks(
+    sector: str,
+    largo_m: Optional[float],
+    ancho_m: Optional[float],
+    features: dict,
+) -> list[str]:
+    """Reglas semánticas post-measure — NO cambian valores, solo flagean.
+
+    Devuelve lista de `suspicious_reasons` (strings) que se agregan a
+    las existentes del measurement. Lista vacía si todo OK.
+
+    Contrato:
+    - Si `largo_m` es None → sin warnings (el null ya será DUDOSO).
+    - Si sector no es reconocido ("cocina" | "isla") → sin warnings.
+    - Los warnings se encadenan (pueden ser >1 si ambas reglas disparan).
+    - El formato del string incluye el valor para debugging + umbral
+      que lo gatilló (`isla_largo_inusual_2.05m_threshold_1.80m`).
+    """
+    warnings: list[str] = []
+
+    if largo_m is None or not isinstance(largo_m, (int, float)):
+        return warnings
+
+    sector_lc = (sector or "").lower().strip()
+    largo_f = float(largo_m)
+
+    # Regla 1: isla con largo >1.8m (caso Bernardi R3).
+    if sector_lc == "isla" and largo_f > _ISLA_LARGO_TIPICO_MAX:
+        warnings.append(
+            f"isla_largo_inusual_{largo_f:.2f}m_threshold_{_ISLA_LARGO_TIPICO_MAX:.2f}m "
+            f"— islas residenciales típicas 1.0-1.8m, valor mayor probable "
+            f"error de asignación bbox↔cota; revisar visualmente"
+        )
+
+    # Regla 2: cocina con pileta + anafe y largo <1.5m (poco espacio para
+    # acomodar ambos artefactos + ancho útil de trabajo).
+    if sector_lc == "cocina":
+        has_sink = bool(
+            features.get("sink_simple")
+            or features.get("sink_double")
+            or features.get("has_pileta")
+        )
+        cooktop = features.get("cooktop_groups") or 0
+        has_anafe = (
+            isinstance(cooktop, (int, float)) and cooktop > 0
+        )
+        if (
+            has_sink
+            and has_anafe
+            and largo_f < _COCINA_CON_ANAFE_PILETA_LARGO_MIN
+        ):
+            warnings.append(
+                f"cocina_con_pileta_y_anafe_largo_corto_{largo_f:.2f}m_"
+                f"threshold_{_COCINA_CON_ANAFE_PILETA_LARGO_MIN:.2f}m "
+                f"— un tramo con ambos artefactos típicamente mide "
+                f"≥{_COCINA_CON_ANAFE_PILETA_LARGO_MIN}m; probable cota mal asignada"
+            )
+
+    return warnings
+
+
 def _aggregate(
     topology: dict,
     region_results: list[dict],
@@ -1736,7 +1825,25 @@ def _aggregate(
             # CONFIRMADO solo si la medición se ancló a las cotas locales y no
             # hay señales de fallback silencioso.
             error = r_result.get("error")
-            suspicious = r_result.get("suspicious_reasons") or []
+            suspicious = list(r_result.get("suspicious_reasons") or [])
+
+            # PR #349 — sanity check semántico post-measure.
+            # Detecta medidas "plausibles geométricamente pero raras
+            # semánticamente" (isla >1.8m, cocina pileta+anafe <1.5m).
+            # NO cambia valores — solo agrega suspicious_reasons para que
+            # el if de abajo promocione a DUDOSO.
+            semantic_warnings = _semantic_sanity_checks(
+                sector=sec_name,
+                largo_m=largo,
+                ancho_m=ancho,
+                features=region.get("features") or {},
+            )
+            if semantic_warnings:
+                suspicious.extend(semantic_warnings)
+                # Propagar al result para que el log region-detail lo muestre
+                # y el caller pueda leer la razón sin rearmar el helper.
+                r_result["suspicious_reasons"] = suspicious
+
             if error or suspicious or largo is None or ancho is None:
                 status = "DUDOSO"
             else:

--- a/api/tests/test_multi_crop_reader.py
+++ b/api/tests/test_multi_crop_reader.py
@@ -32,6 +32,7 @@ from app.modules.quote_engine.multi_crop_reader import (
     _rank_cotas_for_region,
     _rescue_length_ranking,
     _score_cota,
+    _semantic_sanity_checks,
     read_plan_multi_crop,
 )
 
@@ -2525,3 +2526,353 @@ class TestRescueSkipReasons:
             None,  # cuando rescue_applied=True
         }
         assert meta.get("rescue_skip_reason") in known_skip_reasons
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PR #349 — Sanity checks semánticos post-measure
+#
+# Reglas mínimas que flagean medidas "plausibles geométricamente pero
+# raras semánticamente". Caso canónico: Bernardi R3 midió 2.05 como
+# sector=isla con confidence 0.65 → sistema lo promocionó a CONFIRMADO.
+# Post #349: se flagea como `isla_largo_inusual` → suspicious_reasons
+# → aggregator marca DUDOSO automáticamente (sin cambiar valor).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSemanticSanityChecks:
+    """Unit tests del helper `_semantic_sanity_checks`."""
+
+    # ── Regla 1: isla con largo >1.8m ──────────────────────────────────
+
+    def test_isla_largo_mayor_a_1_8m_flagea(self):
+        """Caso canónico Bernardi: isla midió 2.05m → flag isla_largo_inusual."""
+        warnings = _semantic_sanity_checks(
+            sector="isla", largo_m=2.05, ancho_m=0.60, features={},
+        )
+        assert len(warnings) == 1
+        assert "isla_largo_inusual" in warnings[0]
+        assert "2.05" in warnings[0]
+
+    def test_isla_largo_exactamente_1_8m_no_flagea(self):
+        """Límite estricto: solo >1.8 dispara. 1.8 exacto NO."""
+        warnings = _semantic_sanity_checks(
+            sector="isla", largo_m=1.80, ancho_m=0.60, features={},
+        )
+        assert warnings == []
+
+    def test_isla_largo_tipico_1_6m_no_flagea(self):
+        """Valor dentro de rango esperado (1.0-1.8m) → sin warnings."""
+        warnings = _semantic_sanity_checks(
+            sector="isla", largo_m=1.60, ancho_m=0.60, features={},
+        )
+        assert warnings == []
+
+    def test_isla_largo_null_no_flagea(self):
+        """largo_m=None no aplica reglas — será DUDOSO por null igual."""
+        warnings = _semantic_sanity_checks(
+            sector="isla", largo_m=None, ancho_m=0.60, features={},
+        )
+        assert warnings == []
+
+    # ── Regla 2: cocina con pileta + anafe y largo <1.5m ───────────────
+
+    def test_cocina_con_pileta_y_anafe_largo_corto_flagea(self):
+        """Cocina con ambos artefactos y <1.5m → poco espacio físico."""
+        features = {
+            "sink_simple": True,
+            "cooktop_groups": 1,
+        }
+        warnings = _semantic_sanity_checks(
+            sector="cocina", largo_m=1.20, ancho_m=0.60, features=features,
+        )
+        assert len(warnings) == 1
+        assert "cocina_con_pileta_y_anafe_largo_corto" in warnings[0]
+        assert "1.20" in warnings[0]
+
+    def test_cocina_con_pileta_y_anafe_largo_exactamente_1_5m_no_flagea(self):
+        """Límite estricto: solo <1.5 dispara."""
+        features = {"sink_simple": True, "cooktop_groups": 1}
+        warnings = _semantic_sanity_checks(
+            sector="cocina", largo_m=1.50, ancho_m=0.60, features=features,
+        )
+        assert warnings == []
+
+    def test_cocina_con_solo_pileta_sin_anafe_no_flagea(self):
+        """Regla requiere AMBOS artefactos. Solo pileta con largo chico → OK."""
+        features = {"sink_simple": True, "cooktop_groups": 0}
+        warnings = _semantic_sanity_checks(
+            sector="cocina", largo_m=1.20, ancho_m=0.60, features=features,
+        )
+        assert warnings == []
+
+    def test_cocina_con_solo_anafe_sin_pileta_no_flagea(self):
+        """Regla requiere AMBOS artefactos. Solo anafe con largo chico → OK."""
+        features = {"sink_simple": False, "cooktop_groups": 1}
+        warnings = _semantic_sanity_checks(
+            sector="cocina", largo_m=1.20, ancho_m=0.60, features=features,
+        )
+        assert warnings == []
+
+    def test_cocina_con_pileta_doble_y_anafe_largo_corto_flagea(self):
+        """sink_double también cuenta como pileta."""
+        features = {"sink_double": True, "cooktop_groups": 1}
+        warnings = _semantic_sanity_checks(
+            sector="cocina", largo_m=1.30, ancho_m=0.60, features=features,
+        )
+        assert len(warnings) == 1
+        assert "cocina_con_pileta_y_anafe_largo_corto" in warnings[0]
+
+    def test_cocina_con_has_pileta_generico_cuenta(self):
+        """features.has_pileta (sin tipo específico) también cuenta."""
+        features = {"has_pileta": True, "cooktop_groups": 1}
+        warnings = _semantic_sanity_checks(
+            sector="cocina", largo_m=1.40, ancho_m=0.60, features=features,
+        )
+        assert len(warnings) == 1
+
+    def test_cocina_con_largo_normal_no_flagea(self):
+        """Cocina 2.5m con pileta+anafe → normal, sin warnings."""
+        features = {"sink_simple": True, "cooktop_groups": 1}
+        warnings = _semantic_sanity_checks(
+            sector="cocina", largo_m=2.50, ancho_m=0.60, features=features,
+        )
+        assert warnings == []
+
+    # ── Otros sectores no aplican ──────────────────────────────────────
+
+    def test_baño_no_dispara_reglas(self):
+        """Baño con largo 0.5m (chico típico de vanitory) NO dispara reglas
+        de cocina ni isla."""
+        warnings = _semantic_sanity_checks(
+            sector="baño", largo_m=0.50, ancho_m=0.40, features={},
+        )
+        assert warnings == []
+
+    def test_lavadero_no_dispara_reglas(self):
+        warnings = _semantic_sanity_checks(
+            sector="lavadero", largo_m=3.0, ancho_m=0.60, features={},
+        )
+        assert warnings == []
+
+    def test_sector_vacio_no_dispara(self):
+        warnings = _semantic_sanity_checks(
+            sector="", largo_m=2.50, ancho_m=0.60, features={},
+        )
+        assert warnings == []
+
+    def test_sector_none_no_dispara(self):
+        warnings = _semantic_sanity_checks(
+            sector=None, largo_m=2.50, ancho_m=0.60, features={},
+        )
+        assert warnings == []
+
+    # ── Casos borde ────────────────────────────────────────────────────
+
+    def test_ambas_reglas_pueden_dispararse_simultaneamente(self):
+        """Si un sector fuera clasificable como ambos (hipotético), devolvería
+        ambos warnings. En la práctica sector es uno u otro — test defensivo
+        para futuros agregados."""
+        # No existe sector "isla" Y "cocina" al mismo tiempo, pero verificamos
+        # que los warnings se acumulan en lista y no son exclusivos.
+        features = {"sink_simple": True, "cooktop_groups": 1}
+        warnings_isla = _semantic_sanity_checks(
+            sector="isla", largo_m=2.05, ancho_m=0.60, features=features,
+        )
+        warnings_cocina = _semantic_sanity_checks(
+            sector="cocina", largo_m=1.20, ancho_m=0.60, features=features,
+        )
+        # Cada uno dispara 1 warning
+        assert len(warnings_isla) == 1
+        assert len(warnings_cocina) == 1
+        # Son warnings distintos
+        assert warnings_isla != warnings_cocina
+
+
+class TestAggregateAppliesSemanticSanityChecks:
+    """E2E del sanity check a través de `_aggregate`. Verifica que:
+    - el warning se agrega a suspicious_reasons del tramo,
+    - el status pasa a DUDOSO,
+    - el largo_m NO cambia de valor,
+    - se agrega ambigüedad REVISION al sector."""
+
+    def _build_topology(self, regions):
+        return {"view_type": "planta", "regions": regions}
+
+    def test_bernardi_r3_isla_2_05_pasa_a_dudoso(self):
+        """Caso Bernardi post-#349: R3 mide 2.05 con sector=isla.
+        El status que antes era CONFIRMADO ahora es DUDOSO por sanity check."""
+        topology = self._build_topology([
+            {
+                "id": "R3",
+                "bbox_rel": {"x": 0.35, "y": 0.45, "w": 0.25, "h": 0.08},
+                "features": {
+                    "touches_wall": False,  # → clasifica como isla
+                    "sink_double": False,
+                    "sink_simple": False,
+                    "cooktop_groups": 0,
+                },
+            },
+        ])
+        region_results = [
+            {
+                "region_id": "R3",
+                "largo_m": 2.05,
+                "ancho_m": 0.60,
+                "confidence": 0.65,
+                "suspicious_reasons": [],
+            },
+        ]
+        result = _aggregate(topology, region_results)
+        isla = next(s for s in result["sectores"] if s["tipo"] == "isla")
+        tramo = isla["tramos"][0]
+
+        # Valor no cambia
+        assert tramo["largo_m"]["valor"] == 2.05
+        assert tramo["ancho_m"]["valor"] == 0.60
+        # Status pasa a DUDOSO
+        assert tramo["largo_m"]["status"] == "DUDOSO"
+        assert tramo["ancho_m"]["status"] == "DUDOSO"
+        # Descripción tiene "— revisar" porque DUDOSO (patrón preexistente)
+        assert "revisar" in tramo["descripcion"]
+        # Ambigüedad agregada al sector
+        amb_texts = " ".join(a.get("texto") or "" for a in isla["ambiguedades"])
+        assert "isla_largo_inusual" in amb_texts or "dudosa" in amb_texts
+
+    def test_isla_con_largo_normal_1_6m_sigue_confirmado(self):
+        """No regresión: isla midiendo valor típico 1.6m sigue CONFIRMADO."""
+        topology = self._build_topology([
+            {
+                "id": "R_isla",
+                "bbox_rel": {"x": 0.3, "y": 0.4, "w": 0.2, "h": 0.1},
+                "features": {
+                    "touches_wall": False,
+                    "sink_double": False,
+                    "sink_simple": False,
+                    "cooktop_groups": 0,
+                },
+            },
+        ])
+        region_results = [
+            {
+                "region_id": "R_isla",
+                "largo_m": 1.60,
+                "ancho_m": 0.60,
+                "confidence": 0.90,
+                "suspicious_reasons": [],
+            },
+        ]
+        result = _aggregate(topology, region_results)
+        isla = next(s for s in result["sectores"] if s["tipo"] == "isla")
+        tramo = isla["tramos"][0]
+        assert tramo["largo_m"]["valor"] == 1.60
+        assert tramo["largo_m"]["status"] == "CONFIRMADO"
+
+    def test_cocina_normal_sin_pileta_sigue_confirmado(self):
+        """Cocina largo 1.2m sin artefactos (raro pero no aplica regla)."""
+        topology = self._build_topology([
+            {
+                "id": "R_cocina",
+                "bbox_rel": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.3},
+                "features": {
+                    "touches_wall": True,
+                    "sink_simple": False,
+                    "sink_double": False,
+                    "cooktop_groups": 0,
+                },
+            },
+        ])
+        region_results = [
+            {
+                "region_id": "R_cocina",
+                "largo_m": 1.20,
+                "ancho_m": 0.60,
+                "confidence": 0.85,
+                "suspicious_reasons": [],
+            },
+        ]
+        result = _aggregate(topology, region_results)
+        cocina = next(s for s in result["sectores"] if s["tipo"] == "cocina")
+        assert cocina["tramos"][0]["largo_m"]["status"] == "CONFIRMADO"
+
+    def test_cocina_con_pileta_y_anafe_largo_corto_pasa_a_dudoso(self):
+        """Cocina con pileta + anafe + largo 1.2m → DUDOSO por regla 2."""
+        topology = self._build_topology([
+            {
+                "id": "R_cocina",
+                "bbox_rel": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.3},
+                "features": {
+                    "touches_wall": True,
+                    "sink_simple": True,
+                    "sink_double": False,
+                    "cooktop_groups": 1,
+                },
+            },
+        ])
+        region_results = [
+            {
+                "region_id": "R_cocina",
+                "largo_m": 1.20,
+                "ancho_m": 0.60,
+                "confidence": 0.80,
+                "suspicious_reasons": [],
+            },
+        ]
+        result = _aggregate(topology, region_results)
+        cocina = next(s for s in result["sectores"] if s["tipo"] == "cocina")
+        tramo = cocina["tramos"][0]
+        assert tramo["largo_m"]["valor"] == 1.20  # valor no cambia
+        assert tramo["largo_m"]["status"] == "DUDOSO"
+
+    def test_suspicious_reasons_preexistentes_se_preservan(self):
+        """Si ya había suspicious del measurement, el sanity check SUMA
+        al stack, no reemplaza."""
+        topology = self._build_topology([
+            {
+                "id": "R_isla",
+                "bbox_rel": {"x": 0.3, "y": 0.4, "w": 0.2, "h": 0.1},
+                "features": {"touches_wall": False, "cooktop_groups": 0},
+            },
+        ])
+        region_results = [
+            {
+                "region_id": "R_isla",
+                "largo_m": 2.30,  # >1.8 → dispara sanity check
+                "ancho_m": 0.60,
+                "confidence": 0.60,
+                "suspicious_reasons": ["cotas_mode=expanded → cap confidence 0.65"],
+            },
+        ]
+        result = _aggregate(topology, region_results)
+        isla = next(s for s in result["sectores"] if s["tipo"] == "isla")
+        amb_text = " ".join(a.get("texto") or "" for a in isla["ambiguedades"])
+        # Ambos motivos aparecen en la ambigüedad
+        assert "cap confidence" in amb_text
+        assert "isla_largo_inusual" in amb_text
+
+    def test_null_largo_no_dispara_sanity_check(self):
+        """Largo null no aplica regla — ya será DUDOSO por null igual,
+        sin necesidad de doblar razones."""
+        topology = self._build_topology([
+            {
+                "id": "R_isla",
+                "bbox_rel": {"x": 0.3, "y": 0.4, "w": 0.2, "h": 0.1},
+                "features": {"touches_wall": False, "cooktop_groups": 0},
+            },
+        ])
+        region_results = [
+            {
+                "region_id": "R_isla",
+                "largo_m": None,  # null
+                "ancho_m": 0.60,
+                "confidence": 0.0,
+                "suspicious_reasons": [],
+            },
+        ]
+        result = _aggregate(topology, region_results)
+        isla = next(s for s in result["sectores"] if s["tipo"] == "isla")
+        tramo = isla["tramos"][0]
+        assert tramo["largo_m"]["valor"] is None
+        assert tramo["largo_m"]["status"] == "DUDOSO"  # por null, no por sanity
+        # La razón es el null, NO isla_largo_inusual (porque no aplica con null)
+        amb_text = " ".join(a.get("texto") or "" for a in isla["ambiguedades"])
+        assert "isla_largo_inusual" not in amb_text


### PR DESCRIPTION
## Contexto

El Plan #348 descartó cross-region reassignment como NO-GO, pero descubrió un bug grave y silencioso: **Bernardi R3 midió 2.05 como `sector=isla` con confidence 0.65 → sistema lo promocionó a CONFIRMADO.**

Ese error "creíble" es peor operativamente que un null honesto:
- null → operador ve "— × —" y sabe que falta.
- 2.05 CONFIRMADO para isla → operador puede aceptarlo sin revisar.

Este PR es la alternativa 5.1 del ADR #348: reglas semánticas mínimas que NO cambian valor, solo flagean.

## Cambios

**Helper nuevo `_semantic_sanity_checks(sector, largo, ancho, features)`** — devuelve `list[str]` de warnings. Sin side-effects.

**Integración en `_aggregate`:** se llama antes del decide-status. Warnings se agregan a `suspicious_reasons` → aggregator marca DUDOSO automáticamente (lógica preexistente). El valor del `largo_m` **no se toca**.

## Reglas

1. **`isla_largo_inusual`** — `sector==\"isla\" AND largo_m > 1.8m`.
   - Islas residenciales típicas 1.0-1.8m.
   - Caso Bernardi R3: dispara con 2.05m.

2. **`cocina_con_pileta_y_anafe_largo_corto`** — `sector==\"cocina\" AND (pileta) AND (cooktop_groups>0) AND largo_m < 1.5m`.
   - Un tramo con ambos artefactos necesita espacio físico.

Umbrales como constantes módulo-level (`_ISLA_LARGO_TIPICO_MAX=1.80`, `_COCINA_CON_ANAFE_PILETA_LARGO_MIN=1.50`) — ajustables con data de prod.

## Criterio de conservadurismo

Se descartaron reglas agresivas sin evidencia (ej: \"baño largo >2.5m raro\"). Las 2 elegidas son las que Bernardi real justificó + el caso simétrico obvio. Más reglas cuando haya data de prod que las soporte.

## Tests (22 nuevos)

- **TestSemanticSanityChecks (16):** unit del helper.
  - Regla 1 isla: >1.8 flagea, 1.8 exacto no, típico no, null no.
  - Regla 2 cocina: pileta+anafe+corto flagea, 1.5 exacto no, solo pileta o solo anafe no dispara (requiere ambos), sink_double cuenta, has_pileta genérico cuenta.
  - Otros sectores: baño/lavadero/vacío/None no disparan.

- **TestAggregateAppliesSemanticSanityChecks (6):** E2E vía `_aggregate`.
  - **Bernardi R3 isla 2.05 → DUDOSO** (caso canónico).
  - Isla 1.6 normal → CONFIRMADO (no regresión).
  - Suspicious preexistentes se preservan (no los reemplaza).
  - Largo null no dispara sanity (ya DUDOSO por null).

Suite: **1624 passed (+22)**. 16 failed pre-existentes en main.

## Impacto esperado en Bernardi real

**Antes:** R3 `largo_m=2.05, status=CONFIRMADO` → operador puede aceptar → despiece con isla=2.05 m² incorrecto.

**Después:** R3 `largo_m=2.05, status=DUDOSO, suspicious_reasons=[\"isla_largo_inusual_2.05m_threshold_1.80m — islas residenciales típicas 1.0-1.8m, valor mayor probable error de asignación bbox↔cota; revisar visualmente\"]`. Ambigüedad aparece como bullet REVISION en el sector isla.

**Contrato fail-loud reforzado:** el sistema no solo no miente, ahora **desconfía mejor de sí mismo** en casos semánticamente raros.

## NO toca
- topology-cache (Plan B).
- rescue / orphan_trigger.
- brief_analyzer, context_analyzer.
- Frontend.

## Test plan

- [x] 22 tests nuevos pasan.
- [x] Suite completa sin regresión (1624 passed vs 1602 baseline).
- [x] `git diff --stat origin/main..HEAD` = 459+/1- en 2 archivos.
- [ ] CI verde.
- [ ] Post-merge: validar con Bernardi real que R3 ahora aparece como DUDOSO con bullet \"isla_largo_inusual\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)