### PR TITLE
feat(multi-crop): log [semantic-sanity] para observabilidad del PR #349 (PR #350)

### DIFF
--- a/api/app/modules/quote_engine/multi_crop_reader.py
+++ b/api/app/modules/quote_engine/multi_crop_reader.py
@@ -1832,6 +1832,28 @@ def _aggregate(
             # semánticamente" (isla >1.8m, cocina pileta+anafe <1.5m).
             # NO cambia valores — solo agrega suspicious_reasons para que
             # el if de abajo promocione a DUDOSO.
+            #
+            # PR #350 — corrección de doc previa: el log
+            # [multi-crop/region-detail] se emite ANTES de _aggregate
+            # (línea 2369 vs 2373), así que mutar r_result aquí NO
+            # se refleja en ese log. La mutación sirve para que otros
+            # callers que inspeccionen region_results post-aggregate
+            # vean el sanity aplicado. La observabilidad del sanity
+            # vive en el log [semantic-sanity] nuevo (ver abajo).
+            #
+            # Estados:
+            # - status_before_sanity: qué status tendría la región SIN
+            #   aplicar el sanity (solo por error/null/suspicious previos).
+            # - status_after_sanity: estado final después de sumar warnings.
+            # Si son distintos → el sanity es LA razón del DUDOSO. Si son
+            # iguales DUDOSO→DUDOSO, el sanity es adicional; igual vale
+            # loggearlo para auditar que la regla disparó.
+            suspicious_before_sanity = list(suspicious)
+            if error or suspicious_before_sanity or largo is None or ancho is None:
+                status_before_sanity = "DUDOSO"
+            else:
+                status_before_sanity = "CONFIRMADO"
+
             semantic_warnings = _semantic_sanity_checks(
                 sector=sec_name,
                 largo_m=largo,
@@ -1840,9 +1862,23 @@ def _aggregate(
             )
             if semantic_warnings:
                 suspicious.extend(semantic_warnings)
-                # Propagar al result para que el log region-detail lo muestre
-                # y el caller pueda leer la razón sin rearmar el helper.
                 r_result["suspicious_reasons"] = suspicious
+
+                status_after_sanity = "DUDOSO"  # siempre, por definición del helper
+                status_changed_by_sanity = (
+                    status_before_sanity != status_after_sanity
+                )
+                logger.info(
+                    "[semantic-sanity] region=%s sector=%s largo=%s ancho=%s "
+                    "warnings=%s status_before=%s status_after=%s "
+                    "status_changed_by_sanity=%s",
+                    rid, sec_name,
+                    f"{float(largo):.2f}" if isinstance(largo, (int, float)) else largo,
+                    f"{float(ancho):.2f}" if isinstance(ancho, (int, float)) else ancho,
+                    semantic_warnings,
+                    status_before_sanity, status_after_sanity,
+                    status_changed_by_sanity,
+                )
 
             if error or suspicious or largo is None or ancho is None:
                 status = "DUDOSO"

--- a/api/tests/test_multi_crop_reader.py
+++ b/api/tests/test_multi_crop_reader.py
@@ -7,9 +7,10 @@ LLM calls y PIL image ops se mockean. La idea es verificar:
 - detección de fallback silencioso (largo == ancho, valores no anclados)
 - labels genéricos hasta que PR C defina contrato feature-based
 """
+import io
+import logging
 from unittest.mock import AsyncMock, patch
 
-import io
 import pytest
 from PIL import Image
 
@@ -2876,3 +2877,154 @@ class TestAggregateAppliesSemanticSanityChecks:
         # La razón es el null, NO isla_largo_inusual (porque no aplica con null)
         amb_text = " ".join(a.get("texto") or "" for a in isla["ambiguedades"])
         assert "isla_largo_inusual" not in amb_text
+
+
+class TestSemanticSanityObservabilityLog:
+    """PR #350 — Log estructurado [semantic-sanity] dentro de _aggregate.
+
+    Problema que resuelve: el log [multi-crop/region-detail] se emite
+    antes de _aggregate, entonces nunca mostraba el efecto del sanity
+    check del PR #349. Sin este log, confirmar en prod que el sanity
+    está corriendo requería inspeccionar quote_breakdown.dual_read —
+    invisible al operador y a los logs standard de Railway.
+    """
+
+    def _build_topology(self, regions):
+        return {"view_type": "planta", "regions": regions}
+
+    def test_log_emitted_when_sanity_triggers_bernardi_r3(self, caplog):
+        """Caso canónico Bernardi: R3 isla 2.05 → log con campos completos."""
+        topology = self._build_topology([
+            {
+                "id": "R3",
+                "bbox_rel": {"x": 0.35, "y": 0.45, "w": 0.25, "h": 0.08},
+                "features": {
+                    "touches_wall": False,
+                    "sink_double": False,
+                    "sink_simple": False,
+                    "cooktop_groups": 0,
+                },
+            },
+        ])
+        region_results = [{
+            "region_id": "R3", "largo_m": 2.05, "ancho_m": 0.60,
+            "confidence": 0.65, "suspicious_reasons": [],
+        }]
+
+        with caplog.at_level(logging.INFO,
+                             logger="app.modules.quote_engine.multi_crop_reader"):
+            _aggregate(topology, region_results)
+
+        sanity_logs = [r for r in caplog.records if "[semantic-sanity]" in r.message]
+        assert len(sanity_logs) == 1, f"Expected 1 sanity log, got {len(sanity_logs)}: {[r.message for r in sanity_logs]}"
+        log = sanity_logs[0].message
+        # Campos obligatorios grep-friendly (formato key=value)
+        for key in ("region=R3", "sector=isla", "largo=2.05",
+                    "ancho=0.60", "warnings=", "status_before=",
+                    "status_after=", "status_changed_by_sanity="):
+            assert key in log, f"Missing key '{key}' in log: {log}"
+        # Warning específico debe estar en el array
+        assert "isla_largo_inusual" in log
+
+    def test_log_not_emitted_when_no_warnings(self, caplog):
+        """Isla 1.6m normal → no warnings → no log (evitar ruido)."""
+        topology = self._build_topology([
+            {
+                "id": "R_ok",
+                "bbox_rel": {"x": 0.3, "y": 0.4, "w": 0.2, "h": 0.1},
+                "features": {"touches_wall": False, "cooktop_groups": 0},
+            },
+        ])
+        region_results = [{
+            "region_id": "R_ok", "largo_m": 1.60, "ancho_m": 0.60,
+            "confidence": 0.90, "suspicious_reasons": [],
+        }]
+        with caplog.at_level(logging.INFO,
+                             logger="app.modules.quote_engine.multi_crop_reader"):
+            _aggregate(topology, region_results)
+        sanity_logs = [r for r in caplog.records if "[semantic-sanity]" in r.message]
+        assert sanity_logs == []
+
+    def test_log_status_changed_by_sanity_true_when_upgrades_confirmed_to_dudoso(self, caplog):
+        """Si SIN sanity sería CONFIRMADO, y CON sanity es DUDOSO, el log
+        debe decir status_changed_by_sanity=True. Esto es el caso más
+        valioso a rastrear: el sanity SALVÓ a un operador de confirmar
+        un error silencioso."""
+        topology = self._build_topology([
+            {
+                "id": "R_salvado",
+                "bbox_rel": {"x": 0.35, "y": 0.45, "w": 0.25, "h": 0.08},
+                "features": {"touches_wall": False, "cooktop_groups": 0},
+            },
+        ])
+        # Sin suspicious_reasons preexistentes — SIN sanity sería CONFIRMADO.
+        region_results = [{
+            "region_id": "R_salvado", "largo_m": 2.05, "ancho_m": 0.60,
+            "confidence": 0.95, "suspicious_reasons": [],
+        }]
+        with caplog.at_level(logging.INFO,
+                             logger="app.modules.quote_engine.multi_crop_reader"):
+            _aggregate(topology, region_results)
+        sanity_logs = [r for r in caplog.records if "[semantic-sanity]" in r.message]
+        assert len(sanity_logs) == 1
+        log = sanity_logs[0].message
+        assert "status_before=CONFIRMADO" in log
+        assert "status_after=DUDOSO" in log
+        assert "status_changed_by_sanity=True" in log
+
+    def test_log_status_changed_by_sanity_false_when_already_dudoso(self, caplog):
+        """Bernardi real: ya era DUDOSO por suspicious previos del expanded.
+        El sanity agrega otra razón pero no cambia el status. Log muestra
+        status_changed_by_sanity=False para que se distinga."""
+        topology = self._build_topology([
+            {
+                "id": "R3",
+                "bbox_rel": {"x": 0.35, "y": 0.45, "w": 0.25, "h": 0.08},
+                "features": {"touches_wall": False, "cooktop_groups": 0},
+            },
+        ])
+        region_results = [{
+            "region_id": "R3", "largo_m": 2.05, "ancho_m": 0.60,
+            "confidence": 0.65,
+            # Ya había suspicious previos — status_before_sanity=DUDOSO.
+            "suspicious_reasons": ["cotas_mode=expanded → cap confidence 0.65"],
+        }]
+        with caplog.at_level(logging.INFO,
+                             logger="app.modules.quote_engine.multi_crop_reader"):
+            _aggregate(topology, region_results)
+        sanity_logs = [r for r in caplog.records if "[semantic-sanity]" in r.message]
+        assert len(sanity_logs) == 1
+        log = sanity_logs[0].message
+        assert "status_before=DUDOSO" in log
+        assert "status_after=DUDOSO" in log
+        assert "status_changed_by_sanity=False" in log
+
+    def test_log_format_is_grep_friendly(self, caplog):
+        """El formato debe seguir el patrón key=value como [rescue-check]
+        y [context-reconcile] de PRs anteriores. Todos los keys separados
+        por espacio, sin comas ni JSON embebido."""
+        topology = self._build_topology([
+            {
+                "id": "R3",
+                "bbox_rel": {"x": 0.35, "y": 0.45, "w": 0.25, "h": 0.08},
+                "features": {"touches_wall": False, "cooktop_groups": 0},
+            },
+        ])
+        region_results = [{
+            "region_id": "R3", "largo_m": 2.05, "ancho_m": 0.60,
+            "confidence": 0.65, "suspicious_reasons": [],
+        }]
+        with caplog.at_level(logging.INFO,
+                             logger="app.modules.quote_engine.multi_crop_reader"):
+            _aggregate(topology, region_results)
+        log = [r for r in caplog.records if "[semantic-sanity]" in r.message][0].message
+        # Debe arrancar con el tag
+        assert log.startswith("[semantic-sanity] ")
+        # Cada campo key=value separado por espacio
+        expected_keys = [
+            "region=", "sector=", "largo=", "ancho=",
+            "warnings=", "status_before=", "status_after=",
+            "status_changed_by_sanity=",
+        ]
+        for key in expected_keys:
+            assert key in log, f"Missing '{key}' in: {log}"


### PR DESCRIPTION
## Contexto

Post-merge de #349, la corrida real de Bernardi no mostraba en logs que el sanity check se hubiera aplicado. Sospecha inicial: #349 no funciona en runtime.

## Diagnóstico

El sanity check SÍ se aplica en \`_aggregate\`. El problema es que el log de referencia (\`[multi-crop/region-detail]\`) se emite **ANTES** de \`_aggregate\` (línea 2369 vs 2373). Por construcción el log pre-aggregate nunca va a mostrar lógica post-aggregate.

**No hay bug en #349. Hay bug en la observabilidad** (y en el comentario del PR #349 que mentirosamente decía \"propagar al log region-detail\" — ese log ya se emitió).

## Cambios

1. **Nuevo log `[semantic-sanity]`** dentro de \`_aggregate\` cuando el helper devuelve ≥1 warning:

\`\`\`
[semantic-sanity] region=R3 sector=isla largo=2.05 ancho=0.60
  warnings=['isla_largo_inusual_...']
  status_before=DUDOSO status_after=DUDOSO
  status_changed_by_sanity=False
\`\`\`

Formato grep-friendly alineado con \`[rescue-check]\` (#346) y \`[context-reconcile]\` (#347).

2. **Campo `status_changed_by_sanity`** — bool explícito. Distingue:
   - `True`: SIN sanity hubiera sido CONFIRMADO. El sanity **SALVÓ** al operador (métrica directa de ROI).
   - `False`: ya era DUDOSO por suspicious previos. El sanity suma razón pero no cambia status.

3. **Sin ruido**: log solo cuando hay warnings. Regiones normales no emiten nada.

4. **Comentario erróneo del PR #349 corregido**.

## NO cambia

- Heurística del sanity check (igual que #349).
- Thresholds.
- Shape del `r_result` ni del tramo.
- El log `[region-detail]` existente se mantiene donde está.

## Tests (5 nuevos)

- `test_log_emitted_when_sanity_triggers_bernardi_r3`: campos completos.
- `test_log_not_emitted_when_no_warnings`: sin ruido en casos normales.
- `test_log_status_changed_by_sanity_true_when_upgrades_confirmed_to_dudoso`: **caso más valioso** (sanity salvó un confirmado).
- `test_log_status_changed_by_sanity_false_when_already_dudoso`: caso Bernardi real.
- `test_log_format_is_grep_friendly`: formato key=value.

Suite: **1629 passed (+5)**. 16 failed pre-existentes en main.

## Criterio de éxito post-merge

**Corrida de Bernardi debe mostrar en Railway:**

\`\`\`
[semantic-sanity] region=R3 sector=isla largo=2.05 ancho=0.60
  warnings=['isla_largo_inusual_2.05m_threshold_1.80m ...']
  status_before=DUDOSO status_after=DUDOSO
  status_changed_by_sanity=False
\`\`\`

- ✅ Aparece → #349 estaba bien desde el merge. Solo faltaba visibilidad. Frente cerrado.
- ❌ No aparece → hay bug de integración real que debuggeamos con evidencia concreta.

## Test plan

- [x] 5 tests nuevos pasan.
- [x] 22 tests del #349 siguen verdes (no regresión).
- [x] Suite completa sin regresión (1629 vs 1624 baseline).
- [x] `git diff --stat origin/main..HEAD` = 191+/3- en 2 archivos.
- [ ] CI verde.
- [ ] Post-merge: corrida Bernardi real valida si aparece `[semantic-sanity]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)