### PR TITLE
feat(operator-assist): candidatas sugeridas para revisión (PR #355)

### DIFF
--- a/api/app/modules/quote_engine/multi_crop_reader.py
+++ b/api/app/modules/quote_engine/multi_crop_reader.py
@@ -1932,6 +1932,123 @@ def _semantic_sanity_checks(
     return warnings
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# PR #355 — Operator-assist: suggested_candidates
+#
+# Contexto: PR #353 agregó deep expansion (+600px) con cap confidence 0.35.
+# El experimento probó (doc: Plan #348 §8) que deep expansion captura cotas
+# legítimas pero del tramo EQUIVOCADO. El LLM correctamente las rechaza
+# (devuelve null), pero las candidatas quedan enterradas en logs.
+#
+# Este módulo expone esas candidatas al operador vía campo nuevo
+# `suggested_candidates` en el tramo. La UI las renderiza como bloque
+# "Candidatas sugeridas para revisión" (ver mockup PR #355). El click
+# en "Usar/Probar como largo" copia el valor al input SIN confirmar
+# (el tramo queda DUDOSO hasta que el operador confirme).
+#
+# Trigger actual (scope mínimo):
+#   largo_m is None AND
+#   (pool_starved_region=True OR deep_expansion_applied=True) AND
+#   hay candidatas en ranking["length"].
+#
+# Shape EXTENSIBLE para futuros triggers (ej: "tramo con warning fuerte
+# aunque haya valor"). El helper acepta `trigger_override` para abrir
+# el trigger sin cambiar el shape.
+# ─────────────────────────────────────────────────────────────────────────────
+
+_SUGGESTED_CANDIDATES_MAX = 3
+
+
+def _build_suggested_candidates(
+    r_result: dict,
+    ranking: dict,
+    *,
+    trigger_override: bool = False,
+    max_candidates: int = _SUGGESTED_CANDIDATES_MAX,
+) -> list[dict]:
+    """Construye suggested_candidates para el operator-assist UI.
+
+    Expone top-N candidatas del ranking con metadata de origen
+    (`source`, `label`, `origin_desc`, `warning`) para que el frontend
+    pueda renderizarlas con el treatment visual correcto:
+
+    - `source="expanded_rescue"` + `label="mas_probable"`: del rescue
+      normal (+380px). Verde en UI. Texto: "mejor match con el bbox
+      del tramo detectado".
+    - `source="expanded_deep"` + `label="baja_confianza"`: del deep
+      expansion (+680px). Ámbar en UI. Texto: "pool expandido +600px"
+      + warning "posiblemente de tramo vecino".
+
+    Trigger actual (scope PR #355):
+        largo_m is None AND
+        (pool_starved_region OR deep_expansion_applied) AND
+        ranking["length"] no vacío.
+
+    `trigger_override=True` fuerza la exposición ignorando el trigger
+    actual — reservado para futuros casos (ej: exponer candidatas en
+    tramos con warning fuerte aunque tengan valor). No usar en este PR.
+
+    Retorna `[]` si no aplica o no hay candidatas. Lista de dicts
+    ordenada por score desc, top-N.
+    """
+    if not trigger_override:
+        if r_result.get("largo_m") is not None:
+            return []
+        meta = r_result.get("measurement_meta") or {}
+        trigger_ok = bool(
+            meta.get("pool_starved_region")
+            or meta.get("deep_expansion_applied")
+        )
+        if not trigger_ok:
+            return []
+
+    length_ranking = ranking.get("length") or []
+    if not length_ranking:
+        return []
+
+    cotas_mode = r_result.get("_cotas_mode", "")
+    meta = r_result.get("measurement_meta") or {}
+    deep_applied = bool(meta.get("deep_expansion_applied"))
+
+    # Determinar source/label según contexto de medición.
+    # Prioridad: deep_expansion_applied explícito > cotas_mode.
+    if deep_applied or cotas_mode == "expanded_deep":
+        source = "expanded_deep"
+        label = "baja_confianza"
+        origin_desc = "pool expandido +600px"
+        warning = "posiblemente de tramo vecino"
+    elif cotas_mode == "expanded_rescue":
+        source = "expanded_rescue"
+        label = "mas_probable"
+        origin_desc = "mejor match con el bbox del tramo detectado"
+        warning = None
+    else:
+        # Caso raro: pool_starved sin deep ni rescue aplicado. Conservador:
+        # etiquetar como baja confianza para no vender certeza que no hay.
+        source = "expanded_rescue"
+        label = "baja_confianza"
+        origin_desc = "pool del tramo"
+        warning = "medida no confirmada por el modelo — revisar"
+
+    # Top-N por score. El ranking ya viene ordenado desc desde
+    # _rank_cotas_for_region / _rescue_length_ranking.
+    result: list[dict] = []
+    for entry in length_ranking[:max_candidates]:
+        try:
+            valor = float(entry["value"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        result.append({
+            "valor": round(valor, 2),
+            "source": source,
+            "label": label,
+            "origin_desc": origin_desc,
+            "warning": warning,
+            "score": int(entry.get("score", 0)),
+        })
+    return result
+
+
 def _aggregate(
     topology: dict,
     region_results: list[dict],
@@ -2054,6 +2171,15 @@ def _aggregate(
             if contradictions and "a confirmar" not in desc and "revisar" not in desc:
                 desc = f"{desc} — a confirmar"
 
+            # PR #355 — suggested_candidates para operator-assist UI.
+            # Solo se populan cuando el trigger dispara (ver helper).
+            # Array vacío `[]` cuando no aplica (shape estable para el
+            # frontend — nunca None).
+            suggested = _build_suggested_candidates(
+                r_result,
+                r_result.get("_cota_ranking") or {},
+            )
+
             tramo = {
                 "id": rid or f"t{n}",
                 "descripcion": desc,
@@ -2064,6 +2190,7 @@ def _aggregate(
                 "frentin": [],
                 "regrueso": [],
                 "features": region.get("features") or {},
+                "suggested_candidates": suggested,
             }
             if contradictions:
                 tramo["_contradictions"] = contradictions

--- a/api/tests/test_multi_crop_reader.py
+++ b/api/tests/test_multi_crop_reader.py
@@ -20,6 +20,7 @@ from app.modules.quote_engine.multi_crop_reader import (
     _apply_guardrails,
     _bbox_to_px,
     _build_rescue_context,
+    _build_suggested_candidates,
     _call_global_topology,
     _detect_region_brief_contradictions,
     _estimate_plan_scale,
@@ -3839,3 +3840,324 @@ class TestDeepExpansionE2EAggregate:
             a.get("texto") or "" for a in cocina.get("ambiguedades") or []
         )
         assert "deep_expansion" in amb_texts or "REVISAR VISUALMENTE" in amb_texts
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PR #355 — Operator-assist UI: suggested_candidates
+#
+# Backend expone candidatas rescatadas en el tramo para que el frontend
+# las renderice como bloque "Candidatas sugeridas para revisión" con
+# botón "Usar/Probar como largo" que copia el valor al input SIN confirmar.
+#
+# Scope mínimo: trigger = largo_m=null AND (pool_starved OR deep_expansion).
+# Shape extensible (parámetro trigger_override para futuros casos).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestBuildSuggestedCandidates:
+    """Unit tests del helper `_build_suggested_candidates`."""
+
+    # ── Trigger ────────────────────────────────────────────────────────
+
+    def test_largo_not_null_returns_empty(self):
+        """Si largo_m tiene valor, NO se exponen candidatas (operador ya
+        tiene medida, no necesita sugerencias)."""
+        r_result = {
+            "largo_m": 2.05,
+            "ancho_m": 0.60,
+            "measurement_meta": {"pool_starved_region": True},
+        }
+        ranking = {"length": [{"value": 2.35, "score": 50, "bucket": "weak"}]}
+        result = _build_suggested_candidates(r_result, ranking)
+        assert result == []
+
+    def test_neither_pool_starved_nor_deep_returns_empty(self):
+        """Si measurement_meta no tiene pool_starved ni deep_expansion,
+        no se exponen candidatas aunque haya largo=null."""
+        r_result = {
+            "largo_m": None,
+            "measurement_meta": {
+                "pool_starved_region": False,
+                "deep_expansion_applied": False,
+            },
+        }
+        ranking = {"length": [{"value": 2.35, "score": 50, "bucket": "weak"}]}
+        result = _build_suggested_candidates(r_result, ranking)
+        assert result == []
+
+    def test_empty_ranking_returns_empty(self):
+        """pool_starved=True + largo=null + ranking vacío → sin candidatas
+        para mostrar (nada para rescatar)."""
+        r_result = {
+            "largo_m": None,
+            "measurement_meta": {"pool_starved_region": True},
+        }
+        ranking = {"length": []}
+        result = _build_suggested_candidates(r_result, ranking)
+        assert result == []
+
+    def test_trigger_override_bypasses_conditions(self):
+        """trigger_override=True fuerza la exposición (para futuros casos)."""
+        r_result = {
+            "largo_m": 2.05,  # tiene valor
+            "measurement_meta": {},  # sin starved ni deep
+        }
+        ranking = {"length": [{"value": 2.35, "score": 50, "bucket": "weak"}]}
+        result = _build_suggested_candidates(
+            r_result, ranking, trigger_override=True,
+        )
+        assert len(result) == 1
+        assert result[0]["valor"] == 2.35
+
+    # ── Shape y metadata ───────────────────────────────────────────────
+
+    def test_deep_expansion_produces_baja_confianza_label(self):
+        """Cuando deep_expansion_applied=True → label=baja_confianza,
+        warning tramo vecino, origen "pool expandido +600px"."""
+        r_result = {
+            "largo_m": None,
+            "_cotas_mode": "expanded_deep",
+            "measurement_meta": {
+                "deep_expansion_applied": True,
+                "pool_starved_region": False,
+            },
+        }
+        ranking = {"length": [
+            {"value": 2.05, "score": 30, "bucket": "weak"},
+        ]}
+        result = _build_suggested_candidates(r_result, ranking)
+        assert len(result) == 1
+        c = result[0]
+        assert c["valor"] == 2.05
+        assert c["source"] == "expanded_deep"
+        assert c["label"] == "baja_confianza"
+        assert c["origin_desc"] == "pool expandido +600px"
+        assert c["warning"] == "posiblemente de tramo vecino"
+        assert c["score"] == 30
+
+    def test_expanded_rescue_produces_mas_probable_label(self):
+        """Cuando cotas_mode=expanded_rescue (sin deep) → label=mas_probable,
+        sin warning, origen "mejor match con el bbox del tramo detectado"."""
+        r_result = {
+            "largo_m": None,
+            "_cotas_mode": "expanded_rescue",
+            "measurement_meta": {
+                "deep_expansion_applied": False,
+                "pool_starved_region": True,
+            },
+        }
+        ranking = {"length": [
+            {"value": 1.95, "score": 55, "bucket": "weak"},
+        ]}
+        result = _build_suggested_candidates(r_result, ranking)
+        assert len(result) == 1
+        c = result[0]
+        assert c["source"] == "expanded_rescue"
+        assert c["label"] == "mas_probable"
+        assert c["origin_desc"] == "mejor match con el bbox del tramo detectado"
+        assert c["warning"] is None
+
+    # ── Top-N y orden ──────────────────────────────────────────────────
+
+    def test_top_3_preserved_in_score_order(self):
+        """Se exponen las top 3 del ranking (ya viene ordenado desc).
+        Cualquier cantidad mayor se trunca."""
+        r_result = {
+            "largo_m": None,
+            "measurement_meta": {"deep_expansion_applied": True},
+        }
+        # Ranking con 5 entries (pre-ordenado desc por score).
+        ranking = {"length": [
+            {"value": 2.35, "score": 50, "bucket": "weak"},
+            {"value": 2.05, "score": 45, "bucket": "weak"},
+            {"value": 2.75, "score": 40, "bucket": "weak"},
+            {"value": 1.60, "score": 30, "bucket": "unlikely"},
+            {"value": 2.95, "score": 20, "bucket": "unlikely"},
+        ]}
+        result = _build_suggested_candidates(r_result, ranking)
+        assert len(result) == 3
+        assert [c["valor"] for c in result] == [2.35, 2.05, 2.75]
+        assert [c["score"] for c in result] == [50, 45, 40]
+
+    def test_max_candidates_custom_limit(self):
+        """Parámetro max_candidates customizable (1, 2, etc.)."""
+        r_result = {
+            "largo_m": None,
+            "measurement_meta": {"deep_expansion_applied": True},
+        }
+        ranking = {"length": [
+            {"value": 2.35, "score": 50, "bucket": "weak"},
+            {"value": 2.05, "score": 45, "bucket": "weak"},
+        ]}
+        result = _build_suggested_candidates(
+            r_result, ranking, max_candidates=1,
+        )
+        assert len(result) == 1
+        assert result[0]["valor"] == 2.35
+
+    # ── Casos Bernardi reales ──────────────────────────────────────────
+
+    def test_bernardi_r1_deep_expansion_candidates(self):
+        """Caso Bernardi R1 real: deep_expansion_applied, cota 2.05 en el
+        ranking (pescada de tramo vecino según despiece esperado)."""
+        r_result = {
+            "region_id": "R1",
+            "largo_m": None,  # LLM rechazó visualmente
+            "ancho_m": 0.60,
+            "confidence": 0.0,
+            "_cotas_mode": "expanded_deep",
+            "measurement_meta": {
+                "deep_expansion_applied": True,
+                "pool_starved_region": False,
+            },
+        }
+        ranking = {"length": [{"value": 2.05, "score": 35, "bucket": "weak"}]}
+        result = _build_suggested_candidates(r_result, ranking)
+        assert len(result) == 1
+        assert result[0]["valor"] == 2.05
+        assert result[0]["label"] == "baja_confianza"
+        assert result[0]["warning"] == "posiblemente de tramo vecino"
+
+    def test_value_rounding_to_two_decimals(self):
+        """valor se redondea a 2 decimales en el shape del frontend."""
+        r_result = {
+            "largo_m": None,
+            "measurement_meta": {"deep_expansion_applied": True},
+        }
+        ranking = {"length": [
+            {"value": 2.051234, "score": 30, "bucket": "weak"},
+        ]}
+        result = _build_suggested_candidates(r_result, ranking)
+        assert result[0]["valor"] == 2.05
+
+    def test_invalid_value_is_skipped(self):
+        """Si un entry del ranking no tiene 'value' válido, se skipea."""
+        r_result = {
+            "largo_m": None,
+            "measurement_meta": {"deep_expansion_applied": True},
+        }
+        ranking = {"length": [
+            {"score": 30, "bucket": "weak"},  # sin 'value'
+            {"value": "not a number", "score": 25, "bucket": "weak"},  # inválido
+            {"value": 2.35, "score": 20, "bucket": "weak"},  # válido
+        ]}
+        result = _build_suggested_candidates(r_result, ranking)
+        assert len(result) == 1
+        assert result[0]["valor"] == 2.35
+
+
+class TestSuggestedCandidatesE2EAggregate:
+    """E2E: `_aggregate` incluye `suggested_candidates` en el tramo cuando
+    aplica y `[]` cuando no. Contrato estable para el frontend."""
+
+    def _build_topology(self, regions):
+        return {"view_type": "planta", "regions": regions}
+
+    def test_tramo_with_deep_expansion_exposes_candidates(self):
+        topology = self._build_topology([{
+            "id": "R1",
+            "bbox_rel": {"x": 0.2, "y": 0.65, "w": 0.12, "h": 0.05},
+            "features": {"touches_wall": True, "cooktop_groups": 1,
+                         "sink_simple": True},
+        }])
+        region_results = [{
+            "region_id": "R1",
+            "largo_m": None,
+            "ancho_m": 0.60,
+            "confidence": 0.0,
+            "_cotas_mode": "expanded_deep",
+            "measurement_meta": {
+                "deep_expansion_applied": True,
+                "pool_starved_region": False,
+            },
+            "_cota_ranking": {
+                "length": [
+                    {"value": 2.05, "score": 35, "bucket": "weak"},
+                ],
+                "depth": [], "excluded_hard": [],
+                "orientation": "horizontal", "scale_px_per_m": None,
+            },
+            "suspicious_reasons": [],
+        }]
+        result = _aggregate(topology, region_results)
+        cocina = next(s for s in result["sectores"] if s["tipo"] == "cocina")
+        tramo = cocina["tramos"][0]
+
+        assert "suggested_candidates" in tramo
+        assert len(tramo["suggested_candidates"]) == 1
+        c = tramo["suggested_candidates"][0]
+        assert c["valor"] == 2.05
+        assert c["label"] == "baja_confianza"
+
+    def test_tramo_with_valid_measure_has_empty_suggested(self):
+        """Tramo con medida confirmada → suggested_candidates=[]."""
+        topology = self._build_topology([{
+            "id": "R1",
+            "bbox_rel": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.3},
+            "features": {"touches_wall": True, "cooktop_groups": 0},
+        }])
+        region_results = [{
+            "region_id": "R1",
+            "largo_m": 2.0,
+            "ancho_m": 0.6,
+            "confidence": 0.9,
+            "suspicious_reasons": [],
+        }]
+        result = _aggregate(topology, region_results)
+        cocina = next(s for s in result["sectores"] if s["tipo"] == "cocina")
+        tramo = cocina["tramos"][0]
+        assert tramo["suggested_candidates"] == []
+
+    def test_pool_starved_exposes_candidates_if_ranking_has_entries(self):
+        """pool_starved=True + ranking con entries → candidatas expuestas.
+        Caso hipotético: el rescue devolvió items pero el LLM los
+        rechazó y no hubo deep expansion activa."""
+        topology = self._build_topology([{
+            "id": "R1",
+            "bbox_rel": {"x": 0.2, "y": 0.65, "w": 0.12, "h": 0.05},
+            "features": {"touches_wall": True, "cooktop_groups": 0},
+        }])
+        region_results = [{
+            "region_id": "R1",
+            "largo_m": None,
+            "ancho_m": None,
+            "confidence": 0.0,
+            "_cotas_mode": "expanded_rescue",
+            "measurement_meta": {
+                "deep_expansion_applied": False,
+                "pool_starved_region": True,
+            },
+            "_cota_ranking": {
+                "length": [
+                    {"value": 1.95, "score": 55, "bucket": "weak"},
+                ],
+                "depth": [], "excluded_hard": [],
+                "orientation": "horizontal", "scale_px_per_m": None,
+            },
+            "suspicious_reasons": [],
+        }]
+        result = _aggregate(topology, region_results)
+        cocina = next(s for s in result["sectores"] if s["tipo"] == "cocina")
+        tramo = cocina["tramos"][0]
+        assert len(tramo["suggested_candidates"]) == 1
+
+    def test_shape_stable_always_array(self):
+        """Contrato: suggested_candidates es SIEMPRE una lista (nunca None).
+        Facilita el frontend — no tiene que chequear null."""
+        topology = self._build_topology([{
+            "id": "R1",
+            "bbox_rel": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.3},
+            "features": {"touches_wall": True, "cooktop_groups": 0},
+        }])
+        # Region sin measurement_meta, sin ranking — caso edge.
+        region_results = [{
+            "region_id": "R1",
+            "largo_m": 2.0,
+            "ancho_m": 0.6,
+            "confidence": 0.9,
+        }]
+        result = _aggregate(topology, region_results)
+        cocina = next(s for s in result["sectores"] if s["tipo"] == "cocina")
+        tramo = cocina["tramos"][0]
+        assert isinstance(tramo["suggested_candidates"], list)
+        assert tramo["suggested_candidates"] == []

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -1,6 +1,10 @@
 "use client";
 import React, { useState } from "react";
 import CopyButton from "./CopyButton";
+import SuggestedCandidates, {
+  SuggestedCandidate,
+  TramoWithSuggestions,
+} from "./SuggestedCandidates";
 import { dualReadRetry as apiDualReadRetry } from "@/lib/api";
 
 // Helpers:
@@ -60,6 +64,20 @@ const normalizeDualReadData = (raw: DualReadData): DualReadData => {
         }),
         frentin: Array.isArray(t?.frentin) ? t.frentin : [],
         regrueso: Array.isArray(t?.regrueso) ? t.regrueso : [],
+        // PR #355 — normalizar suggested_candidates a lista (shape estable).
+        // Filtramos objetos sin el mínimo shape esperado por el componente.
+        suggested_candidates: Array.isArray(t?.suggested_candidates)
+          ? t.suggested_candidates
+              .filter(
+                (c: unknown): c is SuggestedCandidate =>
+                  typeof c === "object" &&
+                  c !== null &&
+                  typeof (c as SuggestedCandidate).valor === "number" &&
+                  Number.isFinite((c as SuggestedCandidate).valor) &&
+                  ((c as SuggestedCandidate).label === "mas_probable" ||
+                    (c as SuggestedCandidate).label === "baja_confianza"),
+              )
+          : [],
       })),
       ambiguedades: Array.isArray(s?.ambiguedades) ? s.ambiguedades : [],
     })),
@@ -94,6 +112,10 @@ interface Tramo {
   zocalos: Zocalo[];
   frentin: unknown[];
   regrueso: unknown[];
+  // PR #355 — operator-assist. Se popula solo cuando el backend rescató
+  // candidatas del pool pero el LLM las rechazó visualmente (`largo_m=null`).
+  // Array estable — siempre list, nunca null.
+  suggested_candidates?: SuggestedCandidate[];
   _manual?: boolean;
 }
 
@@ -933,6 +955,37 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
           </div>
         );
       })()}
+
+      {/* PR #355 — Candidatas sugeridas para revisión. Aparece solo si
+          algún tramo tiene `suggested_candidates` no vacío (el backend
+          controla el trigger). El click copia el valor al input del
+          largo SIN confirmar — el tramo queda DUDOSO hasta confirmación
+          humana explícita. */}
+      <SuggestedCandidates
+        tramos={editedData.sectores.flatMap<TramoWithSuggestions>(
+          (s, sectorIdx) =>
+            s.tramos
+              .map((t, tramoIdx) => {
+                const cands = t.suggested_candidates || [];
+                if (cands.length === 0) return null;
+                return {
+                  sectorIdx,
+                  tramoIdx,
+                  regionId: t.id,
+                  tramoDescripcion: t.descripcion,
+                  candidates: cands,
+                } satisfies TramoWithSuggestions;
+              })
+              .filter((x): x is TramoWithSuggestions => x !== null),
+        )}
+        onUseAsLargo={(sectorIdx, tramoIdx, valor) => {
+          // Reusa updateField existente — copia el valor + recalcula m².
+          // NO confirma: el status del tramo queda como estaba (DUDOSO
+          // mientras los suspicious_reasons existan). El operador tiene
+          // que confirmar con "Confirmar medidas" después de verificar.
+          updateField(sectorIdx, tramoIdx, "largo_m", valor);
+        }}
+      />
 
       {/* Retry if needed */}
       {data.source !== "DUAL" && !data._retry && (

--- a/web/src/components/chat/SuggestedCandidates.tsx
+++ b/web/src/components/chat/SuggestedCandidates.tsx
@@ -1,0 +1,159 @@
+"use client";
+// PR #355 — Operator-assist: candidatas sugeridas para revisión.
+//
+// Bloque que aparece cuando el backend recuperó candidatas del pool
+// (rescue normal o deep expansion) pero el LLM las rechazó visualmente
+// y dejó `largo_m=null`. Mostramos al operador las opciones para que
+// decida con el plano delante.
+//
+// Contrato:
+// - El click en "Usar/Probar como largo" SOLO copia el valor al input
+//   del largo del tramo. NO confirma, NO cambia status. El tramo queda
+//   DUDOSO hasta que el operador confirme explícitamente.
+// - El componente no renderiza nada si no hay tramos con candidatas.
+import React from "react";
+
+export interface SuggestedCandidate {
+  valor: number;
+  source: string;                 // "expanded_rescue" | "expanded_deep"
+  label: "mas_probable" | "baja_confianza";
+  origin_desc: string;
+  warning: string | null;
+  score: number;
+}
+
+export interface TramoWithSuggestions {
+  sectorIdx: number;
+  tramoIdx: number;
+  regionId: string;
+  tramoDescripcion: string;
+  candidates: SuggestedCandidate[];
+}
+
+interface Props {
+  tramos: TramoWithSuggestions[];
+  onUseAsLargo: (sectorIdx: number, tramoIdx: number, valor: number) => void;
+}
+
+type LabelMeta = {
+  badge: string;
+  badgeClass: string;
+  buttonText: string;
+  buttonClass: string;
+};
+
+const LABEL_META: Record<"mas_probable" | "baja_confianza", LabelMeta> = {
+  mas_probable: {
+    badge: "MÁS PROBABLE",
+    // Verde tenue. Diseño V3 no tiene una variable verde en el index, usamos
+    // tailwind green-400 con background sutil.
+    badgeClass:
+      "bg-[rgba(52,211,153,0.12)] text-[#34d399] border-[rgba(52,211,153,0.25)]",
+    buttonText: "Usar como largo",
+    // Primary — destaca como acción confiada.
+    buttonClass:
+      "bg-acc-bg border border-acc/40 text-acc hover:bg-[rgba(166,197,255,0.22)]",
+  },
+  baja_confianza: {
+    badge: "BAJA CONFIANZA",
+    badgeClass: "bg-amb-bg text-amb border-amb/30",
+    buttonText: "Probar como largo",
+    // Outlined — destaca que es tentativo, operador tiene que revisar.
+    buttonClass:
+      "border border-b1 text-t1 hover:bg-[rgba(255,255,255,0.04)]",
+  },
+};
+
+const subtitleFor = (candidates: SuggestedCandidate[]): string => {
+  const n = candidates.length;
+  if (n === 0) return "";
+  if (n === 1) {
+    return candidates[0].label === "baja_confianza"
+      ? "1 candidata · baja confianza"
+      : "1 candidata";
+  }
+  return `${n} candidatas`;
+};
+
+const formatMeters = (v: number): string =>
+  // Usamos coma decimal (es-AR) para consistencia con el resto del UI.
+  v.toFixed(2).replace(".", ",");
+
+export default function SuggestedCandidates({
+  tramos,
+  onUseAsLargo,
+}: Props) {
+  if (tramos.length === 0) return null;
+
+  return (
+    <div
+      className="mx-5 mb-4 p-4 rounded-xl border border-b1 bg-[rgba(255,255,255,0.02)]"
+      data-testid="suggested-candidates-block"
+    >
+      <h4 className="text-[11px] font-semibold uppercase tracking-[0.1em] text-acc mb-1">
+        Candidatas sugeridas para revisión
+      </h4>
+      <p className="text-[12px] italic text-t3 mb-4 leading-[1.4]">
+        Revisá antes de aplicar. Las opciones con menor confianza requieren
+        verificación visual en el plano.
+      </p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {tramos.map((t) => (
+          <div
+            key={`${t.sectorIdx}-${t.tramoIdx}`}
+            className="p-3.5 rounded-xl border border-b1 bg-[rgba(255,255,255,0.015)]"
+          >
+            <div className="text-[13px] text-t1 font-medium">
+              Región {t.regionId} · {t.tramoDescripcion}
+            </div>
+            <div className="text-[11px] text-t3 mb-3">
+              {subtitleFor(t.candidates)}
+            </div>
+            <div className="flex flex-col gap-3.5">
+              {t.candidates.map((c, i) => {
+                const meta = LABEL_META[c.label] ?? LABEL_META.baja_confianza;
+                const isLast = i === t.candidates.length - 1;
+                return (
+                  <div
+                    key={i}
+                    className={`flex flex-col gap-1.5 ${
+                      isLast ? "" : "pb-3 border-b border-b1"
+                    }`}
+                  >
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-[18px] font-semibold text-t1">
+                        {formatMeters(c.valor)} m
+                      </span>
+                      <span
+                        className={`px-2 py-0.5 rounded-md border text-[10px] font-semibold uppercase tracking-wide ${meta.badgeClass}`}
+                      >
+                        {meta.badge}
+                      </span>
+                    </div>
+                    <div className="text-[12px] text-t2">{c.origin_desc}</div>
+                    {c.warning && (
+                      <div className="text-[11px] text-amb flex items-start gap-1.5">
+                        <span aria-hidden>⚠</span>
+                        <span>{c.warning}</span>
+                      </div>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() =>
+                        onUseAsLargo(t.sectorIdx, t.tramoIdx, c.valor)
+                      }
+                      className={`self-start mt-1 px-3 py-1.5 rounded-md text-[12px] font-medium transition ${meta.buttonClass}`}
+                    >
+                      {meta.buttonText}
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Cierre del frente reencuadrado en ADR #348 §8

Deep expansion (PR #353) identifica candidatas reales del plano pero del tramo equivocado. El LLM correctamente las rechaza visualmente, dejando largo=null. Las candidatas quedaban enterradas en logs.

**Este PR las expone al operador** como bloque "Candidatas sugeridas para revisión". El click copia el valor al input **sin confirmar** — el tramo queda DUDOSO hasta confirmación humana explícita.

## Diseño

Mockup aprobado:

- **Trigger:** `largo_m=null` AND (`deep_expansion_applied` OR `pool_starved_region`) AND hay candidatas en el ranking.
- **Top 3** por score.
- **Badges:**
  - Verde "MÁS PROBABLE" (rescue normal, +380px) → botón primary "Usar como largo".
  - Ámbar "BAJA CONFIANZA" (deep +600px) → botón outlined "Probar como largo" + warning "posiblemente de tramo vecino".
- **Subtítulo dinámico:** "1 candidata" / "1 candidata · baja confianza" / "N candidatas".
- **Comportamiento del click:** mismo en ambos botones — copia valor, recalcula m², **no toca status ni suspicious**.

## Backend

`_build_suggested_candidates(r_result, ranking, *, trigger_override, max_candidates)`:

- Shape extensible via `trigger_override` para futuros casos.
- Top-N por score.
- Cada candidata: `{valor, source, label, origin_desc, warning, score}`.
- Integrado en `_aggregate` → tramo incluye `suggested_candidates: list` (array estable, nunca null).

## Frontend

Nuevo `SuggestedCandidates.tsx` + integración en `DualReadResult.tsx`:

- Grid 2 columnas desktop / 1 mobile.
- Tailwind consistente con design tokens V3 del codebase.
- Handler del click reusa `updateField` existente — preserva status DUDOSO.
- `normalizeDualReadData` filtra shape inválido (defensivo).

## Contrato del PR (garantías)

1. `suggested_candidates` siempre lista — nunca null.
2. Click NO confirma ni cambia status. Sistema sigue siendo fail-loud.
3. Solo visible con largo=null — no distrae cuando ya hay medida.
4. Shape backend estable para futuros triggers.

## NO toca

- Lógica de medición (rescue/deep intactos).
- Confirmación de medidas.
- topology-cache, brief_analyzer, aggregator en otras partes.

## Tests

**Backend (15 nuevos):**
- TestBuildSuggestedCandidates (11): trigger, shape, orden, Bernardi real, defensivos.
- TestSuggestedCandidatesE2EAggregate (4): integración con `_aggregate`, shape estable.

**Frontend:**
- `tsc --noEmit` ✓
- `eslint` ✓ sin warnings
- `npm run build` ✓ exitoso

**Suite backend: 1670 passed (+15)**. 16 failed pre-existentes.

## Impacto en Bernardi real post-merge

Nuevo bloque arriba de "Las medidas no coinciden":

\`\`\`
┌─────────────────────────────────────────┐
│ CANDIDATAS SUGERIDAS PARA REVISIÓN      │
│                                         │
│ Región R1 · Mesada con anafe, pileta   │
│   1 candidata · baja confianza          │
│   2,05 m  [BAJA CONFIANZA]              │
│   pool expandido +600px                 │
│   ⚠ posiblemente de tramo vecino        │
│   [Probar como largo]                   │
│                                         │
│ Región R2 · Mesada 2                    │
│   1 candidata · baja confianza          │
│   2,95 m  [BAJA CONFIANZA]              │
│   pool expandido +600px                 │
│   ⚠ posiblemente de tramo vecino        │
│   [Probar como largo]                   │
└─────────────────────────────────────────┘
\`\`\`

Operador revisa con el plano delante:
- Candidata correcta → click → copia al input → confirma.
- Candidata de tramo vecino → ignora → edita manual → confirma.

**Cierra el ciclo Plan #348 §8:** de "auto-fill fallido" a "operator-assist efectivo".

## Test plan

- [x] 15 tests backend pasan.
- [x] Suite backend sin regresión (1670 vs 1655).
- [x] Frontend: tsc + eslint + next build ✓.
- [x] `git diff --stat origin/main..HEAD` = 661+ en 4 archivos (backend + frontend).
- [ ] CI verde.
- [ ] Post-merge: Bernardi real muestra el bloque con candidatas + click funciona.

🤖 Generated with [Claude Code](https://claude.com/claude-code)