### PR TITLE
feat(ui): preseleccionar primera opción de pending_questions (PR #356)

### DIFF
--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -401,10 +401,26 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
   const [retrying, setRetrying] = useState(false);
   const [retryError, setRetryError] = useState<string | null>(null);
   const [editedData, setEditedData] = useState<DualReadData>(() => normalizeDualReadData(data));
-  // Respuestas a pending_questions — se arman a medida que el operador
-  // selecciona opciones. Confirmar se bloquea hasta que todas tengan valor.
-  const [pendingAnswers, setPendingAnswers] = useState<Record<string, PendingAnswer>>({});
+  // Respuestas a pending_questions.
+  // PR #356 — pre-cargamos la primera opción "concreta" (no custom) de
+  // cada pregunta como default. Rationale: la primera opción que manda
+  // el backend es típicamente la más común (0.60m estándar residencial,
+  // "Sí frontal + laterales", 0.90m piso-mesada). Menos fricción
+  // operativa. El operador puede cambiar cualquiera antes de confirmar.
+  // `custom` se skippea porque requiere input adicional (detail);
+  // elegirlo automáticamente daría `allQuestionsAnswered=true` sin que
+  // el operador haya escrito el detail, lo cual es mentira.
   const pendingQuestions = data.pending_questions || [];
+  const [pendingAnswers, setPendingAnswers] = useState<Record<string, PendingAnswer>>(() => {
+    const initial: Record<string, PendingAnswer> = {};
+    pendingQuestions.forEach((q) => {
+      const firstConcrete = (q.options || []).find((o) => o.value !== "custom");
+      if (firstConcrete) {
+        initial[q.id] = { id: q.id, value: firstConcrete.value };
+      }
+    });
+    return initial;
+  });
   const allQuestionsAnswered = pendingQuestions.every(q => pendingAnswers[q.id]?.value);
 
   const handleRetry = async () => {


### PR DESCRIPTION
## Feedback operativo

El operador reportó que las preguntas bloqueantes de la card aparecían sin opción marcada por default, obligándolo a clickear cada una. Las primeras opciones son típicamente las más comunes:

- profundidad isla → 0.60 m (estándar)
- patas → frontal + ambos laterales
- alto patas → 0.90 m (piso-mesada)
- alzada → No lleva / similar

## Fix

Inicializar \`pendingAnswers\` con la primera opción "concreta" (no \`custom\`) de cada pregunta.

\`\`\`typescript
const [pendingAnswers, setPendingAnswers] = useState<Record<string, PendingAnswer>>(() => {
  const initial: Record<string, PendingAnswer> = {};
  pendingQuestions.forEach((q) => {
    const firstConcrete = (q.options || []).find((o) => o.value !== "custom");
    if (firstConcrete) {
      initial[q.id] = { id: q.id, value: firstConcrete.value };
    }
  });
  return initial;
});
\`\`\`

## Por qué skip de \`custom\`

\`value=\"custom\"\` requiere input de texto adicional (\`detail\`). Preseleccionarlo haría \`allQuestionsAnswered=true\` sin detalle completado — mentira. La búsqueda es \"primera que NO sea custom\".

Hoy todas las preguntas tienen custom al final como fallback, así que siempre se preselecciona una opción concreta.

## Contrato asumido

El backend ordena las options de más común → menos común. La primera es el default razonable. Si en el futuro una pregunta nueva tiene otro orden, se ordena en el backend, no en el frontend.

## NO cambia

- Backend.
- Lógica de \`allQuestionsAnswered\` (sigue chequeando \`value\` truthy).
- Shape de tipos.
- Handlers onChange (siguen funcionando cuando el operador clickea otra).
- \"Confirmar medidas\" button — ahora queda enabled desde el arranque (consistente: con defaults razonables se puede confirmar directo).

## Validación local

- \`tsc --noEmit\` ✓
- \`eslint\` ✓

## Test plan

- [x] Build local pasa.
- [x] \`git diff --stat origin/main..HEAD\` = 19+/3- en 1 archivo.
- [ ] CI verde.
- [ ] Post-merge: corrida nueva de Bernardi muestra las 4 preguntas con primera opción marcada. Operador puede confirmar sin tocar nada si los defaults aplican, o cambiar las que no.

🤖 Generated with [Claude Code](https://claude.com/claude-code)