### PR TITLE
fix(ui): wiring del apply-flow de candidatas sugeridas + input controlado (PR #357)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -30,7 +30,8 @@
       },
       "devDependencies": {
         "eslint": "^8.57.1",
-        "eslint-config-next": "^14.2.35"
+        "eslint-config-next": "^14.2.35",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -189,6 +190,397 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -644,6 +1036,356 @@
         "node": ">=14"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -684,6 +1426,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -1346,6 +2095,119 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1614,6 +2476,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -1801,6 +2673,16 @@
         "node": ">=10.16.0"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -1890,6 +2772,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1905,6 +2804,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2137,6 +3046,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2358,6 +3277,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -2416,6 +3342,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/escalade": {
@@ -2908,6 +3873,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2916,6 +3891,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4177,6 +5162,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -4191,6 +5183,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4721,6 +5723,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5161,6 +6180,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5409,6 +6473,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5435,6 +6506,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5834,6 +6919,20 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5877,6 +6976,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -6152,6 +7281,155 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -6261,6 +7539,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.2",
@@ -31,6 +33,7 @@
   },
   "devDependencies": {
     "eslint": "^8.57.1",
-    "eslint-config-next": "^14.2.35"
+    "eslint-config-next": "^14.2.35",
+    "vitest": "^2.1.9"
   }
 }

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -5,6 +5,7 @@ import SuggestedCandidates, {
   SuggestedCandidate,
   TramoWithSuggestions,
 } from "./SuggestedCandidates";
+import { applyCandidate } from "@/lib/applyCandidate";
 import { dualReadRetry as apiDualReadRetry } from "@/lib/api";
 
 // Helpers:
@@ -277,7 +278,10 @@ function EditableNumber({
   dblClickEdit = false,
 }: {
   field: FieldValue;
-  onEdit: (v: number) => void;
+  /** PR #357 — ahora acepta `null` para cuando el input queda vacío.
+   *  Antes usábamos `|| 0` que metía un 0 falso cuando el operador
+   *  borraba el valor. El caller maneja null como "sin medida". */
+  onEdit: (v: number | null) => void;
   forceEditable?: boolean;
   /** Si true, el campo arranca como label read-only; doble-click entra en
    *  edit mode. Enter/blur commit (solo si valor válido), Esc cancela. */
@@ -300,18 +304,37 @@ function EditableNumber({
     : "";
 
   // Modo "siempre input" (legacy / manual / CONFLICTO / DUDOSO / UNANCHORED).
-  // defaultValue undefined para valor null → input arranca vacío, el operador
-  // lo completa. Si pusiéramos 0 quedaría un "0.00" que mentiría como medida.
+  //
+  // PR #357 — input CONTROLADO (`value`, no `defaultValue`). Antes usábamos
+  // `defaultValue` (uncontrolled) y eso causaba que cambios externos al
+  // state (ej: click en "Probar como largo" de una candidata sugerida) NO
+  // se reflejaran visualmente en el input — React no re-sincroniza
+  // uncontrolled inputs con props cambiantes. Consecuencia operativa: el
+  // operador clickeaba el botón, el state se actualizaba correctamente,
+  // pero el input seguía vacío y parecía que "el botón no hacía nada".
+  //
+  // Controlled fix:
+  // - `value={field.valor ?? ""}` refleja el state actual siempre.
+  // - onChange pasa `null` cuando el input queda vacío (no `0` — "0" es
+  //   mentira para medidas, "null" es "sin medida").
   if (alwaysEditable) {
     return (
       <input
         type="number"
         step="0.01"
-        defaultValue={field.valor ?? undefined}
+        value={field.valor ?? ""}
         placeholder={field.valor == null ? MISSING : undefined}
         title={reconcileTip || "Valor reconciliado"}
         className="w-16 px-1.5 py-0.5 bg-s1 border border-b2 rounded text-[11px] text-t1 text-right font-mono hover:border-b1/60 focus:border-acc/50 outline-none"
-        onChange={(e) => onEdit(parseFloat(e.target.value) || 0)}
+        onChange={(e) => {
+          const raw = e.target.value;
+          if (raw === "") {
+            onEdit(null);
+            return;
+          }
+          const parsed = parseFloat(raw);
+          onEdit(Number.isFinite(parsed) ? parsed : null);
+        }}
       />
     );
   }
@@ -444,7 +467,14 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
     }
   };
 
-  const updateField = (sectorIdx: number, tramoIdx: number, field: string, val: number) => {
+  // PR #357 — `val` ahora acepta `null` (el input vacío antes se
+  // forzaba a 0 vía `|| 0` que era mentira; ver EditableNumber).
+  const updateField = (
+    sectorIdx: number,
+    tramoIdx: number,
+    field: string,
+    val: number | null,
+  ) => {
     setEditedData((prev) => {
       const next = JSON.parse(JSON.stringify(prev));
       const tramo = next.sectores[sectorIdx].tramos[tramoIdx];
@@ -454,12 +484,16 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
       } else {
         tramo[field].valor = val;
         // Al editar largo o ancho, recalcular m² determinísticamente.
-        // m² queda como valor derivado — no dejamos inconsistencia
-        // largo×ancho≠m² pasar al confirm.
+        // m² queda como valor derivado. Si alguno es null → m² null
+        // (no mentir con 0.00 cuando falta medida).
         if (field === "largo_m" || field === "ancho_m") {
-          const largo = tramo.largo_m.valor || 0;
-          const ancho = tramo.ancho_m.valor || 0;
-          tramo.m2.valor = Math.round(largo * ancho * 100) / 100;
+          const largo = tramo.largo_m.valor;
+          const ancho = tramo.ancho_m.valor;
+          if (typeof largo === "number" && typeof ancho === "number") {
+            tramo.m2.valor = Math.round(largo * ancho * 100) / 100;
+          } else {
+            tramo.m2.valor = null;
+          }
         }
       }
       return next;
@@ -972,34 +1006,40 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
         );
       })()}
 
-      {/* PR #355 — Candidatas sugeridas para revisión. Aparece solo si
-          algún tramo tiene `suggested_candidates` no vacío (el backend
-          controla el trigger). El click copia el valor al input del
-          largo SIN confirmar — el tramo queda DUDOSO hasta confirmación
-          humana explícita. */}
+      {/* PR #355 + #357 — Candidatas sugeridas para revisión. Aparece
+          solo si algún tramo tiene `suggested_candidates` no vacío (el
+          backend controla el trigger). El click aplica el valor al tramo
+          cuyo id === regionId (binding estable, no por índice) vía el
+          helper puro `applyCandidate` de lib/. El tramo queda DUDOSO;
+          el operador confirma explícitamente con "Confirmar medidas". */}
       <SuggestedCandidates
-        tramos={editedData.sectores.flatMap<TramoWithSuggestions>(
-          (s, sectorIdx) =>
-            s.tramos
-              .map((t, tramoIdx) => {
-                const cands = t.suggested_candidates || [];
-                if (cands.length === 0) return null;
-                return {
-                  sectorIdx,
-                  tramoIdx,
-                  regionId: t.id,
-                  tramoDescripcion: t.descripcion,
-                  candidates: cands,
-                } satisfies TramoWithSuggestions;
-              })
-              .filter((x): x is TramoWithSuggestions => x !== null),
+        tramos={editedData.sectores.flatMap<TramoWithSuggestions>((s) =>
+          s.tramos
+            .map((t) => {
+              const cands = t.suggested_candidates || [];
+              if (cands.length === 0) return null;
+              return {
+                regionId: t.id,
+                tramoDescripcion: t.descripcion,
+                candidates: cands,
+              } satisfies TramoWithSuggestions;
+            })
+            .filter((x): x is TramoWithSuggestions => x !== null),
         )}
-        onUseAsLargo={(sectorIdx, tramoIdx, valor) => {
-          // Reusa updateField existente — copia el valor + recalcula m².
-          // NO confirma: el status del tramo queda como estaba (DUDOSO
-          // mientras los suspicious_reasons existan). El operador tiene
-          // que confirmar con "Confirmar medidas" después de verificar.
-          updateField(sectorIdx, tramoIdx, "largo_m", valor);
+        onApply={(regionId, valor) => {
+          setEditedData((prev) => {
+            const result = applyCandidate(prev, regionId, valor);
+            // Logs temporales de verificación (regla 6 del user).
+            // Útiles en prod para confirmar que el regionId del botón
+            // resuelve al tramo correcto y que ningún otro cambia.
+            // eslint-disable-next-line no-console
+            console.log("[candidate-apply]", {
+              regionId,
+              valor,
+              ...result.meta,
+            });
+            return result.state;
+          });
         }}
       />
 

--- a/web/src/components/chat/SuggestedCandidates.tsx
+++ b/web/src/components/chat/SuggestedCandidates.tsx
@@ -23,8 +23,10 @@ export interface SuggestedCandidate {
 }
 
 export interface TramoWithSuggestions {
-  sectorIdx: number;
-  tramoIdx: number;
+  // PR #357 — binding estable por `regionId` (tramo.id del backend).
+  // Antes usábamos (sectorIdx, tramoIdx) que dependía del orden del
+  // flatMap y podía mapear mal al tramo equivocado. regionId es único
+  // cross-sector (R1, R2, R3 del topology) y no depende del render.
   regionId: string;
   tramoDescripcion: string;
   candidates: SuggestedCandidate[];
@@ -32,7 +34,10 @@ export interface TramoWithSuggestions {
 
 interface Props {
   tramos: TramoWithSuggestions[];
-  onUseAsLargo: (sectorIdx: number, tramoIdx: number, valor: number) => void;
+  /** Aplica la candidata al tramo cuyo `id === regionId`. El handler
+   *  en el caller es responsable de resolver regionId → tramo y
+   *  ejecutar la mutación (ver `applyCandidate()` en lib/). */
+  onApply: (regionId: string, valor: number) => void;
 }
 
 type LabelMeta = {
@@ -81,7 +86,7 @@ const formatMeters = (v: number): string =>
 
 export default function SuggestedCandidates({
   tramos,
-  onUseAsLargo,
+  onApply,
 }: Props) {
   if (tramos.length === 0) return null;
 
@@ -101,8 +106,9 @@ export default function SuggestedCandidates({
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         {tramos.map((t) => (
           <div
-            key={`${t.sectorIdx}-${t.tramoIdx}`}
+            key={t.regionId}
             className="p-3.5 rounded-xl border border-b1 bg-[rgba(255,255,255,0.015)]"
+            data-testid={`suggested-card-${t.regionId}`}
           >
             <div className="text-[13px] text-t1 font-medium">
               Región {t.regionId} · {t.tramoDescripcion}
@@ -114,6 +120,13 @@ export default function SuggestedCandidates({
               {t.candidates.map((c, i) => {
                 const meta = LABEL_META[c.label] ?? LABEL_META.baja_confianza;
                 const isLast = i === t.candidates.length - 1;
+                // PR #357 — closure estable sobre regionId y valor de
+                // ESTA iteración. Aunque React normalmente lo hace bien,
+                // lo capturamos explícito en variables locales para
+                // evitar cualquier ambigüedad de scope si el componente
+                // se refactoriza en el futuro.
+                const regionIdForClick = t.regionId;
+                const valorForClick = c.valor;
                 return (
                   <div
                     key={i}
@@ -140,10 +153,9 @@ export default function SuggestedCandidates({
                     )}
                     <button
                       type="button"
-                      onClick={() =>
-                        onUseAsLargo(t.sectorIdx, t.tramoIdx, c.valor)
-                      }
-                      className={`self-start mt-1 px-3 py-1.5 rounded-md text-[12px] font-medium transition ${meta.buttonClass}`}
+                      onClick={() => onApply(regionIdForClick, valorForClick)}
+                      className={`self-start mt-1 px-3 py-1.5 rounded-md text-[12px] font-medium cursor-pointer transition-colors ${meta.buttonClass}`}
+                      data-testid={`apply-${t.regionId}-${c.valor}`}
                     >
                       {meta.buttonText}
                     </button>

--- a/web/src/lib/applyCandidate.test.ts
+++ b/web/src/lib/applyCandidate.test.ts
@@ -1,0 +1,347 @@
+/**
+ * PR #357 — Tests de `applyCandidate`.
+ *
+ * Cubren las 7 reglas que pidió el user para cerrar el fix del apply-flow:
+ * 1. Binding por ID estable (click en R1 → R1; click en R2 → R2).
+ * 2. Ancho default 0.60 en cocina/isla/lavadero cuando null.
+ * 3. NO completar ancho en baño.
+ * 4. NO sobrescribir ancho si ya tenía valor.
+ * 5. Status DUDOSO en largo/ancho/m².
+ * 6. Total m² se recalcula bien.
+ * 7. Otros tramos/sectores no se tocan.
+ */
+import { describe, it, expect } from "vitest";
+import { applyCandidate, StateLike } from "./applyCandidate";
+
+/** Mock state con shape Bernardi realista: 2 sectores, 3 tramos. */
+function makeBernardiState(): StateLike {
+  return {
+    sectores: [
+      {
+        id: "sector_cocina",
+        tipo: "cocina",
+        tramos: [
+          {
+            id: "R1",
+            largo_m: { valor: null, status: "DUDOSO" },
+            ancho_m: { valor: null, status: "DUDOSO" },
+            m2: { valor: null, status: "DUDOSO" },
+          },
+          {
+            id: "R2",
+            largo_m: { valor: null, status: "DUDOSO" },
+            ancho_m: { valor: null, status: "DUDOSO" },
+            m2: { valor: null, status: "DUDOSO" },
+          },
+        ],
+      },
+      {
+        id: "sector_isla",
+        tipo: "isla",
+        tramos: [
+          {
+            id: "R3",
+            largo_m: { valor: 2.05, status: "CONFIRMADO" },
+            ancho_m: { valor: 0.6, status: "CONFIRMADO" },
+            m2: { valor: 1.23, status: "CONFIRMADO" },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("applyCandidate — binding por ID estable (reglas 1, 5 de la spec)", () => {
+  it("click en candidata R1 modifica SOLO R1, no toca R2 ni R3", () => {
+    const state = makeBernardiState();
+    const result = applyCandidate(state, "R1", 2.35);
+
+    // R1 fue el target — tiene el valor nuevo.
+    const r1 = result.state.sectores[0].tramos[0];
+    expect(r1.id).toBe("R1");
+    expect(r1.largo_m.valor).toBe(2.35);
+
+    // R2 intacto (sigue null como antes).
+    const r2 = result.state.sectores[0].tramos[1];
+    expect(r2.id).toBe("R2");
+    expect(r2.largo_m.valor).toBeNull();
+    expect(r2.ancho_m.valor).toBeNull();
+
+    // R3 (sector isla) intacto — su 2.05 original.
+    const r3 = result.state.sectores[1].tramos[0];
+    expect(r3.id).toBe("R3");
+    expect(r3.largo_m.valor).toBe(2.05);
+    expect(r3.ancho_m.valor).toBe(0.6);
+    expect(r3.largo_m.status).toBe("CONFIRMADO");
+  });
+
+  it("click en candidata R2 modifica SOLO R2, no toca R1 ni R3", () => {
+    const state = makeBernardiState();
+    const result = applyCandidate(state, "R2", 2.95);
+
+    const r1 = result.state.sectores[0].tramos[0];
+    expect(r1.largo_m.valor).toBeNull(); // R1 sigue null
+
+    const r2 = result.state.sectores[0].tramos[1];
+    expect(r2.largo_m.valor).toBe(2.95); // R2 recibió el valor
+
+    const r3 = result.state.sectores[1].tramos[0];
+    expect(r3.largo_m.valor).toBe(2.05); // R3 intacto
+  });
+
+  it("click en candidata R3 modifica SOLO R3 (tramo en sector no-primero)", () => {
+    const state = makeBernardiState();
+    // Caso edge: R3 ya tenía valor, ahora se lo reemplazan con una candidata.
+    const result = applyCandidate(state, "R3", 1.6);
+
+    const r3 = result.state.sectores[1].tramos[0];
+    expect(r3.largo_m.valor).toBe(1.6);
+    // Ancho sigue 0.6 (no se sobrescribe porque ya tenía valor).
+    expect(r3.ancho_m.valor).toBe(0.6);
+    // Status pasa a DUDOSO aunque antes era CONFIRMADO.
+    expect(r3.largo_m.status).toBe("DUDOSO");
+    expect(r3.ancho_m.status).toBe("DUDOSO");
+
+    // R1 y R2 intactos.
+    expect(result.state.sectores[0].tramos[0].largo_m.valor).toBeNull();
+    expect(result.state.sectores[0].tramos[1].largo_m.valor).toBeNull();
+  });
+});
+
+describe("applyCandidate — ancho default (reglas 2, 3, 4 de la spec)", () => {
+  it("completa ancho 0.60 en cocina cuando ancho era null", () => {
+    const state = makeBernardiState();
+    const result = applyCandidate(state, "R1", 2.35);
+
+    const r1 = result.state.sectores[0].tramos[0];
+    expect(r1.ancho_m.valor).toBe(0.6);
+    expect(result.meta.anchoAutocompletado).toBe(true);
+  });
+
+  it("completa ancho 0.60 en isla cuando ancho era null", () => {
+    const state: StateLike = {
+      sectores: [
+        {
+          id: "sector_isla",
+          tipo: "isla",
+          tramos: [
+            {
+              id: "R_isla",
+              largo_m: { valor: null, status: "DUDOSO" },
+              ancho_m: { valor: null, status: "DUDOSO" },
+              m2: { valor: null, status: "DUDOSO" },
+            },
+          ],
+        },
+      ],
+    };
+    const result = applyCandidate(state, "R_isla", 1.6);
+    expect(result.state.sectores[0].tramos[0].ancho_m.valor).toBe(0.6);
+    expect(result.meta.anchoAutocompletado).toBe(true);
+  });
+
+  it("completa ancho 0.60 en lavadero cuando ancho era null", () => {
+    const state: StateLike = {
+      sectores: [
+        {
+          id: "sector_lavadero",
+          tipo: "lavadero",
+          tramos: [
+            {
+              id: "R_lav",
+              largo_m: { valor: null, status: "DUDOSO" },
+              ancho_m: { valor: null, status: "DUDOSO" },
+              m2: { valor: null, status: "DUDOSO" },
+            },
+          ],
+        },
+      ],
+    };
+    const result = applyCandidate(state, "R_lav", 1.8);
+    expect(result.state.sectores[0].tramos[0].ancho_m.valor).toBe(0.6);
+  });
+
+  it("NO completa ancho en baño (regla 3)", () => {
+    const state: StateLike = {
+      sectores: [
+        {
+          id: "sector_banio",
+          tipo: "baño",
+          tramos: [
+            {
+              id: "R_banio",
+              largo_m: { valor: null, status: "DUDOSO" },
+              ancho_m: { valor: null, status: "DUDOSO" },
+              m2: { valor: null, status: "DUDOSO" },
+            },
+          ],
+        },
+      ],
+    };
+    const result = applyCandidate(state, "R_banio", 1.2);
+    expect(result.state.sectores[0].tramos[0].ancho_m.valor).toBeNull();
+    expect(result.meta.anchoAutocompletado).toBe(false);
+  });
+
+  it("NO sobrescribe ancho si ya tenía valor (regla 4)", () => {
+    const state: StateLike = {
+      sectores: [
+        {
+          id: "sector_cocina",
+          tipo: "cocina",
+          tramos: [
+            {
+              id: "R_con_ancho",
+              largo_m: { valor: null, status: "DUDOSO" },
+              ancho_m: { valor: 0.7, status: "CONFIRMADO" }, // ya tenía 0.7
+              m2: { valor: null, status: "DUDOSO" },
+            },
+          ],
+        },
+      ],
+    };
+    const result = applyCandidate(state, "R_con_ancho", 2.0);
+    // Ancho sigue en 0.7, NO se sobreescribe.
+    expect(result.state.sectores[0].tramos[0].ancho_m.valor).toBe(0.7);
+    expect(result.meta.anchoAutocompletado).toBe(false);
+  });
+
+  it("normaliza tipo de sector (trim + lowercase)", () => {
+    const state: StateLike = {
+      sectores: [
+        {
+          id: "sector_cocina",
+          tipo: "  COCINA  ", // variación de casing + espacios
+          tramos: [
+            {
+              id: "R1",
+              largo_m: { valor: null, status: "DUDOSO" },
+              ancho_m: { valor: null, status: "DUDOSO" },
+              m2: { valor: null, status: "DUDOSO" },
+            },
+          ],
+        },
+      ],
+    };
+    const result = applyCandidate(state, "R1", 2.35);
+    expect(result.state.sectores[0].tramos[0].ancho_m.valor).toBe(0.6);
+  });
+});
+
+describe("applyCandidate — status DUDOSO (regla 5)", () => {
+  it("setea status DUDOSO en largo, ancho y m² del tramo target", () => {
+    const state = makeBernardiState();
+    const result = applyCandidate(state, "R3", 1.8); // R3 era CONFIRMADO
+
+    const r3 = result.state.sectores[1].tramos[0];
+    expect(r3.largo_m.status).toBe("DUDOSO");
+    expect(r3.ancho_m.status).toBe("DUDOSO");
+    expect(r3.m2.status).toBe("DUDOSO");
+  });
+
+  it("NO toca status de otros tramos al aplicar en un target", () => {
+    const state = makeBernardiState();
+    const result = applyCandidate(state, "R1", 2.35);
+
+    // R3 que era CONFIRMADO sigue CONFIRMADO.
+    const r3 = result.state.sectores[1].tramos[0];
+    expect(r3.largo_m.status).toBe("CONFIRMADO");
+    expect(r3.ancho_m.status).toBe("CONFIRMADO");
+    expect(r3.m2.status).toBe("CONFIRMADO");
+  });
+});
+
+describe("applyCandidate — recálculo de m² (regla 6)", () => {
+  it("recalcula m² cuando largo y ancho son números", () => {
+    const state = makeBernardiState();
+    const result = applyCandidate(state, "R1", 2.35);
+
+    const r1 = result.state.sectores[0].tramos[0];
+    expect(r1.largo_m.valor).toBe(2.35);
+    expect(r1.ancho_m.valor).toBe(0.6);
+    expect(r1.m2.valor).toBe(1.41); // 2.35 × 0.6 = 1.41
+  });
+
+  it("m² queda null si ancho no pudo completarse (baño sin ancho previo)", () => {
+    const state: StateLike = {
+      sectores: [
+        {
+          id: "sector_banio",
+          tipo: "baño",
+          tramos: [
+            {
+              id: "R_banio",
+              largo_m: { valor: null, status: "DUDOSO" },
+              ancho_m: { valor: null, status: "DUDOSO" },
+              m2: { valor: null, status: "DUDOSO" },
+            },
+          ],
+        },
+      ],
+    };
+    const result = applyCandidate(state, "R_banio", 1.2);
+    const tramo = result.state.sectores[0].tramos[0];
+    expect(tramo.largo_m.valor).toBe(1.2);
+    expect(tramo.ancho_m.valor).toBeNull();
+    expect(tramo.m2.valor).toBeNull();
+  });
+
+  it("redondea m² a 2 decimales", () => {
+    const state: StateLike = {
+      sectores: [
+        {
+          id: "sector_cocina",
+          tipo: "cocina",
+          tramos: [
+            {
+              id: "R1",
+              largo_m: { valor: null, status: "DUDOSO" },
+              ancho_m: { valor: 0.625, status: "DUDOSO" },
+              m2: { valor: null, status: "DUDOSO" },
+            },
+          ],
+        },
+      ],
+    };
+    const result = applyCandidate(state, "R1", 2.3333);
+    // 2.3333 × 0.625 = 1.4583... → redondeado 1.46
+    expect(result.state.sectores[0].tramos[0].m2.valor).toBe(1.46);
+  });
+});
+
+describe("applyCandidate — defensivo (regla implícita: fail-soft)", () => {
+  it("regionId no existe → no muta el state", () => {
+    const state = makeBernardiState();
+    const result = applyCandidate(state, "R99_inexistente", 2.35);
+
+    expect(result.meta.found).toBe(false);
+    // Estado devuelto es el mismo (por referencia) — no se hizo clone.
+    expect(result.state).toBe(state);
+  });
+
+  it("no muta el state original cuando encuentra el target", () => {
+    const state = makeBernardiState();
+    const before = JSON.stringify(state);
+    applyCandidate(state, "R1", 2.35);
+
+    // El state original no cambió — applyCandidate hace deep clone.
+    expect(JSON.stringify(state)).toBe(before);
+  });
+});
+
+describe("applyCandidate — meta de diagnóstico (regla 6 del user: logs)", () => {
+  it("meta contiene before/after y target IDs para logs", () => {
+    const state = makeBernardiState();
+    const result = applyCandidate(state, "R1", 2.35);
+
+    expect(result.meta.found).toBe(true);
+    expect(result.meta.targetSectorId).toBe("sector_cocina");
+    expect(result.meta.targetSectorTipo).toBe("cocina");
+    expect(result.meta.targetTramoId).toBe("R1");
+    expect(result.meta.beforeLargo).toBeNull();
+    expect(result.meta.beforeAncho).toBeNull();
+    expect(result.meta.afterLargo).toBe(2.35);
+    expect(result.meta.afterAncho).toBe(0.6);
+    expect(result.meta.anchoAutocompletado).toBe(true);
+  });
+});

--- a/web/src/lib/applyCandidate.ts
+++ b/web/src/lib/applyCandidate.ts
@@ -1,0 +1,155 @@
+/**
+ * PR #357 — applyCandidate: función PURA que aplica una candidata sugerida
+ * al tramo correspondiente.
+ *
+ * Reglas (del user, tarea #357):
+ * 1. Escribe el largo del tramo cuyo `id` === `regionId`. Nunca escribe en
+ *    otro tramo. Binding estable por ID, no por índice de posición.
+ * 2. Si el tramo destino tiene `ancho_m.valor === null` Y sector es
+ *    "cocina" | "isla" | "lavadero" → completa con 0.60 (default residencial).
+ *    NO toca ancho en baño. NO sobrescribe ancho si ya tenía valor.
+ * 3. Marca el tramo como DUDOSO explícitamente: `largo_m.status`,
+ *    `ancho_m.status`, `m2.status` = "DUDOSO".
+ * 4. Recalcula m² con el nuevo largo × ancho.
+ * 5. No toca otros tramos ni otros sectores.
+ * 6. Si no encuentra el tramo (regionId inválido), devuelve el estado sin
+ *    cambios — fail loud sería tirar error, fail soft es no mutar.
+ *
+ * Diseño: función pura `(state, regionId, valor) => nextState`. Facilita
+ * tests sin DOM y mantiene `setEditedData(prev => applyCandidate(prev, ...))`.
+ */
+
+const ANCHO_DEFAULT_RESIDENCIAL = 0.6;
+const SECTOR_CON_ANCHO_DEFAULT = new Set(["cocina", "isla", "lavadero"]);
+
+/** Tipo minimalista que refleja lo que `applyCandidate` necesita. Usado en
+ *  tests para no tener que importar todo el shape de DualReadResult. El
+ *  caller real pasa su `DualReadData` directamente — TypeScript valida
+ *  estructural compatibility (sin index signatures para permitir tipos
+ *  concretos del caller con más campos). */
+export interface FieldLike {
+  valor: number | null;
+  status: string;
+  opus?: number | null;
+  sonnet?: number | null;
+}
+
+export interface TramoLike {
+  id: string;
+  largo_m: FieldLike;
+  ancho_m: FieldLike;
+  m2: FieldLike;
+}
+
+export interface SectorLike {
+  id: string;
+  tipo: string;
+  tramos: TramoLike[];
+}
+
+export interface StateLike {
+  sectores: SectorLike[];
+}
+
+export interface ApplyCandidateResult<S> {
+  state: S;
+  meta: {
+    found: boolean;
+    targetSectorId?: string;
+    targetSectorTipo?: string;
+    targetTramoId?: string;
+    beforeLargo?: number | null;
+    beforeAncho?: number | null;
+    afterLargo: number | null;
+    afterAncho: number | null;
+    anchoAutocompletado: boolean;
+  };
+}
+
+export function applyCandidate<S extends StateLike>(
+  state: S,
+  regionId: string,
+  valor: number,
+): ApplyCandidateResult<S> {
+  // Deep clone para no mutar el state que viene del caller (React quiere
+  // referencias nuevas para detectar cambios de renderizado).
+  const next: S = JSON.parse(JSON.stringify(state));
+
+  // Buscar el tramo por id estable — NO por índice.
+  let targetSectorIdx = -1;
+  let targetTramoIdx = -1;
+  for (let si = 0; si < next.sectores.length; si++) {
+    const sector = next.sectores[si];
+    for (let ti = 0; ti < sector.tramos.length; ti++) {
+      if (sector.tramos[ti].id === regionId) {
+        targetSectorIdx = si;
+        targetTramoIdx = ti;
+        break;
+      }
+    }
+    if (targetSectorIdx !== -1) break;
+  }
+
+  if (targetSectorIdx === -1) {
+    // regionId no existe — no mutamos. El caller ve `meta.found=false`
+    // y puede decidir qué hacer (log error, toast, etc).
+    return {
+      state,
+      meta: {
+        found: false,
+        afterLargo: null,
+        afterAncho: null,
+        anchoAutocompletado: false,
+      },
+    };
+  }
+
+  const sector = next.sectores[targetSectorIdx];
+  const tramo = sector.tramos[targetTramoIdx];
+  const beforeLargo = tramo.largo_m.valor;
+  const beforeAncho = tramo.ancho_m.valor;
+
+  // 1. Escribir largo + marcar DUDOSO.
+  tramo.largo_m.valor = valor;
+  tramo.largo_m.status = "DUDOSO";
+
+  // 2. Ancho default si aplica: null + cocina/isla/lavadero → 0.60.
+  //    NO sobrescribe si ya tenía valor. NO aplica en baño.
+  let anchoAutocompletado = false;
+  if (tramo.ancho_m.valor === null) {
+    const sectorTipoLc = (sector.tipo || "").toLowerCase().trim();
+    if (SECTOR_CON_ANCHO_DEFAULT.has(sectorTipoLc)) {
+      tramo.ancho_m.valor = ANCHO_DEFAULT_RESIDENCIAL;
+      anchoAutocompletado = true;
+    }
+  }
+  // Status del ancho pasa a DUDOSO siempre (el tramo entero entra en
+  // revisión manual).
+  tramo.ancho_m.status = "DUDOSO";
+
+  // 3. Recalcular m² determinísticamente (consistente con updateField
+  //    existente). null si alguno sigue null.
+  const largo = tramo.largo_m.valor;
+  const ancho = tramo.ancho_m.valor;
+  if (typeof largo === "number" && typeof ancho === "number") {
+    tramo.m2.valor = Math.round(largo * ancho * 100) / 100;
+  } else {
+    tramo.m2.valor = null;
+  }
+  tramo.m2.status = "DUDOSO";
+
+  return {
+    state: next,
+    meta: {
+      found: true,
+      targetSectorId: sector.id,
+      targetSectorTipo: sector.tipo,
+      targetTramoId: tramo.id,
+      beforeLargo,
+      beforeAncho,
+      afterLargo: tramo.largo_m.valor,
+      afterAncho: tramo.ancho_m.valor,
+      anchoAutocompletado,
+    },
+  };
+}

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,25 @@
+/// <reference types="vitest" />
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+/**
+ * PR #357 — Vitest setup mínimo para tests de lógica pura.
+ *
+ * Scope intencionalmente chico: sin jsdom, sin React Testing Library.
+ * Los tests apuntan a helpers puros (ej: `applyCandidate`) que no
+ * necesitan DOM. Si en el futuro se quieren tests de componente,
+ * agregar `test.environment: "jsdom"` + `@testing-library/react`.
+ */
+export default defineConfig({
+  test: {
+    // Por default vitest usa `node` environment → sin DOM, más rápido.
+    include: ["src/**/*.test.ts"],
+  },
+  resolve: {
+    alias: {
+      // Mismo alias que tsconfig.json para que `@/lib/...` funcione
+      // dentro de los tests.
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+});


### PR DESCRIPTION
## Bug reportado

Post-#355, el botón "Probar como largo" no hacía nada visible. Operador clickeaba y el input del tramo quedaba vacío. Interpretación razonable del síntoma: "botón no dispara" o "wiring escribe en tramo equivocado".

## Causa raíz (distinta al síntoma)

`EditableNumber` usaba **`defaultValue`** (uncontrolled input) en vez de `value`. React solo lee `defaultValue` UNA vez en el mount — cambios externos al state (click en candidata → `setEditedData`) no se reflejan en el DOM del input, que mantiene su propio state interno.

**El click SÍ actualizaba el state correctamente**, pero era invisible para el operador.

## Fix (en el orden que pidió el user)

1. **Input controlado en `EditableNumber`**: `value={field.valor ?? ""}` + soporte `null` en `onEdit` (no forzar `0` cuando el input queda vacío — 0 es mentira para medidas).
2. **Binding estable por `regionId`** — helper puro `applyCandidate(state, regionId, valor)` en `src/lib/applyCandidate.ts`. Busca por `tramo.id` en todos los sectores, no por índice de posición.
3. **Ancho default 0.60** en cocina/isla/lavadero cuando era `null`. Nunca en baño. Nunca sobrescribe si ya había valor.
4. **Status DUDOSO** explícito en largo/ancho/m² del tramo target al aplicar.
5. **Logs temporales** `[candidate-apply]` con regionId, target resuelto, before/after para verificar en prod.
6. **Tests (17)** en `src/lib/applyCandidate.test.ts` cubriendo todos los casos.

## Tests agregados (17 verdes)

**Binding por ID (3):** click R1/R2/R3 modifica SOLO ese tramo.
**Ancho default (6):** cocina/isla/lavadero completan 0.60, baño no, ancho preexistente no se sobreescribe, normalización de tipo con casing.
**Status DUDOSO (2):** los 3 campos del tramo target pasan a DUDOSO, otros tramos mantienen su status.
**Recálculo m² (3):** redondeo, null-safe, decimales complejos.
**Defensivo (2):** regionId inexistente → no muta (fail-soft), state original no se muta.
**Meta de diagnóstico (1):** payload completo para logs.

## Setup de testing

Vitest mínimo (sin jsdom, sin RTL). Scripts `npm test` + `npm run test:watch`. Unit tests de lógica pura. Extensible si después se agregan tests de componente.

## Validación local

- `tsc --noEmit` ✓ sin errores.
- `eslint src/` ✓ sin errores nuevos (7 warnings preexistentes ajenos al PR).
- `next build` ✓ exitoso.
- `npm test` ✓ 17/17 tests pasan.

## NO toca

- Backend (deep_expansion, ranking, suggested_candidates).
- Calidad semántica de las candidatas (frente aparte, documentado ADR #348 §8).
- Confirmación de medidas.
- Aggregator ni otras partes del pipeline.

## Criterio de aceptación (según user)

- ✅ Click en card de Región RN → valor aparece VISUALMENTE en el input del tramo RN.
- ✅ Ningún otro tramo se toca (binding estable por ID).
- ✅ Ancho 0.60 se completa cuando aplica.
- ✅ Tramo queda DUDOSO.
- ✅ Total recalcula correctamente.
- ✅ Tests cubren los casos.

## Verificación esperada post-merge

Corrida de Bernardi, click en candidata R1 (2,05) →
- Mesada 1 (R1) recibe: largo 2,05, ancho 0,60, m² 1,23.
- Status DUDOSO visible.
- R2 y R3 no cambian.
- Consola: `[candidate-apply] {regionId: "R1", valor: 2.05, found: true, targetSectorId: "sector_cocina", targetTramoId: "R1", beforeLargo: null, afterLargo: 2.05, afterAncho: 0.6, anchoAutocompletado: true}`.

## Separation of concerns explícita

Este PR arregla el **wiring**. La **calidad semántica** de las candidatas (que en Bernardi trae 2,05 y 2,95 que son cotas ajenas) queda como otro frente, ya documentado como no resoluble automáticamente en ADR #348 §8. El operador ve las candidatas con el plano delante y decide.

## Test plan

- [x] 17 tests unit pasan.
- [x] tsc + eslint + build limpios.
- [x] `git diff --stat origin/main..HEAD` = 2266+/389- en 7 archivos.
- [ ] CI verde.
- [ ] Post-merge: corrida Bernardi real con click en candidata muestra valor en el tramo correcto + ancho 0.60 + DUDOSO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)