### PR TITLE
fix(quote): Alzada render corto sin leyenda TRAMOS

### DIFF
--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -426,10 +426,15 @@ def list_pieces(pieces: list, is_edificio: bool = False) -> dict:
             or desc_lower.startswith("zocalo")
             or desc_lower.startswith("zoc ")
         )
+        # Alzada: render simple "L × D Alzada" — sin detalle del operador
+        # ni leyenda TRAMOS. Las alzadas no se parten en 2 tramos como mesadas.
+        is_alzada = desc_lower.startswith("alzada")
         qty = pd.get("quantity", 1)
 
         if is_zocalo:
             label = f"{pd['largo']:.2f}ML X {pd['dim2']:.2f} ZOC"
+        elif is_alzada:
+            label = f"{pd['largo']:.2f} × {pd['dim2']:.2f} Alzada"
         elif pd.get("_is_frentin"):
             # Faldón/frentín: solo se contabiliza como MO (armado × ml).
             # NO sumar m² al material. Render con ml para que el operador
@@ -987,8 +992,14 @@ def calculate_quote(input_data: dict) -> dict:
                 or desc_lower.startswith("zocalo")
                 or desc_lower.startswith("zoc ")
             )
+            # Alzada: formato simple "L × D Alzada" — descarta detalle del
+            # operador (ej: "corrida (fondo completo sin heladera)") y la
+            # leyenda TRAMOS. Las alzadas no se listan como mesadas partidas.
+            is_alzada = desc_lower.startswith("alzada")
             if is_zocalo:
                 label = f'{pd["largo"]:.2f}ML X {pd["dim2"]:.2f} ZOC'
+            elif is_alzada:
+                label = f'{pd["largo"]:.2f} × {pd["dim2"]:.2f} Alzada'
             else:
                 dim2_label = f'{pd["largo"]:.2f} × {pd["dim2"]:.2f}'
                 # PR #48 — strip defensivo: si Valentina metió las dimensiones

--- a/api/tests/test_five_fixes.py
+++ b/api/tests/test_five_fixes.py
@@ -88,6 +88,43 @@ class TestZocaloFormat:
         assert not any("2 TRAMOS" in p["label"] for p in res_edif["pieces"])
 
 
+class TestAlzadaFormat:
+    def test_alzada_renders_short_label(self):
+        """Alzada description must collapse to '{largo} × {dim2} Alzada' — the
+        operator's extra detail (ej: 'corrida (fondo completo sin heladera)')
+        debe descartarse en el render del presupuesto."""
+        result = calculate_quote(_base_input(
+            pieces=[
+                {"description": "Mesada", "largo": 2.0, "prof": 0.6},
+                {"description": "Alzada corrida (fondo completo sin heladera)",
+                 "largo": 3.01, "prof": 0.60},
+            ]
+        ))
+        assert result["ok"]
+        labels = result["sectors"][0]["pieces"]
+        alzada = next((l for l in labels if "Alzada" in l), None)
+        assert alzada is not None, f"expected Alzada row, got {labels}"
+        assert alzada.rstrip(" *") == "3.01 × 0.60 Alzada", (
+            f"Alzada label debe ser '3.01 × 0.60 Alzada', got: {alzada!r}"
+        )
+        assert "fondo completo" not in alzada
+        assert "2 TRAMOS" not in alzada
+
+    def test_alzada_no_2_tramos_even_over_3m(self):
+        """Alzada largo ≥ 3m NO debe recibir la leyenda '(SE REALIZA EN 2 TRAMOS)'."""
+        result = calculate_quote(_base_input(
+            pieces=[
+                {"description": "Mesada", "largo": 2.0, "prof": 0.6},
+                {"description": "Alzada", "largo": 3.50, "prof": 0.60},
+            ]
+        ))
+        assert result["ok"]
+        labels = result["sectors"][0]["pieces"]
+        alzada = next((l for l in labels if "Alzada" in l), None)
+        assert alzada is not None
+        assert "2 TRAMOS" not in alzada
+
+
 # ── Fix 2: Delivery days tiers ──────────────────────────────────────────────
 
 class TestDeliveryTiers:


### PR DESCRIPTION
## Summary
- **Antes:** `3.01 × 0.60 Alzada corrida (fondo completo sin heladera) (SE REALIZA EN 2 TRAMOS)`
- **Ahora:** `3.01 × 0.60 Alzada`
- El detalle del operador y la leyenda _2 TRAMOS_ aplican a mesadas, no a alzadas. Mismo tratamiento que los zócalos, tanto en `list_pieces` como al construir los `sectors` del presupuesto.

## Test plan
- [x] `test_alzada_renders_short_label` — valida el formato exacto y que se descarta el detalle extra
- [x] `test_alzada_no_2_tramos_even_over_3m` — alzada ≥ 3m no recibe la leyenda
- [x] Regresión completa del calculator/list_pieces/excel/document (114 tests passed)
- [ ] Verificar en quote `5f8ae69e-8bce-43fa-84dc-31e0042a6f8c` regenerando PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)