### PR TITLE
fix(regenerate): normalizar Alzadas en sectors cacheados

### DIFF
--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 from typing import Optional, List
 import json
 import logging
+import re
 import uuid
 
 logger = logging.getLogger(__name__)
@@ -469,6 +470,49 @@ async def validate_quote(
 #   - Solo actualiza las URLs de archivos (pdf_url, excel_url, drive_url,
 #     drive_file_id) y appendea un entry a change_history para auditoría.
 
+_ALZADA_LABEL_RE = re.compile(
+    r"^(?P<dim>\d+[.,]\d+\s*[×xX]\s*\d+[.,]\d+)\s+Alzada\b.*$",
+    re.IGNORECASE,
+)
+
+
+def _normalize_piece_labels(sectors: list) -> list:
+    """Rewrite cached piece labels so that Alzadas render as '{L} × {D} Alzada'.
+
+    /regenerate no recalcula — usa el `quote_breakdown.sectors` guardado. Los
+    quotes viejos tienen labels tipo "3.01 × 0.60 Alzada corrida (fondo
+    completo sin heladera) (SE REALIZA EN 2 TRAMOS)" que quedaron pegados.
+    Acá los colapsamos in-memory sin tocar la DB. Preserva sufijos ' *' del
+    override de m² (ver calculator.py).
+    """
+    if not isinstance(sectors, list):
+        return sectors
+    out = []
+    for sec in sectors:
+        if not isinstance(sec, dict):
+            out.append(sec)
+            continue
+        pieces = sec.get("pieces")
+        if not isinstance(pieces, list):
+            out.append(sec)
+            continue
+        new_pieces = []
+        for p in pieces:
+            if isinstance(p, str):
+                base, star = (p[:-2], " *") if p.rstrip().endswith(" *") else (p, "")
+                m = _ALZADA_LABEL_RE.match(base.strip())
+                if m:
+                    new_pieces.append(f"{m.group('dim')} Alzada{star}")
+                else:
+                    new_pieces.append(p)
+            else:
+                new_pieces.append(p)
+        new_sec = dict(sec)
+        new_sec["pieces"] = new_pieces
+        out.append(new_sec)
+    return out
+
+
 def _build_regenerate_doc_data(quote: Quote, bd: dict) -> dict:
     """Prep doc_data for /regenerate: start from the cached breakdown and
     override the fields that the operator can edit manually (no recalc).
@@ -489,6 +533,7 @@ def _build_regenerate_doc_data(quote: Quote, bd: dict) -> dict:
     doc_data.setdefault("discount_pct", 0)
     doc_data.setdefault("sectors", [])
     doc_data.setdefault("mo_items", [])
+    doc_data["sectors"] = _normalize_piece_labels(doc_data["sectors"])
     return doc_data
 
 

--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -426,10 +426,15 @@ def list_pieces(pieces: list, is_edificio: bool = False) -> dict:
             or desc_lower.startswith("zocalo")
             or desc_lower.startswith("zoc ")
         )
+        # Alzada: render simple "L × D Alzada" — sin detalle del operador
+        # ni leyenda TRAMOS. Las alzadas no se parten en 2 tramos como mesadas.
+        is_alzada = desc_lower.startswith("alzada")
         qty = pd.get("quantity", 1)
 
         if is_zocalo:
             label = f"{pd['largo']:.2f}ML X {pd['dim2']:.2f} ZOC"
+        elif is_alzada:
+            label = f"{pd['largo']:.2f} × {pd['dim2']:.2f} Alzada"
         elif pd.get("_is_frentin"):
             # Faldón/frentín: solo se contabiliza como MO (armado × ml).
             # NO sumar m² al material. Render con ml para que el operador
@@ -987,8 +992,14 @@ def calculate_quote(input_data: dict) -> dict:
                 or desc_lower.startswith("zocalo")
                 or desc_lower.startswith("zoc ")
             )
+            # Alzada: formato simple "L × D Alzada" — descarta detalle del
+            # operador (ej: "corrida (fondo completo sin heladera)") y la
+            # leyenda TRAMOS. Las alzadas no se listan como mesadas partidas.
+            is_alzada = desc_lower.startswith("alzada")
             if is_zocalo:
                 label = f'{pd["largo"]:.2f}ML X {pd["dim2"]:.2f} ZOC'
+            elif is_alzada:
+                label = f'{pd["largo"]:.2f} × {pd["dim2"]:.2f} Alzada'
             else:
                 dim2_label = f'{pd["largo"]:.2f} × {pd["dim2"]:.2f}'
                 # PR #48 — strip defensivo: si Valentina metió las dimensiones

--- a/api/tests/test_five_fixes.py
+++ b/api/tests/test_five_fixes.py
@@ -88,6 +88,43 @@ class TestZocaloFormat:
         assert not any("2 TRAMOS" in p["label"] for p in res_edif["pieces"])
 
 
+class TestAlzadaFormat:
+    def test_alzada_renders_short_label(self):
+        """Alzada description must collapse to '{largo} × {dim2} Alzada' — the
+        operator's extra detail (ej: 'corrida (fondo completo sin heladera)')
+        debe descartarse en el render del presupuesto."""
+        result = calculate_quote(_base_input(
+            pieces=[
+                {"description": "Mesada", "largo": 2.0, "prof": 0.6},
+                {"description": "Alzada corrida (fondo completo sin heladera)",
+                 "largo": 3.01, "prof": 0.60},
+            ]
+        ))
+        assert result["ok"]
+        labels = result["sectors"][0]["pieces"]
+        alzada = next((l for l in labels if "Alzada" in l), None)
+        assert alzada is not None, f"expected Alzada row, got {labels}"
+        assert alzada.rstrip(" *") == "3.01 × 0.60 Alzada", (
+            f"Alzada label debe ser '3.01 × 0.60 Alzada', got: {alzada!r}"
+        )
+        assert "fondo completo" not in alzada
+        assert "2 TRAMOS" not in alzada
+
+    def test_alzada_no_2_tramos_even_over_3m(self):
+        """Alzada largo ≥ 3m NO debe recibir la leyenda '(SE REALIZA EN 2 TRAMOS)'."""
+        result = calculate_quote(_base_input(
+            pieces=[
+                {"description": "Mesada", "largo": 2.0, "prof": 0.6},
+                {"description": "Alzada", "largo": 3.50, "prof": 0.60},
+            ]
+        ))
+        assert result["ok"]
+        labels = result["sectors"][0]["pieces"]
+        alzada = next((l for l in labels if "Alzada" in l), None)
+        assert alzada is not None
+        assert "2 TRAMOS" not in alzada
+
+
 # ── Fix 2: Delivery days tiers ──────────────────────────────────────────────
 
 class TestDeliveryTiers:

--- a/api/tests/test_router.py
+++ b/api/tests/test_router.py
@@ -447,6 +447,49 @@ class TestRegenerateDocDataBuild:
         assert data["sectors"] == []
         assert data["mo_items"] == []
 
+    def test_normalize_alzada_labels_in_cached_sectors(self):
+        """Quotes viejos tienen Alzadas con detalle + leyenda TRAMOS pegados
+        en el label cacheado. Regenerate debe colapsarlos a '{L} × {D} Alzada'
+        sin modificar mesadas ni otros labels."""
+        from app.modules.agent.router import _build_regenerate_doc_data
+        from app.models.quote import Quote
+
+        quote = Quote(id="q1", client_name="X", project="Y", notes=None)
+        bd = {
+            "sectors": [{
+                "label": "Cocina",
+                "pieces": [
+                    "0.38 × 0.60 Placa tramo izquierdo",
+                    "2.03 × 0.60 Placa tramo derecho",
+                    "3.01 × 0.60 Alzada corrida (fondo completo sin heladera) (SE REALIZA EN 2 TRAMOS)",
+                    "4.10 × 0.65 Mesada tramo 1 (SE REALIZA EN 2 TRAMOS)",
+                ],
+            }],
+        }
+
+        data = _build_regenerate_doc_data(quote, bd)
+        pieces = data["sectors"][0]["pieces"]
+        assert pieces[0] == "0.38 × 0.60 Placa tramo izquierdo"
+        assert pieces[1] == "2.03 × 0.60 Placa tramo derecho"
+        assert pieces[2] == "3.01 × 0.60 Alzada"
+        # Mesadas no se tocan — la leyenda 2 TRAMOS es válida para mesadas
+        assert pieces[3] == "4.10 × 0.65 Mesada tramo 1 (SE REALIZA EN 2 TRAMOS)"
+
+    def test_normalize_preserves_override_star_on_alzada(self):
+        """Si el label tenía sufijo ' *' (override de m²), debe preservarse."""
+        from app.modules.agent.router import _build_regenerate_doc_data
+        from app.models.quote import Quote
+
+        quote = Quote(id="q1", client_name="X", project="Y", notes=None)
+        bd = {
+            "sectors": [{
+                "label": "Cocina",
+                "pieces": ["3.01 × 0.60 Alzada corrida (SE REALIZA EN 2 TRAMOS) *"],
+            }],
+        }
+        data = _build_regenerate_doc_data(quote, bd)
+        assert data["sectors"][0]["pieces"][0] == "3.01 × 0.60 Alzada *"
+
 
 # ── X-API-Key auth fallback ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Complemento de [#359](https://github.com/javi10823/ia-agent-quote-marble-operator/pull/359). Ese PR arregla `calculate_quote()` pero `/regenerate` **no recalcula** — lee `quote_breakdown.sectors` guardado. Los presupuestos viejos seguían regenerando el PDF con el label largo.
- Este PR agrega `_normalize_piece_labels()` que colapsa Alzadas al vuelo en `_build_regenerate_doc_data()`: `"3.01 × 0.60 Alzada corrida (...) (SE REALIZA EN 2 TRAMOS)"` → `"3.01 × 0.60 Alzada"`.
- Preserva el sufijo `*` del override de m². Mesadas y demás labels no se tocan.

## Test plan
- [x] `test_normalize_alzada_labels_in_cached_sectors` — colapso de Alzada sin tocar otros labels
- [x] `test_normalize_preserves_override_star_on_alzada` — sufijo `*` se mantiene
- [x] Tests existentes de `_build_regenerate_doc_data` siguen pasando
- [x] Regresión router + calculator (115 tests)
- [ ] Regenerar PDF del quote `5f8ae69e-8bce-43fa-84dc-31e0042a6f8c` post-deploy y verificar

🤖 Generated with [Claude Code](https://claude.com/claude-code)