### PR TITLE
fix(alzada): colapsar en Paso 2 + contar aparte en Dual Read

### DIFF
--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -1171,7 +1171,13 @@ def build_deterministic_paso2(calc: dict) -> str:
     for p in pieces:
         if p.get("_is_frentin"):
             continue
-        desc = p.get("description", "")
+        desc = p.get("description", "") or ""
+        # Alzadas: colapsar a "Alzada" — el detalle del operador
+        # (ej: "corrida (fondo completo sin heladera)") agrega ruido en la
+        # tabla de Paso 2 y es inconsistente con el label del PDF (PR #359).
+        # Mesadas/placas mantienen su descripción completa.
+        if desc.lower().lstrip().startswith("alzada"):
+            desc = "Alzada"
         largo = p.get("largo", 0)
         dim2 = p.get("dim2", p.get("prof", 0))
         qty = p.get("quantity", 1) or 1

--- a/api/tests/test_seven_fixes.py
+++ b/api/tests/test_seven_fixes.py
@@ -208,6 +208,33 @@ class TestDeterministicPaso2:
         assert "5%" in paso2
         assert "DESCUENTO" in paso2
 
+    def test_paso2_alzada_description_collapsed(self):
+        """Alzada en Paso 2 debe renderizarse como 'Alzada' — sin el detalle
+        del operador (ej: 'corrida (fondo completo sin heladera)'). Consistente
+        con el PDF (PR #359) y con el Dual Read del frontend."""
+        from app.modules.quote_engine.calculator import calculate_quote, build_deterministic_paso2
+        result = calculate_quote({
+            "client_name": "Luciana Villagra", "project": "Cocina",
+            "material": "Blanco Nube", "catalog": "materials-purastone", "sku": "BLANCO_NUBE",
+            "pieces": [
+                {"largo": 2.03, "prof": 0.60, "description": "Placa tramo derecho"},
+                {"largo": 3.01, "prof": 0.60,
+                 "description": "Alzada corrida (fondo completo sin heladera)"},
+            ],
+            "localidad": "Rosario", "colocacion": True,
+            "pileta": "empotrada_cliente",
+            "plazo": "30 dias",
+        })
+        assert result["ok"]
+        paso2 = build_deterministic_paso2(result)
+        # El detalle extra del operador NO debe aparecer en la tabla
+        assert "fondo completo sin heladera" not in paso2
+        assert "corrida" not in paso2
+        # La fila de Alzada existe con el nombre colapsado
+        assert "| Alzada |" in paso2
+        # Las placas mantienen su descripción completa
+        assert "| Placa tramo derecho |" in paso2
+
     def test_paso2_delivery_matches_config(self):
         """Paso 2 delivery days must match what calculator returns."""
         from app.modules.quote_engine.calculator import calculate_quote, build_deterministic_paso2

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -646,12 +646,15 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
   // Totals
   let mesadasM2 = 0;
   let zocalosM2 = 0;
-  let piecesCount = 0;
+  let mesadasCount = 0;
+  let alzadasCount = 0;
   let zocalosCount = 0;
   editedData.sectores.forEach((s) =>
     s.tramos.forEach((t) => {
       mesadasM2 += safeNum(t.m2?.valor);
-      piecesCount += 1;
+      const isAlzada = (t.descripcion || "").toLowerCase().trimStart().startsWith("alzada");
+      if (isAlzada) alzadasCount += 1;
+      else mesadasCount += 1;
       t.zocalos.forEach((z) => {
         const ml = safeNum(z.ml);
         if (ml > 0) {
@@ -737,8 +740,11 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
         })()}
         <h3 className="font-serif italic text-[19px] font-medium text-t1 -tracking-[0.01em] leading-tight">{firstSectorHead || title}</h3>
         <span className="ml-auto text-[12px] text-t3 font-mono hidden md:inline tabular-nums">
-          {piecesCount} {piecesCount === 1 ? "mesada" : "mesadas"} · {zocalosCount}{" "}
-          {zocalosCount === 1 ? "zócalo" : "zócalos"}
+          {mesadasCount} {mesadasCount === 1 ? "mesada" : "mesadas"}
+          {alzadasCount > 0 && (
+            <> · {alzadasCount} {alzadasCount === 1 ? "alzada" : "alzadas"}</>
+          )}
+          {" · "}{zocalosCount} {zocalosCount === 1 ? "zócalo" : "zócalos"}
         </span>
         <CopyButton
           text={despieceMarkdown}
@@ -973,7 +979,12 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
           </div>
           <div className="mt-4 grid grid-cols-[1fr_auto] gap-x-4 gap-y-1.5 text-[12px] font-mono tabular-nums">
             <span className="text-t3 font-sans">
-              Mesadas <span className="text-t4">({piecesCount})</span>
+              Mesadas <span className="text-t4">({mesadasCount})</span>
+              {alzadasCount > 0 && (
+                <>
+                  {" "}· Alzadas <span className="text-t4">({alzadasCount})</span>
+                </>
+              )}
             </span>
             <span className="text-t1 text-right">{mesadasM2.toFixed(2)} m²</span>
             <span className="text-t3 font-sans">


### PR DESCRIPTION
## Summary
Cierra 2 bugs del hilo Alzada detectados después de [#359](https://github.com/javi10823/ia-agent-quote-marble-operator/pull/359) / [#360](https://github.com/javi10823/ia-agent-quote-marble-operator/pull/360):

- **Bug E (backend):** la tabla de Paso 2 del chat renderizaba `\"Alzada corrida (fondo completo sin heladera)\"` — inconsistente con el PDF y con el Dual Read. `build_deterministic_paso2` ahora colapsa Alzadas a `\"Alzada\"`.
- **Bug D (frontend):** el header del `DualReadResult` contaba Alzadas como mesadas (`\"3 mesadas · 0 zócalos\"` con 2 placas + 1 alzada). Ahora muestra `\"2 mesadas · 1 alzada · 0 zócalos\"` y la tarjeta Total a cortar separa los conteos.

Las mesadas/placas siguen mostrando descripción completa (no tocadas).

## Test plan
- [x] `test_paso2_alzada_description_collapsed` — valida colapso + que las placas siguen íntegras
- [x] Regresión: 204 tests pasando (test_seven_fixes, test_five_fixes, test_list_pieces, test_fase1_regresion, test_quote_engine, test_router)
- [x] `tsc --noEmit` sin errores en `DualReadResult.tsx`
- [ ] Verificar en quote `5f8ae69e-8bce-43fa-84dc-31e0042a6f8c` post-deploy:
  - [ ] Paso 2 chat: `| Alzada | 3,01 x 0,6 | — | 1,81 |`
  - [ ] Header Dual Read: `2 mesadas · 1 alzada · 0 zócalos`

🤖 Generated with [Claude Code](https://claude.com/claude-code)