### PR TITLE
fix(ui): reservar espacio para CopyButton en MessageBubble (Bug B)

### DIFF
--- a/web/src/components/chat/MessageBubble.tsx
+++ b/web/src/components/chat/MessageBubble.tsx
@@ -105,7 +105,16 @@ const Block = memo(function Block({ block, isLast, isStreaming, actionText }: { 
 
   const showCopy = !isStreaming && hasCopyableContent(block.content);
   return (
-    <div className={clsx("relative px-[18px] py-3.5 bg-s2 text-[15px] leading-[1.7] text-t2", !isLast && "border-b border-b1")}>
+    <div
+      className={clsx(
+        "relative px-[18px] py-3.5 bg-s2 text-[15px] leading-[1.7] text-t2",
+        // Reservar espacio para el CopyButton absolute — sin esto el título
+        // del mensaje (ej: "## PASO 2 — Validación — ...") se mete debajo
+        // del botón y se pisa visualmente.
+        showCopy && "pr-[60px] sm:pr-[140px]",
+        !isLast && "border-b border-b1",
+      )}
+    >
       {showCopy && (
         <>
           <div className="absolute top-3 right-3 hidden sm:block z-10">


### PR DESCRIPTION
## Summary
**Bug B:** el `CopyButton` absolute-positioned (`top-3 right-3`) dentro de `MessageBubble` se superponía con la primera línea del mensaje — típicamente el título \`## PASO 2 — Validación — Luciana Villagra / Cocina\` quedaba pisado por el botón \"Copiar Paso 2\".

### Fix
Agregar `pr-[60px] sm:pr-[140px]` al contenedor cuando `showCopy=true`. Reserva el ancho del botón (44px mobile icon-only / ~130px desktop) para que el texto envuelva correctamente y no se meta debajo.

## Test plan
- [x] CI Frontend Build pasa
- [ ] Verificar post-deploy: abrir quote con mensaje Paso 2 — botón \"Copiar Paso 2\" y título no se pisan
- [ ] Mobile viewport: `pr-[60px]` reserva los 44px del botón iconOnly

🤖 Generated with [Claude Code](https://claude.com/claude-code)