### PR TITLE
fix(paso2): mostrar MERMA — NO APLICA con motivo (Bug C)

### DIFF
--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -1206,6 +1206,9 @@ def build_deterministic_paso2(calc: dict) -> str:
     # Merma — se COBRA como línea separada (regla calculation-formulas.md:
     # "Grand total suma principal + sobrante"). Antes se mostraba como info
     # sin sumar al total; ahora explicitamos que va al grand total.
+    # Siempre se renderiza el estado (APLICA / NO APLICA) con motivo —
+    # paridad con el bloque de DESCUENTOS más abajo. Si aplica=False sin
+    # estado, el operador no sabe si falta calcular o si no corresponde.
     if merma.get("aplica"):
         lines.append("**MERMA — APLICA**")
         lines.append(f"- {merma.get('motivo', '')}")
@@ -1214,6 +1217,11 @@ def build_deterministic_paso2(calc: dict) -> str:
             sob_total = round(sob_m2 * price_unit)
             _fmt_sob = fmt_usd(sob_total) if currency == "USD" else fmt_ars(sob_total)
             lines.append(f"- Sobrante facturable: **{sob_m2:.2f} m² × {fmt_usd(price_unit) if currency == 'USD' else fmt_ars(price_unit)} = {_fmt_sob}** (se suma al total)".replace(".", ","))
+    else:
+        lines.append("**MERMA — NO APLICA**")
+        _motivo_nm = (merma.get("motivo") or "").strip()
+        if _motivo_nm:
+            lines.append(f"- {_motivo_nm}")
     lines.append("")
 
     # Descuento

--- a/api/tests/test_seven_fixes.py
+++ b/api/tests/test_seven_fixes.py
@@ -235,6 +235,30 @@ class TestDeterministicPaso2:
         # Las placas mantienen su descripción completa
         assert "| Placa tramo derecho |" in paso2
 
+    def test_paso2_shows_merma_no_aplica_with_motivo(self):
+        """Cuando merma no aplica (ej: Negro Brasil), Paso 2 debe renderizar
+        **MERMA — NO APLICA** + motivo. Paridad con el bloque DESCUENTOS.
+        Antes quedaba una sección en blanco y el operador no sabía si el
+        cálculo había corrido o estaba pendiente."""
+        from app.modules.quote_engine.calculator import calculate_quote, build_deterministic_paso2
+        result = calculate_quote({
+            "client_name": "Test", "project": "Cocina",
+            "material": "Negro Brasil", "catalog": "materials-granito-importado",
+            "sku": "NEGRO_BRASIL",
+            "pieces": [{"largo": 2.0, "prof": 0.6, "description": "Mesada"}],
+            "localidad": "Rosario", "colocacion": True,
+            "pileta": "empotrada_cliente",
+            "plazo": "30 dias",
+        })
+        assert result["ok"]
+        assert result["merma"]["aplica"] is False
+        paso2 = build_deterministic_paso2(result)
+        assert "**MERMA — NO APLICA**" in paso2, (
+            "Paso 2 debe mostrar MERMA — NO APLICA cuando no aplica"
+        )
+        # El motivo de Negro Brasil debe figurar como contexto
+        assert "Negro Brasil" in paso2
+
     def test_paso2_delivery_matches_config(self):
         """Paso 2 delivery days must match what calculator returns."""
         from app.modules.quote_engine.calculator import calculate_quote, build_deterministic_paso2


### PR DESCRIPTION
## Summary
**Bug C:** cuando la merma no aplica (Negro Brasil, edificio, materiales no sintéticos), el Paso 2 dejaba la sección en blanco. El operador no sabía si el cálculo había corrido o si faltaba — regresión silenciosa del builder determinístico.

### Fix
`build_deterministic_paso2` ahora siempre renderiza el estado de merma:
- Si `aplica=True`: `**MERMA — APLICA**` + motivo + sobrante facturable (sin cambios)
- Si `aplica=False`: `**MERMA — NO APLICA**` + motivo si viene (ej: `Negro Brasil — nunca merma`)

Paridad con el bloque `DESCUENTOS — NO APLICA` que ya seguía este patrón.

El `DetailView.tsx` del frontend ya renderizaba ambos estados vía `InfoBar` — no necesita cambios.

## Test plan
- [x] `test_paso2_shows_merma_no_aplica_with_motivo` — Negro Brasil debe mostrar NO APLICA + motivo
- [x] 179 tests de regresión (test_seven_fixes, test_five_fixes, test_regression, test_list_pieces, test_quote_engine, test_discount_parse) siguen pasando
- [x] Ningún test asertaba ausencia de \"MERMA\" en Paso 2 (no regresión)

🤖 Generated with [Claude Code](https://claude.com/claude-code)