### PR TITLE
fix(brief): strippear Markdown bold en el extractor de contexto (Bug F)

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1142,12 +1142,18 @@ def _extract_quote_info(user_message: str) -> dict:
       - "Munge / A1335"               (separador simple cliente/obra)
       - "Pérez — obra Casa Laprida"   (dash)
       - "cliente X proyecto Y material Z"
+      - "**CLIENTE:** X **OBRA:** Y"   (brief con Markdown bold)
     """
     import re
     info = {}
     msg = (user_message or "").strip()
     if not msg:
         return info
+    # Strip Markdown bold/italic antes de regex-extraer. El operador a veces
+    # pega un brief formateado ("**CLIENTE:** Luciana") y los asteriscos se
+    # colaban dentro de los valores capturados ("** Luciana" en vez de
+    # "Luciana"), además de romper el slicing del extractor de material.
+    msg = re.sub(r"\*{1,3}", "", msg)
 
     # Delimitadores que señalan fin del nombre. "obra" y "proyecto" son
     # límite válido para cortar el nombre del cliente cuando vienen juntos.
@@ -1197,33 +1203,35 @@ def _extract_quote_info(user_message: str) -> dict:
             info["client_name"] = m2.group(1).strip().title()
             info["project"] = m2.group(2).strip().title()
 
-    # Try to find material name
+    # Try to find material name — opera sobre `msg` (ya sin Markdown bold)
+    # para que briefs formateados con "**MATERIAL:** Purastone..." extraigan
+    # "Purastone Blanco Nube" limpio en vez de "TERIAL:** Purastone...".
     material_keywords = [
         "silestone", "dekton", "neolith", "purastone", "puraprima",
         "laminatto", "negro brasil", "blanco norte", "granito",
         "mármol", "marmol",
     ]
-    msg_lower = user_message.lower()
+    msg_lower = msg.lower()
     for kw in material_keywords:
         if kw in msg_lower:
             # Find the full material name around the keyword
             idx = msg_lower.index(kw)
             # Grab surrounding words for context. Hard-cap both sides to
             # prevent runaway extraction when message has no comma/space.
-            start = max(0, user_message.rfind(" ", 0, max(0, idx - 1)) + 1)
+            start = max(0, msg.rfind(" ", 0, idx) + 1)
             # Limit start to at most 10 chars before idx (avoid capturing
             # markdown headers like "**MATERIAL:**" or prior lines).
             start = max(start, idx - 10)
             # End: prefer newline/comma/" con ", fallback to +40 chars
             candidates = []
             for delim in ["\n", "\r", ",", " con ", " — ", " - "]:
-                p = user_message.find(delim, idx)
+                p = msg.find(delim, idx)
                 if p != -1:
                     candidates.append(p)
-            end = min(candidates) if candidates else min(len(user_message), idx + 40)
+            end = min(candidates) if candidates else min(len(msg), idx + 40)
             # Hard cap: material name never > 100 chars
             end = min(end, idx + 100)
-            info["material"] = user_message[start:end].strip()
+            info["material"] = msg[start:end].strip()
             break
 
     return info

--- a/api/tests/test_extract_quote_info.py
+++ b/api/tests/test_extract_quote_info.py
@@ -1,0 +1,77 @@
+"""Tests de `_extract_quote_info`: parseo de cliente/proyecto/material desde
+el brief del operador. Cubre briefs con Markdown bold (`**CLIENTE:** ...`)
+que antes colaban asteriscos en los valores extraídos (Bug F)."""
+from app.modules.agent.agent import _extract_quote_info
+
+
+class TestMarkdownBoldBrief:
+    """Brief con `**LABEL:**` — pre-strip de Markdown bold antes del regex."""
+
+    def test_markdown_bold_client_has_no_asterisks(self):
+        """`**CLIENTE:** Luciana Villagra Dos` no debe quedar con `**`
+        colándose dentro del nombre ni trailing del título."""
+        msg = (
+            "**CLIENTE:** Luciana Villagra Dos\n"
+            "**OBRA:** Cocina\n"
+            "**MATERIAL:** Purastone Blanco Nube — 20mm"
+        )
+        info = _extract_quote_info(msg)
+        assert info.get("client_name") == "Luciana Villagra Dos", info
+        assert "*" not in info.get("client_name", "")
+
+    def test_markdown_bold_project_has_no_asterisks(self):
+        msg = (
+            "**CLIENTE:** Luciana\n"
+            "**OBRA:** Cocina\n"
+            "**MATERIAL:** Purastone"
+        )
+        info = _extract_quote_info(msg)
+        assert info.get("project") == "Cocina", info
+        assert "*" not in info.get("project", "")
+
+    def test_markdown_bold_material_is_clean(self):
+        """Antes daba 'TERIAL:** Purastone Blanco Nube' por un slicing
+        roto del extractor de material. Ahora debe ser el nombre solo."""
+        msg = (
+            "**CLIENTE:** Luciana\n"
+            "**OBRA:** Cocina\n"
+            "**MATERIAL:** Purastone Blanco Nube — 20mm"
+        )
+        info = _extract_quote_info(msg)
+        mat = info.get("material", "")
+        assert "TERIAL" not in mat, mat
+        assert "*" not in mat, mat
+        assert "Purastone" in mat
+
+    def test_inline_markdown_single_line_no_asterisk_leak(self):
+        """Misma info en una sola línea (sin \\n), también con bold.
+        No testeamos el parseo perfecto del cliente/proyecto (el delimiter
+        regex pide whitespace alrededor de 'obra', y 'OBRA:' no califica —
+        caso edge no reportado en Bug F). Sí validamos que no queden `**`
+        en los valores, que es el corazón del bug."""
+        msg = (
+            "**CLIENTE:** Pérez **OBRA:** Lofts "
+            "**MATERIAL:** Silestone Blanco Norte"
+        )
+        info = _extract_quote_info(msg)
+        for v in info.values():
+            assert "*" not in v, f"asterisk leaked into extracted value: {v!r}"
+        assert "silestone" in info.get("material", "").lower()
+
+
+class TestPlainBriefsStillWork:
+    """No romper los formatos previos (sin Markdown)."""
+
+    def test_explicit_cliente_obra(self):
+        info = _extract_quote_info("Cliente: Munge, Obra: A1335")
+        assert info.get("client_name") == "Munge"
+        assert info.get("project") == "A1335"
+
+    def test_slash_separator(self):
+        info = _extract_quote_info("Juan Pérez / Casa Laprida")
+        assert info.get("client_name") == "Juan Pérez"
+        assert info.get("project") == "Casa Laprida"
+
+    def test_material_only(self):
+        info = _extract_quote_info("cotizar Silestone Blanco Norte para cocina")
+        assert "silestone" in info.get("material", "").lower()


### PR DESCRIPTION
## Summary
**Bug F:** cuando el operador pega el brief con Markdown bold (\`**CLIENTE:** ...\`), la card de contexto mostraba los asteriscos adentro del valor:

| Campo | Antes | Ahora |
|-------|-------|-------|
| Cliente | \`** Luciana Villagra Dos\` | \`Luciana Villagra Dos\` |
| Proyecto | \`** Cocina\` | \`Cocina\` |
| Material | \`TERIAL:** Purastone Blanco Nube\` | \`Purastone Blanco Nube\` |

### Fix
Dos problemas en `_extract_quote_info` (`api/app/modules/agent/agent.py`):

1. **Asteriscos en cliente/proyecto:** los regex no pre-procesaban el mensaje. Ahora `re.sub(r\"\*{1,3}\", \"\", msg)` limpia bold/italic antes del matching.
2. **\"TERIAL:**\" en material:** el slicing usaba `rfind(\" \", 0, idx-1)` — el upper bound exclusivo se comía el espacio inmediatamente antes del keyword, forzando el fallback \"10 chars antes de idx\". Para `**MATERIAL:** Purastone`, esos 10 chars caían justo en la T. Fix: `rfind(\" \", 0, idx)` + operar sobre el `msg` ya limpio.

## Test plan
- [x] `test_markdown_bold_client_has_no_asterisks` — caso exacto reportado
- [x] `test_markdown_bold_project_has_no_asterisks`
- [x] `test_markdown_bold_material_is_clean` — antes daba \"TERIAL:** Purastone\"
- [x] `test_inline_markdown_single_line_no_asterisk_leak` — no-leak en single-line
- [x] `test_explicit_cliente_obra`, `test_slash_separator`, `test_material_only` — formatos previos siguen funcionando
- [ ] Verificar post-deploy con el mismo brief de Luciana Villagra Dos

🤖 Generated with [Claude Code](https://claude.com/claude-code)