### PR TITLE
fix(paso2): short-circuit determinístico — no dejar que el LLM parafrasee (Bug G)

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -3950,6 +3950,7 @@ class AgentService:
             # Process tool calls
             tool_results = []
             _gen_docs_result: dict | None = None
+            _paso2_rendered_out: str | None = None
             for tool_use in tool_use_blocks:
                 if tool_use.name == "list_pieces":
                     _list_pieces_called = True
@@ -4011,6 +4012,19 @@ class AgentService:
                         "content": result,
                     })
                 else:
+                    # Capture calculate_quote's deterministic Paso 2 and strip
+                    # it from what Claude sees. Si queda dentro del tool_result
+                    # JSON el modelo lo parafrasea con precios alucinados
+                    # (Bug G: USD 337 vs el catálogo USD 363). Lo emitimos
+                    # verbatim al stream más abajo.
+                    if (
+                        tool_use.name == "calculate_quote"
+                        and isinstance(result, dict)
+                        and result.get("ok")
+                        and result.get("_paso2_rendered")
+                    ):
+                        _paso2_rendered_out = result["_paso2_rendered"]
+                        result = {k: v for k, v in result.items() if k != "_paso2_rendered"}
                     try:
                         result_json = json.dumps(result, ensure_ascii=False)
                     except (TypeError, ValueError) as e:
@@ -4029,6 +4043,23 @@ class AgentService:
 
             assistant_messages.append({"role": "assistant", "content": _serialize_content(final_message.content)})
             assistant_messages.append({"role": "user", "content": tool_results})
+
+            # ── PASO 2 short-circuit ────────────────────────────────────────
+            # Avoid letting Valentina paraphrase _paso2_rendered. El texto
+            # determinístico lee el catálogo directo (fuente de verdad); el
+            # LLM tiende a reescribirlo alucinando base prices (Bug G: ponía
+            # USD 337 vs USD 363 del catálogo). Emitimos verbatim y cerramos
+            # el turno — mismo patrón que el PASO 3 short-circuit más abajo.
+            if _paso2_rendered_out:
+                try:
+                    yield {"type": "text", "content": _paso2_rendered_out}
+                    assistant_messages.append({
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": _paso2_rendered_out}],
+                    })
+                    break
+                except Exception as _e:
+                    logging.warning(f"paso2 short-circuit failed, falling back to LLM: {_e}")
 
             # ── PASO 3 short-circuit (single-material flow) ─────────────────
             # Avoid letting Valentina paraphrase generate_documents output


### PR DESCRIPTION
## Summary
**Bug G:** el operador veía el Paso 2 DUPLICADO: primero una versión escrita libre por Valentina con números alucinados (USD 337 / USD 1.263 / descuento USD 67) y abajo el determinístico (USD 363 / USD 1.359 / descuento USD 72). El LLM ignoraba la instrucción de `CONTEXT.md:175` ("usá `_paso2_rendered` EXACTO") y parafraseaba con base prices viejos del catálogo.

El correcto es el determinístico — coincide con el PDF generado.

### Fix
Mismo patrón que el PASO 3 short-circuit existente (`generate_documents` — línea ~4038). Cuando `calculate_quote` devuelve `_paso2_rendered`:

1. **Strippear** `_paso2_rendered` del `tool_result` JSON que ve Claude — sin material para reescribir, el LLM no puede alucinarlo.
2. **`yield {\"type\": \"text\", content: paso2_rendered}`** directo al stream.
3. **`break`** del `while True` para cerrar el turno sin pasar por el LLM.

El texto determinístico ya termina con \"¿Confirmás para generar PDF y Excel?\" → no hace falta que Claude agregue nada.

## Test plan
- [x] 150 tests de regresión pasan (router, calculator, seven_fixes, five_fixes, list_pieces, extract_quote_info)
- [x] 61 tests de agent/stream_chat/paso2 siguen verdes
- [ ] Verificar post-deploy: quote Luciana Villagra Dos → Paso 2 aparece UNA sola vez, con el texto determinístico (USD 439 / USD 1.359)

🤖 Generated with [Claude Code](https://claude.com/claude-code)