### PR TITLE
fix(auth): usar Authorization header en mobile (iOS Safari ITP)

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -41,15 +41,40 @@ function handleAuthError(_res: Response): void {
 }
 
 /**
+ * Inyecta `Authorization: Bearer <token>` si hay token en localStorage.
+ * Exportado para usar en flows que no pasan por apiFetch (SSE con fetch
+ * directo, principalmente `streamChat`). Si ya viene un header Authorization
+ * en `init.headers`, NO lo sobreescribe.
+ */
+export function withAuthHeader(init?: RequestInit): RequestInit {
+  if (typeof window === "undefined") return init || {};
+  let token: string | null = null;
+  try { token = localStorage.getItem("dangelo:token"); } catch {}
+  if (!token) return init || {};
+
+  // Normalizar headers a un objeto mutable sin perder los headers originales.
+  const headers = new Headers(init?.headers);
+  if (!headers.has("Authorization")) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+  return { ...init, headers };
+}
+
+/**
  * Wrap `fetch()` → si tira TypeError "Failed to fetch" (red caída / CORS /
  * backend inalcanzable), el browser muestra un mensaje crudo horrible en
  * los toasts. Lo traducimos a algo accionable.
+ *
+ * También inyecta el header `Authorization: Bearer <token>` cuando hay un
+ * JWT en localStorage — fallback para clientes donde la cookie cross-origin
+ * no viaja (iOS Safari con ITP). En desktop el backend prefiere la cookie
+ * igual, así que el header es redundancia inofensiva.
  *
  * Uso: `apiFetch(url, init)` en lugar de `fetch(url, init)`.
  */
 export async function apiFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   try {
-    return await fetch(input, init);
+    return await fetch(input, withAuthHeader(init));
   } catch (err: any) {
     // TypeError: Failed to fetch (Chrome/Safari) / NetworkError (Firefox)
     if (err instanceof TypeError || err?.name === "NetworkError") {
@@ -565,12 +590,15 @@ export async function* streamChat(
 
   let res: Response;
   try {
-    res = await fetch(`${API_BASE}/api/quotes/${quoteId}/chat`, {
+    // withAuthHeader inyecta Authorization: Bearer <token> si hay sesión en
+    // localStorage — imprescindible en iOS Safari (la cookie cross-origin
+    // no viaja), inofensivo en desktop (cookie tiene precedencia server-side).
+    res = await fetch(`${API_BASE}/api/quotes/${quoteId}/chat`, withAuthHeader({
       method: "POST",
       body: formData,
       credentials: "include",
       signal: controller.signal,
-    });
+    }));
   } catch (e: any) {
     clearTimeout(connectTimeout);
     if (e.name === "AbortError") {

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -8,8 +8,14 @@ function resolveApiBase(): string {
 
 const API_BASE = resolveApiBase();
 const STORAGE_KEY = "dangelo:username";
+// JWT en localStorage. Fallback para clientes donde la cookie cross-origin
+// no viaja (iOS Safari con ITP bloqueando third-party cookies). El backend
+// acepta el token vía cookie O header `Authorization: Bearer` — si ambos
+// están presentes, cookie gana (ver api/app/core/auth.py). En desktop el
+// header queda como redundancia inofensiva; en mobile es el único canal.
+const TOKEN_KEY = "dangelo:token";
 
-export async function login(username: string, password: string): Promise<{ ok: boolean; username: string }> {
+export async function login(username: string, password: string): Promise<{ ok: boolean; username: string; token: string }> {
   const res = await fetch(`${API_BASE}/api/auth/login`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -23,9 +29,12 @@ export async function login(username: string, password: string): Promise<{ ok: b
   if (!res.ok) throw new Error("Error de conexión");
   const data = await res.json();
   // Cacheamos el username del lado del cliente para saludos personalizados
-  // (Home hero "Buen día, X."). La sesión real vive en cookie.
-  if (typeof window !== "undefined" && data?.username) {
-    try { localStorage.setItem(STORAGE_KEY, data.username); } catch {}
+  // (Home hero "Buen día, X."). La sesión real vive en cookie + token.
+  if (typeof window !== "undefined") {
+    try {
+      if (data?.username) localStorage.setItem(STORAGE_KEY, data.username);
+      if (data?.token) localStorage.setItem(TOKEN_KEY, data.token);
+    } catch {}
   }
   return data;
 }
@@ -36,8 +45,27 @@ export async function logout(): Promise<void> {
     credentials: "include",
   });
   if (typeof window !== "undefined") {
-    try { localStorage.removeItem(STORAGE_KEY); } catch {}
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+      localStorage.removeItem(TOKEN_KEY);
+    } catch {}
   }
+}
+
+/** JWT guardado tras el último login exitoso (o null si nunca se logueó o
+ * corrió logout). Lo consume `apiFetch` para inyectar el header
+ * `Authorization: Bearer <token>` como fallback cuando la cookie no viaja.
+ *
+ * NOTA seguridad: sí, localStorage es accesible desde JS y por lo tanto
+ * vulnerable a XSS. Asumimos riesgo aceptable porque (a) la app es interna
+ * de un único operador, (b) la alternativa — no poder usar mobile — es
+ * peor, (c) el token expira a las 72hs. Si a futuro habilitamos acceso
+ * multi-usuario o exponemos la app a terceros, mover a IndexedDB con
+ * encriptación o a httpOnly cookie estricta (lo que requeriría rewrite
+ * de arquitectura). */
+export function getAuthToken(): string | null {
+  if (typeof window === "undefined") return null;
+  try { return localStorage.getItem(TOKEN_KEY); } catch { return null; }
 }
 
 /** Username del operador logueado, si está disponible. null si no hay sesión


### PR DESCRIPTION
## Summary
- **PR B (frontend)** del fix split. Depende de #367 (PR A) mergeado en main — sin ese backend este PR es silencioso (el header viaja pero el backend no lo lee).
- Login guarda el JWT en `localStorage`. Todos los fetches mandan `Authorization: Bearer <token>` si hay JWT guardado. Logout limpia el storage.
- En desktop la cookie cross-origin sigue funcionando y gana server-side → comportamiento inalterado. En iOS Safari con ITP bloqueando cookies, el header es el único canal de auth.

## Cambios
- `web/src/lib/auth.ts` — `login()` persiste `data.token` en `localStorage["dangelo:token"]`. `logout()` lo borra. Nueva función `getAuthToken()`.
- `web/src/lib/api.ts` — nuevo helper `withAuthHeader(init)` que lee el token del storage e inyecta `Authorization: Bearer <...>` si existe. `apiFetch()` lo aplica automáticamente a todos los endpoints. `streamChat()` (que usa \`fetch\` directo por el SSE) lo usa explícitamente.

## Comportamiento
| Cliente | Cookie | Header | Backend elige |
|---------|--------|--------|---------------|
| Desktop sin cambios | ✓ viaja | ✓ viaja | cookie (gana) |
| iOS Safari (ITP) | ✗ bloqueada | ✓ viaja | header |
| Usuario nunca logueado | ✗ | ✗ | 401 — igual que antes |
| Token expirado (72hs) | — | viaja vencido | backend rechaza → 401 |

## Trade-off de seguridad
JWT en localStorage es vulnerable a XSS. Aceptado porque (a) la app es interna — un único operador — (b) la alternativa es \"mobile no funciona\", (c) el token expira a 72hs, (d) no hay contenido de terceros en la UI. Documentado en el docstring de \`getAuthToken\`. Si el scope cambia (multi-usuario, exposición externa), migrar a una arquitectura sin localStorage.

## Test plan — QA manual en preview ANTES de mergear
- [ ] **Desktop** (Chrome/Safari/Firefox) en preview URL:
  - [ ] Login entra al dashboard y lista presupuestos
  - [ ] Abrir un presupuesto, ver el chat con Valentina streamear
  - [ ] Config/catalogs carga y permite editar
  - [ ] Settings/users lista usuarios
  - [ ] Logout vuelve a /login y re-entrar funciona
- [ ] **iPhone Safari** (con \"Prevent Cross-Site Tracking\" ON):
  - [ ] Login y dashboard lista presupuestos (hoy falla con 401)
  - [ ] Abrir un presupuesto y chatear
  - [ ] Config carga
- [ ] Solo mergeo si ambos pasan.

## Automatizado
- [x] \`npm run build\` limpio (sin errores de tipo ni lint nuevos)
- [ ] CI checks en Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)