### PR TITLE
fix(cors): permitir preview URLs de Vercel via allow_origin_regex

### DIFF
--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -15,6 +15,19 @@ class Settings(BaseSettings):
     # override a "development" y el cookie sale SameSite=Lax + no Secure.
     APP_ENV: str = "production"
     CORS_ORIGINS: List[str] = ["http://localhost:3000"]
+    # Regex de orígenes permitidos — complementa (no reemplaza) CORS_ORIGINS.
+    # Uso principal: preview URLs de Vercel, que tienen un subdominio único
+    # por commit (`<project>-git-<hash>-<team>.vercel.app`) y no se pueden
+    # listar explícitamente. El default cubre las previews del team actual
+    # sin requerir tocar env vars en Railway para cada deploy.
+    #
+    # Patrón: cualquier URL que empiece con el nombre del proyecto, tenga
+    # algo en el medio, y termine con `-<team>-projects.vercel.app`. No
+    # matchea proyectos ajenos (evita que una URL arbitraria con "vercel.app"
+    # al final sirva para CSRF contra este backend).
+    CORS_ORIGIN_REGEX: str = (
+        r"^https://ia-agent-quote-marble-operator-.+-javi10824s-projects\.vercel\.app$"
+    )
     SECRET_KEY: str
     QUOTE_API_KEY: str = ""
     OPERATOR_EMAIL: str = ""

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -117,6 +117,10 @@ app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.CORS_ORIGINS,
+    # Regex se suma (OR) a allow_origins — cualquiera de las dos matchea.
+    # Vacío por configuración → FastAPI lo ignora. Ver config.py para el
+    # default (previews de Vercel del proyecto/team actual).
+    allow_origin_regex=settings.CORS_ORIGIN_REGEX or None,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/api/tests/test_cors.py
+++ b/api/tests/test_cors.py
@@ -1,0 +1,119 @@
+"""Tests for CORS configuration — preview URLs de Vercel.
+
+Las preview URLs de Vercel tienen subdominios únicos por commit
+(`<project>-git-<hash>-<team>.vercel.app`). No se pueden listar
+estáticamente en `CORS_ORIGINS`, así que el backend usa
+`allow_origin_regex` para permitirlas todas sin abrir la puerta a
+dominios ajenos.
+
+Estos tests verifican que:
+- La regex del default matchea previews del team real.
+- Rechaza orígenes externos (attacker.vercel.app, subdominios de otros teams).
+- El endpoint real responde con header Access-Control-Allow-Origin correcto.
+"""
+
+import re
+import pytest
+from app.core.config import settings
+
+
+class TestCorsRegexPattern:
+    """Unit tests de la regex aislados — no dependen del servidor."""
+
+    @pytest.fixture
+    def pattern(self):
+        return re.compile(settings.CORS_ORIGIN_REGEX)
+
+    def test_matches_preview_url_git_branch(self, pattern):
+        """Preview URL típica de rama: `<project>-git-<branch-hash>-<team>.vercel.app`."""
+        url = "https://ia-agent-quote-marble-operator-git-c-d45cfe-javi10824s-projects.vercel.app"
+        assert pattern.match(url) is not None
+
+    def test_matches_preview_url_pr_hash(self, pattern):
+        """Preview URL con hash de deploy (sin `git-` prefix)."""
+        url = "https://ia-agent-quote-marble-operator-abc123xyz-javi10824s-projects.vercel.app"
+        assert pattern.match(url) is not None
+
+    def test_rejects_different_team(self, pattern):
+        """Team distinto → no matchea. Previene CSRF desde otro proyecto Vercel."""
+        url = "https://ia-agent-quote-marble-operator-git-main-attacker-team.vercel.app"
+        assert pattern.match(url) is None
+
+    def test_rejects_different_project(self, pattern):
+        """Proyecto distinto con mismo team → no matchea."""
+        url = "https://other-project-git-main-javi10824s-projects.vercel.app"
+        assert pattern.match(url) is None
+
+    def test_rejects_plain_vercel_app(self, pattern):
+        """`vercel.app` solo → no matchea."""
+        url = "https://vercel.app"
+        assert pattern.match(url) is None
+
+    def test_rejects_attacker_embedding_project_name(self, pattern):
+        """Atacante que pone el nombre del proyecto como subdominio propio."""
+        url = "https://ia-agent-quote-marble-operator.attacker.com"
+        assert pattern.match(url) is None
+
+    def test_rejects_http_scheme(self, pattern):
+        """Requiere https — un atacante en HTTP no debe poder pasar."""
+        url = "http://ia-agent-quote-marble-operator-x-javi10824s-projects.vercel.app"
+        assert pattern.match(url) is None
+
+    def test_rejects_trailing_path_as_origin(self, pattern):
+        """El Origin header no trae path, pero por las dudas: con path no matchea."""
+        url = "https://ia-agent-quote-marble-operator-x-javi10824s-projects.vercel.app/evil"
+        assert pattern.match(url) is None
+
+
+class TestCorsMiddlewareBehavior:
+    """Tests end-to-end vía TestClient — verifica que CORSMiddleware está
+    armado con la regex y que responde los headers correctos."""
+
+    @pytest.mark.asyncio
+    async def test_preview_origin_gets_cors_headers(self, client_no_auth):
+        """Preflight OPTIONS desde una preview URL debe volver con
+        Access-Control-Allow-Origin echoing el origin."""
+        preview_origin = "https://ia-agent-quote-marble-operator-git-c-d45cfe-javi10824s-projects.vercel.app"
+        res = await client_no_auth.options(
+            "/api/quotes",
+            headers={
+                "Origin": preview_origin,
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        # CORSMiddleware responde al preflight con 200 y los headers CORS
+        assert res.headers.get("access-control-allow-origin") == preview_origin
+        assert res.headers.get("access-control-allow-credentials") == "true"
+
+    @pytest.mark.asyncio
+    async def test_foreign_origin_gets_no_cors_headers(self, client_no_auth):
+        """Origin de un team ajeno → sin header Access-Control-Allow-Origin.
+        El browser bloquea la respuesta — que es lo que queremos."""
+        res = await client_no_auth.options(
+            "/api/quotes",
+            headers={
+                "Origin": "https://evil.attacker.com",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        # Sin allow-origin en la respuesta. (CORSMiddleware puede devolver
+        # 400 o omitir el header según versión — ambos equivalen a bloqueo
+        # desde la perspectiva del browser.)
+        assert res.headers.get("access-control-allow-origin") != "https://evil.attacker.com"
+
+    @pytest.mark.asyncio
+    async def test_listed_origin_still_works(self, client_no_auth):
+        """Las URLs listadas explícitamente en CORS_ORIGINS siguen funcionando —
+        la regex es aditiva, no reemplaza."""
+        # localhost:3000 está en el default de CORS_ORIGINS
+        listed_origin = "http://localhost:3000"
+        if listed_origin not in settings.CORS_ORIGINS:
+            pytest.skip(f"{listed_origin} no está en CORS_ORIGINS de la config de test")
+        res = await client_no_auth.options(
+            "/api/quotes",
+            headers={
+                "Origin": listed_origin,
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert res.headers.get("access-control-allow-origin") == listed_origin


### PR DESCRIPTION
## Summary
- Habilita QA en preview URLs de Vercel. Sin este fix, CORS bloquea cualquier fetch desde la preview antes de llegar al endpoint.
- Prod no cambia (su URL ya está en \`CORS_ORIGINS\`). El regex es aditivo.
- Bloqueante: sin esto no podemos testear PR #368 (frontend mobile fix) en preview.

## Problema
Descubierto intentando QA de PR #368:

\`\`\`
Access to fetch at 'https://ia-agent-.../api/quotes' from origin
'https://ia-agent-quote-marble-operator-git-c-d45cfe-...vercel.app'
has been blocked by CORS policy: No 'Access-Control-Allow-Origin'
header is present on the requested resource.
\`\`\`

Las preview URLs de Vercel tienen subdominio único por commit/branch, imposibles de listar estáticamente.

## Solución
\`CORSMiddleware\` de FastAPI soporta \`allow_origin_regex\` además de \`allow_origins\`. Agrego la setting con default para el team actual y se la paso al middleware.

**Pattern**: \`^https://ia-agent-quote-marble-operator-.+-javi10824s-projects\\.vercel\\.app$\`

### Seguridad
- Anclado \`^\`/\`$\` — no hay bypass con subdominios creativos.
- Exige \`https\`.
- Exige el team \`javi10824s-projects\` — proyectos de otros teams con el mismo nombre no pasan.
- Si cambia el team, se sobrescribe via env var \`CORS_ORIGIN_REGEX\`.

## Test plan
- [x] 8 tests unit de la regex: matchea previews del team, rechaza team ajeno, proyecto ajeno, http, dominios embedding el nombre, con path, sin scheme, etc.
- [x] 3 tests end-to-end: preflight OPTIONS desde preview URL devuelve \`Access-Control-Allow-Origin\` con echo; desde origen ajeno no lo devuelve; localhost:3000 sigue funcionando.
- [x] 36 tests passing (test_auth.py + test_cors.py) — PR A no afectado.
- [ ] Esperar CI + deploy Railway (~2 min tras merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)