### PR TITLE
fix(auth): usar Authorization header en mobile (iOS Safari ITP)

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -41,15 +41,40 @@ function handleAuthError(_res: Response): void {
 }
 
 /**
+ * Inyecta `Authorization: Bearer <token>` si hay token en localStorage.
+ * Exportado para usar en flows que no pasan por apiFetch (SSE con fetch
+ * directo, principalmente `streamChat`). Si ya viene un header Authorization
+ * en `init.headers`, NO lo sobreescribe.
+ */
+export function withAuthHeader(init?: RequestInit): RequestInit {
+  if (typeof window === "undefined") return init || {};
+  let token: string | null = null;
+  try { token = localStorage.getItem("dangelo:token"); } catch {}
+  if (!token) return init || {};
+
+  // Normalizar headers a un objeto mutable sin perder los headers originales.
+  const headers = new Headers(init?.headers);
+  if (!headers.has("Authorization")) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+  return { ...init, headers };
+}
+
+/**
  * Wrap `fetch()` → si tira TypeError "Failed to fetch" (red caída / CORS /
  * backend inalcanzable), el browser muestra un mensaje crudo horrible en
  * los toasts. Lo traducimos a algo accionable.
+ *
+ * También inyecta el header `Authorization: Bearer <token>` cuando hay un
+ * JWT en localStorage — fallback para clientes donde la cookie cross-origin
+ * no viaja (iOS Safari con ITP). En desktop el backend prefiere la cookie
+ * igual, así que el header es redundancia inofensiva.
  *
  * Uso: `apiFetch(url, init)` en lugar de `fetch(url, init)`.
  */
 export async function apiFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   try {
-    return await fetch(input, init);
+    return await fetch(input, withAuthHeader(init));
   } catch (err: any) {
     // TypeError: Failed to fetch (Chrome/Safari) / NetworkError (Firefox)
     if (err instanceof TypeError || err?.name === "NetworkError") {
@@ -565,12 +590,15 @@ export async function* streamChat(
 
   let res: Response;
   try {
-    res = await fetch(`${API_BASE}/api/quotes/${quoteId}/chat`, {
+    // withAuthHeader inyecta Authorization: Bearer <token> si hay sesión en
+    // localStorage — imprescindible en iOS Safari (la cookie cross-origin
+    // no viaja), inofensivo en desktop (cookie tiene precedencia server-side).
+    res = await fetch(`${API_BASE}/api/quotes/${quoteId}/chat`, withAuthHeader({
       method: "POST",
       body: formData,
       credentials: "include",
       signal: controller.signal,
-    });
+    }));
   } catch (e: any) {
     clearTimeout(connectTimeout);
     if (e.name === "AbortError") {

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -8,8 +8,14 @@ function resolveApiBase(): string {
 
 const API_BASE = resolveApiBase();
 const STORAGE_KEY = "dangelo:username";
+// JWT en localStorage. Fallback para clientes donde la cookie cross-origin
+// no viaja (iOS Safari con ITP bloqueando third-party cookies). El backend
+// acepta el token vía cookie O header `Authorization: Bearer` — si ambos
+// están presentes, cookie gana (ver api/app/core/auth.py). En desktop el
+// header queda como redundancia inofensiva; en mobile es el único canal.
+const TOKEN_KEY = "dangelo:token";
 
-export async function login(username: string, password: string): Promise<{ ok: boolean; username: string }> {
+export async function login(username: string, password: string): Promise<{ ok: boolean; username: string; token: string }> {
   const res = await fetch(`${API_BASE}/api/auth/login`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -23,9 +29,12 @@ export async function login(username: string, password: string): Promise<{ ok: b
   if (!res.ok) throw new Error("Error de conexión");
   const data = await res.json();
   // Cacheamos el username del lado del cliente para saludos personalizados
-  // (Home hero "Buen día, X."). La sesión real vive en cookie.
-  if (typeof window !== "undefined" && data?.username) {
-    try { localStorage.setItem(STORAGE_KEY, data.username); } catch {}
+  // (Home hero "Buen día, X."). La sesión real vive en cookie + token.
+  if (typeof window !== "undefined") {
+    try {
+      if (data?.username) localStorage.setItem(STORAGE_KEY, data.username);
+      if (data?.token) localStorage.setItem(TOKEN_KEY, data.token);
+    } catch {}
   }
   return data;
 }
@@ -36,8 +45,27 @@ export async function logout(): Promise<void> {
     credentials: "include",
   });
   if (typeof window !== "undefined") {
-    try { localStorage.removeItem(STORAGE_KEY); } catch {}
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+      localStorage.removeItem(TOKEN_KEY);
+    } catch {}
   }
+}
+
+/** JWT guardado tras el último login exitoso (o null si nunca se logueó o
+ * corrió logout). Lo consume `apiFetch` para inyectar el header
+ * `Authorization: Bearer <token>` como fallback cuando la cookie no viaja.
+ *
+ * NOTA seguridad: sí, localStorage es accesible desde JS y por lo tanto
+ * vulnerable a XSS. Asumimos riesgo aceptable porque (a) la app es interna
+ * de un único operador, (b) la alternativa — no poder usar mobile — es
+ * peor, (c) el token expira a las 72hs. Si a futuro habilitamos acceso
+ * multi-usuario o exponemos la app a terceros, mover a IndexedDB con
+ * encriptación o a httpOnly cookie estricta (lo que requeriría rewrite
+ * de arquitectura). */
+export function getAuthToken(): string | null {
+  if (typeof window === "undefined") return null;
+  try { return localStorage.getItem(TOKEN_KEY); } catch { return null; }
 }
 
 /** Username del operador logueado, si está disponible. null si no hay sesión


### PR DESCRIPTION
## Summary
- **PR B (frontend)** del fix split. QA validado en preview (desktop + iPhone).
- Login guarda el JWT en \`localStorage\`. Todos los fetches mandan \`Authorization: Bearer <token>\`. Logout limpia storage.
- Desktop: cookie sigue siendo el canal principal, header es redundante (cookie gana server-side).
- iPhone: cookie bloqueada por ITP → header es el único canal.

**Re-abierto**: el PR original #368 se cerró al borrar el branch accidentalmente durante el cleanup de #369. Mismo código, rebaseado sobre main (que ahora incluye #367 y #369).

## Dependencias
- #367 (backend auth header) ✓ merged
- #369 (CORS regex para previews Vercel) ✓ merged

## QA en preview
- [x] Desktop — login + dashboard + chat + config OK
- [x] iPhone Safari con ITP — login + dashboard OK (antes fallaba con 401)

## Cambios
- \`web/src/lib/auth.ts\` — \`login()\` persiste \`data.token\`. \`logout()\` lo limpia. \`getAuthToken()\` helper.
- \`web/src/lib/api.ts\` — \`withAuthHeader(init)\` inyecta \`Authorization: Bearer\` si hay token. \`apiFetch()\` lo aplica. \`streamChat()\` (SSE con fetch directo) lo usa explícitamente.

## Trade-off seguridad
JWT en localStorage → vulnerable a XSS. Aceptado: app interna de un operador, token expira a 72hs. Documentado en docstring de \`getAuthToken\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)