### PR TITLE
feat(guardrail): override al preferred cuando gap de score ≥ 20 (Bernardi)

### DIFF
--- a/api/app/modules/quote_engine/multi_crop_reader.py
+++ b/api/app/modules/quote_engine/multi_crop_reader.py
@@ -386,6 +386,32 @@ _SEMANTIC_PRIOR_PENALTY = 25  # Restado si la cota está fuera (magnitud)
 _SEMANTIC_PRIOR_TIE_THRESHOLD = 10  # top1 - top2 ≤ este valor → degradar top1
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Guardrail override — autoridad del ranking sobre la elección del VLM
+#
+# Después del prior semántico (PR #371), había casos donde el ranking invertía
+# correctamente (1.60 preferred, 2.05 weak) pero el VLM de measurement seguía
+# eligiendo 2.05 — desobedeciendo el ranking. El guardrail existente detectaba
+# la anomalía ("VLM eligió weak habiendo preferred") y marcaba DUDOSO, pero
+# mantenía el valor incorrecto.
+#
+# Este override le da dientes al guardrail: cuando el gap de score entre el
+# preferred y la elección del VLM es lo suficientemente grande, sobreescribe
+# el valor al preferred. El status queda DUDOSO (no se fabrica certeza).
+#
+# Umbral por gap — calibrado para Bernardi (gap=25 supera 20):
+#   gap ≥ 20 → override automático (señal de ranking muy fuerte)
+#   10 < gap < 20 → sin override, DUDOSO como hoy (ranking no es autoritario)
+#   gap ≤ 10 → ya degradado a weak por _SEMANTIC_PRIOR_TIE_THRESHOLD
+#
+# Restricciones de seguridad:
+# - Solo override si el preferred existe como candidata válida (no viene de
+#   excluded_hard/perímetro — esto está implícito porque tomamos el preferred
+#   del length_ranking que ya pasó todos los filtros).
+# - Status queda DUDOSO — no fabricamos certeza aunque overrideemos.
+_GUARDRAIL_OVERRIDE_GAP_THRESHOLD = 20
+
+
 def _bbox_to_px(bbox: dict, image_size: tuple[int, int]) -> dict:
     """Convierte bbox_rel {x,y,w,h} 0..1 → coords absolutas px."""
     img_w, img_h = image_size
@@ -1172,6 +1198,7 @@ def _format_ranking_for_prompt(ranking: dict) -> str:
 
 def _apply_guardrails(
     vlm_output: dict, ranking: dict, cotas_mode: str = "local",
+    *, region_id: Optional[str] = None,
 ) -> dict:
     """Post-LLM: valida elección del VLM contra el ranking determinístico
     y baja confidence cuando la elección es sospechosa.
@@ -1186,7 +1213,10 @@ def _apply_guardrails(
          un valor estándar razonable sin cota explícita — aceptable.
        - Fuera del rango típico → halucinación dura, cap 0.3.
     2. Valor en ranking pero bucket weak/unlikely habiendo preferred →
-       cap 0.5, suspicious con detalle.
+       cap 0.5, suspicious con detalle. **Override**: si el gap de score
+       con el preferred es ≥ _GUARDRAIL_OVERRIDE_GAP_THRESHOLD, se
+       sobreescribe el valor al preferred. Status queda DUDOSO
+       (no fabricamos certeza aunque overrideemos).
     3. cotas_mode == "expanded":
        - Cap duro de confidence 0.65 (evidencia ambigua por naturaleza).
        - Si además eligió valor distinto al top-ranked para largo **O**
@@ -1271,6 +1301,44 @@ def _apply_guardrails(
                     f"{top_preferred['score']}) disponible"
                 )
                 confidence = min(confidence, 0.5)
+
+                # ── Override por gap de score ──────────────────────────
+                # El ranking determinístico es más autoritativo cuando la
+                # diferencia de score con lo que eligió el VLM es grande.
+                # Gap ≥ 20 → sobreescribir al preferred. Status queda DUDOSO
+                # (el cap de confidence 0.5 de arriba + el cap de cotas_mode
+                # abajo se encargan de eso).
+                gap = int(top_preferred["score"]) - int(chosen["score"])
+                if gap >= _GUARDRAIL_OVERRIDE_GAP_THRESHOLD:
+                    preferred_value = top_preferred["value"]
+                    field_key = f"{field_name}_m"
+                    vlm_output[field_key] = preferred_value
+                    # Refrescamos la var local para que los caps posteriores
+                    # (cotas_mode=expanded chequea top con el valor actual)
+                    # vean el valor ya overrideado.
+                    if field_name == "largo":
+                        largo = preferred_value
+                    else:
+                        ancho = preferred_value
+                    suspicious.append(
+                        f"{field_name} override: VLM eligió {chosen['value']}m "
+                        f"(score {chosen['score']}) pero ranking tenía preferred "
+                        f"{preferred_value}m (score {top_preferred['score']}, "
+                        f"gap {gap} ≥ {_GUARDRAIL_OVERRIDE_GAP_THRESHOLD}) → "
+                        f"override al preferred, status DUDOSO"
+                    )
+                    logger.info(
+                        "[guardrail-override] region=%s field=%s "
+                        "llm_choice=%s preferred_choice=%s llm_score=%s "
+                        "preferred_score=%s gap=%s reason=weak_chosen_over_strong_preferred",
+                        region_id,
+                        field_name,
+                        chosen["value"],
+                        preferred_value,
+                        chosen["score"],
+                        top_preferred["score"],
+                        gap,
+                    )
             # Si no hay preferred, weak puede ser lo mejor — no castigamos
 
     # ── Cap duro por cotas_mode=expanded ─────────────────────────────
@@ -1750,7 +1818,10 @@ async def _measure_region(
     # (no en el reasoning del VLM que puede sonar convincente y ser falso).
     # PR 2b.1 — además, cap duro de confidence cuando cotas_mode=expanded.
     # PR 2d — cap 0.5 cuando cotas_mode=expanded_rescue.
-    parsed = _apply_guardrails(parsed, ranking, cotas_mode=cotas_mode)
+    # PR #372 — region_id para el log [guardrail-override].
+    parsed = _apply_guardrails(
+        parsed, ranking, cotas_mode=cotas_mode, region_id=region.get("id"),
+    )
 
     # Cuando caímos a fallback expanded (sin rescue), el resultado NUNCA
     # es CONFIRMADO aunque los números sean plausibles — el operador tiene

--- a/api/tests/test_multi_crop_reader.py
+++ b/api/tests/test_multi_crop_reader.py
@@ -4416,3 +4416,253 @@ class TestSemanticPriorRanking:
             assert any("semantic_prior_tie_demoted" in r for r in top["reasons"]), (
                 f"Reason tie_demoted debe estar presente. Reasons: {top['reasons']}"
             )
+
+
+class TestGuardrailOverride:
+    """Override post-LLM cuando el ranking es muy autoritativo — PR #372.
+
+    Contexto: tras el prior semántico (PR #371), el ranking de Bernardi quedó
+    invertido correctamente (1.60 preferred, 2.05 weak). PERO el VLM de
+    measurement seguía eligiendo 2.05, con el sistema marcando DUDOSO sin
+    corregir el valor. Con gap de score grande (≥20), el ranking es
+    suficientemente autoritativo como para sobreescribir la elección del VLM.
+
+    El status queda DUDOSO — no fabricamos certeza aunque overrideemos.
+    """
+
+    def test_bernardi_r3_override_largo_a_1_60_cuando_vlm_eligio_2_05(self):
+        """Caso Bernardi end-to-end:
+        - Ranking post-prior tiene 1.60 preferred (score 80), 2.05 weak (55).
+        - VLM eligió 2.05 desobedeciendo el ranking.
+        - Gap = 80 - 55 = 25 ≥ 20 → override al preferred.
+        - Resultado: largo_m = 1.60.
+        """
+        ranking = {
+            "length": [
+                {"value": 1.60, "score": 80, "bucket": "preferred", "reasons": ["semantic_prior_in_range_isla_+25"]},
+                {"value": 2.05, "score": 55, "bucket": "weak", "reasons": ["semantic_prior_out_of_range_isla_-25"]},
+                {"value": 2.35, "score": 30, "bucket": "unlikely", "reasons": []},
+            ],
+            "depth": [
+                {"value": 0.60, "score": 75, "bucket": "preferred", "reasons": []},
+            ],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 2.05,  # VLM eligió la weak
+            "ancho_m": 0.60,
+            "confidence": 0.8,
+            "reasoning": "la cota 2.05 parece ser del largo visible",
+        }
+        result = _apply_guardrails(vlm_output, ranking, region_id="R3")
+
+        # REQUISITO CENTRAL: valor overrideado al preferred.
+        assert result["largo_m"] == 1.60, (
+            f"largo_m debe ser 1.60 (preferred) post-override, got {result['largo_m']}. "
+            f"Este es el fix central de Bernardi."
+        )
+        # Status DUDOSO — confidence queda ≤ 0.5 (no vendemos certeza).
+        assert result["confidence"] <= 0.5
+
+        # Suspicious debe mencionar override.
+        reasons = result.get("suspicious_reasons") or []
+        assert any("override" in s for s in reasons), (
+            f"Suspicious debe mencionar override. Got: {reasons}"
+        )
+
+    def test_no_override_si_gap_menor_a_threshold(self):
+        """Gap de 15 (< 20) → NO override. Solo DUDOSO como hoy."""
+        ranking = {
+            "length": [
+                {"value": 2.35, "score": 65, "bucket": "preferred", "reasons": []},
+                {"value": 2.95, "score": 50, "bucket": "weak", "reasons": []},
+            ],
+            "depth": [
+                {"value": 0.60, "score": 75, "bucket": "preferred", "reasons": []},
+            ],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 2.95,  # weak, gap=15
+            "ancho_m": 0.60,
+            "confidence": 0.80,
+        }
+        result = _apply_guardrails(vlm_output, ranking, region_id="R1")
+
+        # NO override — valor queda en 2.95.
+        assert result["largo_m"] == 2.95, (
+            f"gap={65-50}=15 < 20 → NO debería hacer override. "
+            f"largo_m debería quedar 2.95, got {result['largo_m']}"
+        )
+        # DUDOSO (cap 0.5) sí se aplica.
+        assert result["confidence"] <= 0.5
+
+    def test_override_con_gap_exacto_en_threshold(self):
+        """Gap = 20 exacto → override (comparación ≥)."""
+        ranking = {
+            "length": [
+                {"value": 1.60, "score": 70, "bucket": "preferred", "reasons": []},
+                {"value": 2.05, "score": 50, "bucket": "weak", "reasons": []},
+            ],
+            "depth": [
+                {"value": 0.60, "score": 75, "bucket": "preferred", "reasons": []},
+            ],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 2.05,
+            "ancho_m": 0.60,
+            "confidence": 0.80,
+        }
+        result = _apply_guardrails(vlm_output, ranking, region_id="R3")
+        assert result["largo_m"] == 1.60, (
+            f"gap=20 EXACTO debe gatillar override. Got {result['largo_m']}"
+        )
+
+    def test_no_override_si_no_hay_preferred(self):
+        """VLM eligió weak y no hay preferred — weak puede ser lo mejor.
+        Sin preferred, nada que comparar → no override."""
+        ranking = {
+            "length": [
+                {"value": 2.05, "score": 50, "bucket": "weak", "reasons": []},
+                {"value": 2.95, "score": 45, "bucket": "weak", "reasons": []},
+            ],
+            "depth": [
+                {"value": 0.60, "score": 75, "bucket": "preferred", "reasons": []},
+            ],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 2.05,
+            "ancho_m": 0.60,
+            "confidence": 0.80,
+        }
+        result = _apply_guardrails(vlm_output, ranking)
+        # Sin preferred → sin suspicious (el guardrail sigue respetando la
+        # lógica existente "no castigamos weak si no hay preferred").
+        assert result["largo_m"] == 2.05
+
+    def test_no_override_cuando_vlm_eligio_el_preferred(self):
+        """VLM eligió el preferred directamente → no hay nada que overridear."""
+        ranking = {
+            "length": [
+                {"value": 1.60, "score": 80, "bucket": "preferred", "reasons": []},
+                {"value": 2.05, "score": 55, "bucket": "weak", "reasons": []},
+            ],
+            "depth": [
+                {"value": 0.60, "score": 75, "bucket": "preferred", "reasons": []},
+            ],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 1.60,  # VLM eligió el preferred
+            "ancho_m": 0.60,
+            "confidence": 0.85,
+        }
+        result = _apply_guardrails(vlm_output, ranking)
+        assert result["largo_m"] == 1.60
+
+    def test_override_aplica_a_ancho_tambien(self):
+        """Simetría: si el VLM eligió ancho weak habiendo preferred con
+        gap grande, override al preferred también en depth."""
+        ranking = {
+            "length": [
+                {"value": 2.00, "score": 80, "bucket": "preferred", "reasons": []},
+            ],
+            "depth": [
+                {"value": 0.60, "score": 80, "bucket": "preferred", "reasons": []},
+                {"value": 0.80, "score": 55, "bucket": "weak", "reasons": []},
+            ],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 2.00,
+            "ancho_m": 0.80,  # VLM eligió weak de ancho
+            "confidence": 0.80,
+        }
+        result = _apply_guardrails(vlm_output, ranking, region_id="R1")
+        assert result["ancho_m"] == 0.60, (
+            f"ancho también debe overridear cuando el gap es grande. "
+            f"Got {result['ancho_m']}"
+        )
+
+    def test_override_no_cambia_ancho_cuando_solo_largo_aplica(self):
+        """Override en largo no debe mutar ancho aunque ambos pasen por
+        el loop."""
+        ranking = {
+            "length": [
+                {"value": 1.60, "score": 80, "bucket": "preferred", "reasons": []},
+                {"value": 2.05, "score": 55, "bucket": "weak", "reasons": []},
+            ],
+            "depth": [
+                {"value": 0.60, "score": 80, "bucket": "preferred", "reasons": []},
+            ],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 2.05,  # será overrideado
+            "ancho_m": 0.60,  # coincide con preferred — no cambia
+            "confidence": 0.80,
+        }
+        result = _apply_guardrails(vlm_output, ranking, region_id="R3")
+        assert result["largo_m"] == 1.60
+        assert result["ancho_m"] == 0.60
+
+    def test_log_guardrail_override_estructurado(self, caplog):
+        """Log [guardrail-override] con los 7 campos auditables."""
+        import logging as _logging
+        ranking = {
+            "length": [
+                {"value": 1.60, "score": 80, "bucket": "preferred", "reasons": []},
+                {"value": 2.05, "score": 55, "bucket": "weak", "reasons": []},
+            ],
+            "depth": [
+                {"value": 0.60, "score": 80, "bucket": "preferred", "reasons": []},
+            ],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 2.05,
+            "ancho_m": 0.60,
+            "confidence": 0.80,
+        }
+
+        with caplog.at_level(_logging.INFO, logger="app.modules.quote_engine.multi_crop_reader"):
+            _apply_guardrails(vlm_output, ranking, region_id="R3")
+
+        override_logs = [r for r in caplog.records if "[guardrail-override]" in r.getMessage()]
+        assert len(override_logs) == 1, (
+            f"Debe haber exactamente 1 log [guardrail-override]. "
+            f"Got {len(override_logs)}: {[r.getMessage() for r in caplog.records]}"
+        )
+        msg = override_logs[0].getMessage()
+        for field in ("region=R3", "field=largo", "llm_choice=2.05", "preferred_choice=1.6",
+                      "llm_score=55", "preferred_score=80", "gap=25",
+                      "reason=weak_chosen_over_strong_preferred"):
+            assert field in msg, f"Log debe contener '{field}'. Got: {msg}"
+
+    def test_override_mantiene_status_dudoso_no_confirmado(self):
+        """Diseño explícito: el override sobreescribe el valor pero NO
+        sube la confidence. El resultado queda DUDOSO — no CONFIRMADO."""
+        ranking = {
+            "length": [
+                {"value": 1.60, "score": 80, "bucket": "preferred", "reasons": []},
+                {"value": 2.05, "score": 55, "bucket": "weak", "reasons": []},
+            ],
+            "depth": [
+                {"value": 0.60, "score": 80, "bucket": "preferred", "reasons": []},
+            ],
+            "excluded_hard": [],
+        }
+        vlm_output = {
+            "largo_m": 2.05,
+            "ancho_m": 0.60,
+            "confidence": 0.95,  # VLM súper confiado
+        }
+        result = _apply_guardrails(vlm_output, ranking, region_id="R3")
+        # Aunque el override sobreescriba al valor correcto, no premiamos
+        # confidence — quedamos en DUDOSO (≤ 0.5).
+        assert result["confidence"] <= 0.5, (
+            f"Post-override confidence debe quedar ≤ 0.5 (DUDOSO). "
+            f"Got {result['confidence']}"
+        )


### PR DESCRIPTION
## Summary
Después de #371 el ranking de Bernardi quedaba invertido correctamente (1.60 preferred score 80, 2.05 weak score 55), pero el VLM de measurement seguía eligiendo 2.05 desobedeciendo el ranking. El guardrail existente detectaba la anomalía pero solo marcaba DUDOSO — mantenía el valor del VLM.

Este PR le da **dientes al guardrail**: cuando el gap entre el score del preferred y el de la elección del VLM es ≥ 20 puntos, el valor se sobreescribe al preferred. Status queda DUDOSO — no fabricamos certeza.

## Diseño por gap

| Gap | Acción |
|-----|--------|
| ≥ 20 | Override al preferred (ranking autoritativo) |
| 11-19 | Sin override, DUDOSO como hoy |
| ≤ 10 | Ya degradado a weak por tie-breaker (#371) |

## Restricciones
- Solo override si preferred existe como candidata válida (implícito: viene del ranking que pasó filtros/excluded_hard).
- Valor refrescado en la var local para que los caps posteriores (cotas_mode=expanded) vean el valor overrideado.
- Simétrico: aplica a largo y ancho.
- **Status DUDOSO se mantiene** — el override corrige el valor sin vender certeza.

## Log auditable
\`[guardrail-override]\` con 7 campos: \`region, field, llm_choice, preferred_choice, llm_score, preferred_score, gap, reason\`.

## Caso Bernardi (verificado)
\`\`\`
ranking post-prior: 1.60 preferred (s=80), 2.05 weak (s=55)
VLM eligió: 2.05   →   gap = 80 - 55 = 25  ≥ 20  →  OVERRIDE
Resultado: largo_m = 1.60, confidence ≤ 0.5 (DUDOSO)
\`\`\`

## Non-goals
- No prompt engineering
- No cambios de ownership/cache/bbox

## Tests (9 nuevos en TestGuardrailOverride)
- [x] Bernardi E2E: largo_m = 1.60 post-override
- [x] Gap = 15 (< 20): NO override
- [x] Gap = 20 exacto: override (≥)
- [x] Sin preferred: NO override (weak puede ser lo mejor)
- [x] VLM ya eligió preferred: no-op
- [x] Ancho: override simétrico
- [x] Aislamiento: override de largo no muta ancho
- [x] Log emitido con todos los campos
- [x] Confidence post-override ≤ 0.5 (DUDOSO mantenido)

**Suite completa**: 1728 passed, 16 pre-existentes failed (evaluations, nada de ranking).

## Test plan post-merge
- [ ] Re-correr Bernardi en prod
- [ ] Verificar UI: R3 ahora muestra \`largo = 1.60\` (antes 2.05)
- [ ] Status debe quedar DUDOSO (no CONFIRMADO)
- [ ] Revisar log \`[guardrail-override]\` en Railway

🤖 Generated with [Claude Code](https://claude.com/claude-code)