### PR TITLE
feat(context-analysis): preseleccionar default común en preguntas bloqueantes

### DIFF
--- a/web/src/components/chat/ContextAnalysis.tsx
+++ b/web/src/components/chat/ContextAnalysis.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState } from "react";
 import CopyButton from "./CopyButton";
+import { pickDefaultOption } from "@/lib/pickDefaultOption";
 
 interface DataRow {
   field: string;
@@ -83,7 +84,21 @@ function SourceBadge({ source }: { source: string }) {
 }
 
 export default function ContextAnalysis({ data, onConfirm }: Props) {
-  const [answers, setAnswers] = useState<Record<string, PendingAnswer>>({});
+  // Preselección de defaults comunes en preguntas bloqueantes — el
+  // operador no tiene que tocar radios para los casos residenciales
+  // típicos. Heurística en `pickDefaultOption`: opción con "estándar"
+  // gana; si no hay, primera no-custom. El operador siempre puede
+  // cambiar la opción antes de confirmar.
+  const [answers, setAnswers] = useState<Record<string, PendingAnswer>>(() => {
+    const init: Record<string, PendingAnswer> = {};
+    for (const q of data.pending_questions || []) {
+      const defaultValue = pickDefaultOption(q.options);
+      if (defaultValue !== null) {
+        init[q.id] = { id: q.id, value: defaultValue };
+      }
+    }
+    return init;
+  });
   const [corrections, setCorrections] = useState<Record<string, string>>({});
   const [editingField, setEditingField] = useState<string | null>(null);
 

--- a/web/src/lib/pickDefaultOption.test.ts
+++ b/web/src/lib/pickDefaultOption.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests de `pickDefaultOption` — heurística de preselect para preguntas
+ * bloqueantes del contexto analysis.
+ *
+ * Casos cubiertos:
+ * - Opción con "estándar" → esa gana (caso feliz Bernardi: profundidad
+ *   isla 0.60 m estándar residencial, alto patas 0.90 m estándar).
+ * - Sin "estándar" → primera no-custom gana (caso Bernardi: patas,
+ *   alzada — ambas arrancan con la opción más común).
+ * - Con opciones custom al inicio → saltea hasta encontrar no-custom.
+ * - Todas custom / sin opciones → null (no inventamos default).
+ * - Mayúsculas/minúsculas y acentos: "Estándar" / "estandar" / "ESTÁNDAR"
+ *   todos matchean.
+ */
+import { describe, it, expect } from "vitest";
+import { pickDefaultOption } from "./pickDefaultOption";
+
+describe("pickDefaultOption", () => {
+  describe("Regla 1: opción con 'estándar' en el label", () => {
+    it("elige la opción marcada como estándar residencial", () => {
+      // Caso real: profundidad isla Bernardi
+      const options = [
+        { value: "0.60", label: "0.60 m (estándar residencial)" },
+        { value: "0.70", label: "0.70 m" },
+        { value: "0.80", label: "0.80 m" },
+        { value: "custom", label: "Otra medida (detallar)" },
+      ];
+      expect(pickDefaultOption(options)).toBe("0.60");
+    });
+
+    it("elige estándar aunque no sea la primera opción", () => {
+      // Caso real: alto patas Bernardi
+      const options = [
+        { value: "0.90", label: "0.90 m (estándar — piso a mesada)" },
+        { value: "0.85", label: "0.85 m" },
+        { value: "0.80", label: "0.80 m" },
+      ];
+      expect(pickDefaultOption(options)).toBe("0.90");
+    });
+
+    it("matchea case-insensitive: Estándar, ESTÁNDAR, estandar", () => {
+      for (const variant of ["Estándar", "ESTÁNDAR", "estándar", "estandar"]) {
+        const options = [
+          { value: "a", label: "A — algo" },
+          { value: "b", label: `B (${variant})` },
+        ];
+        expect(pickDefaultOption(options)).toBe("b");
+      }
+    });
+
+    it("si hay varias opciones con 'estándar', elige la primera", () => {
+      // Defensivo: no debería pasar en copy real, pero el algoritmo
+      // tiene que ser determinístico.
+      const options = [
+        { value: "primero", label: "Primer estándar" },
+        { value: "segundo", label: "Segundo estándar" },
+      ];
+      expect(pickDefaultOption(options)).toBe("primero");
+    });
+  });
+
+  describe("Regla 2: sin 'estándar' → primera no-custom", () => {
+    it("elige la primera opción cuando no hay custom", () => {
+      // Caso real: patas de isla Bernardi
+      const options = [
+        { value: "frontal_y_ambos", label: "Sí — frontal + ambos laterales" },
+        { value: "solo_frontal", label: "Solo frontal" },
+        { value: "solo_laterales", label: "Solo ambos laterales" },
+        { value: "custom", label: "Otra combinación (detallar lados y alto)" },
+        { value: "no", label: "No lleva patas" },
+      ];
+      expect(pickDefaultOption(options)).toBe("frontal_y_ambos");
+    });
+
+    it("alzada: 'No lleva' como primera opción", () => {
+      // Caso real: alzada Bernardi
+      const options = [
+        { value: "no", label: "No lleva" },
+        { value: "5cm", label: "Sí — 5 cm" },
+        { value: "10cm", label: "Sí — 10 cm" },
+        { value: "custom", label: "Sí — otro alto (detallar)" },
+      ];
+      expect(pickDefaultOption(options)).toBe("no");
+    });
+
+    it("saltea opciones custom al buscar la primera", () => {
+      const options = [
+        { value: "custom", label: "Otra medida (detallar)" },
+        { value: "a", label: "Opción A" },
+        { value: "b", label: "Opción B" },
+      ];
+      expect(pickDefaultOption(options)).toBe("a");
+    });
+
+    it("detecta custom por value='custom' aunque el label no diga 'detallar'", () => {
+      const options = [
+        { value: "custom", label: "Personalizar" },
+        { value: "default", label: "Default" },
+      ];
+      expect(pickDefaultOption(options)).toBe("default");
+    });
+
+    it("detecta custom por label con 'otra' (ej: 'Otra combinación')", () => {
+      const options = [
+        { value: "otra_combinacion", label: "Otra combinación (detallar)" },
+        { value: "a", label: "Opción A" },
+      ];
+      expect(pickDefaultOption(options)).toBe("a");
+    });
+  });
+
+  describe("Regla 3: edge cases", () => {
+    it("devuelve null si options es undefined", () => {
+      expect(pickDefaultOption(undefined)).toBeNull();
+    });
+
+    it("devuelve null si options es vacío", () => {
+      expect(pickDefaultOption([])).toBeNull();
+    });
+
+    it("devuelve null si todas las opciones son custom", () => {
+      const options = [
+        { value: "custom", label: "Otra medida (detallar)" },
+        { value: "otro_custom", label: "Otra más (detallar)" },
+      ];
+      expect(pickDefaultOption(options)).toBeNull();
+    });
+  });
+
+  describe("Integración — coherencia con las 4 preguntas de Bernardi", () => {
+    it("cubre exactamente el preselect que el operador hace a mano", () => {
+      // Captura de la UI de Javi confirma estos defaults como los que
+      // marca el operador en la mayoría de los casos residenciales.
+      const profundidad = [
+        { value: "0.60", label: "0.60 m (estándar residencial)" },
+        { value: "0.70", label: "0.70 m" },
+        { value: "0.80", label: "0.80 m" },
+        { value: "custom", label: "Otra medida (detallar)" },
+      ];
+      const patas = [
+        { value: "frontal_y_laterales", label: "Sí — frontal + ambos laterales" },
+        { value: "solo_frontal", label: "Solo frontal" },
+        { value: "solo_laterales", label: "Solo ambos laterales" },
+        { value: "custom", label: "Otra combinación (detallar lados y alto)" },
+        { value: "no", label: "No lleva patas" },
+      ];
+      const altoPatas = [
+        { value: "0.90", label: "0.90 m (estándar — piso a mesada)" },
+        { value: "0.85", label: "0.85 m" },
+        { value: "0.80", label: "0.80 m" },
+        { value: "custom", label: "Otra medida (detallar)" },
+      ];
+      const alzada = [
+        { value: "no", label: "No lleva" },
+        { value: "5cm", label: "Sí — 5 cm" },
+        { value: "10cm", label: "Sí — 10 cm" },
+        { value: "custom", label: "Sí — otro alto (detallar)" },
+      ];
+      expect(pickDefaultOption(profundidad)).toBe("0.60");
+      expect(pickDefaultOption(patas)).toBe("frontal_y_laterales");
+      expect(pickDefaultOption(altoPatas)).toBe("0.90");
+      expect(pickDefaultOption(alzada)).toBe("no");
+    });
+  });
+});

--- a/web/src/lib/pickDefaultOption.ts
+++ b/web/src/lib/pickDefaultOption.ts
@@ -1,0 +1,56 @@
+/**
+ * Heurística para preseleccionar el default más común en una pregunta
+ * bloqueante del bloque "Análisis de contexto".
+ *
+ * Regla (en orden):
+ * 1. Si alguna opción tiene la palabra "estándar" (case-insensitive) en el
+ *    label → esa es la default. El backend la marca explícitamente así
+ *    (ej: "0.60 m (estándar residencial)", "0.90 m (estándar — piso a
+ *    mesada)"). Es un contrato ligero con el copy del backend.
+ * 2. Si no hay "estándar", devolver la primera opción NO custom. Son
+ *    consideradas custom aquellas cuyo `value === "custom"` o el label
+ *    contiene "detallar" o "otra" (typically "Otra medida (detallar)"):
+ *    requieren input adicional, no se pueden usar como default "silencioso".
+ * 3. Si todas las opciones son custom (edge case improbable) → null.
+ *    El operador tiene que elegir explícitamente.
+ *
+ * Diseño:
+ * - Función pura. Misma entrada → misma salida. Fácil de testear.
+ * - No asume qué pregunta es: cualquier pregunta con el shape
+ *   {value, label}[] funciona.
+ * - Si el backend cambia los labels (ej. quita "estándar"), el fallback a
+ *   "primera no custom" preserva el comportamiento razonable.
+ */
+export interface PickableOption {
+  value: string;
+  label: string;
+}
+
+const STANDARD_RE = /est[aá]ndar/i;
+const CUSTOM_RE = /(detallar|otra)/i;
+
+function isCustomOption(opt: PickableOption): boolean {
+  if (opt.value === "custom") return true;
+  return CUSTOM_RE.test(opt.label);
+}
+
+/**
+ * Elige el value default para una pregunta con opciones, o null si no hay
+ * un default razonable. Ver comentario arriba para la heurística.
+ */
+export function pickDefaultOption(
+  options: PickableOption[] | undefined,
+): string | null {
+  if (!options || options.length === 0) return null;
+
+  // Regla 1 — opción marcada como "estándar" en el label
+  const standard = options.find(o => STANDARD_RE.test(o.label));
+  if (standard) return standard.value;
+
+  // Regla 2 — primera opción no custom
+  const firstNonCustom = options.find(o => !isCustomOption(o));
+  if (firstNonCustom) return firstNonCustom.value;
+
+  // Regla 3 — todas son custom → null (sin preselect)
+  return null;
+}


### PR DESCRIPTION
## Summary
Las preguntas bloqueantes arrancaban vacías, obligando al operador a clickear en cada radio aun en los casos residenciales típicos (profundidad isla 0.60, alto patas 0.90, etc).

Ahora se preselecciona automáticamente la opción default usando una heurística determinística y auditable. El operador puede cambiar cualquier opción antes de confirmar — el preselect es sugerencia, no commitment.

## Heurística (orden)
1. **Opción con "estándar"** en el label (case-insensitive) → esa gana. Contrato ligero con el copy del backend: `"0.60 m (estándar residencial)"`, `"0.90 m (estándar — piso a mesada)"`.
2. **Sin "estándar"** → primera opción NO custom. Custom = `value==="custom"` o label con "detallar"/"otra" (requieren input adicional).
3. **Todas custom** → `null`, sin preselect (no inventamos default).

## Aplicado a las 4 preguntas de Bernardi
| Pregunta | Preselect | Regla |
|----------|-----------|-------|
| Profundidad isla | `0.60 m (estándar residencial)` | 1 |
| Patas isla | `Sí — frontal + ambos laterales` | 2 |
| Alto patas | `0.90 m (estándar — piso a mesada)` | 1 |
| Alzada | `No lleva` | 2 |

Coincide con lo que el operador ya marcaba a mano (confirmado en capturas).

## Cambios
- Nuevo `web/src/lib/pickDefaultOption.ts`: función pura, testeable aislado.
- `ContextAnalysis.tsx`: initial state de `answers` computa defaults al montar usando la heurística.

## Scope tight
- Solo frontend. Backend intacto.
- No cambia validación "respondé todas antes de confirmar" — el preselect es un valor válido, pasa el gate.
- No toca tech_detections (ya tienen su propio preselect por detección).
- Cascade (`isla_presence=no` oculta dependientes) sigue igual.

## Tests (13 nuevos)
- [x] Regla 1 con variantes de "estándar": case-insensitive, con/sin acentos, múltiples matches
- [x] Regla 2: primera no-custom cuando no hay "estándar"
- [x] Regla 2: saltea opciones custom al inicio
- [x] Regla 2: detecta custom por value o por label ("otra"/"detallar")
- [x] Edge cases: undefined, vacío, todo-custom → null
- [x] Integración con las 4 preguntas reales de Bernardi

**Total vitest**: 30 passed (13 nuevos + 17 existentes). Build limpio.

## Cuándo volver a mirar esto
Si aparece una pregunta nueva donde el default deseado no coincide con la heurística:
- Primera opción: ajustar el copy del backend (agregar "(estándar ...)" al label de la opción correcta).
- Si eso no alcanza: el backend puede emitir un flag explícito `is_default: true` por opción y el frontend lo respeta antes de la heurística. Migración directa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)