### PR TITLE
feat(context): authority/truthfulness del summary post-confirmación

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -532,6 +532,13 @@ async def _run_dual_read(
                     _bd2["dual_read_planilla_m2"] = planilla_m2
                     _bd2["dual_read_crop_label"] = crop_label
                     _bd2["context_analysis_pending"] = _context
+                    # PR #374 — Persistir análisis crudo del brief para que
+                    # el handler DUAL_READ_CONFIRMED arme commercial_attrs
+                    # con precedencia brief > dual_read (sin re-correr
+                    # analyze_brief que es una llamada LLM extra).
+                    _brief_raw = _context.get("_brief_analysis_raw")
+                    if _brief_raw:
+                        _bd2["brief_analysis"] = _brief_raw
                     await db.execute(update(Quote).where(Quote.id == quote_id).values(quote_breakdown=_bd2))
                     await db.commit()
                 except Exception as _e_px:
@@ -1445,17 +1452,52 @@ class AgentService:
                         )
                 except Exception as _e_ans:
                     logging.warning(f"[pending-questions] apply_answers failed: {_e_ans}")
-                from app.modules.quote_engine.dual_reader import build_verified_context
-                _verified_ctx = build_verified_context(_confirmed_json)
+                from app.modules.quote_engine.dual_reader import (
+                    build_verified_context,
+                    build_commercial_attrs,
+                )
+                # PR #374 — Juntar atributos comerciales con precedencia
+                # explícita (operator_answer > brief > dual_read > default)
+                # para que el verified_context le diga al LLM qué wording
+                # usar ("confirmado" solo si source=operator_answer). Antes
+                # el LLM re-leía el plano y sobreafirmaba ("2 anafes
+                # confirmados" cuando dual_read había detectado 1).
                 _qr0 = await db.execute(select(Quote).where(Quote.id == quote_id))
                 _q0 = _qr0.scalar_one_or_none()
+                _bd0 = dict(_q0.quote_breakdown or {}) if _q0 else {}
+                _saved_dual = _bd0.get("dual_read_result") or {}
+                # Reconstruir el analysis del brief (si está cacheado).
+                # Fallback: diccionario vacío → reconcile se cae al dual_read.
+                _ctx_analysis = _bd0.get("brief_analysis") or {}
+                # Respuestas del operador a la card de contexto
+                # (verified_context_analysis guarda `{"answers": [...]}`).
+                _vca = _bd0.get("verified_context_analysis") or {}
+                _op_answers_ctx = _vca.get("answers") or []
+                # Sumar también las pending_answers aplicadas en este turno
+                # (frontend las manda dentro del _confirmed_json).
+                _op_answers_turn = _confirmed_json.get("pending_answers") or []
+                _op_answers = list(_op_answers_ctx) + list(_op_answers_turn)
+                _commercial_attrs = build_commercial_attrs(
+                    analysis=_ctx_analysis,
+                    dual_result=_saved_dual,
+                    operator_answers=_op_answers,
+                )
+                _verified_ctx = build_verified_context(
+                    _confirmed_json, commercial_attrs=_commercial_attrs,
+                )
                 if _q0:
-                    _bd0 = dict(_q0.quote_breakdown or {})
                     _bd0["verified_measurements"] = _confirmed_json
                     _bd0["verified_context"] = _verified_ctx
+                    # Guardar también los commercial_attrs estructurados
+                    # para auditoría y uso futuro (ej: templates de docs).
+                    _bd0["verified_commercial_attrs"] = _commercial_attrs
                     await db.execute(update(Quote).where(Quote.id == quote_id).values(quote_breakdown=_bd0))
                     await db.commit()
-                logging.info(f"[dual-read] Verified measurements saved for {quote_id} (early handler)")
+                logging.info(
+                    f"[dual-read] Verified measurements + commercial attrs "
+                    f"saved for {quote_id} (early handler). "
+                    f"attrs_keys={list(_commercial_attrs.keys())}"
+                )
                 # Reemplazar el mensaje por un prompt que Claude entienda.
                 # El verified_context entra al system prompt via build_system_prompt.
                 # PR #75 — evitar que el regex de _extract_quote_info matchee

--- a/api/app/modules/quote_engine/context_analyzer.py
+++ b/api/app/modules/quote_engine/context_analyzer.py
@@ -256,27 +256,75 @@ def _build_assumptions(
             "source": "brief",
         })
 
-    # Anafe si brief da count explícito
-    anafe_count = analysis.get("anafe_count")
-    if anafe_count is not None:
+    # Anafe — reconciliación brief ↔ dual_read. Antes: solo brief (si brief
+    # no mencionaba anafe, la assumption desaparecía y el LLM post-confirm
+    # re-leía el plano contando anafes visibles y podía decir "2 anafes
+    # confirmados" aunque dual_read había detectado 1. Ahora con fallback
+    # a dual_read, la assumption sale con el valor estructurado + source.
+    # El wording del row evita "confirmado" si viene de dual_read (source
+    # es lo que lleva la autoridad; el texto es informativo).
+    feats = _scan_features(dual_result)
+    anafe_rec = reconcile_anafe_count(analysis, feats)
+    if anafe_rec["final"] is not None:
+        n = anafe_rec["final"]
+        source = anafe_rec["source"]
+        brief_gas_elec = source == "brief" and analysis.get("anafe_gas_y_electrico")
+        gas_elec_suffix = " (gas + eléctrico)" if brief_gas_elec else ""
+        # Wording escalonado: "confirmado" NO lo usa el backend acá —
+        # la palabra queda reservada para cuando el operador responde la
+        # tech_detection o una pending_question. El post-confirm LLM debe
+        # leer `source` y decidir wording según la precedencia explícita.
+        if source == "brief":
+            value = f"{n} anafe{'s' if n != 1 else ''}{gas_elec_suffix}"
+        elif source == "dual_read":
+            value = f"{n} anafe{'s' if n != 1 else ''} — detectado en plano"
+        else:
+            value = f"{n} anafe{'s' if n != 1 else ''}"
+        note = None
+        if anafe_rec["divergent"]:
+            # Divergencia: surface-ear en la card como nota, no esconder.
+            note = (
+                f"Divergencia: brief={anafe_rec['brief_value']} vs "
+                f"plano={anafe_rec['dual_read_value']}. Revisar visualmente."
+            )
         assumptions.append({
             "field": "Anafe — cantidad",
-            "value": f"{anafe_count} anafe{'s' if anafe_count != 1 else ''}"
-                    + (" (gas + eléctrico)" if analysis.get("anafe_gas_y_electrico") else ""),
-            "source": "brief",
+            "value": value,
+            "source": source,
+            "note": note,
         })
 
-    # Pileta: si brief da tipo (apoyo/empotrada/doble)
+    # Pileta — reconciliación brief ↔ dual_read (mismo patrón que anafe).
+    # `pileta_simple_doble` es el campo canónico. `pileta_type` (apoyo /
+    # empotrada) sigue como dato adicional del brief si existe.
+    pileta_rec = reconcile_pileta_simple_doble(analysis, feats)
+    if pileta_rec["final"] is not None:
+        val = pileta_rec["final"]
+        source = pileta_rec["source"]
+        if val == "no":
+            value = "No lleva"
+        elif source == "brief":
+            value = val.capitalize()
+        else:  # dual_read
+            label = "Simple (1 bacha)" if val == "simple" else "Doble (2 bachas)"
+            value = f"{label} — detectada en plano"
+        note = None
+        if pileta_rec["divergent"]:
+            note = (
+                f"Divergencia: brief={pileta_rec['brief_value']} vs "
+                f"plano={pileta_rec['dual_read_value']}. Revisar visualmente."
+            )
+        assumptions.append({
+            "field": "Pileta — bachas",
+            "value": value,
+            "source": source,
+            "note": note,
+        })
+
     if analysis.get("pileta_type"):
         assumptions.append({
             "field": "Pileta — montaje",
             "value": analysis["pileta_type"].capitalize(),
-            "source": "brief",
-        })
-    if analysis.get("pileta_simple_doble"):
-        assumptions.append({
-            "field": "Pileta — bachas",
-            "value": analysis["pileta_simple_doble"].capitalize(),
             "source": "brief",
         })
     if analysis.get("mentions_johnson"):
@@ -434,65 +482,117 @@ _ANAFE_OPTIONS = [
 ]
 
 
-def _detect_pileta(analysis: dict, feats: dict) -> dict | None:
-    # Valor del brief y del dual_read, evaluados antes de decidir para
-    # poder loggear la reconciliación incluyendo divergent flag.
+# ─────────────────────────────────────────────────────────────────────────────
+# PR #374 — Reconciliación pura (brief ↔ dual_read) exportable
+#
+# Extraídas de los `_detect_*` tech detections para que puedan ser usadas
+# también por `_build_assumptions` y `build_verified_context` (dual_reader).
+# Antes el assumptions layer solo miraba `analysis.get("anafe_count")` y si
+# el brief no lo mencionaba el campo desaparecía del resumen → el LLM
+# post-confirmación re-leía el plano y contaba 2 anafes cuando el dual_read
+# había detectado 1. Ahora el assumption se cae al dual_read y el LLM
+# recibe el valor estructurado como fuente de verdad.
+#
+# Precedencia canónica (enforcement en código, no en prompt):
+#   operator_answer > brief > dual_read > default
+#
+# Diseño:
+# - Funciones puras, sin side effects (excepto log de reconcile — mismo
+#   formato que _reconcile_work_types).
+# - Devuelven dict canónico: {final, source, confidence, divergent,
+#   brief_value, dual_read_value}.
+# - `_detect_*` se reescriben encima de estas, sumando solo la forma
+#   schema de tech_detection.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def reconcile_anafe_count(analysis: dict, feats: dict) -> dict:
+    """Resuelve `anafe_count` con precedencia brief → dual_read.
+
+    Returns dict con:
+        final: int | None — valor resuelto
+        source: "brief" | "dual_read" | "default"
+        confidence: float | None
+        divergent: bool — True si brief y dual_read discrepan
+        brief_value, dual_read_value: los valores originales
+    """
+    ac = analysis.get("anafe_count")
+    cg = feats.get("cooktop_groups") or 0
+
+    brief_v = ac if isinstance(ac, int) and ac >= 0 else None
+    dr_v = int(cg) if cg > 0 else None
+
+    divergent = (
+        brief_v is not None and dr_v is not None and brief_v != dr_v
+    )
+
+    if brief_v is not None:
+        final, source, conf = brief_v, "brief", 0.95
+    elif dr_v is not None:
+        final, source, conf = dr_v, "dual_read", 0.70
+    else:
+        final, source, conf = None, "default", None
+
+    _log_reconcile(
+        "anafe_count",
+        brief_value=brief_v,
+        dual_read_value=dr_v,
+        final=final,
+        source=source,
+        confidence=conf,
+        divergent=divergent,
+    )
+    return {
+        "final": final,
+        "source": source,
+        "confidence": conf,
+        "divergent": divergent,
+        "brief_value": brief_v,
+        "dual_read_value": dr_v,
+    }
+
+
+def reconcile_pileta_simple_doble(analysis: dict, feats: dict) -> dict:
+    """Resuelve `pileta_simple_doble` con precedencia brief → dual_read.
+
+    Valores posibles: "simple" | "doble" | "no" | None.
+
+    Returns dict con shape de `reconcile_anafe_count`.
+    """
     brief_v = analysis.get("pileta_simple_doble")  # "simple"|"doble"|None
-    # dual_read_v canónico: "doble" si sink_double, "simple" si sink_simple,
-    # "?" si has_pileta pero sin tipo, None si nada.
-    if feats["sink_double"]:
+
+    if feats.get("sink_double"):
         dr_v = "doble"
-    elif feats["sink_simple"]:
+    elif feats.get("sink_simple"):
         dr_v = "simple"
-    elif feats["has_pileta"]:
+    elif feats.get("has_pileta"):
         dr_v = "present_unknown"
     else:
         dr_v = None
 
-    # Caso especial: brief dice "no pileta" explícito.
+    # brief explicit "no pileta"
     brief_explicit_no = (
         analysis.get("pileta_mentioned") is False
         and _has_explicit_no_pileta(analysis)
     )
 
-    # Divergencia real: ambos con valor válido Y distintos. "present_unknown"
-    # NO se considera divergent contra "simple"/"doble" del brief (el dual_read
-    # confirma presencia sin desmentir el tipo).
     divergent = False
     if brief_v in ("simple", "doble") and dr_v in ("simple", "doble"):
         divergent = brief_v != dr_v
     elif brief_explicit_no and dr_v in ("simple", "doble", "present_unknown"):
-        divergent = True  # brief dice no, plano detecta → inconsistencia
+        divergent = True
 
-    # Decisión (precedencia brief > dual_read, como siempre).
-    result: dict | None
     if brief_v in ("simple", "doble"):
         final, source, conf = brief_v, "brief", 0.95
-        display = "Simple (1 bacha)" if brief_v == "simple" else "Doble (2 bachas)"
-        result = _mk("pileta_simple_doble", "Pileta", brief_v, display,
-                     _PILETA_OPTIONS, source, conf)
     elif brief_explicit_no:
         final, source, conf = "no", "brief", 0.95
-        result = _mk("pileta_simple_doble", "Pileta", "no", "No lleva",
-                     _PILETA_OPTIONS, source, conf)
     elif dr_v == "doble":
         final, source, conf = "doble", "dual_read", 0.80
-        result = _mk("pileta_simple_doble", "Pileta", "doble",
-                     "Doble (2 bachas) — detectada en plano",
-                     _PILETA_OPTIONS, source, conf)
     elif dr_v == "simple":
         final, source, conf = "simple", "dual_read", 0.75
-        result = _mk("pileta_simple_doble", "Pileta", "simple",
-                     "Simple (1 bacha) — detectada en plano",
-                     _PILETA_OPTIONS, source, conf)
     elif dr_v == "present_unknown":
-        final, source, conf = None, "dual_read", 0.55
-        result = _mk("pileta_simple_doble", "Pileta", None,
-                     "Presente — tipo a confirmar",
-                     _PILETA_OPTIONS, source, conf)
+        final, source, conf = None, "dual_read", 0.55  # detectada pero tipo a confirmar
     else:
         final, source, conf = None, "default", None
-        result = None
 
     _log_reconcile(
         "pileta_simple_doble",
@@ -505,7 +605,46 @@ def _detect_pileta(analysis: dict, feats: dict) -> dict | None:
         confidence=conf,
         divergent=divergent,
     )
-    return result
+    return {
+        "final": final,
+        "source": source,
+        "confidence": conf,
+        "divergent": divergent,
+        "brief_value": brief_v,
+        "dual_read_value": dr_v,
+    }
+
+
+def _detect_pileta(analysis: dict, feats: dict) -> dict | None:
+    """Tech detection para la card UI. La reconciliación pura ya la hace
+    `reconcile_pileta_simple_doble` — acá solo armamos el schema de
+    display + options para el radio del frontend."""
+    rec = reconcile_pileta_simple_doble(analysis, feats)
+    final, source, conf = rec["final"], rec["source"], rec["confidence"]
+    dr_v = rec["dual_read_value"]
+
+    if final == "simple" and source == "brief":
+        return _mk("pileta_simple_doble", "Pileta", "simple", "Simple (1 bacha)",
+                   _PILETA_OPTIONS, source, conf)
+    if final == "doble" and source == "brief":
+        return _mk("pileta_simple_doble", "Pileta", "doble", "Doble (2 bachas)",
+                   _PILETA_OPTIONS, source, conf)
+    if final == "no":
+        return _mk("pileta_simple_doble", "Pileta", "no", "No lleva",
+                   _PILETA_OPTIONS, source, conf)
+    if final == "doble" and source == "dual_read":
+        return _mk("pileta_simple_doble", "Pileta", "doble",
+                   "Doble (2 bachas) — detectada en plano",
+                   _PILETA_OPTIONS, source, conf)
+    if final == "simple" and source == "dual_read":
+        return _mk("pileta_simple_doble", "Pileta", "simple",
+                   "Simple (1 bacha) — detectada en plano",
+                   _PILETA_OPTIONS, source, conf)
+    if final is None and dr_v == "present_unknown":
+        return _mk("pileta_simple_doble", "Pileta", None,
+                   "Presente — tipo a confirmar",
+                   _PILETA_OPTIONS, source, conf)
+    return None
 
 
 def _detect_isla(analysis: dict, feats: dict) -> dict | None:
@@ -543,46 +682,24 @@ def _detect_isla(analysis: dict, feats: dict) -> dict | None:
 
 
 def _detect_anafe(analysis: dict, feats: dict) -> dict | None:
-    ac = analysis.get("anafe_count")
-    cg = feats["cooktop_groups"]
-
-    brief_v = ac if isinstance(ac, int) and ac >= 0 else None
-    dr_v = int(cg) if cg > 0 else None
-
-    # Divergent: brief explícito Y dual_read también Y distintos.
-    # brief=0 y dr>0 también es divergencia (brief dice que no hay).
-    divergent = (
-        brief_v is not None and dr_v is not None and brief_v != dr_v
-    )
-
-    if brief_v is not None:
+    """Tech detection para la card UI. La reconciliación pura ya la hace
+    `reconcile_anafe_count` — acá solo armamos el schema del radio."""
+    rec = reconcile_anafe_count(analysis, feats)
+    final, source, conf = rec["final"], rec["source"], rec["confidence"]
+    if final is None:
+        return None
+    if source == "brief":
         disp = (
             "2 (gas + eléctrico)"
-            if brief_v == 2 and analysis.get("anafe_gas_y_electrico")
-            else f"{brief_v}"
+            if final == 2 and analysis.get("anafe_gas_y_electrico")
+            else f"{final}"
         )
-        final, source, conf = brief_v, "brief", 0.95
-        result = _mk("anafe_count", "Anafe", str(brief_v), disp,
-                     _ANAFE_OPTIONS, source, conf)
-    elif dr_v is not None:
-        final, source, conf = dr_v, "dual_read", 0.70
-        result = _mk("anafe_count", "Anafe", str(dr_v),
-                     f"{dr_v} — detectado en plano",
-                     _ANAFE_OPTIONS, source, conf)
-    else:
-        final, source, conf = None, "default", None
-        result = None
-
-    _log_reconcile(
-        "anafe_count",
-        brief_value=brief_v,
-        dual_read_value=dr_v,
-        final=final,
-        source=source,
-        confidence=conf,
-        divergent=divergent,
-    )
-    return result
+        return _mk("anafe_count", "Anafe", str(final), disp,
+                   _ANAFE_OPTIONS, source, conf)
+    # dual_read o default — wording "detectado en plano" (no "confirmado")
+    return _mk("anafe_count", "Anafe", str(final),
+               f"{final} — detectado en plano",
+               _ANAFE_OPTIONS, source, conf)
 
 
 def _has_explicit_no_pileta(analysis: dict) -> bool:
@@ -679,6 +796,10 @@ async def build_context_analysis(
             "extraction_method": analysis.get("extraction_method"),
             "work_types": analysis.get("work_types") or [],
         },
+        # PR #374 — Full analysis crudo expuesto para consumo backend-only
+        # (handler DUAL_READ_CONFIRMED lo lee para construir commercial_attrs
+        # con precedencia brief > dual_read). El frontend lo ignora.
+        "_brief_analysis_raw": analysis,
     }
 
 

--- a/api/app/modules/quote_engine/dual_reader.py
+++ b/api/app/modules/quote_engine/dual_reader.py
@@ -836,23 +836,36 @@ def _check_m2(result: dict, planilla_m2: Optional[float]) -> Optional[str]:
 # Context injection
 # ═══════════════════════════════════════════════════════
 
-def build_verified_context(confirmed_data: dict) -> str:
-    """Build injection text from operator-confirmed measurements.
+def build_verified_context(
+    confirmed_data: dict,
+    commercial_attrs: dict | None = None,
+) -> str:
+    """Build injection text from operator-confirmed measurements + commercial
+    attributes with authority/precedence annotations.
 
     PR #80: el despiece confirmado es INMUTABLE desde el punto de vista
-    de Valentina. No se emiten warnings ni se piden aclaraciones sobre
-    piezas con status CONFLICTO o zócalos con ml=0 — se asume que el
-    operador intencionalmente confirmó esa configuración (ya sea
-    clickeando × para remover, editando inputs, o con + Agregar).
+    de Valentina.
 
-    Si el operador detecta un error post-confirmación, el flujo es:
-    reabrir Paso 1 (ver card_editor handler en agent.py), editar, y
-    re-confirmar. El Paso 2 se regenera recién con el nuevo despiece.
+    PR #374: atributos comerciales (anafe_count, pileta_simple_doble, etc.)
+    también se inyectan con su source y wording escalonado. Esto impide
+    que el LLM re-lea la imagen post-confirmación y sobreafirme hechos
+    (ej: "2 anafes confirmados" cuando el dual_read detectó 1). Si vos
+    eres el LLM leyendo esto: **usá estos valores. NO re-contés desde
+    la imagen.** El wording que uses en el resumen debe respetar el
+    source: "confirmado" solo si source=operator_answer.
 
-    Esta función antes (PR #59) surface-ba "pending_questions" para
-    zócalos CONFLICTO sin resolver → resultaba en ruido (Valentina
-    preguntaba de vuelta cosas que el operador ya había decidido). La
-    regla nueva es: confirmado es confirmado.
+    `commercial_attrs` shape esperado:
+        {
+          "anafe_count": {"value": int, "source": str},
+          "pileta_simple_doble": {"value": str, "source": str},
+          "isla_presence": {"value": bool, "source": str},
+          "operator_answers": [{"id": str, "value": str, "label": str}],
+          "divergences": [{"field": str, "brief_value": ..., "dual_read_value": ...}]
+        }
+    Todos los campos son opcionales — solo se emite lo que venga.
+
+    Precedencia (autoridad) canónica:
+        operator_answer > brief > dual_read > default
     """
     lines = [
         "[MEDIDAS VERIFICADAS POR DOBLE LECTURA + OPERADOR — FUENTE DE VERDAD]",
@@ -884,4 +897,197 @@ def build_verified_context(confirmed_data: dict) -> str:
                 # ml=0 → ignorado (operador lo descartó intencionalmente)
         lines.append("")
 
+    # ── Atributos comerciales con precedencia explícita ──────────────
+    if commercial_attrs:
+        lines.extend(_format_commercial_attrs_block(commercial_attrs))
+
     return "\n".join(lines)
+
+
+# Wording según source — determinístico, no dejarlo al LLM.
+# Precedencia: operator_answer > brief > dual_read > default.
+_SOURCE_WORDING = {
+    "operator_answer": "confirmado por operador",
+    "operator": "confirmado por operador",  # alias
+    "brief": "del brief",
+    "dual_read": "detectado en plano",
+    "default": "asumido (revisar)",
+}
+
+
+def _source_wording(source: str | None) -> str:
+    """Mapea un source a un fragmento de texto con certeza apropiada.
+
+    Regla central del PR: "confirmado" solo cuando source=operator_answer.
+    Si el LLM en el resumen quiere decir "X confirmado", tiene que venir
+    de acá. Para otros sources el wording degrada a "del brief" /
+    "detectado en plano" / "asumido (revisar)".
+    """
+    if not source:
+        return "asumido (revisar)"
+    return _SOURCE_WORDING.get(source, "asumido (revisar)")
+
+
+def _format_commercial_attrs_block(attrs: dict) -> list[str]:
+    """Construye las líneas del bloque "ATRIBUTOS COMERCIALES" del
+    verified_context. Cada campo lleva su source explícito. El LLM debe
+    respetar esos sources al generar el resumen — no usar wording de
+    certeza ("confirmado") salvo cuando source=operator_answer.
+    """
+    lines: list[str] = [
+        "[ATRIBUTOS COMERCIALES — FUENTE DE VERDAD POR CAMPO]",
+        "⛔ USÁ SOLO ESTOS VALORES. NO re-cuentes desde la imagen.",
+        "⛔ Wording del resumen: 'confirmado' SOLO si source=operator_answer.",
+        "   brief → 'del brief'. dual_read → 'detectado en plano'.",
+        "   default → 'asumido (revisar)'. Si no está listado → 'pendiente'.",
+        "",
+    ]
+    had_any = False
+
+    def _emit(field: str, value, source: str | None) -> None:
+        nonlocal had_any
+        wording = _source_wording(source)
+        lines.append(f"  {field}: {value}  [source={source or 'default'} — {wording}]")
+        had_any = True
+
+    anafe = attrs.get("anafe_count")
+    if anafe and anafe.get("value") is not None:
+        _emit("anafe_count", anafe["value"], anafe.get("source"))
+
+    pileta = attrs.get("pileta_simple_doble")
+    if pileta and pileta.get("value") is not None:
+        _emit("pileta_simple_doble", pileta["value"], pileta.get("source"))
+
+    isla = attrs.get("isla_presence")
+    if isla and isla.get("value") is not None:
+        _emit("isla_presence", "sí" if isla["value"] else "no", isla.get("source"))
+
+    # Respuestas del operador a pending_questions (profundidad isla,
+    # patas, alto patas, alzada, etc). Son autoridad máxima: el operador
+    # las respondió explícitamente.
+    op_answers = attrs.get("operator_answers") or []
+    if op_answers:
+        lines.append("")
+        lines.append("  Respuestas del operador (source=operator_answer — CONFIRMADAS):")
+        for a in op_answers:
+            qid = a.get("id", "?")
+            val = a.get("label") or a.get("value") or "?"
+            lines.append(f"    - {qid}: {val}")
+        had_any = True
+
+    # Divergencias explícitas — para que el LLM NO las esconda.
+    divs = attrs.get("divergences") or []
+    if divs:
+        lines.append("")
+        lines.append("  ⚠ DIVERGENCIAS entre fuentes (flag 'revisar' en el resumen):")
+        for d in divs:
+            field = d.get("field", "?")
+            bv = d.get("brief_value")
+            dv = d.get("dual_read_value")
+            lines.append(f"    - {field}: brief={bv} vs plano={dv}")
+        had_any = True
+
+    lines.append("")
+    if not had_any:
+        # No hubo ningún atributo estructurado — bloque vacío pero aún así
+        # emitido para que el LLM vea que "no hay nada confirmado" y
+        # evite inventar.
+        lines.append("  (ningún atributo comercial con valor estructurado — pedí al operador)")
+        lines.append("")
+    return lines
+
+
+def build_commercial_attrs(
+    analysis: dict | None,
+    dual_result: dict | None,
+    operator_answers: list | None = None,
+) -> dict:
+    """Orquesta la reconciliación de atributos comerciales para el
+    verified_context. Usa la capa pura de reconcile_* de context_analyzer
+    (no duplica lógica).
+
+    Precedencia aplicada:
+    - Si operator_answers incluye un answer para anafe_count / pileta_*,
+      ese gana (source=operator_answer).
+    - Sino, reconcile_* decide entre brief y dual_read.
+
+    Devuelve dict compatible con `build_verified_context(commercial_attrs=)`.
+    """
+    # Lazy import para evitar dependencia circular dual_reader ↔ context_analyzer.
+    from app.modules.quote_engine.context_analyzer import (
+        reconcile_anafe_count,
+        reconcile_pileta_simple_doble,
+        _scan_features,
+    )
+
+    analysis = analysis or {}
+    dual_result = dual_result or {}
+    feats = _scan_features(dual_result)
+
+    # Operator answers → índice por field id (los ids coinciden con el
+    # campo canónico: "anafe_count", "pileta_simple_doble", etc.)
+    op_by_field: dict[str, dict] = {}
+    for a in operator_answers or []:
+        fid = a.get("id")
+        if fid:
+            op_by_field[fid] = a
+
+    out: dict = {}
+
+    # anafe_count
+    if "anafe_count" in op_by_field:
+        a = op_by_field["anafe_count"]
+        try:
+            val = int(a.get("value"))
+            out["anafe_count"] = {"value": val, "source": "operator_answer"}
+        except (TypeError, ValueError):
+            pass
+    else:
+        rec = reconcile_anafe_count(analysis, feats)
+        if rec["final"] is not None:
+            out["anafe_count"] = {"value": rec["final"], "source": rec["source"]}
+        if rec["divergent"]:
+            out.setdefault("divergences", []).append({
+                "field": "anafe_count",
+                "brief_value": rec["brief_value"],
+                "dual_read_value": rec["dual_read_value"],
+            })
+
+    # pileta_simple_doble
+    if "pileta_simple_doble" in op_by_field:
+        a = op_by_field["pileta_simple_doble"]
+        val = a.get("value")
+        if val:
+            out["pileta_simple_doble"] = {"value": val, "source": "operator_answer"}
+    else:
+        rec = reconcile_pileta_simple_doble(analysis, feats)
+        if rec["final"] is not None:
+            out["pileta_simple_doble"] = {
+                "value": rec["final"], "source": rec["source"],
+            }
+        if rec["divergent"]:
+            out.setdefault("divergences", []).append({
+                "field": "pileta_simple_doble",
+                "brief_value": rec["brief_value"],
+                "dual_read_value": rec["dual_read_value"],
+            })
+
+    # isla_presence — derivable de feats/analysis.
+    isla_brief = bool(analysis.get("isla_mentioned"))
+    isla_dr = bool(feats.get("has_isla"))
+    if "isla_presence" in op_by_field:
+        val = op_by_field["isla_presence"].get("value")
+        if val in ("yes", "no"):
+            out["isla_presence"] = {"value": val == "yes", "source": "operator_answer"}
+    elif isla_brief:
+        out["isla_presence"] = {"value": True, "source": "brief"}
+    elif isla_dr:
+        out["isla_presence"] = {"value": True, "source": "dual_read"}
+
+    # Todas las respuestas del operador, para que el LLM las vea como
+    # "confirmadas" aunque no estén en los campos canónicos (ej:
+    # isla_profundidad, isla_patas, alzada).
+    if operator_answers:
+        out["operator_answers"] = list(operator_answers)
+
+    return out

--- a/api/tests/test_context_analyzer.py
+++ b/api/tests/test_context_analyzer.py
@@ -744,3 +744,175 @@ class TestReconcileLogFormat:
         for key in ("field=", "brief_value=", "dual_read_value=", "final=",
                     "source=", "confidence=", "divergent="):
             assert key in log, f"Missing key '{key}' in log: {log}"
+
+
+# ═══════════════════════════════════════════════════════
+# PR #374 — Reconcile puros + assumptions con fallback brief→dual_read
+# ═══════════════════════════════════════════════════════
+
+from app.modules.quote_engine.context_analyzer import (  # noqa: E402
+    reconcile_anafe_count,
+    reconcile_pileta_simple_doble,
+    _build_assumptions,
+)
+
+
+class TestReconcileAnafePure:
+    """Helper puro exportable — no depende del schema de tech_detection.
+
+    Bernardi real: brief sin mención de anafe + dual_read detectó 1 anafe
+    (cooktop_groups=1). El reconcile debe devolver final=1 source=dual_read
+    para que el assumptions layer pueda surface-ar el valor.
+    """
+
+    def test_bernardi_brief_silent_dual_read_detected(self):
+        analysis = {"anafe_count": None}
+        feats = {"cooktop_groups": 1, "sink_double": False, "sink_simple": True,
+                 "has_pileta": True, "has_isla": True}
+        rec = reconcile_anafe_count(analysis, feats)
+        assert rec["final"] == 1
+        assert rec["source"] == "dual_read"
+        assert rec["divergent"] is False
+
+    def test_brief_wins_over_dual_read(self):
+        analysis = {"anafe_count": 2, "anafe_gas_y_electrico": True}
+        feats = {"cooktop_groups": 1, "sink_double": False, "sink_simple": False,
+                 "has_pileta": False, "has_isla": False}
+        rec = reconcile_anafe_count(analysis, feats)
+        assert rec["final"] == 2
+        assert rec["source"] == "brief"
+        assert rec["divergent"] is True
+
+    def test_neither_returns_none(self):
+        rec = reconcile_anafe_count({}, {"cooktop_groups": 0})
+        assert rec["final"] is None
+        assert rec["source"] == "default"
+
+
+class TestReconcilePiletaPure:
+    def test_bernardi_brief_silent_dual_read_simple(self):
+        """Bernardi: brief sin mención de pileta tipo, dual_read detectó
+        pileta simple → fallback a dual_read."""
+        analysis = {"pileta_simple_doble": None, "pileta_mentioned": True}
+        feats = {"cooktop_groups": 1, "sink_double": False, "sink_simple": True,
+                 "has_pileta": True, "has_isla": True}
+        rec = reconcile_pileta_simple_doble(analysis, feats)
+        assert rec["final"] == "simple"
+        assert rec["source"] == "dual_read"
+
+    def test_bernardi_operator_corrects_to_doble(self):
+        """Caso Javi: el operador respondió 'es 1 anafe y 1 pileta doble'
+        contradiciendo el dual_read que dijo 'simple'. En el layer de
+        `_build_assumptions` esto todavía no se ve (solo brief/dual_read);
+        el operator_answer entra en build_commercial_attrs más arriba."""
+        analysis = {"pileta_simple_doble": "doble", "pileta_mentioned": True}
+        feats = {"cooktop_groups": 1, "sink_double": False, "sink_simple": True,
+                 "has_pileta": True, "has_isla": True}
+        rec = reconcile_pileta_simple_doble(analysis, feats)
+        assert rec["final"] == "doble"
+        assert rec["source"] == "brief"
+        assert rec["divergent"] is True
+
+
+class TestAssumptionsFallbackToDualRead:
+    """Regresión Bernardi: brief silencioso + dual_read con anafe/pileta →
+    assumption DEBE aparecer con source=dual_read. Antes desaparecía."""
+
+    def _bernardi_dual(self):
+        """Dual_read idéntico al log real de Bernardi: cocina con 1 anafe,
+        pileta simple + isla sin artefactos."""
+        return {
+            "sectores": [
+                {
+                    "id": "cocina",
+                    "tipo": "cocina",
+                    "tramos": [{
+                        "id": "t1",
+                        "descripcion": "Mesada con pileta y anafe",
+                        "largo_m": {"valor": 2.05, "status": "CONFIRMADO"},
+                        "ancho_m": {"valor": 0.60, "status": "CONFIRMADO"},
+                        "m2": {"valor": 1.23, "status": "CONFIRMADO"},
+                        "zocalos": [],
+                        "features": {
+                            "cooktop_groups": 1,
+                            "sink_simple": True,
+                            "sink_double": False,
+                            "has_pileta": True,
+                            "has_isla": False,
+                        },
+                    }],
+                },
+                {
+                    "id": "isla",
+                    "tipo": "isla",
+                    "tramos": [{
+                        "id": "t2",
+                        "descripcion": "Isla",
+                        "largo_m": {"valor": 1.60, "status": "DUDOSO"},
+                        "ancho_m": {"valor": 0.60, "status": "DUDOSO"},
+                        "m2": {"valor": 0.96, "status": "DUDOSO"},
+                        "zocalos": [],
+                        "features": {},
+                    }],
+                },
+            ],
+        }
+
+    def test_anafe_assumption_falls_back_to_dual_read_when_brief_silent(self):
+        """Brief Bernardi: 'pura prima onix white mate Erica Bernardi SIN
+        zocalos en rosario con colocacion' — NO menciona anafe. Dual read
+        tiene cooktop_groups=1. Antes: assumption desaparecía → LLM
+        re-contaba desde imagen y decía '2 anafes'. Ahora: assumption
+        con source=dual_read.
+        """
+        analysis = {"anafe_count": None}  # brief no menciona
+        dual = self._bernardi_dual()
+        assumps = _build_assumptions(analysis, None, dual, config_defaults={})
+        anafe = next((a for a in assumps if a["field"] == "Anafe — cantidad"), None)
+        assert anafe is not None, (
+            "Anafe assumption debe aparecer aunque el brief no lo mencione "
+            "(fallback a dual_read)"
+        )
+        assert "1 anafe" in anafe["value"]
+        assert anafe["source"] == "dual_read"
+        assert "detectado en plano" in anafe["value"]
+
+    def test_pileta_assumption_falls_back_to_dual_read(self):
+        analysis = {"pileta_simple_doble": None, "pileta_mentioned": False}
+        dual = self._bernardi_dual()
+        assumps = _build_assumptions(analysis, None, dual, config_defaults={})
+        pileta = next((a for a in assumps if a["field"] == "Pileta — bachas"), None)
+        assert pileta is not None
+        assert pileta["source"] == "dual_read"
+        assert "detectada en plano" in pileta["value"]
+
+    def test_brief_gas_electrico_still_wins_with_note(self):
+        """Si brief dice '2 anafes (gas + electrico)' pero dual_read solo
+        detectó 1: brief gana por precedencia y note marca divergencia."""
+        analysis = {
+            "anafe_count": 2, "anafe_gas_y_electrico": True,
+            "pileta_simple_doble": None, "pileta_mentioned": False,
+        }
+        dual = self._bernardi_dual()
+        assumps = _build_assumptions(analysis, None, dual, config_defaults={})
+        anafe = next(a for a in assumps if a["field"] == "Anafe — cantidad")
+        assert "2 anafes" in anafe["value"]
+        assert anafe["source"] == "brief"
+        assert anafe["note"] is not None
+        assert "divergencia" in anafe["note"].lower()
+
+    def test_no_anafe_no_pileta_when_neither_source_has_them(self):
+        """Dual read sin anafe/pileta + brief sin mencionar → no emitir
+        assumption vacía. El resumen no debe mencionar anafes."""
+        analysis = {"anafe_count": None}
+        dual = {"sectores": [{
+            "id": "cocina", "tipo": "cocina",
+            "tramos": [{
+                "id": "t1", "descripcion": "Mesada",
+                "largo_m": {"valor": 2.0}, "ancho_m": {"valor": 0.6},
+                "m2": {"valor": 1.2}, "zocalos": [], "features": {},
+            }],
+        }]}
+        assumps = _build_assumptions(analysis, None, dual, config_defaults={})
+        assert not any("Anafe" in a["field"] for a in assumps)
+        assert not any("bachas" in a.get("field", "").lower() for a in assumps)

--- a/api/tests/test_dual_reader.py
+++ b/api/tests/test_dual_reader.py
@@ -274,3 +274,323 @@ class TestCompareFloat:
     def test_both_zero(self):
         status, val = _compare_float(0, 0)
         assert status == "CONFIRMADO"
+
+
+# ═══════════════════════════════════════════════════════
+# PR #374 — commercial_attrs + wording authority
+# ═══════════════════════════════════════════════════════
+
+from app.modules.quote_engine.dual_reader import (  # noqa: E402
+    build_commercial_attrs,
+    _source_wording,
+)
+
+
+class TestSourceWording:
+    """Regla central: 'confirmado' SOLO si source=operator_answer."""
+
+    def test_operator_answer_is_confirmado(self):
+        assert _source_wording("operator_answer") == "confirmado por operador"
+
+    def test_operator_alias(self):
+        assert _source_wording("operator") == "confirmado por operador"
+
+    def test_brief_is_del_brief_not_confirmado(self):
+        wording = _source_wording("brief")
+        assert "confirmado" not in wording
+        assert "brief" in wording
+
+    def test_dual_read_is_detectado_not_confirmado(self):
+        wording = _source_wording("dual_read")
+        assert "confirmado" not in wording
+        assert "detectado" in wording
+
+    def test_default_or_none_is_revisar(self):
+        assert "revisar" in _source_wording("default")
+        assert "revisar" in _source_wording(None)
+        assert "revisar" in _source_wording("unknown_source")
+
+
+class TestBuildCommercialAttrsBernardi:
+    """Precedencia canónica:
+        operator_answer > brief > dual_read > default
+
+    Bernardi en el log real: brief sin mención de anafe, dual_read
+    detectó 1 anafe (cooktop_groups=1), pero el resumen comercial decía
+    '2 anafes confirmados'. Fix: inyectar anafe_count estructurado con
+    source=dual_read al verified_context.
+    """
+
+    def _bernardi_dual(self) -> dict:
+        return {
+            "sectores": [
+                {
+                    "id": "cocina", "tipo": "cocina",
+                    "tramos": [{
+                        "id": "t1", "descripcion": "Mesada",
+                        "largo_m": {"valor": 2.05},
+                        "ancho_m": {"valor": 0.60},
+                        "m2": {"valor": 1.23},
+                        "zocalos": [], "features": {
+                            "cooktop_groups": 1, "sink_simple": True,
+                            "sink_double": False, "has_pileta": True,
+                        },
+                    }],
+                },
+                {
+                    "id": "isla", "tipo": "isla",
+                    "tramos": [{
+                        "id": "t2", "descripcion": "Isla",
+                        "largo_m": {"valor": 1.60},
+                        "ancho_m": {"valor": 0.60},
+                        "m2": {"valor": 0.96},
+                        "zocalos": [], "features": {},
+                    }],
+                },
+            ],
+        }
+
+    def test_anafe_from_dual_read_when_brief_silent(self):
+        analysis = {"anafe_count": None}
+        attrs = build_commercial_attrs(
+            analysis=analysis, dual_result=self._bernardi_dual(),
+        )
+        assert attrs["anafe_count"] == {"value": 1, "source": "dual_read"}
+
+    def test_pileta_from_dual_read_when_brief_silent(self):
+        analysis = {"pileta_simple_doble": None, "pileta_mentioned": True}
+        attrs = build_commercial_attrs(
+            analysis=analysis, dual_result=self._bernardi_dual(),
+        )
+        assert attrs["pileta_simple_doble"] == {"value": "simple", "source": "dual_read"}
+
+    def test_operator_answer_overrides_brief_and_dual_read(self):
+        """Precedencia máxima: si el operador respondió, ganamos por WO.
+        Caso Javi: 'es 1 anafe y 1 pileta doble' — brief dice 'simple',
+        dual_read dice 'simple', operador cambia a 'doble'."""
+        analysis = {"pileta_simple_doble": "simple", "pileta_mentioned": True}
+        attrs = build_commercial_attrs(
+            analysis=analysis,
+            dual_result=self._bernardi_dual(),
+            operator_answers=[{"id": "pileta_simple_doble", "value": "doble"}],
+        )
+        assert attrs["pileta_simple_doble"] == {
+            "value": "doble", "source": "operator_answer",
+        }
+
+    def test_operator_anafe_override_to_1_stops_dual_read_2(self):
+        """Si el LLM antes contaba 2 por la imagen y operador respondió
+        anafe_count=1, el commercial_attrs debe usar 1 con
+        source=operator_answer → en el verified_context se imprime como
+        'confirmado por operador'."""
+        analysis = {"anafe_count": None}
+        dual = self._bernardi_dual()
+        # forzar cooktop_groups=2 (simulando el error del VLM de imagen)
+        dual["sectores"][0]["tramos"][0]["features"]["cooktop_groups"] = 2
+        attrs = build_commercial_attrs(
+            analysis=analysis, dual_result=dual,
+            operator_answers=[{"id": "anafe_count", "value": "1"}],
+        )
+        assert attrs["anafe_count"] == {"value": 1, "source": "operator_answer"}
+
+    def test_divergence_surfaces_when_brief_contradicts_dual_read(self):
+        """Brief dice '2 anafes' pero dual_read dice 1 → divergence se
+        surface como array en el output para que el LLM la muestre como
+        'revisar', no la esconda."""
+        analysis = {"anafe_count": 2, "anafe_gas_y_electrico": True}
+        attrs = build_commercial_attrs(
+            analysis=analysis, dual_result=self._bernardi_dual(),
+        )
+        # Brief gana por precedencia
+        assert attrs["anafe_count"] == {"value": 2, "source": "brief"}
+        # Y la divergencia queda registrada
+        divs = attrs.get("divergences") or []
+        assert any(d["field"] == "anafe_count" for d in divs)
+        anafe_div = next(d for d in divs if d["field"] == "anafe_count")
+        assert anafe_div["brief_value"] == 2
+        assert anafe_div["dual_read_value"] == 1
+
+    def test_operator_answers_passed_through_for_llm_visibility(self):
+        """Respuestas del operador a pending_questions (ej: profundidad
+        isla, alzada) pasan en bloque al verified_context para que el LLM
+        las vea como 'confirmadas'."""
+        attrs = build_commercial_attrs(
+            analysis={}, dual_result=self._bernardi_dual(),
+            operator_answers=[
+                {"id": "isla_profundidad", "value": "0.60", "label": "0.60 m"},
+                {"id": "isla_patas", "value": "frontal_y_laterales",
+                 "label": "Sí — frontal + ambos laterales"},
+            ],
+        )
+        assert len(attrs["operator_answers"]) == 2
+        ids = {a["id"] for a in attrs["operator_answers"]}
+        assert ids == {"isla_profundidad", "isla_patas"}
+
+
+class TestVerifiedContextWithCommercialAttrs:
+    """El texto inyectado al system prompt debe:
+    1. Incluir el bloque de atributos comerciales cuando hay commercial_attrs.
+    2. Usar wording escalonado según source (no "confirmado" para todo).
+    3. Incluir divergencias visibles.
+    """
+
+    def _min_confirmed(self) -> dict:
+        return {
+            "sectores": [{
+                "id": "cocina",
+                "tramos": [{
+                    "id": "t1", "descripcion": "Mesada",
+                    "largo_m": {"valor": 2.05},
+                    "ancho_m": {"valor": 0.60},
+                    "m2": {"valor": 1.23},
+                    "zocalos": [],
+                }],
+            }],
+        }
+
+    def test_without_commercial_attrs_is_backwards_compatible(self):
+        ctx = build_verified_context(self._min_confirmed())
+        # Sigue teniendo el header clásico, no rompe callers legacy.
+        assert "VERIFICADAS" in ctx
+        # Pero NO tiene el bloque nuevo.
+        assert "ATRIBUTOS COMERCIALES" not in ctx
+
+    def test_with_dual_read_source_uses_detectado_not_confirmado(self):
+        """Bernardi: anafe source=dual_read → wording 'detectado en plano'."""
+        ctx = build_verified_context(
+            self._min_confirmed(),
+            commercial_attrs={"anafe_count": {"value": 1, "source": "dual_read"}},
+        )
+        assert "ATRIBUTOS COMERCIALES" in ctx
+        assert "anafe_count: 1" in ctx
+        assert "source=dual_read" in ctx
+        assert "detectado en plano" in ctx
+        # La palabra "confirmado" NO debe aparecer en el bloque comercial
+        # asociada al anafe.
+        commercial_block = ctx.split("ATRIBUTOS COMERCIALES")[1]
+        # Permitido solo como parte de la instrucción "confirmado SOLO si..."
+        # pero no aplicado al campo.
+        assert "anafe_count: 1" in commercial_block
+        anafe_line = next(
+            line for line in commercial_block.splitlines() if "anafe_count: 1" in line
+        )
+        assert "detectado" in anafe_line and "confirmado" not in anafe_line
+
+    def test_with_operator_answer_source_uses_confirmado(self):
+        """Si el operador respondió, el wording SÍ es 'confirmado'."""
+        ctx = build_verified_context(
+            self._min_confirmed(),
+            commercial_attrs={"anafe_count": {"value": 1, "source": "operator_answer"}},
+        )
+        anafe_line = next(
+            line for line in ctx.splitlines() if "anafe_count: 1" in line
+        )
+        assert "confirmado por operador" in anafe_line
+
+    def test_divergences_shown_with_revisar_flag(self):
+        ctx = build_verified_context(
+            self._min_confirmed(),
+            commercial_attrs={
+                "anafe_count": {"value": 2, "source": "brief"},
+                "divergences": [{
+                    "field": "anafe_count",
+                    "brief_value": 2,
+                    "dual_read_value": 1,
+                }],
+            },
+        )
+        assert "DIVERGENCIAS" in ctx
+        assert "brief=2 vs plano=1" in ctx
+        assert "revisar" in ctx.lower()
+
+    def test_imperative_instructions_present(self):
+        """El bloque comercial debe ser imperativo: decir al LLM que NO
+        re-cuente desde la imagen y cuáles son las reglas de wording."""
+        ctx = build_verified_context(
+            self._min_confirmed(),
+            commercial_attrs={"anafe_count": {"value": 1, "source": "dual_read"}},
+        )
+        assert "USÁ SOLO" in ctx or "usá solo" in ctx.lower()
+        assert "NO re-cuentes" in ctx or "no re-cuentes" in ctx.lower()
+        assert "operator_answer" in ctx  # regla de wording
+
+    def test_operator_answers_listed_as_confirmed(self):
+        ctx = build_verified_context(
+            self._min_confirmed(),
+            commercial_attrs={
+                "operator_answers": [
+                    {"id": "isla_profundidad", "value": "0.60", "label": "0.60 m"},
+                ],
+            },
+        )
+        assert "operator_answer" in ctx
+        assert "CONFIRMADAS" in ctx or "confirmadas" in ctx.lower()
+        assert "isla_profundidad" in ctx
+        assert "0.60" in ctx
+
+
+class TestBernardiEndToEndTruthfulness:
+    """Caso Bernardi completo: el verified_context inyectado al LLM debe
+    tener anafe=1 (no 2) con wording de no-certeza, aunque la imagen
+    muestre dos cooktops visibles. El LLM no debería generar '2 anafes
+    confirmados' porque el prompt le dice explícitamente:
+    1. USÁ SOLO estos valores (no re-cuentes).
+    2. Wording 'confirmado' SOLO si source=operator_answer.
+    """
+
+    def test_bernardi_verified_context_stops_double_count(self):
+        confirmed_measures = {
+            "sectores": [{
+                "id": "cocina",
+                "tramos": [{
+                    "id": "t1", "descripcion": "Mesada con pileta",
+                    "largo_m": {"valor": 2.05},
+                    "ancho_m": {"valor": 0.60},
+                    "m2": {"valor": 1.23},
+                    "zocalos": [],
+                }],
+            }],
+        }
+        attrs = build_commercial_attrs(
+            analysis={"anafe_count": None,
+                      "pileta_simple_doble": None, "pileta_mentioned": True},
+            dual_result={"sectores": [{
+                "id": "cocina", "tipo": "cocina",
+                "tramos": [{
+                    "id": "t1", "descripcion": "Mesada",
+                    "features": {"cooktop_groups": 1, "sink_simple": True,
+                                 "has_pileta": True, "sink_double": False},
+                }],
+            }]},
+            operator_answers=[],
+        )
+        ctx = build_verified_context(confirmed_measures, commercial_attrs=attrs)
+
+        # El anafe debe aparecer como 1 detectado en plano (NO "2 anafes").
+        assert "anafe_count: 1" in ctx
+        assert "source=dual_read" in ctx
+        # El LLM ve explícitamente la regla anti-overstatement.
+        assert "NO re-cuentes desde la imagen" in ctx or "no re-cuentes desde la imagen" in ctx.lower()
+
+    def test_bernardi_with_operator_correction_pileta_doble(self):
+        """El operador responde 'pileta doble' en las preguntas bloqueantes.
+        Eso debe ganar incluso si dual_read dijo 'simple'."""
+        attrs = build_commercial_attrs(
+            analysis={"pileta_simple_doble": None, "pileta_mentioned": True},
+            dual_result={"sectores": [{
+                "id": "cocina", "tipo": "cocina",
+                "tramos": [{
+                    "features": {"sink_simple": True, "sink_double": False,
+                                 "has_pileta": True},
+                }],
+            }]},
+            operator_answers=[{"id": "pileta_simple_doble", "value": "doble"}],
+        )
+        ctx = build_verified_context({"sectores": []}, commercial_attrs=attrs)
+        assert "pileta_simple_doble: doble" in ctx
+        assert "source=operator_answer" in ctx
+        # Wording escalonado: operator_answer → "confirmado por operador"
+        pileta_line = next(
+            line for line in ctx.splitlines() if "pileta_simple_doble: doble" in line
+        )
+        assert "confirmado por operador" in pileta_line


### PR DESCRIPTION
## Summary
Fix del bug de overstatement en el resumen comercial post `DUAL_READ_CONFIRMED`.

**Caso Bernardi** (confirmado en logs):
- `[context-reconcile] field=anafe_count dual_read_value=1 final=1 source=dual_read`
- Pero el resumen decía: *"2 anafes visibles en plano → 2× ANAFE confirmados"*

**Root cause**: el LLM en la segunda pasada re-leía el plano y contaba anafes visibles porque (a) el `anafe_count=1` no llegaba al prompt como autoridad, y (b) no había regla de wording que limitara "confirmado" a datos estructuralmente confirmados.

## Cambios

| Capa | Cambio |
|------|--------|
| `context_analyzer` | Nuevos helpers puros `reconcile_anafe_count` / `reconcile_pileta_simple_doble`. `_build_assumptions` los usa con fallback brief→dual_read. `_detect_*` reusa los helpers (DRY). |
| `dual_reader` | Nuevo `build_commercial_attrs` con precedencia **operator_answer > brief > dual_read > default**. Nuevo `_source_wording` determinístico (enforcement en código, no prompt). |
| `dual_reader` | `build_verified_context` extendido: bloque "[ATRIBUTOS COMERCIALES — FUENTE DE VERDAD POR CAMPO]" con instrucciones imperativas + wording por source + divergencias visibles. |
| `agent.py` | Handler `DUAL_READ_CONFIRMED` calcula commercial_attrs desde brief_analysis + dual_read + operator_answers y los pasa al verified_context. Persiste `brief_analysis` y `verified_commercial_attrs` en breakdown. |

## Precedencia canónica (enforcement en código)
\`\`\`
operator_answer > brief > dual_read > default
\`\`\`

## Wording escalonado determinístico
| source | wording |
|--------|---------|
| operator_answer | "confirmado por operador" |
| brief | "del brief" |
| dual_read | "detectado en plano" |
| default / None | "asumido (revisar)" |

**"confirmado" SÓLO sale de operator_answer.** El LLM recibe esta regla explícita en el prompt + los valores ya etiquetados con su source.

## Non-goals (explícito, no se toca)
- Medición / ranking / guardrail (frente R1/R2 candidate quality)
- UI del frontend (el texto sale del LLM)
- Lógica de validación "respondé todas"

## Tests (28 nuevos)
- \`TestReconcileAnafePure\` / \`TestReconcilePiletaPure\` (5): helpers puros + Bernardi brief-silent.
- \`TestAssumptionsFallbackToDualRead\` (4): regresión Bernardi — anafe sale con source=dual_read cuando brief silencia.
- \`TestSourceWording\` (5): regla central "confirmado solo si operator_answer".
- \`TestBuildCommercialAttrsBernardi\` (6): precedencia completa + divergence surface + operator override.
- \`TestVerifiedContextWithCommercialAttrs\` (6): wording escalonado + instrucciones imperativas + backwards-compat.
- \`TestBernardiEndToEndTruthfulness\` (2): E2E stop del double-count + operator correction pileta doble.

**Suite completa**: 1756 passed (+28), 16 pre-existentes failed (evaluations, no relacionado).

## Test plan post-merge
- [ ] Re-correr Bernardi en prod
- [ ] Verificar que el resumen comercial:
  - Dice "1 anafe detectado en plano" (NO "2 anafes confirmados")
  - Si el operador responde "pileta doble", el resumen usa "pileta doble (confirmado por operador)"
- [ ] Revisar logs Railway: \`[context-reconcile]\` debe mostrar anafe_count con source=dual_read y divergent=False

🤖 Generated with [Claude Code](https://claude.com/claude-code)