### PR TITLE
fix(quote): persistir client_name temprano desde _run_dual_read (visibilidad en listado)

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -539,7 +539,40 @@ async def _run_dual_read(
                     _brief_raw = _context.get("_brief_analysis_raw")
                     if _brief_raw:
                         _bd2["brief_analysis"] = _brief_raw
-                    await db.execute(update(Quote).where(Quote.id == quote_id).values(quote_breakdown=_bd2))
+                    # PR #375 — Persistir temprano client_name / project /
+                    # material / localidad en las columnas dedicadas de Quote
+                    # para que el quote aparezca en el listado del dashboard
+                    # desde el turno 1 (sin esperar al while loop de Claude).
+                    # Antes: _run_dual_read hace return early con la card
+                    # emitida, nunca llega al save del while loop donde
+                    # corría `_extract_quote_info` — la columna `client_name`
+                    # quedaba vacía aunque el breakdown tuviera el valor, y
+                    # el filtro del listado (que consulta la columna) lo
+                    # trataba como empty draft.
+                    #
+                    # Reglas:
+                    # - Sólo completar columnas que están vacías ("" o None).
+                    #   NO pisar valores previos del operador.
+                    # - Sanitizar (trim, strip markdown, truncate 450 chars).
+                    # - Tolerante a fallos: si `analysis` o `quote` no están,
+                    #   se sigue igual (el comportamiento pre-#375).
+                    _col_updates = _extract_column_updates_from_analysis(
+                        _brief_raw or {}, _ck_quote,
+                    )
+                    if _col_updates:
+                        await db.execute(
+                            update(Quote)
+                            .where(Quote.id == quote_id)
+                            .values(quote_breakdown=_bd2, **_col_updates)
+                        )
+                        logging.info(
+                            f"[context-analysis] early column persist for "
+                            f"{quote_id}: fields={list(_col_updates.keys())}"
+                        )
+                    else:
+                        await db.execute(
+                            update(Quote).where(Quote.id == quote_id).values(quote_breakdown=_bd2)
+                        )
                     await db.commit()
                 except Exception as _e_px:
                     logging.warning(f"[context-analysis] persist pending failed: {_e_px}")
@@ -1139,6 +1172,69 @@ TOOLS = [
 
 
 # ── HELPERS ───────────────────────────────────────────────────────────────────
+
+def _extract_column_updates_from_analysis(
+    analysis: dict, current_quote,
+) -> dict:
+    """PR #375 — Arma el dict de update() para columnas dedicadas de Quote
+    (client_name, project, material, localidad) desde el análisis del brief,
+    respetando lo que ya existe.
+
+    Usado por `_run_dual_read` para que el quote quede visible en el
+    listado del dashboard desde el turno 1 (sin esperar a que el while
+    loop de Claude corra `_extract_quote_info` — ese punto nunca se
+    alcanza si el flujo emite `context_analysis` y hace return early).
+
+    Reglas:
+    - Sólo propone columnas que están vacías en el quote actual
+      (`""` o `None`). NO pisa valores previos del operador.
+    - Sanitiza: strip whitespace, remueve markdown bold (\\*\\*), y
+      trunca a 450 chars (DB columns son VARCHAR(500)).
+    - Si `analysis` es None/empty o `current_quote` es None, devuelve {}.
+    - Si el `analysis` no tiene un campo, ese no se toca.
+
+    Args:
+        analysis: dict del brief_analyzer (puede contener client_name,
+                  project, material, localidad como strings o None).
+        current_quote: ORM Quote object con los valores actuales en DB.
+                       Si es None, no se puede comparar → devuelve {}.
+
+    Returns:
+        Dict con las columnas a updatear (mapeable directo a values() del
+        update). Vacío si no hay nada que actualizar.
+    """
+    import re as _re
+    if not current_quote or not analysis:
+        return {}
+    _MAX_FIELD = 450
+
+    def _clean(s) -> str:
+        if not s or not isinstance(s, str):
+            return ""
+        s = _re.sub(r"[\r\n]+", " ", s)
+        s = _re.sub(r"\*+", "", s)
+        return s.strip()[:_MAX_FIELD]
+
+    updates: dict = {}
+    # Sólo tocamos columnas vacías. "" y None se consideran vacías.
+    def _is_empty(v) -> bool:
+        return v is None or v == ""
+
+    candidates = [
+        ("client_name", analysis.get("client_name")),
+        ("project", analysis.get("project")),
+        ("material", analysis.get("material")),
+        ("localidad", analysis.get("localidad")),
+    ]
+    for field, raw_value in candidates:
+        if not _is_empty(getattr(current_quote, field, None)):
+            # Operador o flujo anterior ya seteó valor — no pisar.
+            continue
+        cleaned = _clean(raw_value)
+        if cleaned:
+            updates[field] = cleaned
+    return updates
+
 
 def _extract_quote_info(user_message: str) -> dict:
     """Extract client name, project (obra) and material from user message.

--- a/api/tests/test_extract_quote_info.py
+++ b/api/tests/test_extract_quote_info.py
@@ -75,3 +75,136 @@ class TestPlainBriefsStillWork:
     def test_material_only(self):
         info = _extract_quote_info("cotizar Silestone Blanco Norte para cocina")
         assert "silestone" in info.get("material", "").lower()
+
+
+# ═══════════════════════════════════════════════════════
+# PR #375 — persistencia temprana de columnas Quote.* desde brief_analysis
+# ═══════════════════════════════════════════════════════
+
+from unittest.mock import MagicMock  # noqa: E402
+from app.modules.agent.agent import _extract_column_updates_from_analysis  # noqa: E402
+
+
+def _make_quote(client_name="", project="", material="", localidad=""):
+    """Mock Quote ORM con atributos indexables. Usamos MagicMock con spec
+    sólo por los getattr que necesitamos — suficiente para el helper."""
+    q = MagicMock()
+    q.client_name = client_name
+    q.project = project
+    q.material = material
+    q.localidad = localidad
+    return q
+
+
+class TestExtractColumnUpdatesFromAnalysis:
+    """Bernardi: brief dice 'Cliente: Erica Bernardi' → el analysis lo
+    detecta, pero el flujo hace return early con la card y nunca llega
+    al save del while loop. El quote queda `client_name=""` en DB y el
+    filtro del listado lo trata como empty draft.
+
+    El helper puro toma el analysis + quote actual y devuelve las
+    columnas a setear (sólo las vacías). Lo llama `_run_dual_read` al
+    persistir la card para que desde el turno 1 el quote sea visible.
+    """
+
+    def test_bernardi_populates_empty_columns_from_brief(self):
+        """Caso central: quote recién creado (todo vacío), brief con datos."""
+        quote = _make_quote()
+        analysis = {
+            "client_name": "Erica Bernardi",
+            "project": "",
+            "material": "Puraprima Onix White Mate",
+            "localidad": "Rosario",
+        }
+        updates = _extract_column_updates_from_analysis(analysis, quote)
+        assert updates == {
+            "client_name": "Erica Bernardi",
+            "material": "Puraprima Onix White Mate",
+            "localidad": "Rosario",
+        }
+        assert "project" not in updates  # era vacío y el analysis no trae
+
+    def test_does_not_overwrite_existing_client_name(self):
+        """Regla central: NO pisar valores previos del operador o de
+        turnos anteriores."""
+        quote = _make_quote(client_name="Juan Pérez (manual)")
+        analysis = {"client_name": "Erica Bernardi"}
+        updates = _extract_column_updates_from_analysis(analysis, quote)
+        assert "client_name" not in updates
+
+    def test_partial_fill_respects_existing_and_completes_empty(self):
+        """Quote tiene material pero no cliente → completa cliente, no
+        toca material."""
+        quote = _make_quote(material="Silestone ya seteado")
+        analysis = {
+            "client_name": "Nuevo Cliente",
+            "material": "Otro material (analysis)",
+        }
+        updates = _extract_column_updates_from_analysis(analysis, quote)
+        assert updates == {"client_name": "Nuevo Cliente"}
+        assert "material" not in updates
+
+    def test_strips_markdown_bold_before_persisting(self):
+        """`**CLIENTE:** X` — el analyze_brief a veces deja ** residual
+        en el value, el helper los limpia antes de persistir."""
+        quote = _make_quote()
+        analysis = {"client_name": "**Luciana Villagra**"}
+        updates = _extract_column_updates_from_analysis(analysis, quote)
+        assert updates["client_name"] == "Luciana Villagra"
+        assert "*" not in updates["client_name"]
+
+    def test_strips_newlines(self):
+        quote = _make_quote()
+        analysis = {"client_name": "Cliente\nCon\nSaltos"}
+        updates = _extract_column_updates_from_analysis(analysis, quote)
+        assert "\n" not in updates["client_name"]
+        assert "\r" not in updates["client_name"]
+
+    def test_truncates_long_values_to_450(self):
+        """DB columns son VARCHAR(500). Defensivo: truncar a 450."""
+        quote = _make_quote()
+        long_name = "X" * 600
+        analysis = {"client_name": long_name}
+        updates = _extract_column_updates_from_analysis(analysis, quote)
+        assert len(updates["client_name"]) == 450
+
+    def test_empty_analysis_returns_empty(self):
+        quote = _make_quote()
+        assert _extract_column_updates_from_analysis({}, quote) == {}
+        assert _extract_column_updates_from_analysis(None, quote) == {}
+
+    def test_none_quote_returns_empty(self):
+        """Sin quote no hay nada con qué comparar → empty update, no crash."""
+        assert _extract_column_updates_from_analysis({"client_name": "X"}, None) == {}
+
+    def test_analysis_with_none_fields_skipped(self):
+        """Analysis con `None` en varios campos (estado común con brief
+        vacío): no emitir updates para esos fields."""
+        quote = _make_quote()
+        analysis = {
+            "client_name": None,
+            "project": None,
+            "material": None,
+            "localidad": None,
+        }
+        assert _extract_column_updates_from_analysis(analysis, quote) == {}
+
+    def test_non_string_values_treated_as_empty(self):
+        """Si el analysis trae un tipo raro (int, dict), no romper."""
+        quote = _make_quote()
+        analysis = {"client_name": 42, "project": {"foo": "bar"}}
+        assert _extract_column_updates_from_analysis(analysis, quote) == {}
+
+    def test_whitespace_only_values_dropped(self):
+        quote = _make_quote()
+        analysis = {"client_name": "   ", "project": "\n\t"}
+        assert _extract_column_updates_from_analysis(analysis, quote) == {}
+
+    def test_existing_none_is_treated_as_empty(self):
+        """En DB, si el campo nunca fue seteado puede ser `None` (no `""`).
+        Ambos se consideran vacíos."""
+        quote = _make_quote(client_name=None)
+        analysis = {"client_name": "Nuevo"}
+        updates = _extract_column_updates_from_analysis(analysis, quote)
+        assert updates == {"client_name": "Nuevo"}
+

--- a/api/tests/test_router.py
+++ b/api/tests/test_router.py
@@ -70,6 +70,43 @@ class TestListQuotes:
         assert resp.status_code == 200
         assert len(resp.json()) == 2
 
+    @pytest.mark.asyncio
+    async def test_quote_becomes_visible_when_client_name_set(self, client):
+        """PR #375 — regresión: un quote recién creado (empty draft)
+        NO aparece en el listado. Apenas se setea `client_name`
+        (ej: desde _run_dual_read al emitir la card de análisis), el
+        quote se hace visible en el dashboard desde ese turno.
+
+        Antes, con _extract_quote_info corriendo sólo al final del while
+        loop de Claude (que nunca se alcanza cuando _run_dual_read hace
+        return early con la card), la columna client_name quedaba vacía
+        y el filtro del listado trataba el quote como empty draft aunque
+        tuviera plano + mensajes + datos en el breakdown.
+        """
+        create = await client.post("/api/quotes")
+        qid = create.json()["id"]
+
+        # Paso 1: quote recién creado, todavía sin client_name → NO en lista.
+        listing_before = await client.get("/api/quotes")
+        assert listing_before.status_code == 200
+        ids_before = {q["id"] for q in listing_before.json()}
+        assert qid not in ids_before, (
+            "Quote con client_name vacío debería estar oculto del listado"
+        )
+
+        # Paso 2: _run_dual_read simula setear client_name desde el brief.
+        # Usamos PATCH como proxy — es la misma columna que updatearía el
+        # helper _extract_column_updates_from_analysis.
+        await client.patch(f"/api/quotes/{qid}", json={"client_name": "Erica Bernardi"})
+
+        # Paso 3: ahora SÍ debe aparecer en el listado.
+        listing_after = await client.get("/api/quotes")
+        ids_after = {q["id"] for q in listing_after.json()}
+        assert qid in ids_after, (
+            "Quote con client_name seteado debe aparecer en el listado desde "
+            "ese turno (no esperar a confirmación de medidas)"
+        )
+
 
 # ── GET /api/quotes/:id — detail ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Fix a la causa real por la que un quote nuevo "desaparece" del listado del dashboard aunque esté persistido en DB con plano + chat + contexto detectado.

## Root cause

\`_run_dual_read\` emite la card de análisis de contexto y hace \`return (True, chunks)\` → **nunca se alcanza** el \`save\` del while loop de Claude (agent.py:4171+) donde \`_extract_quote_info\` populaba las columnas \`Quote.client_name\`/\`project\`/\`material\`.

Resultado: el quote queda con \`client_name=""\` aunque el \`breakdown.context_analysis_pending.data_known\` tenga "Erica Bernardi" detectado desde el turno 1. El filtro de \`list_quotes\` (router.py:184-192) consulta la columna, no el breakdown → lo trata como empty draft y lo oculta.

URL directa del quote → funciona. Dashboard → quote invisible. El operador siente que "no se persistió".

## Fix quirúrgico

Nuevo helper puro \`_extract_column_updates_from_analysis(analysis, current_quote)\` en \`agent.py\`. Usa el \`_brief_analysis_raw\` que ya exponía \`build_context_analysis\` desde PR #374 y arma el dict de \`update()\` para columnas vacías.

Integrado en \`_run_dual_read\` en el mismo commit donde se persiste \`context_analysis_pending\` — no se agregan llamadas al LLM ni otra transaction, sólo se amplía el \`.values()\`.

### Reglas del helper (auditables en tests)
1. **Sólo completa columnas vacías** (None o ""). NO pisa valores previos del operador.
2. Sanitiza: strip whitespace, remueve markdown bold, normaliza newlines.
3. Trunca a 450 chars (DB cols son VARCHAR(500)).
4. Sin analysis / sin quote → return {} (no crash).
5. Valores non-string del analysis → tratados como vacíos (defensivo).

### Log nuevo
\`\`\`
[context-analysis] early column persist for <quote_id>: fields=['client_name', 'material', 'localidad']
\`\`\`

## Non-goals (explícito)
- **NO** tocar el filtro de \`list_quotes\`.
- **NO** tocar \`cleanup_empty_drafts\`.
- **NO** sumar fallback del filtro a plano/messages.
- **NO** frente de summary authority (#374) ni candidate quality R1/R2.

## Tests (13 nuevos)

**Helper puro** (\`TestExtractColumnUpdatesFromAnalysis\`, 12):
- Bernardi populates empty columns from brief ✓
- NO overwrite existing client_name ✓
- Partial fill respects existing + completes empty ✓
- Strips markdown bold / newlines ✓
- Truncates to 450 ✓
- Empty / None analysis / None quote → {} ✓
- None fields en analysis → skipped ✓
- Non-string values tratados como empty ✓
- Whitespace-only dropped ✓
- Existing None treated as empty ✓

**Integration** (\`TestListQuotes\`, 1):
- \`test_quote_becomes_visible_when_client_name_set\` — quote vacío oculto, quote con cliente seteado visible. Usa PATCH como proxy del helper (no mockea \`_run_dual_read\` entero).

**Suite completa**: 1769 passed (+13), 16 pre-existentes failed (evaluations, nada relacionado).

## Test plan post-merge
- [ ] Re-correr Bernardi en prod: quote nuevo con brief "Cliente: X ..." debería aparecer en el dashboard **desde el turno 1** (antes de confirmar contexto).
- [ ] Revisar Railway logs: \`[context-analysis] early column persist for <qid>\` con lista de fields.
- [ ] Validar que operadores NO pierden valores previos si ya habían seteado algo manualmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)