### PR TITLE
fix(isla): piezas derivadas determinísticas de patas isla (bug Bernardi 0.90×0.90)

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1551,6 +1551,7 @@ class AgentService:
                 from app.modules.quote_engine.dual_reader import (
                     build_verified_context,
                     build_commercial_attrs,
+                    build_derived_isla_pieces,
                 )
                 # PR #374 — Juntar atributos comerciales con precedencia
                 # explícita (operator_answer > brief > dual_read > default)
@@ -1578,8 +1579,20 @@ class AgentService:
                     dual_result=_saved_dual,
                     operator_answers=_op_answers,
                 )
+                # PR #377 — Piezas derivadas determinísticas desde las
+                # respuestas del operador (ej: patas de isla). Evita
+                # que el LLM calcule dimensiones a ojo y emita 0.90×0.90
+                # en una pata lateral que debería ser 0.60×0.90.
+                _derived_pieces, _derived_warnings = build_derived_isla_pieces(
+                    operator_answers=_op_answers,
+                    verified_measurements=_confirmed_json,
+                )
+                for _w in _derived_warnings:
+                    logging.info(f"[derived-pieces] {_w}")
                 _verified_ctx = build_verified_context(
-                    _confirmed_json, commercial_attrs=_commercial_attrs,
+                    _confirmed_json,
+                    commercial_attrs=_commercial_attrs,
+                    derived_pieces=_derived_pieces or None,
                 )
                 if _q0:
                     _bd0["verified_measurements"] = _confirmed_json
@@ -1587,6 +1600,11 @@ class AgentService:
                     # Guardar también los commercial_attrs estructurados
                     # para auditoría y uso futuro (ej: templates de docs).
                     _bd0["verified_commercial_attrs"] = _commercial_attrs
+                    # PR #377 — piezas derivadas disponibles para auditoría
+                    # y para que consumers downstream (ej: templates de
+                    # docs) no re-calculen.
+                    if _derived_pieces:
+                        _bd0["verified_derived_pieces"] = _derived_pieces
                     await db.execute(update(Quote).where(Quote.id == quote_id).values(quote_breakdown=_bd0))
                     await db.commit()
                 logging.info(

--- a/api/app/modules/quote_engine/dual_reader.py
+++ b/api/app/modules/quote_engine/dual_reader.py
@@ -839,6 +839,7 @@ def _check_m2(result: dict, planilla_m2: Optional[float]) -> Optional[str]:
 def build_verified_context(
     confirmed_data: dict,
     commercial_attrs: dict | None = None,
+    derived_pieces: list[dict] | None = None,
 ) -> str:
     """Build injection text from operator-confirmed measurements + commercial
     attributes with authority/precedence annotations.
@@ -901,7 +902,45 @@ def build_verified_context(
     if commercial_attrs:
         lines.extend(_format_commercial_attrs_block(commercial_attrs))
 
+    # ── Piezas derivadas determinísticamente (PR #377) ───────────────
+    # Separadas de los atributos — el LLM copia literal estas piezas en
+    # el Paso 1. Backend arma las dimensiones; el LLM no las calcula.
+    if derived_pieces:
+        lines.extend(_format_derived_pieces_block(derived_pieces))
+
     return "\n".join(lines)
+
+
+def _format_derived_pieces_block(pieces: list[dict]) -> list[str]:
+    """Bloque imperativo con piezas ya calculadas desde respuestas del
+    operador. El LLM debe copiarlas literal en el Paso 1.
+
+    PR #377 — resuelve bug Bernardi 22/04/2026 donde el LLM calculaba
+    mal patas laterales de isla (emitía 0.90×0.90 en vez de 0.60×0.90)
+    porque el prompt le pasaba los atributos del operador como etiquetas
+    planas sin instrucción de combinar dimensiones.
+
+    Ahora el backend calcula las piezas (Pata lateral = prof×alto,
+    Pata frontal = largo×alto) y se las pasa ya listas al LLM.
+    """
+    lines: list[str] = [
+        "[PIEZAS DERIVADAS DE RESPUESTAS DEL OPERADOR — DETERMINÍSTICAS]",
+        "⛔ Estas piezas están CALCULADAS por el backend desde los datos",
+        "   confirmados por el operador. Copialas LITERAL en el Paso 1.",
+        "⛔ NO recalcular dimensiones. NO cambiar el orden. NO omitir.",
+        "⛔ Si pensás que hay un error, volvé al operador — no las editues.",
+        "",
+    ]
+    for p in pieces:
+        desc = p.get("description", "?")
+        largo = p.get("largo")
+        prof = p.get("prof")
+        m2 = p.get("m2")
+        lines.append(
+            f"  {desc}: {largo} × {prof} = {m2} m²"
+        )
+    lines.append("")
+    return lines
 
 
 # Wording según source — determinístico, no dejarlo al LLM.
@@ -995,6 +1034,173 @@ def _format_commercial_attrs_block(attrs: dict) -> list[str]:
         lines.append("  (ningún atributo comercial con valor estructurado — pedí al operador)")
         lines.append("")
     return lines
+
+
+def _parse_float_answer(a: dict | None) -> float | None:
+    """Convierte una operator_answer del tipo radio-with-detail a float.
+
+    La UI guarda los values como strings ("0.60", "0.90"). Cuando el
+    operador elige "custom" puede haber un detail con el número en texto.
+    Devuelve None si no parsea — señal de "dato faltante" río abajo.
+    """
+    if not a:
+        return None
+    for key in ("value", "detail"):
+        raw = a.get(key)
+        if raw is None:
+            continue
+        try:
+            if isinstance(raw, (int, float)):
+                f = float(raw)
+                if f > 0:
+                    return f
+                continue
+            s = str(raw).strip().replace(",", ".")
+            # remueve sufijo "m" si está
+            s = re.sub(r"m\s*$", "", s, flags=re.IGNORECASE).strip()
+            f = float(s)
+            if f > 0:
+                return f
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+# Mapeo explícito de `isla_patas.value` → lista de lados activos. Centralizado
+# para que si el schema de la pregunta cambia (ver pending_questions.py), el
+# helper siga alineado. Si el value no está acá → no se emite nada (fallback
+# seguro, no inventar).
+_ISLA_PATAS_SIDES = {
+    "frontal_y_ambos_laterales": ["frontal", "lateral_izq", "lateral_der"],
+    # alias histórico más corto que apareció en algunas cards
+    "frontal_y_laterales": ["frontal", "lateral_izq", "lateral_der"],
+    "solo_frontal": ["frontal"],
+    "solo_laterales": ["lateral_izq", "lateral_der"],
+    "no": [],
+    # "custom" → sin mapping determinístico; el LLM debe preguntar al
+    # operador cuáles lados. NO emitir piezas automáticas.
+}
+
+
+def build_derived_isla_pieces(
+    operator_answers: list | None,
+    verified_measurements: dict | None,
+) -> tuple[list[dict], list[str]]:
+    """Expande las respuestas confirmadas del operador sobre patas de isla
+    a piezas físicas ya calculadas. Scope SOLO patas de isla (frontal /
+    laterales) — no extrapola a frentines, zócalos ni otros derivados.
+
+    Regla de dimensiones (alineada con quote-033 y la regla física):
+      - Pata frontal  = `largo_isla × alto_patas`
+      - Pata lateral  = `profundidad_isla × alto_patas`
+
+    Datos base requeridos (TODOS). Si falta alguno → devolvemos
+    lista vacía + warning. NO inventar dimensiones.
+      - operator_answer `isla_patas` con value reconocido (distinto de
+        "custom" y "no"-con-patas).
+      - operator_answer `isla_patas_alto` con valor numérico parseable.
+      - operator_answer `isla_profundidad` con valor numérico parseable.
+      - `verified_measurements` con un sector tipo "isla" y largo > 0.
+
+    Returns:
+        (pieces, warnings)
+        pieces: list[{description, largo, prof, m2, source}] determinísticas
+        warnings: list de strings explicando por qué no se emitió (si aplica)
+    """
+    warnings: list[str] = []
+    if not operator_answers:
+        return [], []
+
+    by_id: dict[str, dict] = {}
+    for a in operator_answers:
+        fid = a.get("id") if isinstance(a, dict) else None
+        if fid:
+            by_id[fid] = a
+
+    patas_ans = by_id.get("isla_patas")
+    if not patas_ans:
+        # No se preguntó / no se respondió. No es error — simplemente no
+        # hay derivadas que emitir.
+        return [], []
+
+    patas_value = patas_ans.get("value")
+    sides = _ISLA_PATAS_SIDES.get(patas_value)
+    if sides is None:
+        # value="custom" u otro no mapeable. El LLM debe preguntar.
+        warnings.append(
+            f"isla_patas={patas_value!r} no se puede expandir automáticamente "
+            f"(ej: 'custom'). No se emiten piezas derivadas."
+        )
+        return [], warnings
+    if not sides:
+        # "no" → no hay patas. Nada que emitir, sin warning.
+        return [], []
+
+    # Datos base — todos obligatorios para emitir piezas.
+    alto = _parse_float_answer(by_id.get("isla_patas_alto"))
+    prof = _parse_float_answer(by_id.get("isla_profundidad"))
+
+    # largo_isla viene de las medidas verificadas (sector tipo="isla").
+    largo_isla: float | None = None
+    for sector in (verified_measurements or {}).get("sectores", []) or []:
+        if (sector.get("tipo") or "").lower() != "isla":
+            continue
+        for tramo in sector.get("tramos", []) or []:
+            largo_field = tramo.get("largo_m")
+            if isinstance(largo_field, dict):
+                v = largo_field.get("valor")
+            else:
+                v = largo_field
+            try:
+                if v is not None and float(v) > 0:
+                    largo_isla = float(v)
+                    break
+            except (TypeError, ValueError):
+                continue
+        if largo_isla:
+            break
+
+    missing: list[str] = []
+    if alto is None:
+        missing.append("isla_patas_alto")
+    if prof is None and any(s.startswith("lateral") for s in sides):
+        missing.append("isla_profundidad")
+    if largo_isla is None and "frontal" in sides:
+        missing.append("largo_isla (de medidas verificadas)")
+    if missing:
+        warnings.append(
+            f"No se emiten piezas derivadas de patas isla — faltan datos "
+            f"base: {', '.join(missing)}. El LLM debe preguntar al operador "
+            f"o resolver antes de listar patas."
+        )
+        return [], warnings
+
+    def _mk_piece(desc: str, largo_v: float, prof_v: float) -> dict:
+        return {
+            "description": desc,
+            "largo": round(float(largo_v), 2),
+            "prof": round(float(prof_v), 2),
+            "m2": round(float(largo_v) * float(prof_v), 2),
+            "source": "derived_from_operator_answers",
+        }
+
+    pieces: list[dict] = []
+    # Orden: frontal primero, luego laterales (izq, der). Match con cómo
+    # lo escribe el LLM en ejemplos válidos (quote-033).
+    if "frontal" in sides:
+        pieces.append(_mk_piece(
+            "Pata frontal isla", largo_isla, alto,
+        ))
+    if "lateral_izq" in sides:
+        pieces.append(_mk_piece(
+            "Pata lateral isla izq", prof, alto,
+        ))
+    if "lateral_der" in sides:
+        pieces.append(_mk_piece(
+            "Pata lateral isla der", prof, alto,
+        ))
+
+    return pieces, warnings
 
 
 def build_commercial_attrs(

--- a/api/tests/test_dual_reader.py
+++ b/api/tests/test_dual_reader.py
@@ -594,3 +594,331 @@ class TestBernardiEndToEndTruthfulness:
             line for line in ctx.splitlines() if "pileta_simple_doble: doble" in line
         )
         assert "confirmado por operador" in pileta_line
+
+
+# ═══════════════════════════════════════════════════════
+# PR #377 — build_derived_isla_pieces (bug Bernardi: laterales 0.90×0.90)
+# ═══════════════════════════════════════════════════════
+
+from app.modules.quote_engine.dual_reader import (  # noqa: E402
+    build_derived_isla_pieces,
+)
+
+
+def _bernardi_measurements(largo_isla=1.60):
+    """Medidas verificadas típicas de Bernardi: cocina con 2 mesadas
+    + 1 sector isla con largo confirmado por el operador."""
+    return {
+        "sectores": [
+            {
+                "id": "cocina", "tipo": "cocina",
+                "tramos": [
+                    {"id": "t1", "descripcion": "Mesada con pileta",
+                     "largo_m": {"valor": 2.05}, "ancho_m": {"valor": 0.60},
+                     "m2": {"valor": 1.23}},
+                    {"id": "t2", "descripcion": "Mesada 2",
+                     "largo_m": {"valor": 2.95}, "ancho_m": {"valor": 0.60},
+                     "m2": {"valor": 1.77}},
+                ],
+            },
+            {
+                "id": "isla", "tipo": "isla",
+                "tramos": [
+                    {"id": "t3", "descripcion": "Tapa isla",
+                     "largo_m": {"valor": largo_isla},
+                     "ancho_m": {"valor": 0.60},
+                     "m2": {"valor": round(largo_isla * 0.60, 2)}},
+                ],
+            },
+        ],
+    }
+
+
+class TestBuildDerivedIslaPiecesBernardi:
+    """Caso central del bug: operador confirmó patas solo_laterales,
+    alto 0.90, prof isla 0.60. El LLM en Paso 1 emitía
+        'Pata lateral isla izq | 0.90 × 0.90'
+    cuando debería ser
+        'Pata lateral isla izq | 0.60 × 0.90'.
+
+    El helper determinístico resuelve esto calculando en backend:
+    pata lateral = prof_isla × alto_patas.
+    """
+
+    def test_bernardi_solo_laterales_exact(self):
+        """Caso EXACTO del bug — laterales deben salir 0.60 × 0.90."""
+        pieces, warnings = build_derived_isla_pieces(
+            operator_answers=[
+                {"id": "isla_patas", "value": "solo_laterales"},
+                {"id": "isla_patas_alto", "value": "0.90"},
+                {"id": "isla_profundidad", "value": "0.60"},
+            ],
+            verified_measurements=_bernardi_measurements(),
+        )
+        assert warnings == []
+        assert len(pieces) == 2
+        izq = next(p for p in pieces if "izq" in p["description"].lower())
+        der = next(p for p in pieces if "der" in p["description"].lower())
+        assert izq["largo"] == 0.60 and izq["prof"] == 0.90
+        assert der["largo"] == 0.60 and der["prof"] == 0.90
+        assert izq["m2"] == 0.54
+        assert der["m2"] == 0.54
+        # Nunca 0.90×0.90
+        assert not any(p["largo"] == 0.90 and p["prof"] == 0.90 for p in pieces)
+
+    def test_frontal_y_ambos_laterales_emits_three(self):
+        """Frontal usa largo_isla; laterales usan prof_isla."""
+        pieces, warnings = build_derived_isla_pieces(
+            operator_answers=[
+                {"id": "isla_patas", "value": "frontal_y_ambos_laterales"},
+                {"id": "isla_patas_alto", "value": "0.90"},
+                {"id": "isla_profundidad", "value": "0.60"},
+            ],
+            verified_measurements=_bernardi_measurements(largo_isla=1.60),
+        )
+        assert warnings == []
+        assert len(pieces) == 3
+        frontal = next(p for p in pieces if "frontal" in p["description"].lower())
+        # Frontal = largo_isla × alto
+        assert frontal["largo"] == 1.60 and frontal["prof"] == 0.90
+        assert frontal["m2"] == 1.44
+        # Laterales = prof_isla × alto
+        laterales = [p for p in pieces if "lateral" in p["description"].lower()]
+        assert len(laterales) == 2
+        for lat in laterales:
+            assert lat["largo"] == 0.60 and lat["prof"] == 0.90
+            assert lat["m2"] == 0.54
+
+    def test_solo_frontal_emits_one(self):
+        pieces, _ = build_derived_isla_pieces(
+            operator_answers=[
+                {"id": "isla_patas", "value": "solo_frontal"},
+                {"id": "isla_patas_alto", "value": "0.90"},
+                # prof no es necesaria si solo hay frontal
+            ],
+            verified_measurements=_bernardi_measurements(largo_isla=2.40),
+        )
+        assert len(pieces) == 1
+        assert pieces[0]["description"].lower().startswith("pata frontal")
+        assert pieces[0]["largo"] == 2.40
+        assert pieces[0]["prof"] == 0.90
+
+    def test_solo_frontal_does_not_require_profundidad(self):
+        """Si solo hay frontal, la profundidad de la isla no se usa →
+        debe poder emitir la pieza sin isla_profundidad."""
+        pieces, warnings = build_derived_isla_pieces(
+            operator_answers=[
+                {"id": "isla_patas", "value": "solo_frontal"},
+                {"id": "isla_patas_alto", "value": "0.90"},
+            ],
+            verified_measurements=_bernardi_measurements(),
+        )
+        assert warnings == []
+        assert len(pieces) == 1
+
+    def test_patas_no_emits_nothing(self):
+        """'No lleva patas' → 0 piezas, sin warnings (es una respuesta
+        válida, no una omisión)."""
+        pieces, warnings = build_derived_isla_pieces(
+            operator_answers=[
+                {"id": "isla_patas", "value": "no"},
+                {"id": "isla_patas_alto", "value": "0.90"},
+                {"id": "isla_profundidad", "value": "0.60"},
+            ],
+            verified_measurements=_bernardi_measurements(),
+        )
+        assert pieces == []
+        assert warnings == []
+
+    def test_missing_alto_emits_warning_no_pieces(self):
+        """Falta isla_patas_alto → no emitir, warning claro."""
+        pieces, warnings = build_derived_isla_pieces(
+            operator_answers=[
+                {"id": "isla_patas", "value": "frontal_y_ambos_laterales"},
+                {"id": "isla_profundidad", "value": "0.60"},
+                # isla_patas_alto ausente
+            ],
+            verified_measurements=_bernardi_measurements(),
+        )
+        assert pieces == []
+        assert len(warnings) == 1
+        assert "isla_patas_alto" in warnings[0]
+
+    def test_missing_prof_emits_warning_only_when_laterales(self):
+        """Falta isla_profundidad pero solo hay frontal → NO es warning
+        (no se usa la prof). Falta prof + hay laterales → SÍ warning."""
+        # Solo frontal → sin warning, se emite la pieza
+        pieces_ok, warns_ok = build_derived_isla_pieces(
+            operator_answers=[
+                {"id": "isla_patas", "value": "solo_frontal"},
+                {"id": "isla_patas_alto", "value": "0.90"},
+            ],
+            verified_measurements=_bernardi_measurements(),
+        )
+        assert len(pieces_ok) == 1
+        assert warns_ok == []
+
+        # Con laterales y sin prof → no emitir, warning
+        pieces_miss, warns_miss = build_derived_isla_pieces(
+            operator_answers=[
+                {"id": "isla_patas", "value": "solo_laterales"},
+                {"id": "isla_patas_alto", "value": "0.90"},
+            ],
+            verified_measurements=_bernardi_measurements(),
+        )
+        assert pieces_miss == []
+        assert len(warns_miss) == 1
+        assert "isla_profundidad" in warns_miss[0]
+
+    def test_missing_largo_isla_warning_only_when_frontal(self):
+        """Si no hay sector isla en las medidas pero el operador pidió
+        frontal → warning. Si pidió solo laterales → sin warning (frontal
+        no se usa)."""
+        measurements_no_isla = {"sectores": [{"tipo": "cocina", "tramos": []}]}
+
+        # Frontal sin largo_isla → warning
+        _, warns = build_derived_isla_pieces(
+            operator_answers=[
+                {"id": "isla_patas", "value": "frontal_y_ambos_laterales"},
+                {"id": "isla_patas_alto", "value": "0.90"},
+                {"id": "isla_profundidad", "value": "0.60"},
+            ],
+            verified_measurements=measurements_no_isla,
+        )
+        assert len(warns) == 1
+        assert "largo_isla" in warns[0]
+
+        # Solo laterales sin largo_isla → OK, no lo necesita
+        pieces_lat, warns_lat = build_derived_isla_pieces(
+            operator_answers=[
+                {"id": "isla_patas", "value": "solo_laterales"},
+                {"id": "isla_patas_alto", "value": "0.90"},
+                {"id": "isla_profundidad", "value": "0.60"},
+            ],
+            verified_measurements=measurements_no_isla,
+        )
+        assert len(pieces_lat) == 2
+        assert warns_lat == []
+
+    def test_custom_value_does_not_invent_pieces(self):
+        """isla_patas='custom' — el LLM debe preguntar al operador.
+        Helper devuelve warning, NO inventa piezas."""
+        pieces, warnings = build_derived_isla_pieces(
+            operator_answers=[
+                {"id": "isla_patas", "value": "custom",
+                 "detail": "solo una pata detrás"},
+                {"id": "isla_patas_alto", "value": "0.90"},
+                {"id": "isla_profundidad", "value": "0.60"},
+            ],
+            verified_measurements=_bernardi_measurements(),
+        )
+        assert pieces == []
+        assert len(warnings) == 1
+        assert "custom" in warnings[0]
+
+    def test_empty_inputs_return_empty(self):
+        pieces, warnings = build_derived_isla_pieces(
+            operator_answers=None, verified_measurements=None,
+        )
+        assert pieces == []
+        assert warnings == []
+        pieces, warnings = build_derived_isla_pieces(
+            operator_answers=[], verified_measurements={},
+        )
+        assert pieces == []
+        assert warnings == []
+
+    def test_no_isla_patas_answer_returns_empty_no_warning(self):
+        """Operador no respondió la pregunta de patas (ej: no hay isla).
+        Sin warnings ni piezas — no es una omisión real."""
+        pieces, warnings = build_derived_isla_pieces(
+            operator_answers=[
+                {"id": "alzada", "value": "no"},
+                {"id": "isla_patas_alto", "value": "0.90"},
+            ],
+            verified_measurements=_bernardi_measurements(),
+        )
+        assert pieces == []
+        assert warnings == []
+
+    def test_custom_detail_parseable_alto(self):
+        """isla_patas_alto='custom' con detail='0.75' → se parsea."""
+        pieces, warnings = build_derived_isla_pieces(
+            operator_answers=[
+                {"id": "isla_patas", "value": "solo_frontal"},
+                {"id": "isla_patas_alto", "value": "custom", "detail": "0.75"},
+            ],
+            verified_measurements=_bernardi_measurements(),
+        )
+        assert warnings == []
+        assert len(pieces) == 1
+        assert pieces[0]["prof"] == 0.75
+
+    def test_comma_decimal_accepted(self):
+        """El operador puede ingresar '0,75' (coma) en el detail."""
+        pieces, _ = build_derived_isla_pieces(
+            operator_answers=[
+                {"id": "isla_patas", "value": "solo_frontal"},
+                {"id": "isla_patas_alto", "value": "custom", "detail": "0,75 m"},
+            ],
+            verified_measurements=_bernardi_measurements(),
+        )
+        assert len(pieces) == 1
+        assert pieces[0]["prof"] == 0.75
+
+    def test_pieces_include_source_marker(self):
+        """Cada pieza derivada debe marcarse con source para auditoría."""
+        pieces, _ = build_derived_isla_pieces(
+            operator_answers=[
+                {"id": "isla_patas", "value": "solo_frontal"},
+                {"id": "isla_patas_alto", "value": "0.90"},
+            ],
+            verified_measurements=_bernardi_measurements(),
+        )
+        assert all(p.get("source") == "derived_from_operator_answers" for p in pieces)
+
+
+class TestVerifiedContextEmitsDerivedPiecesBlock:
+    """El bloque 'PIEZAS DERIVADAS' debe aparecer en el texto del
+    verified_context cuando hay piezas, con instrucciones imperativas
+    de copiar literal. Y debe estar SEPARADO del bloque de atributos."""
+
+    def _min_confirmed(self) -> dict:
+        return {"sectores": [{"id": "cocina", "tramos": [{
+            "id": "t1", "descripcion": "Mesada",
+            "largo_m": {"valor": 2.0}, "ancho_m": {"valor": 0.60},
+            "m2": {"valor": 1.20}, "zocalos": [],
+        }]}]}
+
+    def test_no_derived_block_when_empty(self):
+        ctx = build_verified_context(self._min_confirmed(), derived_pieces=None)
+        assert "PIEZAS DERIVADAS" not in ctx
+
+    def test_derived_block_present_with_pieces(self):
+        pieces = [
+            {"description": "Pata lateral isla izq", "largo": 0.60, "prof": 0.90, "m2": 0.54},
+            {"description": "Pata lateral isla der", "largo": 0.60, "prof": 0.90, "m2": 0.54},
+        ]
+        ctx = build_verified_context(self._min_confirmed(), derived_pieces=pieces)
+        assert "PIEZAS DERIVADAS" in ctx
+        assert "COPIALAS LITERAL" in ctx.upper() or "copialas literal" in ctx.lower()
+        assert "NO recalcular" in ctx
+        # Las dimensiones deben aparecer exactamente
+        assert "0.6 × 0.9 = 0.54 m²" in ctx
+
+    def test_separated_from_commercial_attrs_block(self):
+        pieces = [
+            {"description": "Pata frontal isla", "largo": 1.60, "prof": 0.90, "m2": 1.44},
+        ]
+        ctx = build_verified_context(
+            self._min_confirmed(),
+            commercial_attrs={"anafe_count": {"value": 1, "source": "dual_read"}},
+            derived_pieces=pieces,
+        )
+        # Ambos bloques presentes
+        assert "ATRIBUTOS COMERCIALES" in ctx
+        assert "PIEZAS DERIVADAS" in ctx
+        # Y separados: el de derivadas aparece después del de atributos
+        # (orden estable para que el LLM los lea en secuencia natural:
+        #  medidas → atributos → piezas derivadas).
+        assert ctx.index("ATRIBUTOS COMERCIALES") < ctx.index("PIEZAS DERIVADAS")


### PR DESCRIPTION
## Summary
Bug Bernardi 22/04/2026: el Paso 1 emitía patas laterales **0.90 × 0.90** en lugar de **0.60 × 0.90** (la profundidad real de la isla). El LLM calculaba a ojo desde etiquetas planas del verified_context y confundía los ejes al rotar la pata 90°.

**Solución**: autoridad en código, no prompt. Nuevo helper determinístico en backend que expande las respuestas del operador a piezas con dimensiones ya calculadas. El LLM las copia literal.

## Fórmulas (regla física, ahora en código)
- **Pata frontal** = `largo_isla × alto_patas` (ej: 1.60 × 0.90)
- **Pata lateral** = `profundidad_isla × alto_patas` (ej: 0.60 × 0.90)

## Nuevo helper `build_derived_isla_pieces`
- Lee operator_answers + verified_measurements.
- Cobertura por value de \`isla_patas\`: \`frontal_y_ambos_laterales\` (3), \`solo_frontal\` (1), \`solo_laterales\` (2), \`no\` (0), \`custom\` (0 + warning).
- Datos requeridos solo cuando se usan (ej: profundidad solo si hay lateral).
- Si falta cualquier dato base → **vacío + warning claro**. **NO inventa.**

## Bloque separado en verified_context
Nueva sección \`[PIEZAS DERIVADAS DE RESPUESTAS DEL OPERADOR — DETERMINÍSTICAS]\` con instrucciones imperativas:
> ⛔ Estas piezas están CALCULADAS por el backend. Copialas LITERAL en el Paso 1. NO recalcular. NO cambiar el orden.

Separada del bloque de atributos comerciales (orden estable: medidas → atributos → derivadas).

## Wire
- \`agent.py\` handler \`DUAL_READ_CONFIRMED\` llama \`build_derived_isla_pieces\` con operator_answers + verified_measurements.
- Las piezas se inyectan al verified_context y se persisten en \`breakdown.verified_derived_pieces\` para auditoría.
- Log nuevo: \`[derived-pieces] <warning>\`.

## Non-goals
- NO candidate quality R1/R2.
- NO extrapolación a frentines/zócalos/otros derivados (scope cerrado).
- NO cambios al calculator.
- NO UI.

## Tests (17 nuevos)

**\`TestBuildDerivedIslaPiecesBernardi\`** (13):
- ✅ Bernardi exact: solo_laterales → 0.60 × 0.90, **nunca** 0.90 × 0.90
- ✅ frontal_y_ambos_laterales → 3 piezas, frontal usa largo, laterales usan prof
- ✅ solo_frontal → 1 pieza, no requiere profundidad
- ✅ patas 'no' → 0 piezas, sin warnings
- ✅ Missing alto → warning + sin piezas
- ✅ Missing prof → warning solo si hay laterales (no si solo frontal)
- ✅ Missing largo_isla → warning solo si hay frontal
- ✅ \`custom\` → warning, no inventa
- ✅ Empty inputs → empty
- ✅ \`isla_patas_alto=custom\` con detail '0,75 m' → parseado (incluye coma decimal)
- ✅ Pieces marcadas con \`source=derived_from_operator_answers\`

**\`TestVerifiedContextEmitsDerivedPiecesBlock\`** (3):
- Sin derived_pieces → no emite bloque
- Con derived_pieces → bloque con instrucciones imperativas
- Bloques separados y en orden: atributos → derivadas

**Suite completa**: 1798 passed (+17), 16 pre-existentes failed (no relacionados).

## Test plan post-merge
- [ ] Re-correr Bernardi: en el Paso 1 las patas laterales deben salir **0.60 × 0.90 = 0.54 m²** cada una. Total de isla con laterales = 0.96 + 0.54 + 0.54 = 2.04. Total general 5.04 m² (no 5.58).
- [ ] Ver log Railway: \`[derived-pieces] ...\` solo si faltan datos.
- [ ] Ver que \`breakdown.verified_derived_pieces\` queda persistido para auditoría.
- [ ] Caso con isla sin patas (operador respondió "no") → Paso 1 no lista patas, sin warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)