### PR TITLE
feat(flow): lock post-confirmación + botón 'Editar despiece' explícito

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1707,25 +1707,16 @@ class AgentService:
                         dict(_existing_card), _ops
                     )
                     # Guardar el card patcheado + limpiar Paso 2 state si
-                    # estamos revirtiendo.
+                    # estamos revirtiendo. PR #378 — la lista de campos
+                    # limpiar vive en `card_editor.reset_quote_to_paso1`
+                    # (reutilizada por el endpoint reopen-measurements).
                     try:
-                        _cm_bd_new = dict(_cm_bd)
-                        _cm_bd_new["dual_read_result"] = _patched_card
                         if _reverting_from_paso2:
-                            # Limpiar todo el state post-confirmación para
-                            # que el flujo vuelva a Paso 1.
-                            for _stale in (
-                                "verified_context", "verified_measurements",
-                                "measurements_confirmed", "material_name",
-                                "material_m2", "material_price_unit",
-                                "material_currency", "discount_amount",
-                                "discount_pct", "total_ars", "total_usd",
-                                "mo_items", "sectors", "sinks", "piece_details",
-                                "mo_discount_amount", "mo_discount_pct",
-                                "total_mo_ars", "sobrante_m2", "sobrante_total",
-                                "paso1_pieces", "paso1_total_m2",
-                            ):
-                                _cm_bd_new.pop(_stale, None)
+                            from app.modules.agent.card_editor import reset_quote_to_paso1
+                            _cm_bd_new = reset_quote_to_paso1(_cm_bd)
+                        else:
+                            _cm_bd_new = dict(_cm_bd)
+                        _cm_bd_new["dual_read_result"] = _patched_card
                         await db.execute(
                             update(Quote).where(Quote.id == quote_id).values(
                                 quote_breakdown=_cm_bd_new,

--- a/api/app/modules/agent/card_editor.py
+++ b/api/app/modules/agent/card_editor.py
@@ -364,3 +364,109 @@ def format_patch_summary(applied: list[str], errors: list[str]) -> str:
             "(zócalo/mesada/sector) y qué medidas?"
         )
     return "\n".join(lines)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# PR #378 — Lock post-confirmación y reopen explícito
+#
+# Helper reutilizable para resetear un quote de Paso 2 → Paso 1.
+# Consumidores:
+#   1. El revert automático del card_editor cuando detecta una
+#      modificación desde el chat post-confirmación.
+#   2. El endpoint POST /api/quotes/:id/reopen-measurements que usa el
+#      frontend cuando el operador aprieta "Editar despiece".
+#
+# Antes este bloque de limpieza estaba inline en agent.py (líneas
+# ~1715-1728). Lo centralizamos acá para una sola fuente de verdad —
+# si mañana se agrega un nuevo campo derivado de Paso 2 (ej:
+# verified_derived_pieces en PR #377, verified_commercial_attrs en
+# #374), este helper lo cubre y no hay que cambiar 2 lugares.
+# ─────────────────────────────────────────────────────────────────────
+
+
+# Lista canónica de keys de `quote_breakdown` que representan estado
+# derivado de Paso 2 (material + MO + totales + contexto confirmado).
+# Al resetear a Paso 1 se quitan todas. `dual_read_result` NO está acá
+# — ese es el despiece, se preserva (eventualmente con patch aplicado
+# por el caller antes del reset).
+_PASO2_DERIVED_KEYS = (
+    # Confirmación de medidas
+    "verified_context",
+    "verified_measurements",
+    "measurements_confirmed",  # campo legacy — se limpia por defensa
+    "verified_commercial_attrs",  # PR #374
+    "verified_derived_pieces",  # PR #377
+    # Material + pricing
+    "material_name",
+    "material_m2",
+    "material_price_unit",
+    "material_currency",
+    "discount_amount",
+    "discount_pct",
+    # Totales
+    "total_ars",
+    "total_usd",
+    "total_mo_ars",
+    # MO + sectores + piezas detalladas
+    "mo_items",
+    "sectors",
+    "sinks",
+    "piece_details",
+    "mo_discount_amount",
+    "mo_discount_pct",
+    # Merma / sobrante
+    "sobrante_m2",
+    "sobrante_total",
+    # Paso 1 snapshots
+    "paso1_pieces",
+    "paso1_total_m2",
+)
+
+
+def is_paso2_confirmed(quote_breakdown: dict | None) -> bool:
+    """True si el quote ya pasó por la confirmación de medidas
+    (`verified_context` existe).
+
+    Usado tanto por el endpoint reopen como por el frontend
+    (indirectamente via el breakdown que trae GET /quotes/:id) para
+    decidir si mostrar los inputs lockeados + el botón "Editar despiece".
+    """
+    if not quote_breakdown:
+        return False
+    return bool(
+        quote_breakdown.get("verified_context")
+        or quote_breakdown.get("measurements_confirmed")
+    )
+
+
+def reset_quote_to_paso1(
+    quote_breakdown: dict | None,
+    *,
+    preserve_dual_read_result: bool = True,
+) -> dict:
+    """Devuelve un breakdown nuevo con todos los campos de Paso 2 limpios
+    — lleva al quote al estado "Paso 1 en edición".
+
+    No muta el input. No accede a DB (mantener el helper puro).
+
+    Args:
+        quote_breakdown: el dict actual (puede ser None o {}).
+        preserve_dual_read_result: si True (default), el despiece en
+            `dual_read_result` se preserva — el operador lo edita desde
+            ahí. Si el caller quiere reemplazarlo (ej: patch aplicado
+            antes del reset), lo sobrescribe en el breakdown que
+            devuelva este helper.
+
+    Returns:
+        Nuevo dict con las keys de Paso 2 removidas. El resto del
+        breakdown (brief_analysis, dual_read_plan_hash, context_analysis_pending,
+        verified_context_analysis, y cualquier metadata) se preserva.
+    """
+    if not quote_breakdown:
+        return {}
+    new_bd = dict(quote_breakdown)
+    for key in _PASO2_DERIVED_KEYS:
+        new_bd.pop(key, None)
+    if not preserve_dual_read_result:
+        new_bd.pop("dual_read_result", None)
+    return new_bd

--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -371,6 +371,95 @@ async def update_status(
     return {"ok": True}
 
 
+# ── REOPEN MEASUREMENTS (unlock post-confirmation editing) ─────────────────
+#
+# PR #378 — El operador aprieta "Editar despiece" en la UI cuando quiere
+# corregir medidas/piezas después de haber confirmado. Este endpoint
+# invalida el Paso 2 (borra material + MO + totales + commercial_attrs
+# + derived_pieces) y deja el quote en estado "Paso 1 editable" — el
+# operador corrige, reconfirma, Valentina regenera Paso 2 limpio.
+#
+# Alternativa que usábamos antes: el operador escribía "agregá zócalo..."
+# en el chat y card_editor detectaba keywords para hacer lo mismo. Sigue
+# funcionando (mismo helper `reset_quote_to_paso1`), pero este endpoint
+# es explícito: un click, no-chat-prompt.
+#
+# Prohibido en quotes con status {validated, sent} — ya se generó PDF
+# al cliente. Si el operador necesita rearmar, hay que duplicar el quote
+# (separate flow) o cambiar status manualmente.
+
+@router.post("/quotes/{quote_id}/reopen-measurements")
+async def reopen_measurements(
+    quote_id: str,
+    db: AsyncSession = Depends(get_db),
+):
+    """Resetea el quote a Paso 1 para permitir edición post-confirmación.
+
+    Returns the updated quote (con Paso 2 state ya limpiado).
+
+    Codes:
+        200 — reopen aplicado, breakdown con Paso 2 limpio.
+        404 — quote no existe.
+        409 — status no permite reopen (validated/sent).
+        400 — no había confirmación previa (nada que reabrir).
+    """
+    from app.modules.agent.card_editor import (
+        reset_quote_to_paso1,
+        is_paso2_confirmed,
+    )
+    result = await db.execute(select(Quote).where(Quote.id == quote_id))
+    quote = result.scalar_one_or_none()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Presupuesto no encontrado")
+
+    # Status gate: validated/sent no se reabre (PDF ya entregado).
+    status_value = quote.status.value if hasattr(quote.status, "value") else str(quote.status)
+    if status_value in ("validated", "sent"):
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"El presupuesto está en estado '{status_value}'. No se puede "
+                "reabrir edición — el PDF ya fue generado/enviado. Duplicá el "
+                "quote si necesitás rearmar."
+            ),
+        )
+
+    bd = quote.quote_breakdown or {}
+    if not is_paso2_confirmed(bd):
+        # Idempotencia + claridad: si no hay nada que reabrir (el quote
+        # sigue en Paso 1 o es nuevo), devolvemos 400 para que la UI
+        # sepa que el botón está en un estado inconsistente. El caso
+        # normal es que la UI solo muestre el botón si is_paso2_confirmed
+        # es true (el breakdown trae verified_context).
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "No hay confirmación de medidas que reabrir. El quote ya "
+                "está en Paso 1 editable."
+            ),
+        )
+
+    new_bd = reset_quote_to_paso1(bd)
+    # También limpiamos total_ars / total_usd en la tabla (reflejan lo
+    # calculado en Paso 2). brief_analysis y client_name se preservan.
+    await db.execute(
+        update(Quote)
+        .where(Quote.id == quote_id)
+        .values(
+            quote_breakdown=new_bd,
+            total_ars=None,
+            total_usd=None,
+        )
+    )
+    await db.commit()
+
+    # Refetch para devolver shape consistente con el listado.
+    refreshed = await db.execute(select(Quote).where(Quote.id == quote_id))
+    q = refreshed.scalar_one()
+    logger.info(f"[reopen] quote {quote_id} reset to Paso 1")
+    return q
+
+
 # ── VALIDATE QUOTE (generate docs + change status) ──────────────────────────
 
 @router.post("/quotes/{quote_id}/validate")

--- a/api/tests/test_card_editor.py
+++ b/api/tests/test_card_editor.py
@@ -199,3 +199,130 @@ class TestFormatPatchSummary:
     def test_empty_both(self):
         s = format_patch_summary([], [])
         assert "detallar" in s
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PR #378 — reset_quote_to_paso1 + is_paso2_confirmed helpers
+# ═══════════════════════════════════════════════════════════════════════
+
+from app.modules.agent.card_editor import (  # noqa: E402
+    reset_quote_to_paso1,
+    is_paso2_confirmed,
+    _PASO2_DERIVED_KEYS,
+)
+
+
+def _full_paso2_breakdown() -> dict:
+    """Breakdown de un quote post Paso 2 — todos los campos derivados
+    llenos. Usado para validar que el reset los limpia todos."""
+    return {
+        # Campos que DEBEN preservarse (Paso 1 + metadata)
+        "dual_read_result": {"sectores": [{"tipo": "cocina", "tramos": [{"id": "t1"}]}]},
+        "dual_read_plan_hash": "abc123",
+        "brief_analysis": {"client_name": "Erica Bernardi"},
+        "context_analysis_pending": {"tech_detections": []},
+        "verified_context_analysis": {"answers": []},
+        # Campos de Paso 2 — TODOS deben limpiarse
+        "verified_context": "[MEDIDAS VERIFICADAS...]",
+        "verified_measurements": {"sectores": []},
+        "measurements_confirmed": True,  # legacy
+        "verified_commercial_attrs": {"anafe_count": {"value": 1}},
+        "verified_derived_pieces": [{"description": "Pata frontal"}],
+        "material_name": "PURASTONE",
+        "material_m2": 6.48,
+        "material_price_unit": 527,
+        "material_currency": "USD",
+        "discount_amount": 0,
+        "discount_pct": 0,
+        "total_ars": 797177,
+        "total_usd": 4128,
+        "total_mo_ars": 797177,
+        "mo_items": [{"description": "Colocación"}],
+        "sectors": [{"label": "COCINA"}],
+        "sinks": [],
+        "piece_details": [{"description": "Mesada"}],
+        "mo_discount_amount": 0,
+        "mo_discount_pct": 0,
+        "sobrante_m2": 0,
+        "sobrante_total": 0,
+        "paso1_pieces": [],
+        "paso1_total_m2": 6.48,
+    }
+
+
+class TestIsPaso2Confirmed:
+    def test_none_is_false(self):
+        assert is_paso2_confirmed(None) is False
+
+    def test_empty_is_false(self):
+        assert is_paso2_confirmed({}) is False
+
+    def test_verified_context_marker(self):
+        assert is_paso2_confirmed({"verified_context": "X"}) is True
+
+    def test_measurements_confirmed_legacy_marker(self):
+        assert is_paso2_confirmed({"measurements_confirmed": True}) is True
+
+    def test_only_dual_read_result_is_not_confirmed(self):
+        """Quote en Paso 1 con card emitida pero sin confirmar → no bloqueado."""
+        bd = {"dual_read_result": {"sectores": []}}
+        assert is_paso2_confirmed(bd) is False
+
+
+class TestResetQuoteToPaso1:
+    """El helper deja el breakdown en estado 'Paso 1 editable', preservando
+    metadata (brief_analysis, dual_read_result, client context)."""
+
+    def test_removes_all_paso2_derived_keys(self):
+        bd = _full_paso2_breakdown()
+        reset = reset_quote_to_paso1(bd)
+        for key in _PASO2_DERIVED_KEYS:
+            assert key not in reset, f"{key} no se limpió"
+
+    def test_preserves_dual_read_result_by_default(self):
+        bd = _full_paso2_breakdown()
+        reset = reset_quote_to_paso1(bd)
+        assert "dual_read_result" in reset
+        assert reset["dual_read_result"] == bd["dual_read_result"]
+
+    def test_preserves_brief_analysis_and_metadata(self):
+        bd = _full_paso2_breakdown()
+        reset = reset_quote_to_paso1(bd)
+        assert reset.get("brief_analysis") == {"client_name": "Erica Bernardi"}
+        assert reset.get("dual_read_plan_hash") == "abc123"
+        assert "context_analysis_pending" in reset
+        assert "verified_context_analysis" in reset
+
+    def test_preserve_dual_read_result_false_removes_it(self):
+        bd = _full_paso2_breakdown()
+        reset = reset_quote_to_paso1(bd, preserve_dual_read_result=False)
+        assert "dual_read_result" not in reset
+
+    def test_idempotent_on_empty_breakdown(self):
+        assert reset_quote_to_paso1({}) == {}
+        assert reset_quote_to_paso1(None) == {}
+
+    def test_idempotent_second_call(self):
+        """Aplicar reset dos veces == aplicarlo una vez. No falla."""
+        bd = _full_paso2_breakdown()
+        once = reset_quote_to_paso1(bd)
+        twice = reset_quote_to_paso1(once)
+        assert once == twice
+
+    def test_does_not_mutate_input(self):
+        """Funcional puro — el dict original queda intacto."""
+        bd = _full_paso2_breakdown()
+        bd_snapshot = dict(bd)
+        _ = reset_quote_to_paso1(bd)
+        assert bd == bd_snapshot
+
+    def test_handles_partial_paso2_state(self):
+        """Si solo algunos campos de Paso 2 están presentes, limpia los que
+        hay sin romper por los que faltan."""
+        bd = {
+            "dual_read_result": {"x": 1},
+            "verified_context": "texto",
+            "material_name": "X",
+        }
+        reset = reset_quote_to_paso1(bd)
+        assert reset == {"dual_read_result": {"x": 1}}

--- a/api/tests/test_router.py
+++ b/api/tests/test_router.py
@@ -753,3 +753,138 @@ class TestQuoteEngine:
         qid = resp.json()["quotes"][0]["quote_id"]
         detail = (await client.get(f"/api/quotes/{qid}")).json()
         assert detail["source"] == "web"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PR #378 — Endpoint POST /api/quotes/:id/reopen-measurements
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestReopenMeasurements:
+    """Endpoint que permite al operador reabrir edición después de haber
+    confirmado medidas. Invalida el Paso 2 (material + MO + totales) y
+    deja el quote en 'Paso 1 editable'."""
+
+    async def _make_paso2_quote(self, client, db_session) -> str:
+        """Helper: crea quote y lo pone en estado post-Paso 2 (con
+        verified_context + material + totales)."""
+        from app.models.quote import Quote
+        from sqlalchemy import select, update
+        create = await client.post("/api/quotes")
+        qid = create.json()["id"]
+        # Parchear el breakdown directo en DB para simular Paso 2 completo.
+        bd = {
+            "dual_read_result": {"sectores": [{"tipo": "cocina"}]},
+            "brief_analysis": {"client_name": "Erica Bernardi"},
+            "verified_context": "[MEDIDAS VERIFICADAS...]",
+            "verified_measurements": {"sectores": []},
+            "verified_commercial_attrs": {"anafe_count": {"value": 1}},
+            "material_name": "PURASTONE",
+            "total_ars": 797177,
+            "total_usd": 4128,
+            "mo_items": [{"description": "Colocación"}],
+            "sectors": [{"label": "COCINA"}],
+        }
+        await db_session.execute(
+            update(Quote).where(Quote.id == qid).values(
+                quote_breakdown=bd,
+                total_ars=797177,
+                total_usd=4128,
+            )
+        )
+        await db_session.commit()
+        return qid
+
+    @pytest.mark.asyncio
+    async def test_reopen_clears_paso2_state(self, client, db_session):
+        """Post-reopen: verified_context, material, totales, mo_items desaparecen;
+        dual_read_result y brief_analysis se preservan."""
+        qid = await self._make_paso2_quote(client, db_session)
+
+        resp = await client.post(f"/api/quotes/{qid}/reopen-measurements")
+        assert resp.status_code == 200, resp.text
+
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        bd = detail["quote_breakdown"] or {}
+        # Paso 2 limpio
+        assert "verified_context" not in bd
+        assert "verified_measurements" not in bd
+        assert "verified_commercial_attrs" not in bd
+        assert "material_name" not in bd
+        assert "mo_items" not in bd
+        assert "sectors" not in bd
+        # Paso 1 preservado
+        assert "dual_read_result" in bd
+        assert bd.get("brief_analysis", {}).get("client_name") == "Erica Bernardi"
+        # Totales de la tabla también limpios
+        assert detail["total_ars"] is None
+        assert detail["total_usd"] is None
+
+    @pytest.mark.asyncio
+    async def test_reopen_404_for_nonexistent_quote(self, client):
+        resp = await client.post("/api/quotes/00000000-0000-0000-0000-000000000000/reopen-measurements")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_reopen_400_when_no_confirmation_yet(self, client):
+        """Quote nuevo (sin Paso 2) — no hay nada que reabrir → 400."""
+        create = await client.post("/api/quotes")
+        qid = create.json()["id"]
+        resp = await client.post(f"/api/quotes/{qid}/reopen-measurements")
+        assert resp.status_code == 400
+        assert "confirmaci" in resp.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_reopen_409_when_validated(self, client, db_session):
+        """Status=validated → 409 (PDF ya generado, no se reabre)."""
+        from app.models.quote import Quote, QuoteStatus
+        from sqlalchemy import update
+        qid = await self._make_paso2_quote(client, db_session)
+        await db_session.execute(
+            update(Quote).where(Quote.id == qid).values(status=QuoteStatus.VALIDATED)
+        )
+        await db_session.commit()
+
+        resp = await client.post(f"/api/quotes/{qid}/reopen-measurements")
+        assert resp.status_code == 409
+        assert "validated" in resp.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_reopen_409_when_sent(self, client, db_session):
+        from app.models.quote import Quote, QuoteStatus
+        from sqlalchemy import update
+        qid = await self._make_paso2_quote(client, db_session)
+        await db_session.execute(
+            update(Quote).where(Quote.id == qid).values(status=QuoteStatus.SENT)
+        )
+        await db_session.commit()
+
+        resp = await client.post(f"/api/quotes/{qid}/reopen-measurements")
+        assert resp.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_reopen_idempotent_second_call_returns_400(self, client, db_session):
+        """Después del primer reopen el quote ya no tiene verified_context;
+        el segundo reopen devuelve 400 (nada que reabrir)."""
+        qid = await self._make_paso2_quote(client, db_session)
+        r1 = await client.post(f"/api/quotes/{qid}/reopen-measurements")
+        assert r1.status_code == 200
+        r2 = await client.post(f"/api/quotes/{qid}/reopen-measurements")
+        assert r2.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_reopen_preserves_client_name_column(self, client, db_session):
+        """La columna Quote.client_name NO se pisa — es trabajo real persistido
+        y reabrir medidas no debería perderlo (el cliente sigue siendo el mismo)."""
+        qid = await self._make_paso2_quote(client, db_session)
+        from app.models.quote import Quote
+        from sqlalchemy import update
+        await db_session.execute(
+            update(Quote).where(Quote.id == qid).values(
+                client_name="Erica Bernardi",
+            )
+        )
+        await db_session.commit()
+
+        await client.post(f"/api/quotes/{qid}/reopen-measurements")
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        assert detail["client_name"] == "Erica Bernardi"

--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useRouter, useParams } from "next/navigation";
-import { fetchQuote, streamChat, markQuoteAsRead, validateQuote, updateQuote, type QuoteDetail, type QuoteEditablePatch } from "@/lib/api";
+import { fetchQuote, streamChat, markQuoteAsRead, validateQuote, updateQuote, reopenMeasurements, type QuoteDetail, type QuoteEditablePatch } from "@/lib/api";
 import { useQuotes } from "@/lib/quotes-context";
 import MessageBubble from "@/components/chat/MessageBubble";
 import CopyButton from "@/components/chat/CopyButton";
@@ -15,6 +15,7 @@ import RegenerateButton from "@/components/quote/RegenerateButton";
 import EditableField from "@/components/quote/EditableField";
 import ContextAnalysis from "@/components/chat/ContextAnalysis";
 import HomeHero from "@/components/chat/HomeHero";
+import { useToast } from "@/lib/toast-context";
 import clsx from "clsx";
 import { A, I, O, N, DOT, SUP2, DASH, ITEM, WARN, CIRCLE, ARROW, XMARK, CLOUD, WAVE, PAGE, PICTURE, CLIP, RULER, TAG, FOLDER, CHART } from "@/lib/chars";
 import { VALID_FILE_TYPES as PARENT_VALID_TYPES, MAX_FILE_SIZE as PARENT_MAX_SIZE, MAX_FILES as PARENT_MAX_FILES } from "@/lib/constants";
@@ -128,6 +129,7 @@ export default function QuotePage() {
   const router = useRouter();
   const params = useParams();
   const quoteId = params.id as string;
+  const toast = useToast();
 
   const [quote, setQuote] = useState<QuoteDetail | null>(null);
   const [messages, setMessages] = useState<UIMessage[]>([]);
@@ -675,12 +677,17 @@ export default function QuotePage() {
                       try {
                         const DualReadResult = require("@/components/chat/DualReadResult").default;
                         const dualData = JSON.parse(msg.content.replace("__DUAL_READ__", ""));
+                        // PR #378 — lock si el quote ya tiene verified_context
+                        // (ya se confirmó). Para editar hay que apretar
+                        // "Editar despiece" que llama a /reopen-measurements.
+                        const isLocked = !!quote?.quote_breakdown?.verified_context;
                         return (
                           <div className="msg-anim flex gap-3 items-start">
                             <div className="max-w-full">
                               <DualReadResult
                                 data={dualData}
                                 quoteId={quoteId}
+                                locked={isLocked}
                                 onConfirm={(verified: unknown) => {
                                   send(`[DUAL_READ_CONFIRMED]${JSON.stringify(verified)}`);
                                 }}
@@ -720,6 +727,41 @@ export default function QuotePage() {
                           Corregir
                         </button>
                       </div>
+                      {/* PR #378 — "Editar despiece" cuando el quote ya
+                          tiene verified_context (Paso 2 calculado). Llama
+                          al endpoint /reopen-measurements que limpia Paso 2
+                          y deja el despiece editable otra vez. Confirmación
+                          obligatoria porque es destructivo: se pierde el
+                          cálculo actual y el operador tiene que re-confirmar
+                          medidas antes de generar PDF. */}
+                      {quote?.quote_breakdown?.verified_context && (
+                        <div className="mt-2 ml-[42px]">
+                          <button
+                            onClick={async () => {
+                              const ok = window.confirm(
+                                "Vas a invalidar el cálculo actual y volver a edición del despiece. " +
+                                "Vas a tener que reconfirmar las medidas para regenerar el presupuesto. " +
+                                "\n\n¿Continuar?"
+                              );
+                              if (!ok) return;
+                              try {
+                                await reopenMeasurements(quoteId);
+                                toast("Despiece reabierto. Editá las medidas y volvé a confirmar.", "success");
+                                // Refresh quote para que el frontend re-renderee
+                                // DualReadResult en modo editable (locked=false).
+                                const fresh = await fetchQuote(quoteId);
+                                setQuote(fresh);
+                              } catch (err) {
+                                const msg = err instanceof Error ? err.message : "Error al reabrir edición";
+                                toast(msg, "error");
+                              }
+                            }}
+                            className="w-full px-4 py-2 rounded-lg text-[12px] font-medium bg-transparent border border-amb/40 text-amb cursor-pointer hover:bg-amb/10 transition"
+                          >
+                            ↩ Editar despiece (invalida el cálculo actual)
+                          </button>
+                        </div>
+                      )}
                     </>
                   )}
                   {isLastReal && lastFailedMsg && !msg.isStreaming && !sending && msg.content.includes(WARN) && (

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -213,6 +213,13 @@ interface Props {
   quoteId: string;
   onConfirm: (verified: DualReadData) => void;
   onRetry?: (newData: DualReadData) => void;
+  /** PR #378 — Cuando true, el despiece se muestra en modo read-only:
+   *  inputs deshabilitados, CTA "Confirmar medidas" oculto. Usado
+   *  cuando el quote ya tiene `verified_context` (ya se confirmó y
+   *  ahora se está en Paso 2). Para editar, operador aprieta
+   *  "Editar despiece" afuera de esta card → endpoint reopen limpia
+   *  Paso 2 → re-render desbloqueado. */
+  locked?: boolean;
 }
 
 type IconStyle = { cls: string; char: string };
@@ -277,6 +284,7 @@ function EditableNumber({
   onEdit,
   forceEditable = false,
   dblClickEdit = false,
+  locked = false,
 }: {
   field: FieldValue;
   /** PR #357 — ahora acepta `null` para cuando el input queda vacío.
@@ -287,14 +295,37 @@ function EditableNumber({
   /** Si true, el campo arranca como label read-only; doble-click entra en
    *  edit mode. Enter/blur commit (solo si valor válido), Esc cancela. */
   dblClickEdit?: boolean;
+  /** PR #378 — Lock post-confirmación. Cuando true fuerza modo read-only
+   *  suprimiendo forceEditable/dblClickEdit/status=DUDOSO. La UI ya no
+   *  permite edits sin antes "Reabrir edición" (endpoint
+   *  /reopen-measurements), que limpia Paso 2 y desbloquea. Evita el
+   *  estado ambiguo "edité pero no se persiste ni reconfirma".
+   */
+  locked?: boolean;
 }) {
+  // Hooks SIEMPRE al tope (rules-of-hooks). El early return por `locked`
+  // va después. No usamos los refs/state cuando locked pero es barato
+  // mantenerlos allocados — render cost es mínimo y no hay leak.
+  const [editing, setEditing] = React.useState(false);
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const originalRef = React.useRef<number>(safeNum(field.valor));
+
+  // Lock tiene precedencia absoluta — no hay edit mode mientras esté on.
+  // El tooltip explica al operador por qué no puede editar.
+  if (locked) {
+    return (
+      <span
+        className="text-t2 select-none cursor-not-allowed"
+        title="Confirmado — usá 'Editar despiece' para modificar"
+      >
+        {displayNum(field.valor)}
+      </span>
+    );
+  }
   const alwaysEditable = forceEditable
     || field.status === "CONFLICTO"
     || field.status === "DUDOSO"
     || field.status === "UNANCHORED";
-  const [editing, setEditing] = React.useState(false);
-  const inputRef = React.useRef<HTMLInputElement | null>(null);
-  const originalRef = React.useRef<number>(safeNum(field.valor));
 
   // PR #69 — tooltip revela Opus/Sonnet originales (cuando hay reconciliación)
   const tooltipParts: string[] = [];
@@ -421,7 +452,7 @@ function EditableZocalo({
   );
 }
 
-export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Props) {
+export default function DualReadResult({ data, quoteId, onConfirm, onRetry, locked = false }: Props) {
   const [retrying, setRetrying] = useState(false);
   const [retryError, setRetryError] = useState<string | null>(null);
   const [editedData, setEditedData] = useState<DualReadData>(() => normalizeDualReadData(data));
@@ -819,6 +850,7 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
                         onEdit={(v) => updateField(si, ti, "largo_m", v)}
                         forceEditable={tramo._manual}
                         dblClickEdit
+                        locked={locked}
                       />
                       <span className="text-t4 ml-0.5">m</span>
                     </div>
@@ -828,6 +860,7 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
                         onEdit={(v) => updateField(si, ti, "ancho_m", v)}
                         forceEditable={tramo._manual}
                         dblClickEdit
+                        locked={locked}
                       />
                       <span className="text-t4 ml-0.5">m</span>
                     </div>
@@ -840,6 +873,7 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
                         field={tramo.m2}
                         onEdit={(v) => updateField(si, ti, "m2", v)}
                         forceEditable={tramo._manual}
+                        locked={locked}
                       />
                       {/* PR #68 — botón × también en mesadas para remover duplicados
                           / piezas ajenas (heladera, bajo mesada) que el dual_read
@@ -1199,22 +1233,32 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry }: Pr
 
       {/* Actions */}
       <div className="flex gap-2 px-5 py-4 border-t border-b1 bg-s2">
-        <button
-          className="flex-1 py-2.5 px-4 rounded-xl text-[13px] font-semibold bg-acc hover:bg-acc-hover text-white transition disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-acc"
-          onClick={() => {
-            const payload = {
-              ...editedData,
-              pending_answers: Object.values(pendingAnswers),
-            };
-            onConfirm(payload as DualReadData);
-          }}
-          disabled={!allQuestionsAnswered}
-          title={!allQuestionsAnswered ? "Respondé las preguntas pendientes primero" : undefined}
-        >
-          {allQuestionsAnswered
-            ? `Confirmar medidas · ${totalM2.toFixed(2)} m²`
-            : `Respondé ${pendingQuestions.length - Object.values(pendingAnswers).filter(a => a.value).length} pregunta(s) pendiente(s)`}
-        </button>
+        {locked ? (
+          // PR #378 — Despiece ya confirmado. El CTA original queda
+          // reemplazado por un banner explicando el estado. El botón
+          // "Editar despiece" vive en el layout del chat (afuera de
+          // esta card) y llama al endpoint /reopen-measurements.
+          <div className="flex-1 py-2.5 px-4 rounded-xl text-[13px] font-medium bg-grn-bg text-grn border border-grn/30 text-center">
+            ✓ Medidas confirmadas — usá &ldquo;Editar despiece&rdquo; para modificar
+          </div>
+        ) : (
+          <button
+            className="flex-1 py-2.5 px-4 rounded-xl text-[13px] font-semibold bg-acc hover:bg-acc-hover text-white transition disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-acc"
+            onClick={() => {
+              const payload = {
+                ...editedData,
+                pending_answers: Object.values(pendingAnswers),
+              };
+              onConfirm(payload as DualReadData);
+            }}
+            disabled={!allQuestionsAnswered}
+            title={!allQuestionsAnswered ? "Respondé las preguntas pendientes primero" : undefined}
+          >
+            {allQuestionsAnswered
+              ? `Confirmar medidas · ${totalM2.toFixed(2)} m²`
+              : `Respondé ${pendingQuestions.length - Object.values(pendingAnswers).filter(a => a.value).length} pregunta(s) pendiente(s)`}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -164,6 +164,10 @@ export interface QuoteBreakdown {
   mo_items?: MOItem[];
   total_ars?: number;
   total_usd?: number;
+  /** PR #378 — Presente cuando el operador ya confirmó medidas (Paso 2).
+   *  Usado por el frontend como flag para lockear edits inline del
+   *  despiece y mostrar el botón "Editar despiece". */
+  verified_context?: string;
 }
 
 export interface QuoteDetail extends Quote {
@@ -474,6 +478,29 @@ export async function validateQuote(id: string): Promise<{ ok: boolean; pdf_url?
     throw new Error(err.detail || "Error al validar presupuesto");
   }
   return res.json();
+}
+
+/**
+ * PR #378 — Reabre la edición del despiece después de haber confirmado
+ * medidas. Limpia el Paso 2 (material + MO + totales + contexto verificado)
+ * y deja el quote en estado Paso 1 editable. El operador corrige,
+ * reconfirma, y Valentina regenera Paso 2 limpio.
+ *
+ * Errores:
+ *  - 404: quote no existe.
+ *  - 409: status es `validated` o `sent` (PDF ya entregado, no se reabre).
+ *  - 400: no había confirmación previa (nada que reabrir).
+ */
+export async function reopenMeasurements(id: string): Promise<void> {
+  const res = await apiFetch(
+    `${API_BASE}/api/quotes/${id}/reopen-measurements`,
+    { method: "POST", credentials: "include" },
+  );
+  handleAuthError(res);
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || "Error al reabrir edición del despiece");
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
Bug reportado: después de confirmar medidas, la UI seguía dejando editar inputs del despiece pero esos edits **no se persistían** → PDF terminaba usando el breakdown del Paso 2 viejo. Estado ambiguo: UI mostraba los números editados, DB y PDF tenían los anteriores.

**Decisión: Modelo A — lock fuerte con reopen explícito**. Después de confirmar, el despiece queda read-only. Para modificar, botón "Editar despiece" que llama a un endpoint nuevo que limpia el Paso 2 y deja el quote en estado "Paso 1 editable" para reconfirmar.

## Flujo resultante

| Estado | Editable | CTAs |
|--------|----------|------|
| **Paso 1** (sin verified_context) | Inputs del despiece editables | "Confirmar medidas" |
| **Paso 2** (con verified_context) | Inputs **bloqueados** con tooltip + banner verde | "Confirmar" / "Corregir" + **"Editar despiece"** |
| **Click "Editar despiece"** | Confirm → POST reopen → Paso 2 limpio en DB → refetch → vuelve a Paso 1 editable | — |

## Cambios

### Backend
- **Helper puro `reset_quote_to_paso1(breakdown)`** en \`card_editor.py\` — lista canónica de 23 keys de Paso 2 que se limpian. Idempotente, no muta input.
- **Helper `is_paso2_confirmed(breakdown)`** — señal determinística (verified_context o measurements_confirmed presente).
- **Endpoint \`POST /api/quotes/:id/reopen-measurements\`**:
  - 200 con quote updated
  - 404 quote inexistente
  - **409** si status in (validated, sent) — PDF ya entregado
  - 400 si no había confirmación previa
  - Limpia también \`Quote.total_ars\` / \`total_usd\` (reflejan Paso 2)
  - Preserva: \`dual_read_result\`, \`brief_analysis\`, \`client_name\` column, \`verified_context_analysis\`, metadata del plano
- **Refactor**: card_editor handler en agent.py ahora usa el mismo helper (DRY — una sola lista de keys a limpiar).

### Frontend
- **Prop \`locked\` en \`EditableNumber\`**: precedencia absoluta sobre \`forceEditable\`/\`dblClickEdit\`/\`status\`. Render read-only con tooltip.
- **Prop \`locked\` en \`DualReadResult\`**: propaga a los 3 EditableNumber. Cuando locked, el CTA "Confirmar medidas" se reemplaza por banner verde.
- **Helper \`reopenMeasurements(id)\`** en \`lib/api.ts\`.
- **Botón "↩ Editar despiece (invalida el cálculo actual)"** en el layout del chat, aparece junto a "Confirmar"/"Corregir" cuando \`quote.quote_breakdown.verified_context\` existe.
- **Confirmación obligatoria**: \`window.confirm("Vas a invalidar el cálculo actual y volver a edición del despiece. Vas a tener que reconfirmar las medidas para regenerar el presupuesto. ¿Continuar?")\`.

## Riesgos mitigados
- Status validated/sent → 409 (PDF ya entregado, duplicar quote si se quiere rearmar)
- Click accidental → confirmación obligatoria
- Breakdown desactualizado → refetch tras reopen

## Non-goals
- NO candidate quality R1/R2
- NO summary authority (#374) ni otros bugs previos
- NO cambios al calculator
- NO rewrite del card_editor (se reusa)

## Tests (21 nuevos)

**\`TestIsPaso2Confirmed\`** (5): None/empty/verified_context/measurements_confirmed legacy/solo dual_read_result no cuenta.

**\`TestResetQuoteToPaso1\`** (8): limpia los 23 keys; preserva dual_read_result/brief_analysis/metadata; preserve=False lo borra; idempotencia; no muta input; partial state.

**\`TestReopenMeasurements\`** (7): endpoint limpia Paso 2; 404; 400 sin confirmación; 409 validated; 409 sent; idempotencia (2do call → 400); preserva client_name column.

**Backend suite**: 1818 passed (+20), 16 pre-existentes failed (no relacionados).
**Frontend**: vitest 30 passed, build limpio.

## Test plan post-merge
- [ ] Quote recién creado: inputs editables, botón "Confirmar medidas" visible.
- [ ] Confirmar medidas → entrar a Paso 2. Los inputs del despiece deben estar bloqueados (tooltip al hover). Banner verde: "Medidas confirmadas".
- [ ] Botón "↩ Editar despiece" visible cerca del "Confirmar" final. Click → confirm dialog.
- [ ] Aceptar confirm → Paso 2 limpio en DB, UI vuelve a Paso 1 editable.
- [ ] Cancelar confirm → nada cambia.
- [ ] Intentar reopen en quote validated → toast de error ("status validated/sent").

🤖 Generated with [Claude Code](https://claude.com/claude-code)