### PR TITLE
fix(chat): persistir JSON real de cards para reconstruir estado al reabrir

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -335,7 +335,14 @@ async def _run_dual_read(
                         "text": (user_message or "").strip() or f"(adjuntó plano: {plan_filename})",
                     }],
                 }
-                _asst_entry = {"role": "assistant", "content": "__DUAL_READ_CARD_SHOWN__"}
+                # PR #379 — Persistir el JSON real de la card (no un marker
+                # vacío). El frontend ya sabe renderizar `__DUAL_READ__<json>`
+                # como card. Así al reabrir el quote el chat reconstruye el
+                # estado real — no quedan placeholders crudos `_SHOWN_`.
+                _asst_entry = {
+                    "role": "assistant",
+                    "content": f"__DUAL_READ__{_json.dumps(_existing_dr, ensure_ascii=False)}",
+                }
                 await db.execute(
                     update(Quote)
                     .where(Quote.id == quote_id)
@@ -592,7 +599,12 @@ async def _run_dual_read(
                             "text": (user_message or "").strip() or f"(adjuntó plano: {plan_filename})",
                         }],
                     }
-                    _asst_entry = {"role": "assistant", "content": "__CONTEXT_ANALYSIS_SHOWN__"}
+                    # PR #379 — JSON real en el content (no `_SHOWN_` marker)
+                    # para que el chat se reconstruya al reabrir el quote.
+                    _asst_entry = {
+                        "role": "assistant",
+                        "content": f"__CONTEXT_ANALYSIS__{_json.dumps(_context, ensure_ascii=False)}",
+                    }
                     if _ck_quote:
                         await db.execute(
                             update(Quote).where(Quote.id == quote_id).values(
@@ -650,7 +662,11 @@ async def _run_dual_read(
                         "text": (user_message or "").strip() or f"(adjuntó plano: {plan_filename})",
                     }],
                 }
-                _asst_entry2 = {"role": "assistant", "content": "__DUAL_READ_CARD_SHOWN__"}
+                # PR #379 — JSON real en lugar de marker `_SHOWN_` vacío.
+                _asst_entry2 = {
+                    "role": "assistant",
+                    "content": f"__DUAL_READ__{_json.dumps(_dual_result, ensure_ascii=False)}",
+                }
                 await db.execute(
                     update(Quote)
                     .where(Quote.id == quote_id)
@@ -1502,11 +1518,24 @@ class AgentService:
                 )
                 yield {"type": "dual_read_result", "content": json.dumps(_saved_dual, ensure_ascii=False)}
                 yield {"type": "done", "content": ""}
-                # Persist assistant entry en historial
+                # PR #379 — Persistir el flujo real al DB:
+                # - user turn: el `[CONTEXT_CONFIRMED]<json>` que mandó el
+                #   frontend (el frontend lo detecta y renderiza como
+                #   pill "Contexto confirmado ✅").
+                # - assistant: `__DUAL_READ__<json>` con la card real.
+                # Antes persistíamos un fake user "(contexto confirmado)"
+                # + marker `_SHOWN_` sin data — ambos quedaban como texto
+                # crudo al reabrir el quote.
                 try:
                     _turn = [
-                        {"role": "user", "content": [{"type": "text", "text": "(contexto confirmado)"}]},
-                        {"role": "assistant", "content": "__DUAL_READ_CARD_SHOWN__"},
+                        {
+                            "role": "user",
+                            "content": [{"type": "text", "text": user_message}],
+                        },
+                        {
+                            "role": "assistant",
+                            "content": f"__DUAL_READ__{json.dumps(_saved_dual, ensure_ascii=False)}",
+                        },
                     ]
                     if _q_ctx:
                         await db.execute(
@@ -1868,6 +1897,8 @@ class AgentService:
                                 _persist_bd["dual_read_result"] = _text_card
                                 _persist_bd["context_analysis_pending"] = _context_tp
                                 _persist_update["quote_breakdown"] = _persist_bd
+                                # PR #379 — JSON real en content para que el
+                                # chat reconstruya la card al reabrir.
                                 _persist_update["messages"] = list(
                                     _tp_quote.messages or []
                                 ) + [
@@ -1879,7 +1910,7 @@ class AgentService:
                                     },
                                     {
                                         "role": "assistant",
-                                        "content": "__CONTEXT_ANALYSIS_SHOWN__",
+                                        "content": f"__CONTEXT_ANALYSIS__{json.dumps(_context_tp, ensure_ascii=False)}",
                                     },
                                 ]
                                 await db.execute(
@@ -1908,9 +1939,14 @@ class AgentService:
                         _persist_bd = dict(_tp_bd)
                         _persist_bd["dual_read_result"] = _text_card
                         _persist_update["quote_breakdown"] = _persist_bd
+                        # PR #379 — JSON real de la card para reconstrucción
+                        # al reabrir el quote.
                         _persist_update["messages"] = list(_tp_quote.messages or []) + [
                             {"role": "user", "content": [{"type": "text", "text": user_message}]},
-                            {"role": "assistant", "content": "__DUAL_READ_CARD_SHOWN__"},
+                            {
+                                "role": "assistant",
+                                "content": f"__DUAL_READ__{json.dumps(_text_card, ensure_ascii=False)}",
+                            },
                         ]
                         await db.execute(
                             update(Quote).where(Quote.id == quote_id).values(**_persist_update)
@@ -3252,9 +3288,23 @@ class AgentService:
             else:
                 clean_messages.append(msg)
 
-        # Save clean content before injection
-        import copy
-        clean_user_content = copy.deepcopy(content)
+        # PR #379 — `clean_user_content` es lo que persiste en DB como user
+        # turn. Antes era `copy.deepcopy(content)` que arrastraba TODO lo
+        # que va a Claude: el plan image binary, el bloque "[TEXTO
+        # EXTRAÍDO DEL PDF — DATOS EXACTOS]..." con el dump completo del
+        # PDF, y los bloques "[SISTEMA — ...]" que se inyectan más abajo.
+        # Ese payload no pertenece al historial de chat del operador — es
+        # input interno para Claude. Al reabrir el quote se mostraba como
+        # si el operador hubiera escrito todo eso.
+        #
+        # Ahora: el user turn en DB es SOLO el texto que escribió el
+        # operador (o un placeholder "(adjuntó plano: X)" si subió un
+        # plano sin texto). El content completo sigue yendo a Claude
+        # intacto — esto afecta solo la persistencia.
+        _text_for_db = (user_message or "").strip() or (
+            f"(adjuntó plano: {plan_filename})" if plan_filename else "(adjunto plano)"
+        )
+        clean_user_content = [{"type": "text", "text": _text_for_db}]
 
         # Inject context hint based on quote state
         try:

--- a/api/tests/test_chat_history_persistence.py
+++ b/api/tests/test_chat_history_persistence.py
@@ -1,0 +1,179 @@
+"""Tests de persistencia del historial del chat — PR #379.
+
+Objetivo: cuando el operador cierra un borrador y lo vuelve a abrir, el
+chat reconstruye el recorrido real (cards, pills, Paso 2). Para lograr
+eso, el backend debe persistir el JSON real de las cards en `content`,
+no placeholders vacíos `_SHOWN_`.
+
+No testamos el flujo async completo con LLM (caro + flaky). Testamos
+los bloques determinísticos que persisten `Quote.messages`:
+
+- `_run_dual_read` Case 2 (re-emit) + emit inicial + legacy fallback.
+- Handler CONTEXT_CONFIRMED.
+- Handler text-parse (legacy path).
+- `clean_user_content` en el while loop de Claude (content que va a DB).
+
+Para cada uno validamos shape del `content` persistido, NO el side
+effect del turno siguiente.
+"""
+import json
+import re
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Grep-style tests sobre el código — defensa contra regresión
+#
+# Si alguien vuelve a introducir un marker `_SHOWN_` como content
+# literal o un fake turn "(contexto confirmado)" en agent.py, estos
+# tests fallan y apuntan exactamente al patrón prohibido.
+# ─────────────────────────────────────────────────────────────────────
+
+AGENT_PATH = "app/modules/agent/agent.py"
+
+
+def _agent_source() -> str:
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[1]
+    with open(root / AGENT_PATH, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+class TestAgentSourceHasNoLegacyPlaceholders:
+    """Guard contra regresiones de PR #379."""
+
+    def test_no_literal_shown_markers_as_content(self):
+        """El content de un message persistido nunca debe ser `"__X_SHOWN__"`
+        como string literal. Debe ser `f"__X__{json.dumps(data)}"`.
+
+        Match exacto: `"content": "__..._SHOWN__"` con comillas de string
+        (no f-string). Si lo que aparece es `f"..."` queda fuera del match.
+        """
+        src = _agent_source()
+        # Busca patrón estricto de dict literal con content string plano
+        # que termine en _SHOWN__. Tolera backslash + variaciones de indent.
+        pattern = re.compile(
+            r'"content"\s*:\s*"__[A-Z_]+_SHOWN__"'
+        )
+        matches = pattern.findall(src)
+        assert not matches, (
+            f"Regresión: `_SHOWN_` placeholders literales en content. "
+            f"Matches: {matches}\n"
+            f"Persistí el JSON real con f-string `f\"__...__{{json.dumps(...)}}\"`."
+        )
+
+    def test_no_fake_user_contexto_confirmado(self):
+        """El fake user turn `"(contexto confirmado)"` fue reemplazado
+        por el `[CONTEXT_CONFIRMED]<json>` real que el frontend ya
+        detecta como pill."""
+        src = _agent_source()
+        pattern = re.compile(r'"text"\s*:\s*"\(contexto confirmado\)"')
+        assert not pattern.search(src), (
+            "Regresión: fake user turn '(contexto confirmado)' vuelto a "
+            "introducirse. En su lugar persistir el `user_message` que es "
+            "el `[CONTEXT_CONFIRMED]<json>` original del frontend."
+        )
+
+    def test_clean_user_content_not_deepcopy_of_content(self):
+        """Pre-#379 se hacía `clean_user_content = copy.deepcopy(content)`
+        lo cual arrastraba a DB el text extraído del PDF y bloques
+        `[SISTEMA — ...]`. Ahora debe construirse desde `user_message`
+        solo (texto plano del operador)."""
+        src = _agent_source()
+        assert "clean_user_content = copy.deepcopy(content)" not in src, (
+            "Regresión: `clean_user_content = copy.deepcopy(content)` "
+            "persiste bloques internos del content. Usar un dict literal "
+            "con solo el `user_message` como text."
+        )
+
+
+class TestAgentSourceUsesRealJsonInCardPersistence:
+    """El backend debe persistir `__DUAL_READ__<json>` y
+    `__CONTEXT_ANALYSIS__<json>` con el JSON real de la card. Estos
+    formatos son los que el frontend sabe renderizar como cards —
+    reconstrucción del estado real al reabrir el quote."""
+
+    def test_dual_read_persisted_as_json_content(self):
+        """Tiene que aparecer al menos una persistencia con el patrón
+        correcto: f"__DUAL_READ__{...json.dumps...}"."""
+        src = _agent_source()
+        # Al menos 3 lugares conocidos (Case 2 re-emit, legacy fallback,
+        # CONTEXT_CONFIRMED handler).
+        pattern = re.compile(
+            r'f"__DUAL_READ__\{[^}]*json\.dumps'
+        )
+        matches = pattern.findall(src)
+        # Uso _json en vez de json (alias) en algunas partes del módulo;
+        # relajo con un segundo regex defensivo.
+        alt = re.compile(r'f"__DUAL_READ__\{_?json\.dumps')
+        all_matches = pattern.findall(src) + alt.findall(src)
+        assert len(all_matches) >= 3, (
+            f"Esperaba al menos 3 persistencias como "
+            f"`f\"__DUAL_READ__{{json.dumps(...)}}\"`. Got {len(all_matches)}."
+        )
+
+    def test_context_analysis_persisted_as_json_content(self):
+        src = _agent_source()
+        pattern = re.compile(r'f"__CONTEXT_ANALYSIS__\{_?json\.dumps')
+        matches = pattern.findall(src)
+        # Al menos 2 lugares (first emit en _run_dual_read, text-parse path).
+        assert len(matches) >= 2, (
+            f"Esperaba ≥2 persistencias como "
+            f"`f\"__CONTEXT_ANALYSIS__{{json.dumps(...)}}\"`. Got {len(matches)}."
+        )
+
+
+class TestCleanUserContentShape:
+    """Unit test del constructor de `clean_user_content` post-#379.
+
+    Extrajimos la lógica en un shape reproducible: solo un bloque de
+    texto con el user_message (sin imagen, sin PDF extraído, sin
+    hints de sistema).
+    """
+
+    def _build_clean(self, user_message: str, plan_filename: str | None = None):
+        """Reproducción del bloque post-#379 en agent.py."""
+        _text_for_db = (user_message or "").strip() or (
+            f"(adjuntó plano: {plan_filename})" if plan_filename
+            else "(adjunto plano)"
+        )
+        return [{"type": "text", "text": _text_for_db}]
+
+    def test_uses_user_message_verbatim(self):
+        clean = self._build_clean("cotizar cocina con pileta")
+        assert clean == [{"type": "text", "text": "cotizar cocina con pileta"}]
+
+    def test_empty_message_with_plan_shows_filename(self):
+        clean = self._build_clean("", plan_filename="bernardi.pdf")
+        assert clean == [{"type": "text", "text": "(adjuntó plano: bernardi.pdf)"}]
+
+    def test_empty_message_without_plan_shows_generic(self):
+        clean = self._build_clean("")
+        assert clean == [{"type": "text", "text": "(adjunto plano)"}]
+
+    def test_dual_read_confirmed_passes_through(self):
+        """El user_message `[DUAL_READ_CONFIRMED]<json>` va tal cual —
+        el frontend lo detecta como pill verde."""
+        msg = '[DUAL_READ_CONFIRMED]{"sectores":[]}'
+        clean = self._build_clean(msg)
+        assert clean[0]["text"] == msg
+
+    def test_context_confirmed_passes_through(self):
+        msg = '[CONTEXT_CONFIRMED]{"answers":[]}'
+        clean = self._build_clean(msg)
+        assert clean[0]["text"] == msg
+
+    def test_pdf_extracted_text_is_never_in_output(self):
+        """Aunque el `content` que va a Claude contenga el bloque PDF,
+        `clean_user_content` se construye desde `user_message` — el
+        bloque nunca aparece."""
+        user_msg = "cotizar con plano adjunto"
+        clean = self._build_clean(user_msg)
+        rendered = json.dumps(clean)
+        assert "TEXTO EXTRAÍDO DEL PDF" not in rendered
+        assert "[SISTEMA" not in rendered
+
+    def test_whitespace_user_message_treated_as_empty(self):
+        clean = self._build_clean("   \n\t  ", plan_filename="x.pdf")
+        assert clean[0]["text"] == "(adjuntó plano: x.pdf)"

--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -72,6 +72,20 @@ function buildFullSnapshot(quote: QuoteDetail | null, messages: UIMessage[]): st
     if (content.startsWith("__CONTEXT_ANALYSIS__")) return;
     if (content.startsWith("[SYSTEM_TRIGGER")) return;
     if (content.startsWith("[CONTEXT_CONFIRMED]")) return;
+    // PR #379 — Filtros defensivos para quotes viejos que quedaron con
+    // placeholders en DB (pre-#379 el backend persistía markers `_SHOWN_`
+    // vacíos y un fake user turn "(contexto confirmado)"). En quotes
+    // nuevos estos ya no aparecen — el backend persiste el JSON real de
+    // la card. Estos filtros evitan el leak visual para el historial
+    // legacy hasta que se corra un PR de rehydrate aparte.
+    if (content === "__DUAL_READ_CARD_SHOWN__") return;
+    if (content === "__CONTEXT_ANALYSIS_SHOWN__") return;
+    if (content === "(contexto confirmado)") return;
+    // También filtramos bloques internos del system prompt que pre-#379
+    // se persistían como user turn (TEXTO EXTRAÍDO DEL PDF + hints de
+    // SISTEMA) vía copy.deepcopy(content).
+    if (content.startsWith("[TEXTO EXTRAÍDO DEL PDF")) return;
+    if (content.startsWith("[SISTEMA")) return;
 
     if (content.startsWith("[DUAL_READ_CONFIRMED]")) {
       parts.push("**Operador:** \u2705 Medidas verificadas", "");
@@ -608,6 +622,29 @@ export default function QuotePage() {
               // Hide ghost messages (dots from sanitization)
               const isDot = msg.content.trim() === "." || msg.content.trim() === "..";
               if (isDot) return null;
+
+              // PR #379 — Filtros defensivos para quotes legacy cuyo historial
+              // en DB quedó con placeholders vacíos o texto interno leakeado.
+              // En quotes nuevos el backend ya persiste el JSON real de las
+              // cards → estos strings no deberían aparecer. Dejamos el filtro
+              // defensivo hasta que se corra un PR de rehydrate de quotes
+              // viejos aparte.
+              const trimmedContent = msg.content.trim();
+              if (trimmedContent === "__DUAL_READ_CARD_SHOWN__") return null;
+              if (trimmedContent === "__CONTEXT_ANALYSIS_SHOWN__") return null;
+              // Fake user turn "(contexto confirmado)" persistido pre-#379
+              // cuando el operador confirmaba el contexto. Ahora se usa
+              // el [CONTEXT_CONFIRMED]<json> real que el frontend detecta
+              // como pill.
+              if (msg.role === "user" && trimmedContent === "(contexto confirmado)") return null;
+              // Bloques internos del system prompt que pre-#379 se
+              // persistían como user turn por un copy.deepcopy del
+              // content completo (con el text extraído del PDF y hints
+              // inyectados al LLM).
+              if (msg.role === "user" && (
+                trimmedContent.startsWith("[TEXTO EXTRAÍDO DEL PDF") ||
+                trimmedContent.startsWith("[SISTEMA")
+              )) return null;
 
               return (
                 <div key={msg.id}>


### PR DESCRIPTION
## Summary
Al cerrar un borrador y volver a entrar, el chat mostraba:
- Mensajes del usuario con **"[TEXTO EXTRAÍDO DEL PDF]..."** + hints internos del system prompt como si el operador los hubiera escrito.
- Placeholders crudos **\`__DUAL_READ_CARD_SHOWN__\`** / **\`__CONTEXT_ANALYSIS_SHOWN__\`**.
- Fake user turn **"(contexto confirmado)"** que nadie escribió.

**Objetivo del fix**: **reconstruir el estado real** del chat al reabrir (cards, pills, Paso 2) — no ocultar basura. Los quotes nuevos salen bien. Los viejos con historial ya roto en DB **no se arreglan con este PR** (rehydrate va aparte).

## Root cause
3 bugs pre-existentes en persistencia de \`Quote.messages\`:
1. Markers \`_SHOWN_\` vacíos como \`content\` de assistant turns (pensados como dedup, no como mensajes).
2. \`clean_user_content = copy.deepcopy(content)\` arrastraba a DB el plan binary + bloque \`[TEXTO EXTRAÍDO DEL PDF]\` + hints \`[SISTEMA — ...]\` que van solo a Claude.
3. Fake user turn \`"(contexto confirmado)"\` al confirmar contexto.

Invisibles en sesión activa (el chat se renderiza desde state React local). Solo se notaban al refetch tras navegar.

## Cambios — backend (7 sitios en agent.py)
Reemplazo de markers \`_SHOWN_\` por **JSON real** con el mismo formato que el frontend ya maneja por SSE (\`__CONTEXT_ANALYSIS__<json>\`, \`__DUAL_READ__<json>\`):

1. \`_run_dual_read\` Case 2 re-emit (l.338)
2. \`_run_dual_read\` context first emit (l.595)
3. \`_run_dual_read\` legacy dual_read (l.653)
4. Handler \`[CONTEXT_CONFIRMED]\` (l.1507): quitar fake user + usar \`user_message\` real (\`[CONTEXT_CONFIRMED]<json>\` → frontend muestra pill)
5. Text-parse context (l.1882)
6. Text-parse legacy (l.1913)
7. \`clean_user_content\` (l.3257): construir desde \`user_message\` pelado, no \`copy.deepcopy(content)\`

## Cambios — frontend (filtros defensivos)
En \`quote/[id]/page.tsx\`:
- Render: omite bubbles con \`__X_SHOWN__\`, \`(contexto confirmado)\`, \`[TEXTO EXTRAÍDO DEL PDF...\`, \`[SISTEMA...\`.
- \`buildFullSnapshot\`: mismos filtros (evita basura legacy en "copiar todo").

En quotes nuevos los filtros no matchean nada. Para quotes viejos, ocultan los leftovers hasta que rehydrate corra.

## Alcance explícito
- ✅ **Quotes nuevos**: chat reconstruye cards, pills y Paso 2 al reabrir.
- ❌ **Quotes viejos** (ej: los Bernardi que venías probando): tienen markers vacíos en DB — las cards no reaparecen. Filtros defensivos solo ocultan la basura. Para recuperarlos → PR separado de rehydrate desde \`quote_breakdown\`.

## Non-goals
- NO candidate quality R1/R2.
- NO calculator.
- NO rehydrate de quotes viejos (PR separado).
- NO cambios al flujo de #378 (lock + reopen).

## Tests (12 nuevos)

**\`TestAgentSourceHasNoLegacyPlaceholders\`** (3) — guards contra regresión:
- No hay \`"content": "__X_SHOWN__"\` literal en agent.py
- No hay \`"(contexto confirmado)"\` como fake user turn
- No hay \`copy.deepcopy(content)\` en la construcción de \`clean_user_content\`

**\`TestAgentSourceUsesRealJsonInCardPersistence\`** (2) — verifica que el backend usa \`f"__DUAL_READ__{json.dumps(...)}"\` (≥3 sitios) y \`f"__CONTEXT_ANALYSIS__{json.dumps(...)}"\` (≥2 sitios).

**\`TestCleanUserContentShape\`** (7) — unit de la nueva lógica:
- User message verbatim
- Empty + plan_filename → "(adjuntó plano: X)"
- Empty + sin filename → "(adjunto plano)"
- \`[DUAL_READ_CONFIRMED]<json>\` passthrough
- \`[CONTEXT_CONFIRMED]<json>\` passthrough
- Nunca aparece "TEXTO EXTRAÍDO" o "[SISTEMA" en output
- Whitespace-only tratado como empty

**Suite backend**: 1830 passed (+12), 16 pre-existentes failed (no relacionados).
**Build web**: limpio.

## Test plan post-merge
- [ ] Quote **NUEVO**: subir plano → confirmar contexto → confirmar medidas → llegar a Paso 2. Salir del quote y volver a entrar.
  - **Esperado**: chat con brief del operador, card de análisis de contexto (con respuestas), pill "Contexto confirmado ✅", card del despiece (locked), pill "Medidas verificadas ✅", Paso 2, botones "Confirmar"/"Corregir"/"Editar despiece".
- [ ] Verificar que no aparecen placeholders crudos ni texto extraído del PDF como mensaje.
- [ ] Quote **VIEJO** (Bernardi actual): aceptar que las cards no se reconstruyen (markers vacíos en DB) pero **no se ve basura** — filtros defensivos hacen su trabajo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)