### PR TITLE
feat(rehydrate): endpoint para reparar historial legacy (quotes viejos)

### DIFF
--- a/api/app/modules/agent/card_editor.py
+++ b/api/app/modules/agent/card_editor.py
@@ -439,6 +439,182 @@ def is_paso2_confirmed(quote_breakdown: dict | None) -> bool:
     )
 
 
+# ─────────────────────────────────────────────────────────────────────
+# PR #380 — Rehydrate de historial de chat (para quotes legacy)
+#
+# PR #379 arregló la persistencia hacia adelante: los quotes nuevos
+# guardan en `Quote.messages` el JSON real de las cards en lugar de
+# placeholders `_SHOWN_`, no arrastran el bloque "[TEXTO EXTRAÍDO DEL
+# PDF]" al content del user turn, y no persisten el fake user
+# "(contexto confirmado)".
+#
+# Este helper ataca lo opuesto: quotes VIEJOS que ya quedaron con
+# historial contaminado en DB. Aplica el mismo criterio de "reconstruir
+# estado real" sobre los messages persistidos, usando el `quote_breakdown`
+# como fuente de verdad para rehidratar las cards cuando sea posible.
+#
+# Reglas de diseño (condiciones del operador):
+# - **Idempotente**: correrlo N veces devuelve siempre el mismo shape.
+#   Si no hay nada que reconstruir, devuelve (messages_in, False).
+# - **No inventar**: si falta la data fuente (ej: no hay
+#   `dual_read_result` cacheado), se descarta el marker en lugar de
+#   rellenar con un placeholder falso.
+# - **No tocar cálculo**: el `quote_breakdown` se LEE pero no se
+#   modifica. Totales, MO, material — intactos.
+# - **Preservar mensajes legítimos**: brief del operador (truncado si
+#   estaba contaminado), Paso 2 markdown, turns user reales, cards
+#   ya en formato correcto — todos intactos.
+# - **No empeorar quotes sanos**: si el historial ya no tiene markers
+#   legacy, el helper devuelve changed=False y el caller skipea el
+#   UPDATE.
+# ─────────────────────────────────────────────────────────────────────
+
+
+# Patrones prohibidos que el helper detecta en el content de un user
+# turn para limpieza (el bloque va solo a Claude, no al historial).
+_CONTAMINATION_PREFIXES = (
+    "[TEXTO EXTRAÍDO DEL PDF",
+    "[SISTEMA",
+)
+
+
+def _content_to_text(content) -> str:
+    """Flatten content (string o lista de blocks) a un solo string.
+
+    El shape de `Quote.messages[i].content` puede ser:
+    - string (turns simples, el path común post-#379)
+    - list[{"type": "text", "text": "..."}] (bloques, pre-#379 casi
+      siempre para user turns con plan_image + text).
+
+    Para las comparaciones de patrón necesitamos un string canónico.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text") or "")
+        return "".join(parts)
+    return ""
+
+
+def _strip_contamination(text: str) -> str:
+    """Corta el text al primer marker de contaminación interna.
+
+    Un user turn pre-#379 podía ser "cotizar cocina X [TEXTO EXTRAÍDO
+    DEL PDF — DATOS EXACTOS]... dump completo...". Queremos conservar
+    la parte real ("cotizar cocina X") y descartar el resto.
+    """
+    first_marker = -1
+    for marker in _CONTAMINATION_PREFIXES:
+        idx = text.find(marker)
+        if idx != -1 and (first_marker == -1 or idx < first_marker):
+            first_marker = idx
+    if first_marker == -1:
+        return text
+    return text[:first_marker]
+
+
+def rehydrate_messages(
+    messages: list[dict] | None,
+    quote_breakdown: dict | None,
+) -> tuple[list[dict], bool]:
+    """Reconstruye el historial de chat para un quote legacy.
+
+    Detección + transformación en un solo pase:
+
+    1. Marker `__DUAL_READ_CARD_SHOWN__` (assistant) →
+       - Si `breakdown.dual_read_result` existe: reemplazar por
+         `__DUAL_READ__{json}` con el JSON real. Frontend lo renderiza
+         como card.
+       - Si no: descartar el turn (no reconstruible, no inventamos).
+
+    2. Marker `__CONTEXT_ANALYSIS_SHOWN__` (assistant) →
+       - Si `breakdown.context_analysis_pending` existe (pre-confirm):
+         reemplazar por `__CONTEXT_ANALYSIS__{json}`.
+       - Si no (post-confirm poppea ese campo): descartar. La
+         información sigue viva en `verified_context_analysis` y se
+         usa downstream; la card visual se pierde — aceptado.
+
+    3. User turn "(contexto confirmado)" → descartar. Era un fake
+       separador visual. El `[CONTEXT_CONFIRMED]<json>` real que
+       confirma el contexto ya existe como turn previo y el frontend
+       lo renderiza como pill.
+
+    4. User turn con `[TEXTO EXTRAÍDO DEL PDF` o `[SISTEMA` en el
+       content → truncar al primer marker. Si queda algo después del
+       trim, mantener ese text como el content real del turn. Si queda
+       vacío, reemplazar por "(adjunto plano)".
+
+    5. Cualquier otro turn → preservar tal cual.
+
+    Returns:
+        (new_messages, changed) — changed=True si el helper hizo algún
+        cambio, False si el historial ya estaba limpio (idempotencia).
+    """
+    if not messages:
+        return (list(messages or []), False)
+
+    quote_breakdown = quote_breakdown or {}
+    dual_read = quote_breakdown.get("dual_read_result")
+    context_pending = quote_breakdown.get("context_analysis_pending")
+
+    new_messages: list[dict] = []
+    changed = False
+
+    for msg in messages:
+        role = msg.get("role")
+        content = msg.get("content")
+        text = _content_to_text(content).strip()
+
+        # Rule 3 — fake user turn "(contexto confirmado)"
+        if role == "user" and text == "(contexto confirmado)":
+            changed = True
+            continue
+
+        # Rule 1 — __DUAL_READ_CARD_SHOWN__
+        if role == "assistant" and text == "__DUAL_READ_CARD_SHOWN__":
+            changed = True
+            if dual_read:
+                new_content = (
+                    "__DUAL_READ__"
+                    + json.dumps(dual_read, ensure_ascii=False)
+                )
+                new_messages.append({**msg, "content": new_content})
+            # Else: descartar (no reconstruible)
+            continue
+
+        # Rule 2 — __CONTEXT_ANALYSIS_SHOWN__
+        if role == "assistant" and text == "__CONTEXT_ANALYSIS_SHOWN__":
+            changed = True
+            if context_pending:
+                new_content = (
+                    "__CONTEXT_ANALYSIS__"
+                    + json.dumps(context_pending, ensure_ascii=False)
+                )
+                new_messages.append({**msg, "content": new_content})
+            # Else: descartar (no reconstruible post-confirmación)
+            continue
+
+        # Rule 4 — user turn contaminado con bloques internos
+        if role == "user" and any(
+            prefix in text for prefix in _CONTAMINATION_PREFIXES
+        ):
+            cleaned = _strip_contamination(text).strip()
+            changed = True
+            if not cleaned:
+                cleaned = "(adjunto plano)"
+            # Normalizamos content como string puro post-#379.
+            new_messages.append({**msg, "content": cleaned})
+            continue
+
+        # Preservar el turn legítimo.
+        new_messages.append(msg)
+
+    return (new_messages, changed)
+
+
 def reset_quote_to_paso1(
     quote_breakdown: dict | None,
     *,

--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -460,6 +460,61 @@ async def reopen_measurements(
     return q
 
 
+# ── REHYDRATE LEGACY CHAT HISTORY (non-destructive) ─────────────────────────
+#
+# PR #380 — Repara quotes viejos cuyo `Quote.messages` quedó con placeholders
+# `_SHOWN_` vacíos, bloques internos del system prompt pegados al user
+# turn, o fake turns "(contexto confirmado)". El helper puro
+# `rehydrate_messages` reconstruye el historial usando `quote_breakdown`
+# como fuente de verdad (dual_read_result, context_analysis_pending)
+# sin inventar data ausente.
+#
+# Idempotente: si el historial ya está limpio, `changed=False` y no hay
+# UPDATE a DB. No toca cálculo, totales ni pricing — solo `messages`.
+#
+# Uso típico: operador abre un quote viejo, ve markers crudos, llama
+# este endpoint (manualmente o vía UI futura). También usable desde
+# un script de migration one-shot.
+
+@router.post("/quotes/{quote_id}/rehydrate-history")
+async def rehydrate_history(
+    quote_id: str,
+    db: AsyncSession = Depends(get_db),
+):
+    """Reconstruye el historial de chat desde `quote_breakdown` si hay
+    markers legacy. No modifica nada del cálculo.
+
+    Codes:
+        200 con {changed: bool, quote_id} — idempotente si changed=False.
+        404 — quote no existe.
+    """
+    from app.modules.agent.card_editor import rehydrate_messages
+
+    result = await db.execute(select(Quote).where(Quote.id == quote_id))
+    quote = result.scalar_one_or_none()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Presupuesto no encontrado")
+
+    new_messages, changed = rehydrate_messages(
+        list(quote.messages or []), quote.quote_breakdown or {},
+    )
+
+    if not changed:
+        return {"changed": False, "quote_id": quote_id}
+
+    await db.execute(
+        update(Quote)
+        .where(Quote.id == quote_id)
+        .values(messages=new_messages)
+    )
+    await db.commit()
+    logger.info(
+        f"[rehydrate] quote {quote_id} messages updated: "
+        f"{len(quote.messages or [])} → {len(new_messages)} turns"
+    )
+    return {"changed": True, "quote_id": quote_id, "turn_count": len(new_messages)}
+
+
 # ── VALIDATE QUOTE (generate docs + change status) ──────────────────────────
 
 @router.post("/quotes/{quote_id}/validate")

--- a/api/tests/test_card_editor.py
+++ b/api/tests/test_card_editor.py
@@ -326,3 +326,275 @@ class TestResetQuoteToPaso1:
         }
         reset = reset_quote_to_paso1(bd)
         assert reset == {"dual_read_result": {"x": 1}}
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PR #380 — rehydrate_messages helper (historial legacy)
+# ═══════════════════════════════════════════════════════════════════════
+
+import json  # noqa: E402
+from app.modules.agent.card_editor import rehydrate_messages  # noqa: E402
+
+
+def _legacy_bernardi_messages() -> list[dict]:
+    """Historial real de un quote pre-#379 — con todos los patrones
+    contaminados que el helper debe limpiar."""
+    return [
+        # Brief del operador con el bloque PDF pegado (bug copy.deepcopy)
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        "nuevo presupuesto material en pura prima onix white mate "
+                        "Cliente: Erica Bernardi SIN zocalos en rosario\n\n"
+                        "[TEXTO EXTRAÍDO DEL PDF — DATOS EXACTOS]\n"
+                        "⛔ Extraído con precisión 100%...\n"
+                        "Tabla 3 (página 1) --- 1,60 ---\n"
+                        "[SISTEMA — EDICIÓN LIBRE]\n"
+                        "Este presupuesto tiene un cálculo previo..."
+                    ),
+                }
+            ],
+        },
+        # Marker placeholder — reemplazable si hay context_analysis_pending
+        {"role": "assistant", "content": "__CONTEXT_ANALYSIS_SHOWN__"},
+        # Turn real de confirmación de contexto (frontend lo marca como pill)
+        {"role": "user", "content": '[CONTEXT_CONFIRMED]{"answers":[]}'},
+        # Fake user turn — descartable
+        {"role": "user", "content": "(contexto confirmado)"},
+        # Marker del despiece — reemplazable si hay dual_read_result
+        {"role": "assistant", "content": "__DUAL_READ_CARD_SHOWN__"},
+        # Turn de confirmación de medidas (pill)
+        {"role": "user", "content": '[DUAL_READ_CONFIRMED]{"sectores":[]}'},
+        # Paso 2 assistant markdown legítimo
+        {"role": "assistant", "content": "## PASO 2 — Validación ..."},
+        # Final user turn legítimo
+        {"role": "user", "content": "Confirmo"},
+    ]
+
+
+def _bernardi_breakdown(with_context_pending: bool = True) -> dict:
+    """Breakdown con data mínima para reconstruir las cards."""
+    bd = {
+        "dual_read_result": {
+            "sectores": [{"id": "cocina", "tipo": "cocina", "tramos": []}],
+        },
+    }
+    if with_context_pending:
+        bd["context_analysis_pending"] = {
+            "data_known": [{"field": "Cliente", "value": "Erica Bernardi", "source": "brief"}],
+            "assumptions": [],
+            "pending_questions": [],
+        }
+    return bd
+
+
+class TestRehydrateMessagesBernardi:
+    """Caso central: el historial Bernardi-shape con todos los patrones
+    contaminados se transforma al shape post-#379 usando el breakdown
+    como fuente de verdad."""
+
+    def test_bernardi_full_rehydrate(self):
+        msgs = _legacy_bernardi_messages()
+        bd = _bernardi_breakdown()
+        new_msgs, changed = rehydrate_messages(msgs, bd)
+        assert changed is True
+
+        # Brief del operador: truncado al marker [TEXTO EXTRAÍDO
+        brief = new_msgs[0]
+        assert brief["role"] == "user"
+        brief_text = brief["content"] if isinstance(brief["content"], str) else "".join(
+            b.get("text", "") for b in brief["content"] if b.get("type") == "text"
+        )
+        assert "pura prima onix" in brief_text.lower()
+        assert "TEXTO EXTRAÍDO" not in brief_text
+        assert "[SISTEMA" not in brief_text
+
+        # __CONTEXT_ANALYSIS_SHOWN__ → __CONTEXT_ANALYSIS__<json>
+        ctx_turn = new_msgs[1]
+        assert ctx_turn["role"] == "assistant"
+        assert ctx_turn["content"].startswith("__CONTEXT_ANALYSIS__")
+        ctx_json = json.loads(ctx_turn["content"].replace("__CONTEXT_ANALYSIS__", "", 1))
+        assert any(
+            r.get("field") == "Cliente" and r.get("value") == "Erica Bernardi"
+            for r in ctx_json.get("data_known", [])
+        )
+
+        # [CONTEXT_CONFIRMED] preservado
+        assert new_msgs[2]["content"].startswith("[CONTEXT_CONFIRMED]")
+
+        # (contexto confirmado) descartado → el siguiente es el DUAL_READ
+        dual_turn = new_msgs[3]
+        assert dual_turn["role"] == "assistant"
+        assert dual_turn["content"].startswith("__DUAL_READ__")
+        dual_json = json.loads(dual_turn["content"].replace("__DUAL_READ__", "", 1))
+        assert dual_json["sectores"][0]["tipo"] == "cocina"
+
+        # [DUAL_READ_CONFIRMED] preservado
+        assert new_msgs[4]["content"].startswith("[DUAL_READ_CONFIRMED]")
+
+        # Paso 2 preservado
+        assert new_msgs[5]["content"].startswith("## PASO 2")
+
+        # "Confirmo" preservado
+        assert new_msgs[6]["content"] == "Confirmo"
+
+        # Total: 8 originales → 7 (se descartó "(contexto confirmado)")
+        assert len(new_msgs) == 7
+
+    def test_idempotent_second_call_returns_unchanged(self):
+        """Idempotencia — condición del PR: correr 2 veces da el mismo
+        resultado y la segunda marca changed=False."""
+        msgs = _legacy_bernardi_messages()
+        bd = _bernardi_breakdown()
+        once, changed1 = rehydrate_messages(msgs, bd)
+        assert changed1 is True
+        twice, changed2 = rehydrate_messages(once, bd)
+        assert changed2 is False
+        assert once == twice
+
+    def test_no_invention_when_dual_read_missing(self):
+        """Si no hay `dual_read_result` en el breakdown, el marker
+        __DUAL_READ_CARD_SHOWN__ se descarta en lugar de fabricar data."""
+        msgs = [
+            {"role": "user", "content": "brief"},
+            {"role": "assistant", "content": "__DUAL_READ_CARD_SHOWN__"},
+        ]
+        new_msgs, changed = rehydrate_messages(msgs, {})
+        assert changed is True
+        assert len(new_msgs) == 1  # marker descartado
+        assert new_msgs[0]["content"] == "brief"
+
+    def test_no_invention_when_context_pending_missing(self):
+        """Mismo criterio para context_analysis — post-confirmación
+        `context_analysis_pending` se poppea del breakdown. El helper no
+        reconstruye la card (acepta perderla) en lugar de fabricar."""
+        msgs = [
+            {"role": "user", "content": "brief"},
+            {"role": "assistant", "content": "__CONTEXT_ANALYSIS_SHOWN__"},
+        ]
+        new_msgs, changed = rehydrate_messages(msgs, {"dual_read_result": {}})
+        assert changed is True
+        assert len(new_msgs) == 1
+        assert new_msgs[0]["content"] == "brief"
+
+
+class TestRehydrateMessagesIdempotence:
+    """Condición explícita: quotes sanos quedan intactos."""
+
+    def test_clean_history_is_noop(self):
+        """Historial ya limpio (post-#379) → changed=False, identity."""
+        msgs = [
+            {"role": "user", "content": "cotizar cocina"},
+            {
+                "role": "assistant",
+                "content": '__CONTEXT_ANALYSIS__{"data_known":[]}',
+            },
+            {"role": "user", "content": '[CONTEXT_CONFIRMED]{"answers":[]}'},
+            {
+                "role": "assistant",
+                "content": '__DUAL_READ__{"sectores":[]}',
+            },
+            {"role": "user", "content": '[DUAL_READ_CONFIRMED]{"sectores":[]}'},
+            {"role": "assistant", "content": "## PASO 2"},
+            {"role": "user", "content": "Confirmo"},
+        ]
+        new_msgs, changed = rehydrate_messages(msgs, {"dual_read_result": {}})
+        assert changed is False
+        assert new_msgs == msgs
+
+    def test_empty_messages(self):
+        assert rehydrate_messages([], {}) == ([], False)
+        assert rehydrate_messages(None, {}) == ([], False)
+
+    def test_none_breakdown_still_cleans_contamination(self):
+        """Aun sin breakdown: `(contexto confirmado)` y `[TEXTO
+        EXTRAÍDO]` se limpian. Los markers `_SHOWN_` se descartan
+        (sin data para rehidratar)."""
+        msgs = [
+            {"role": "user", "content": [{"type": "text", "text": "brief\n[TEXTO EXTRAÍDO DEL PDF]\ndump"}]},
+            {"role": "user", "content": "(contexto confirmado)"},
+            {"role": "assistant", "content": "__DUAL_READ_CARD_SHOWN__"},
+        ]
+        new_msgs, changed = rehydrate_messages(msgs, None)
+        assert changed is True
+        # Brief truncado + fake user descartado + marker descartado
+        assert len(new_msgs) == 1
+        brief_text = new_msgs[0]["content"]
+        assert "brief" in brief_text
+        assert "TEXTO EXTRAÍDO" not in brief_text
+
+
+class TestRehydrateContentShape:
+    """Tests de edge cases del shape de `content`: string vs list vs
+    mixed."""
+
+    def test_content_list_with_text_block_truncated(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "cotizar [TEXTO EXTRAÍDO DEL PDF] dump"},
+                ],
+            }
+        ]
+        new_msgs, changed = rehydrate_messages(msgs, {})
+        assert changed is True
+        # Se normaliza a string
+        assert new_msgs[0]["content"] == "cotizar"
+
+    def test_content_fully_contaminated_falls_back_to_placeholder(self):
+        """Si todo el content es contaminación, queda placeholder."""
+        msgs = [
+            {
+                "role": "user",
+                "content": "[TEXTO EXTRAÍDO DEL PDF]\n dump completo sin brief",
+            }
+        ]
+        new_msgs, changed = rehydrate_messages(msgs, {})
+        assert changed is True
+        assert new_msgs[0]["content"] == "(adjunto plano)"
+
+    def test_content_with_multiple_markers_truncates_at_first(self):
+        """Si aparecen ambos markers, corta en el que esté primero."""
+        msgs = [
+            {
+                "role": "user",
+                "content": (
+                    "cotizar la cocina"
+                    "\n[SISTEMA — EDICIÓN LIBRE]\nhint"
+                    "\n[TEXTO EXTRAÍDO DEL PDF]\ndump"
+                ),
+            }
+        ]
+        new_msgs, changed = rehydrate_messages(msgs, {})
+        assert changed is True
+        assert new_msgs[0]["content"] == "cotizar la cocina"
+
+    def test_ignores_legitimate_brackets_in_content(self):
+        """Un texto con corchetes que no son markers internos (ej: el
+        operador escribe '[x2]') no se toca."""
+        msgs = [
+            {
+                "role": "user",
+                "content": "necesito [x2] mesadas iguales",
+            }
+        ]
+        new_msgs, changed = rehydrate_messages(msgs, {})
+        assert changed is False
+        assert new_msgs == msgs
+
+
+class TestRehydrateDoesNotTouchBreakdown:
+    """Condición del PR: el cálculo/totales no se tocan."""
+
+    def test_breakdown_is_read_not_mutated(self):
+        bd = _bernardi_breakdown()
+        bd_snapshot = json.loads(json.dumps(bd))
+        msgs = _legacy_bernardi_messages()
+        rehydrate_messages(msgs, bd)
+        # El breakdown no cambia
+        assert bd == bd_snapshot
+

--- a/api/tests/test_router.py
+++ b/api/tests/test_router.py
@@ -888,3 +888,169 @@ class TestReopenMeasurements:
         await client.post(f"/api/quotes/{qid}/reopen-measurements")
         detail = (await client.get(f"/api/quotes/{qid}")).json()
         assert detail["client_name"] == "Erica Bernardi"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PR #380 — Endpoint rehydrate-history
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestRehydrateHistoryEndpoint:
+    """Endpoint que limpia historial legacy usando el breakdown como
+    fuente de verdad. Idempotente y no destructivo."""
+
+    @pytest.mark.asyncio
+    async def test_404_for_nonexistent_quote(self, client):
+        resp = await client.post(
+            "/api/quotes/00000000-0000-0000-0000-000000000000/rehydrate-history"
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_200_changed_false_on_clean_quote(self, client, db_session):
+        """Quote sin markers legacy → changed=False, no UPDATE."""
+        from app.models.quote import Quote
+        from sqlalchemy import update
+        create = await client.post("/api/quotes")
+        qid = create.json()["id"]
+        clean_msgs = [
+            {"role": "user", "content": "cotizar cocina"},
+            {"role": "assistant", "content": "## PASO 2"},
+        ]
+        await db_session.execute(
+            update(Quote).where(Quote.id == qid).values(messages=clean_msgs)
+        )
+        await db_session.commit()
+
+        resp = await client.post(f"/api/quotes/{qid}/rehydrate-history")
+        assert resp.status_code == 200
+        assert resp.json()["changed"] is False
+        # Los messages no cambiaron
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        assert len(detail["messages"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_200_rehydrates_legacy_bernardi_shape(self, client, db_session):
+        """Historial legacy con placeholders → se reconstruye usando el
+        dual_read_result del breakdown."""
+        from app.models.quote import Quote
+        from sqlalchemy import update
+        create = await client.post("/api/quotes")
+        qid = create.json()["id"]
+        legacy_msgs = [
+            {"role": "user", "content": "brief con [TEXTO EXTRAÍDO DEL PDF] dump"},
+            {"role": "assistant", "content": "__DUAL_READ_CARD_SHOWN__"},
+            {"role": "user", "content": "(contexto confirmado)"},
+        ]
+        bd = {"dual_read_result": {"sectores": [{"tipo": "cocina"}]}}
+        await db_session.execute(
+            update(Quote).where(Quote.id == qid).values(
+                messages=legacy_msgs, quote_breakdown=bd,
+            )
+        )
+        await db_session.commit()
+
+        resp = await client.post(f"/api/quotes/{qid}/rehydrate-history")
+        assert resp.status_code == 200
+        assert resp.json()["changed"] is True
+
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        msgs = detail["messages"]
+        # Brief limpio
+        brief = msgs[0]["content"]
+        brief_text = brief if isinstance(brief, str) else "".join(
+            b.get("text", "") for b in brief if b.get("type") == "text"
+        )
+        assert "TEXTO EXTRAÍDO" not in brief_text
+        # Card de despiece reconstruida
+        assert msgs[1]["content"].startswith("__DUAL_READ__")
+        # Fake (contexto confirmado) descartado
+        assert len(msgs) == 2
+
+    @pytest.mark.asyncio
+    async def test_idempotent_second_call(self, client, db_session):
+        from app.models.quote import Quote
+        from sqlalchemy import update
+        create = await client.post("/api/quotes")
+        qid = create.json()["id"]
+        legacy_msgs = [
+            {"role": "user", "content": "brief"},
+            {"role": "assistant", "content": "__DUAL_READ_CARD_SHOWN__"},
+        ]
+        bd = {"dual_read_result": {"sectores": []}}
+        await db_session.execute(
+            update(Quote).where(Quote.id == qid).values(
+                messages=legacy_msgs, quote_breakdown=bd,
+            )
+        )
+        await db_session.commit()
+
+        r1 = await client.post(f"/api/quotes/{qid}/rehydrate-history")
+        assert r1.json()["changed"] is True
+        r2 = await client.post(f"/api/quotes/{qid}/rehydrate-history")
+        assert r2.json()["changed"] is False
+
+    @pytest.mark.asyncio
+    async def test_does_not_modify_breakdown_or_status(self, client, db_session):
+        """Condición del PR: no toca cálculo. Verificamos que breakdown,
+        total_ars, total_usd y status quedan intactos."""
+        from app.models.quote import Quote
+        from sqlalchemy import update
+        create = await client.post("/api/quotes")
+        qid = create.json()["id"]
+        legacy_msgs = [
+            {"role": "assistant", "content": "__DUAL_READ_CARD_SHOWN__"},
+        ]
+        bd = {
+            "dual_read_result": {"sectores": []},
+            "material_name": "PURASTONE",
+            "total_ars": 797177,
+            "total_usd": 4128,
+        }
+        await db_session.execute(
+            update(Quote).where(Quote.id == qid).values(
+                messages=legacy_msgs,
+                quote_breakdown=bd,
+                total_ars=797177,
+                total_usd=4128,
+            )
+        )
+        await db_session.commit()
+
+        await client.post(f"/api/quotes/{qid}/rehydrate-history")
+
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        assert detail["total_ars"] == 797177
+        assert detail["total_usd"] == 4128
+        assert detail["quote_breakdown"]["material_name"] == "PURASTONE"
+        assert detail["quote_breakdown"]["total_ars"] == 797177
+
+    @pytest.mark.asyncio
+    async def test_preserves_clean_messages_between_legacy(self, client, db_session):
+        """Si en el medio hay mensajes legítimos (ej: Paso 2 markdown),
+        se preservan tal cual mientras los adyacentes se rehidratan."""
+        from app.models.quote import Quote
+        from sqlalchemy import update
+        create = await client.post("/api/quotes")
+        qid = create.json()["id"]
+        legacy_msgs = [
+            {"role": "user", "content": "brief"},
+            {"role": "assistant", "content": "__DUAL_READ_CARD_SHOWN__"},
+            {"role": "assistant", "content": "## PASO 2 — Validación\n\nmateriales y precios"},
+            {"role": "user", "content": "Confirmo"},
+        ]
+        bd = {"dual_read_result": {"sectores": []}}
+        await db_session.execute(
+            update(Quote).where(Quote.id == qid).values(
+                messages=legacy_msgs, quote_breakdown=bd,
+            )
+        )
+        await db_session.commit()
+
+        await client.post(f"/api/quotes/{qid}/rehydrate-history")
+
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        msgs = detail["messages"]
+        assert len(msgs) == 4
+        assert msgs[1]["content"].startswith("__DUAL_READ__")
+        assert msgs[2]["content"].startswith("## PASO 2")
+        assert msgs[3]["content"] == "Confirmo"


### PR DESCRIPTION
## Summary
PR separado de #379. Repara quotes viejos cuyo \`Quote.messages\` quedó contaminado en DB con placeholders \`_SHOWN_\` vacíos, bloques internos del system prompt pegados al user turn, y fake turns \`"(contexto confirmado)"\`.

Helper puro + endpoint. Sin tocar cálculo. Idempotente. No inventa.

## Condiciones respetadas

| Condición del user | Cómo |
|---|---|
| Reconstruye cards desde \`quote_breakdown\` si hay data suficiente | Usa \`dual_read_result\` y \`context_analysis_pending\`. Reemplaza el marker con JSON real en el formato que el frontend ya maneja. |
| Idempotente | Si historial está limpio → \`changed=False\`, no UPDATE. Test explícito lo valida. |
| No toca cálculo / totales / pricing | Breakdown se LEE pero no se muta. Test valida material_name/totales intactos. |
| No inventa si falta info | Sin \`dual_read_result\` → marker descartado. Sin \`context_analysis_pending\` → marker descartado. |
| Deja intactos los quotes sanos | Mensajes post-#379 pasan sin cambios. |

## Diseño

### Helper puro \`rehydrate_messages(messages, quote_breakdown)\`
En \`card_editor.py\` junto a \`reset_quote_to_paso1\`. Retorna \`(new_messages, changed)\`. Sin side effects, no LLM.

5 reglas de transformación en un pase:
1. \`__DUAL_READ_CARD_SHOWN__\` → \`__DUAL_READ__<json>\` desde breakdown (o descartar).
2. \`__CONTEXT_ANALYSIS_SHOWN__\` → \`__CONTEXT_ANALYSIS__<json>\` desde breakdown (o descartar).
3. \`"(contexto confirmado)"\` user turn → descartar.
4. User turn con \`[TEXTO EXTRAÍDO DEL PDF\` o \`[SISTEMA\` → truncar al primer marker. Si queda vacío → \`"(adjunto plano)"\`.
5. Otros turns → preservar.

Soporta \`str\` y \`list[{type,text}]\` como content. Normaliza a string limpio.

### Endpoint \`POST /api/quotes/:id/rehydrate-history\`
- 200 con \`{changed, quote_id, turn_count?}\`.
- 404 quote inexistente.
- Sin gate de status — también funciona sobre validated/sent (no toca el contenido del presupuesto).

## Non-goals
- NO re-ejecuta LLM para reconstruir la card de contexto post-confirm (info no cacheada). Se acepta perder esa card visual; datos siguen en \`verified_context_analysis\`.
- NO cambia la persistencia hacia adelante (eso es #379).
- NO UI automática — endpoint manual por ahora.

## Uso
\`\`\`bash
curl -X POST https://<api>/api/quotes/<id>/rehydrate-history
\`\`\`

Primera llamada: \`{"changed": true, "quote_id": "...", "turn_count": N}\`
Segunda llamada: \`{"changed": false, "quote_id": "..."}\`

## Tests (18 nuevos)

**\`TestRehydrateMessagesBernardi\`** (4): full rehydrate + idempotencia + no-invent casos.

**\`TestRehydrateMessagesIdempotence\`** (3): clean noop + empty + None breakdown.

**\`TestRehydrateContentShape\`** (4): list content, fully contaminated, múltiples markers, corchetes legítimos.

**\`TestRehydrateDoesNotTouchBreakdown\`** (1): breakdown no se muta.

**\`TestRehydrateHistoryEndpoint\`** (6): 404, changed=false, rehidrata Bernardi, idempotencia, preserva breakdown/status/totales, preserva mensajes legítimos entre legacy.

**Suite completa**: 1848 passed (+18), 16 pre-existentes failed (no relacionados).

## Test plan post-merge
- [ ] Quote Bernardi viejo (el que venías probando): \`curl -X POST .../rehydrate-history\`.
- [ ] Refetch el quote, abrir el chat: ver cards reales en lugar de placeholders.
- [ ] Segundo curl → \`changed: false\` (idempotencia).
- [ ] Comparar que \`total_ars\` / \`total_usd\` / \`material_name\` siguen iguales pre vs post rehydrate.
- [ ] Un quote que ya se creó post-#379 (limpio) → \`changed: false\` desde la primera llamada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)