### PR TITLE
fix(rehydrate): usar verified_measurements sobre dual_read_result

### DIFF
--- a/api/app/modules/agent/card_editor.py
+++ b/api/app/modules/agent/card_editor.py
@@ -557,11 +557,26 @@ def rehydrate_messages(
         return (list(messages or []), False)
 
     quote_breakdown = quote_breakdown or {}
-    dual_read = quote_breakdown.get("dual_read_result")
+    # PR #382 — Fuente de verdad para la card del despiece:
+    # - `verified_measurements` (post-confirm del operador, incluye edits
+    #   y candidatas aplicadas — las 3 medidas confirmadas de Bernardi).
+    # - `dual_read_result` (pre-confirm — puede tener tramos vacíos que el
+    #   dual_read no pudo resolver y el operador iba a llenar).
+    # Prioridad: verified > dual_read. Si el quote pasó por confirmación
+    # de medidas, la card debe reflejar el estado final, no el snapshot
+    # original.
+    dual_read_source = (
+        quote_breakdown.get("verified_measurements")
+        or quote_breakdown.get("dual_read_result")
+    )
     context_pending = quote_breakdown.get("context_analysis_pending")
 
     new_messages: list[dict] = []
     changed = False
+
+    def _dual_read_block() -> str:
+        """Serializa la card de despiece con la fuente autoritativa."""
+        return "__DUAL_READ__" + json.dumps(dual_read_source, ensure_ascii=False)
 
     for msg in messages:
         role = msg.get("role")
@@ -573,16 +588,34 @@ def rehydrate_messages(
             changed = True
             continue
 
-        # Rule 1 — __DUAL_READ_CARD_SHOWN__
+        # Rule 1 — __DUAL_READ_CARD_SHOWN__ (marker vacío)
         if role == "assistant" and text == "__DUAL_READ_CARD_SHOWN__":
             changed = True
-            if dual_read:
-                new_content = (
-                    "__DUAL_READ__"
-                    + json.dumps(dual_read, ensure_ascii=False)
-                )
-                new_messages.append({**msg, "content": new_content})
+            if dual_read_source:
+                new_messages.append({**msg, "content": _dual_read_block()})
             # Else: descartar (no reconstruible)
+            continue
+
+        # Rule 1b (PR #382) — __DUAL_READ__<json> stale
+        # Escenario: el helper viejo ya rehidrató un quote usando
+        # `dual_read_result` (pre-confirm) en lugar de
+        # `verified_measurements`. El content quedó como
+        # `__DUAL_READ__<dual_read_result>` con tramos vacíos. Detectamos
+        # el mismatch y regeneramos con la fuente correcta.
+        #
+        # Idempotencia: si el JSON embebido ya coincide con
+        # `dual_read_source`, no se marca changed.
+        if role == "assistant" and text.startswith("__DUAL_READ__") and dual_read_source:
+            try:
+                existing = json.loads(text.replace("__DUAL_READ__", "", 1))
+            except (json.JSONDecodeError, ValueError):
+                existing = None
+            if existing != dual_read_source:
+                changed = True
+                new_messages.append({**msg, "content": _dual_read_block()})
+                continue
+            # Ya coincide — preservar sin tocar.
+            new_messages.append(msg)
             continue
 
         # Rule 2 — __CONTEXT_ANALYSIS_SHOWN__

--- a/api/tests/test_card_editor.py
+++ b/api/tests/test_card_editor.py
@@ -598,3 +598,190 @@ class TestRehydrateDoesNotTouchBreakdown:
         # El breakdown no cambia
         assert bd == bd_snapshot
 
+
+# ═══════════════════════════════════════════════════════════════════════
+# PR #382 — rehydrate usa verified_measurements sobre dual_read_result
+# ═══════════════════════════════════════════════════════════════════════
+#
+# Caso observado por Javi: quote Bernardi rehidratado con #380 mostraba
+# las mesadas de cocina vacías en la card del despiece, mientras que
+# el mensaje de Valentina en Paso 2 listaba las 3 medidas confirmadas.
+#
+# Root cause: #380 leía solo `dual_read_result` (estado pre-confirm
+# del backend — las mesadas de cocina quedaban vacías esperando que
+# el operador las llenara con candidatas sugeridas o edits). Tras la
+# confirmación del operador, las medidas reales viven en
+# `verified_measurements`.
+#
+# Fix: el helper prioriza verified_measurements > dual_read_result.
+
+
+def _bernardi_with_verified_measurements() -> dict:
+    """Breakdown de Bernardi post-confirm. `dual_read_result` tiene las
+    mesadas de cocina vacías (el estado que el dual_read detectó
+    originalmente), pero `verified_measurements` tiene las 3 medidas
+    confirmadas por el operador."""
+    return {
+        "dual_read_result": {
+            "sectores": [
+                {
+                    "id": "cocina", "tipo": "cocina",
+                    "tramos": [
+                        # Vacías — el dual_read no pudo resolverlas
+                        {"id": "t1", "descripcion": "Mesada con pileta",
+                         "largo_m": {"valor": 0}, "ancho_m": {"valor": 0}, "m2": {"valor": 0}},
+                        {"id": "t2", "descripcion": "Mesada 2",
+                         "largo_m": {"valor": 0}, "ancho_m": {"valor": 0}, "m2": {"valor": 0}},
+                    ],
+                },
+                {
+                    "id": "isla", "tipo": "isla",
+                    "tramos": [
+                        # La única que el dual_read resolvió
+                        {"id": "t3", "descripcion": "Mesada isla",
+                         "largo_m": {"valor": 1.60}, "ancho_m": {"valor": 0.60}, "m2": {"valor": 0.96}},
+                    ],
+                },
+            ],
+        },
+        "verified_measurements": {
+            "sectores": [
+                {
+                    "id": "cocina", "tipo": "cocina",
+                    "tramos": [
+                        # Ahora con las medidas confirmadas por el operador
+                        {"id": "t1", "descripcion": "Mesada con pileta",
+                         "largo_m": {"valor": 2.05}, "ancho_m": {"valor": 0.60}, "m2": {"valor": 1.23}},
+                        {"id": "t2", "descripcion": "Mesada 2",
+                         "largo_m": {"valor": 2.95}, "ancho_m": {"valor": 0.60}, "m2": {"valor": 1.77}},
+                    ],
+                },
+                {
+                    "id": "isla", "tipo": "isla",
+                    "tramos": [
+                        {"id": "t3", "descripcion": "Mesada isla",
+                         "largo_m": {"valor": 1.60}, "ancho_m": {"valor": 0.60}, "m2": {"valor": 0.96}},
+                    ],
+                },
+            ],
+        },
+    }
+
+
+class TestRehydrateUsesVerifiedMeasurements:
+    def test_prefers_verified_over_dual_read_result(self):
+        """Bernardi: si hay verified_measurements, la card debe reflejar
+        ESOS valores (3 medidas), no dual_read_result (solo isla)."""
+        msgs = [
+            {"role": "user", "content": "brief"},
+            {"role": "assistant", "content": "__DUAL_READ_CARD_SHOWN__"},
+        ]
+        bd = _bernardi_with_verified_measurements()
+        new_msgs, changed = rehydrate_messages(msgs, bd)
+        assert changed is True
+        assert len(new_msgs) == 2
+
+        card_content = new_msgs[1]["content"]
+        assert card_content.startswith("__DUAL_READ__")
+        parsed = json.loads(card_content.replace("__DUAL_READ__", "", 1))
+        # Las 3 mesadas con sus medidas confirmadas
+        cocina_tramos = parsed["sectores"][0]["tramos"]
+        assert cocina_tramos[0]["largo_m"]["valor"] == 2.05
+        assert cocina_tramos[1]["largo_m"]["valor"] == 2.95
+        isla_tramo = parsed["sectores"][1]["tramos"][0]
+        assert isla_tramo["largo_m"]["valor"] == 1.60
+
+    def test_falls_back_to_dual_read_when_no_verified(self):
+        """Sin verified_measurements (quote pre-confirm): usa dual_read_result
+        como antes (compat con comportamiento previo)."""
+        msgs = [
+            {"role": "assistant", "content": "__DUAL_READ_CARD_SHOWN__"},
+        ]
+        bd = {
+            "dual_read_result": {"sectores": [{"tipo": "cocina", "tramos": []}]},
+        }
+        new_msgs, changed = rehydrate_messages(msgs, bd)
+        assert changed is True
+        card_content = new_msgs[0]["content"]
+        parsed = json.loads(card_content.replace("__DUAL_READ__", "", 1))
+        assert parsed["sectores"][0]["tipo"] == "cocina"
+
+    def test_regenerates_stale_dual_read_content(self):
+        """Regresión del bug observado: un quote rehidratado previamente
+        con el helper viejo quedó con `__DUAL_READ__<dual_read_result>`
+        (incompleto). Al re-correr el helper con verified_measurements
+        presente, debe REGENERAR el content con la fuente autoritativa."""
+        bd = _bernardi_with_verified_measurements()
+        # Content stale: tiene el dual_read_result (mesadas vacías) embebido
+        stale_content = "__DUAL_READ__" + json.dumps(bd["dual_read_result"], ensure_ascii=False)
+        msgs = [
+            {"role": "user", "content": "brief"},
+            {"role": "assistant", "content": stale_content},
+        ]
+        new_msgs, changed = rehydrate_messages(msgs, bd)
+        assert changed is True
+        # Regenerado con verified_measurements
+        new_content = new_msgs[1]["content"]
+        parsed = json.loads(new_content.replace("__DUAL_READ__", "", 1))
+        cocina_tramos = parsed["sectores"][0]["tramos"]
+        assert cocina_tramos[0]["largo_m"]["valor"] == 2.05
+        assert cocina_tramos[1]["largo_m"]["valor"] == 2.95
+
+    def test_idempotent_with_verified_source(self):
+        """Run 2x → segundo call changed=False (el content ya tiene el
+        JSON correcto desde el primero)."""
+        bd = _bernardi_with_verified_measurements()
+        msgs = [
+            {"role": "assistant", "content": "__DUAL_READ_CARD_SHOWN__"},
+        ]
+        once, changed1 = rehydrate_messages(msgs, bd)
+        assert changed1 is True
+        twice, changed2 = rehydrate_messages(once, bd)
+        assert changed2 is False
+        assert once == twice
+
+    def test_preserves_content_when_already_matches_source(self):
+        """Si el content actual coincide exactamente con dual_read_source,
+        no se toca (idempotencia fuerte)."""
+        bd = _bernardi_with_verified_measurements()
+        good_content = (
+            "__DUAL_READ__"
+            + json.dumps(bd["verified_measurements"], ensure_ascii=False)
+        )
+        msgs = [
+            {"role": "user", "content": "brief"},
+            {"role": "assistant", "content": good_content},
+        ]
+        new_msgs, changed = rehydrate_messages(msgs, bd)
+        assert changed is False
+        assert new_msgs == msgs
+
+    def test_stale_content_without_verified_preserved(self):
+        """Si solo hay dual_read_result (sin verified), y el content
+        actual `__DUAL_READ__<json>` ya coincide con dual_read_result,
+        no se toca. Defensa: no regenerar sin causa."""
+        bd = {"dual_read_result": {"sectores": [{"tipo": "cocina"}]}}
+        current = "__DUAL_READ__" + json.dumps(bd["dual_read_result"], ensure_ascii=False)
+        msgs = [
+            {"role": "assistant", "content": current},
+        ]
+        new_msgs, changed = rehydrate_messages(msgs, bd)
+        assert changed is False
+        assert new_msgs == msgs
+
+    def test_invalid_json_in_stale_content_regenerated(self):
+        """Content con `__DUAL_READ__<garbage>` (JSON roto) — el helper
+        detecta el parse error y regenera con la fuente actual en lugar
+        de preservar el garbage."""
+        bd = _bernardi_with_verified_measurements()
+        msgs = [
+            {"role": "assistant", "content": "__DUAL_READ__{not valid json"},
+        ]
+        new_msgs, changed = rehydrate_messages(msgs, bd)
+        assert changed is True
+        parsed = json.loads(
+            new_msgs[0]["content"].replace("__DUAL_READ__", "", 1)
+        )
+        # Regenerado con verified_measurements
+        assert parsed["sectores"][0]["tramos"][0]["largo_m"]["valor"] == 2.05
+


### PR DESCRIPTION
## Summary
Bug observado en quote Bernardi rehidratado: la card del despiece mostraba las mesadas de cocina **vacías** aunque Valentina en el mismo chat listaba las 3 medidas confirmadas.

## Root cause
\`rehydrate_messages\` de #380 leía solo \`quote_breakdown.dual_read_result\` (snapshot pre-confirm donde el backend no pudo resolver todas las mesadas). Ignoraba \`verified_measurements\` que tiene los valores finales con edits del operador.

## Fix
\`\`\`python
dual_read_source = (
    quote_breakdown.get("verified_measurements")  # post-confirm: 3 medidas
    or quote_breakdown.get("dual_read_result")     # fallback pre-confirm
)
\`\`\`

Además, **regeneración defensiva** para quotes ya rehidratados mal con el helper viejo:
- Si el content es \`__DUAL_READ__<json>\` pero el JSON embebido no coincide con \`dual_read_source\` → regenerar.
- Si coincide → preservar (idempotencia).

Así el quote Bernardi se arregla re-ejecutando el endpoint:
\`\`\`js
fetch("/api/quotes/253825ad-.../rehydrate-history", {
  method: "POST", credentials: "include"
}).then(r => r.json()).then(console.log)
// → { changed: true, turn_count: 20 }
\`\`\`

## Tests (7 nuevos en \`TestRehydrateUsesVerifiedMeasurements\`)
- ✅ Caso Bernardi: verified > dual_read
- ✅ Fallback cuando no hay verified
- ✅ **Regresión del bug real**: content stale se regenera con verified
- ✅ Idempotencia (run 2x → changed=False)
- ✅ Content que ya coincide no se toca
- ✅ Sin verified, content coincidente con dual_read_result no se toca
- ✅ JSON roto en content → regenera

**41 tests previos del helper**: sin cambios, siguen passing.
**Suite completa**: 1855 passed (+7), 16 pre-existentes failed.

## No toca
- Cálculo / totales / pricing.
- Endpoint \`/rehydrate-history\` (firma igual).
- Persistencia hacia adelante (#379).
- UI (#381).

## Test plan post-merge
1. Ir al quote Bernardi (\`253825ad-...\`).
2. DevTools Console:
   \`\`\`js
   fetch("/api/quotes/253825ad-ae8f-49ef-85ee-6e5416afb3c9/rehydrate-history", {
     method: "POST", credentials: "include"
   }).then(r => r.json()).then(console.log)
   \`\`\`
3. Esperado: \`{changed: true, turn_count: 20}\` porque el helper detecta el content stale y regenera.
4. Hard reload de la página del quote.
5. Card del despiece debe mostrar las 3 medidas: **2.05 × 0.60**, **2.95 × 0.60**, **1.60 × 0.60**.
6. Re-ejecutar el fetch → \`{changed: false}\` (idempotencia).

🤖 Generated with [Claude Code](https://claude.com/claude-code)