### PR TITLE
feat(reopen): cortar historial desde la card al editar despiece/contexto

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1506,7 +1506,14 @@ class AgentService:
                 # Guardar verified_context_analysis (gate para no re-preguntar)
                 _bd_ctx["verified_context_analysis"] = _ctx_payload
                 _bd_ctx["dual_read_result"] = _saved_dual
-                _bd_ctx.pop("context_analysis_pending", None)
+                # PR #383 — NO pop `context_analysis_pending`. Se preserva
+                # como snapshot para que el endpoint /reopen-context pueda
+                # regenerar la card `__CONTEXT_ANALYSIS__` con los mismos
+                # data_known + assumptions + pending_questions que el
+                # operador vio al confirmar. El gate "ya se confirmó
+                # contexto" usa `verified_context_analysis` (no
+                # `context_analysis_pending`), por lo que preservarlo no
+                # re-dispara la card a mitad del flujo.
                 if _q_ctx:
                     await db.execute(
                         update(Quote).where(Quote.id == quote_id).values(quote_breakdown=_bd_ctx)

--- a/api/app/modules/agent/card_editor.py
+++ b/api/app/modules/agent/card_editor.py
@@ -648,6 +648,78 @@ def rehydrate_messages(
     return (new_messages, changed)
 
 
+# ─────────────────────────────────────────────────────────────────────
+# PR #383 — Reset del historial al reabrir edición
+#
+# Cuando el operador aprieta "Editar despiece" o "Editar contexto"
+# (endpoints /reopen-measurements y /reopen-context), se corta el chat
+# desde la card respectiva y se regenera con los datos actuales del
+# breakdown. Objetivo: evitar que el historial viejo (Paso 2 stale,
+# preguntas de Valentina pidiendo datos que ya están, etc.) quede
+# mezclado con el estado nuevo post-edición.
+#
+# Regla explícita del operador: "Nunca dejar historial viejo mezclado
+# con estado nuevo. Nunca borrar el brief inicial del operador." — por
+# eso el corte es desde la card hacia adelante, preservando todo lo
+# previo (brief, attachments, turns comerciales pre-card).
+# ─────────────────────────────────────────────────────────────────────
+
+
+def truncate_history_at_card(
+    messages: list[dict] | None,
+    *,
+    marker_prefix: str,
+    new_payload: dict | None,
+) -> tuple[list[dict], bool]:
+    """Corta el historial desde el ÚLTIMO turn `assistant` cuyo content
+    empieza con `marker_prefix` (inclusive) y opcionalmente regenera ese
+    turn con `new_payload`.
+
+    Args:
+        messages: turns tal como están en `Quote.messages`. Puede ser None.
+        marker_prefix: `"__DUAL_READ__"` o `"__CONTEXT_ANALYSIS__"`.
+        new_payload: si no es None, se serializa a JSON y se appendea
+            como nuevo turn assistant con el mismo `marker_prefix`.
+            Si es None, la card NO se regenera — el historial queda sin
+            ella (caso raro: reabrir cuando no hay data para reconstruir).
+
+    Returns:
+        `(new_messages, changed)`. `changed=False` si no se encontró el
+        marker en el historial (no hay nada que cortar — el helper no
+        agrega una card from scratch).
+
+    Idempotente pragmáticamente: llamar 2 veces con el mismo payload
+    produce el mismo resultado (se corta después del assistant con
+    marker, se vuelve a regenerar con el mismo payload).
+    """
+    if not messages:
+        return ([], False)
+
+    last_idx = -1
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if msg.get("role") != "assistant":
+            continue
+        content_text = _content_to_text(msg.get("content"))
+        if content_text.startswith(marker_prefix):
+            last_idx = i
+            break
+
+    if last_idx == -1:
+        # No encontramos la card. No inventamos — devolvemos el
+        # historial sin tocar. El endpoint caller decide qué hacer
+        # (típicamente: reset del breakdown igual, pero chat intacto).
+        return (list(messages), False)
+
+    new_messages = list(messages[:last_idx])
+    if new_payload is not None:
+        new_messages.append({
+            "role": "assistant",
+            "content": marker_prefix + json.dumps(new_payload, ensure_ascii=False),
+        })
+    return (new_messages, True)
+
+
 def reset_quote_to_paso1(
     quote_breakdown: dict | None,
     *,
@@ -678,4 +750,23 @@ def reset_quote_to_paso1(
         new_bd.pop(key, None)
     if not preserve_dual_read_result:
         new_bd.pop("dual_read_result", None)
+    return new_bd
+
+
+def reset_quote_to_pre_context(quote_breakdown: dict | None) -> dict:
+    """Reset al estado "pre-confirmación de contexto" — tira todo lo de
+    Paso 2 + `verified_context_analysis` pero preserva
+    `context_analysis_pending` (para regenerar la card de contexto) y
+    `dual_read_result`.
+
+    Usado por el endpoint `/reopen-context`: el operador quiere modificar
+    un dato del análisis de contexto (ej: material, cantidad de anafes,
+    dirección). Volvemos a un estado donde la card `__CONTEXT_ANALYSIS__`
+    es re-renderizable y el chat posterior (dual_read + Paso 2) queda
+    invalidado.
+    """
+    if not quote_breakdown:
+        return {}
+    new_bd = reset_quote_to_paso1(quote_breakdown)
+    new_bd.pop("verified_context_analysis", None)
     return new_bd

--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -395,10 +395,22 @@ async def reopen_measurements(
 ):
     """Resetea el quote a Paso 1 para permitir edición post-confirmación.
 
-    Returns the updated quote (con Paso 2 state ya limpiado).
+    Side-effects (PR #383):
+    - Promueve `verified_measurements` → `dual_read_result` si existe
+      (para que la card re-emitida muestre las medidas editadas, no el
+      snapshot pre-edit).
+    - Corta `Quote.messages` desde el último turn assistant con
+      `__DUAL_READ__` (inclusive) y regenera esa card con el despiece
+      actualizado. El historial posterior (Paso 2 stale, preguntas de
+      Valentina con datos viejos, etc.) se descarta — "nunca dejar
+      historial viejo mezclado con estado nuevo".
+    - El brief inicial del operador y todo lo previo a la card se
+      preservan tal cual.
+
+    Returns the updated quote.
 
     Codes:
-        200 — reopen aplicado, breakdown con Paso 2 limpio.
+        200 — reopen aplicado, breakdown con Paso 2 limpio + chat cortado.
         404 — quote no existe.
         409 — status no permite reopen (validated/sent).
         400 — no había confirmación previa (nada que reabrir).
@@ -406,6 +418,7 @@ async def reopen_measurements(
     from app.modules.agent.card_editor import (
         reset_quote_to_paso1,
         is_paso2_confirmed,
+        truncate_history_at_card,
     )
     result = await db.execute(select(Quote).where(Quote.id == quote_id))
     quote = result.scalar_one_or_none()
@@ -439,7 +452,22 @@ async def reopen_measurements(
             ),
         )
 
+    # PR #383 — preservar las medidas editadas promoviéndolas a
+    # dual_read_result. `reset_quote_to_paso1` borra verified_measurements,
+    # entonces lo capturamos antes. Si el operador nunca editó
+    # (verified_measurements no existe), dual_read_result queda como estaba.
+    verified = bd.get("verified_measurements")
     new_bd = reset_quote_to_paso1(bd)
+    if verified:
+        new_bd["dual_read_result"] = verified
+
+    # Cortar historial desde la card de despiece + regenerar.
+    new_messages, _ = truncate_history_at_card(
+        list(quote.messages or []),
+        marker_prefix="__DUAL_READ__",
+        new_payload=new_bd.get("dual_read_result"),
+    )
+
     # También limpiamos total_ars / total_usd en la tabla (reflejan lo
     # calculado en Paso 2). brief_analysis y client_name se preservan.
     await db.execute(
@@ -447,6 +475,7 @@ async def reopen_measurements(
         .where(Quote.id == quote_id)
         .values(
             quote_breakdown=new_bd,
+            messages=new_messages,
             total_ars=None,
             total_usd=None,
         )
@@ -456,7 +485,113 @@ async def reopen_measurements(
     # Refetch para devolver shape consistente con el listado.
     refreshed = await db.execute(select(Quote).where(Quote.id == quote_id))
     q = refreshed.scalar_one()
-    logger.info(f"[reopen] quote {quote_id} reset to Paso 1")
+    logger.info(
+        f"[reopen-measurements] quote {quote_id} reset to Paso 1; "
+        f"messages: {len(quote.messages or [])} → {len(new_messages)}"
+    )
+    return q
+
+
+# ── REOPEN CONTEXT (editar card de análisis de contexto) ──────────────────
+#
+# PR #383 — Gemelo del endpoint /reopen-measurements pero para la card de
+# contexto (`__CONTEXT_ANALYSIS__`). El operador aprieta "Editar contexto"
+# cuando necesita cambiar un dato comercial que ya respondió (ej:
+# corregir la cantidad de anafes, cambiar material, rectificar dirección).
+#
+# Diferencias vs /reopen-measurements:
+# - Gate de reopen: `verified_context_analysis` existe (contexto confirmado),
+#   no `verified_context` (medidas confirmadas).
+# - El reset limpia también `verified_context_analysis` + todo lo de
+#   Paso 2. `context_analysis_pending` se PRESERVA (preservado también
+#   post-confirm gracias al cambio en `agent.py` del mismo PR) para que
+#   la card se pueda regenerar con los mismos `data_known + assumptions
+#   + pending_questions` que vio el operador al confirmar.
+# - El corte del chat es en `__CONTEXT_ANALYSIS__`. Todo lo posterior
+#   (dual_read card, [DUAL_READ_CONFIRMED], Paso 2 markdown, etc.) se
+#   descarta. Brief y turns pre-card de contexto se preservan.
+
+@router.post("/quotes/{quote_id}/reopen-context")
+async def reopen_context(
+    quote_id: str,
+    db: AsyncSession = Depends(get_db),
+):
+    """Resetea el quote al estado pre-confirmación del contexto.
+
+    Side-effects:
+    - Limpia Paso 2 + `verified_context_analysis` + `verified_context`
+      + `verified_measurements` del breakdown.
+    - Preserva `dual_read_result`, `context_analysis_pending`,
+      `brief_analysis` y metadata (plan hash, etc.).
+    - Corta `Quote.messages` desde el último turn assistant con
+      `__CONTEXT_ANALYSIS__` (inclusive) y regenera esa card con
+      `context_analysis_pending` actual.
+
+    Codes:
+        200 — reopen aplicado, contexto editable.
+        404 — quote no existe.
+        409 — status no permite reopen (validated/sent).
+        400 — no había confirmación de contexto para reabrir.
+    """
+    from app.modules.agent.card_editor import (
+        reset_quote_to_pre_context,
+        truncate_history_at_card,
+    )
+    result = await db.execute(select(Quote).where(Quote.id == quote_id))
+    quote = result.scalar_one_or_none()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Presupuesto no encontrado")
+
+    status_value = quote.status.value if hasattr(quote.status, "value") else str(quote.status)
+    if status_value in ("validated", "sent"):
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"El presupuesto está en estado '{status_value}'. No se puede "
+                "reabrir edición — el PDF ya fue generado/enviado. Duplicá el "
+                "quote si necesitás rearmar."
+            ),
+        )
+
+    bd = quote.quote_breakdown or {}
+    if not bd.get("verified_context_analysis"):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "No hay confirmación de contexto que reabrir. El quote aún "
+                "no pasó por la card de análisis."
+            ),
+        )
+
+    new_bd = reset_quote_to_pre_context(bd)
+
+    # Cortar historial desde la card de contexto + regenerar con
+    # context_analysis_pending (preservado post-#383).
+    context_payload = new_bd.get("context_analysis_pending")
+    new_messages, _ = truncate_history_at_card(
+        list(quote.messages or []),
+        marker_prefix="__CONTEXT_ANALYSIS__",
+        new_payload=context_payload,
+    )
+
+    await db.execute(
+        update(Quote)
+        .where(Quote.id == quote_id)
+        .values(
+            quote_breakdown=new_bd,
+            messages=new_messages,
+            total_ars=None,
+            total_usd=None,
+        )
+    )
+    await db.commit()
+
+    refreshed = await db.execute(select(Quote).where(Quote.id == quote_id))
+    q = refreshed.scalar_one()
+    logger.info(
+        f"[reopen-context] quote {quote_id} reset to pre-context; "
+        f"messages: {len(quote.messages or [])} → {len(new_messages)}"
+    )
     return q
 
 

--- a/api/tests/test_card_editor.py
+++ b/api/tests/test_card_editor.py
@@ -6,6 +6,8 @@ from app.modules.agent.card_editor import (
     is_card_modification_message,
     apply_card_patch,
     format_patch_summary,
+    truncate_history_at_card,
+    reset_quote_to_pre_context,
 )
 
 
@@ -468,9 +470,12 @@ class TestRehydrateMessagesBernardi:
         assert new_msgs[0]["content"] == "brief"
 
     def test_no_invention_when_context_pending_missing(self):
-        """Mismo criterio para context_analysis — post-confirmación
-        `context_analysis_pending` se poppea del breakdown. El helper no
-        reconstruye la card (acepta perderla) en lugar de fabricar."""
+        """Mismo criterio para context_analysis — si el breakdown no
+        tiene `context_analysis_pending` (quote viejo antes de #383, o
+        quote que nunca pasó por la card), el helper no fabrica data.
+        Nota: post-#383 el handler [CONTEXT_CONFIRMED] preserva
+        context_analysis_pending, pero los breakdowns legacy pueden no
+        tenerlo."""
         msgs = [
             {"role": "user", "content": "brief"},
             {"role": "assistant", "content": "__CONTEXT_ANALYSIS_SHOWN__"},
@@ -784,4 +789,249 @@ class TestRehydrateUsesVerifiedMeasurements:
         )
         # Regenerado con verified_measurements
         assert parsed["sectores"][0]["tramos"][0]["largo_m"]["valor"] == 2.05
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PR #383 — truncate_history_at_card (corte + regeneración al reabrir)
+# ═══════════════════════════════════════════════════════════════════════
+#
+# Regla del operador: "Editar despiece / Editar contexto" debe cortar
+# el chat desde la card respectiva y regenerarla con el estado nuevo.
+# Nunca se borra lo previo a la card (brief del operador + comentarios
+# iniciales). Nunca se deja historial viejo mezclado con estado nuevo.
+
+
+def _bernardi_confirmed_history() -> list[dict]:
+    """Historial completo de un quote que pasó contexto + medidas +
+    Paso 2. Base para los tests de corte."""
+    return [
+        {"role": "user", "content": "cotizar cocina + isla en pura prima"},
+        {"role": "assistant", "content": '__CONTEXT_ANALYSIS__{"data_known":[{"field":"Material","value":"Pura Prima"}],"pending_questions":[]}'},
+        {"role": "user", "content": '[CONTEXT_CONFIRMED]{"answers":[]}'},
+        {"role": "assistant", "content": '__DUAL_READ__{"sectores":[{"id":"cocina","tramos":[{"largo_m":{"valor":2.05}}]}]}'},
+        {"role": "user", "content": '[DUAL_READ_CONFIRMED]{"sectores":[]}'},
+        {"role": "assistant", "content": "## PASO 2 — Validación\nMaterial: PURASTONE\nTotal: $797.177"},
+        {"role": "user", "content": "Confirmo"},
+    ]
+
+
+class TestTruncateHistoryAtCard:
+    def test_truncates_at_dual_read_and_regenerates(self):
+        """Corte en __DUAL_READ__: preserva brief + context + confirmación
+        de contexto; descarta card vieja + [DUAL_READ_CONFIRMED] + Paso 2
+        + confirmación del operador. Appendea card regenerada con payload
+        nuevo."""
+        msgs = _bernardi_confirmed_history()
+        new_payload = {"sectores": [{"id": "cocina", "tramos": [{"largo_m": {"valor": 2.20}}]}]}
+
+        new_msgs, changed = truncate_history_at_card(
+            msgs,
+            marker_prefix="__DUAL_READ__",
+            new_payload=new_payload,
+        )
+        assert changed is True
+
+        # Pre-card: brief + CONTEXT_ANALYSIS + CONTEXT_CONFIRMED → 3 turns.
+        # Post-card: se descartan los 4 posteriores (card vieja, confirmación,
+        # Paso 2 markdown, "Confirmo").
+        # Nueva card regenerada → total 4 turns.
+        assert len(new_msgs) == 4
+
+        # Brief preservado
+        assert new_msgs[0]["content"] == "cotizar cocina + isla en pura prima"
+        # Card de contexto preservada
+        assert new_msgs[1]["content"].startswith("__CONTEXT_ANALYSIS__")
+        # Confirmación de contexto preservada
+        assert new_msgs[2]["content"].startswith("[CONTEXT_CONFIRMED]")
+        # Card de despiece regenerada con el payload nuevo
+        assert new_msgs[3]["role"] == "assistant"
+        assert new_msgs[3]["content"].startswith("__DUAL_READ__")
+        parsed = json.loads(new_msgs[3]["content"].replace("__DUAL_READ__", "", 1))
+        assert parsed["sectores"][0]["tramos"][0]["largo_m"]["valor"] == 2.20
+
+    def test_truncates_at_context_analysis_and_regenerates(self):
+        """Corte en __CONTEXT_ANALYSIS__: preserva solo el brief."""
+        msgs = _bernardi_confirmed_history()
+        new_payload = {"data_known": [{"field": "Material", "value": "PURASTONE"}]}
+
+        new_msgs, changed = truncate_history_at_card(
+            msgs,
+            marker_prefix="__CONTEXT_ANALYSIS__",
+            new_payload=new_payload,
+        )
+        assert changed is True
+
+        # Solo el brief + card de contexto regenerada = 2 turns.
+        assert len(new_msgs) == 2
+        assert new_msgs[0]["content"] == "cotizar cocina + isla en pura prima"
+        assert new_msgs[1]["content"].startswith("__CONTEXT_ANALYSIS__")
+        parsed = json.loads(new_msgs[1]["content"].replace("__CONTEXT_ANALYSIS__", "", 1))
+        assert parsed["data_known"][0]["value"] == "PURASTONE"
+
+    def test_no_marker_returns_unchanged(self):
+        """Si el historial no tiene la card, no hay nada que cortar."""
+        msgs = [
+            {"role": "user", "content": "brief"},
+            {"role": "assistant", "content": "Hola, te falta el plano."},
+        ]
+        new_msgs, changed = truncate_history_at_card(
+            msgs,
+            marker_prefix="__DUAL_READ__",
+            new_payload={"sectores": []},
+        )
+        assert changed is False
+        assert new_msgs == msgs
+
+    def test_empty_messages_noop(self):
+        new_msgs, changed = truncate_history_at_card(
+            [],
+            marker_prefix="__DUAL_READ__",
+            new_payload={"x": 1},
+        )
+        assert changed is False
+        assert new_msgs == []
+
+    def test_none_messages_noop(self):
+        new_msgs, changed = truncate_history_at_card(
+            None,
+            marker_prefix="__DUAL_READ__",
+            new_payload={"x": 1},
+        )
+        assert changed is False
+        assert new_msgs == []
+
+    def test_cuts_at_last_card_when_multiple(self):
+        """Si hay múltiples __DUAL_READ__ (ej: card re-emitida después
+        de un patch desde chat), cortar al último — es el estado más
+        reciente del despiece en el historial."""
+        msgs = [
+            {"role": "user", "content": "brief"},
+            {"role": "assistant", "content": '__DUAL_READ__{"v":1}'},  # vieja
+            {"role": "user", "content": "agregá un zócalo"},
+            {"role": "assistant", "content": '__DUAL_READ__{"v":2}'},  # última
+            {"role": "user", "content": "[DUAL_READ_CONFIRMED]{}"},
+            {"role": "assistant", "content": "Paso 2..."},
+        ]
+        new_msgs, changed = truncate_history_at_card(
+            msgs,
+            marker_prefix="__DUAL_READ__",
+            new_payload={"v": 3},
+        )
+        assert changed is True
+        # brief + card vieja + "agregá zócalo" + card regenerada = 4
+        assert len(new_msgs) == 4
+        assert new_msgs[1]["content"] == '__DUAL_READ__{"v":1}'  # primera preservada
+        assert new_msgs[2]["content"] == "agregá un zócalo"
+        last_parsed = json.loads(new_msgs[3]["content"].replace("__DUAL_READ__", "", 1))
+        assert last_parsed["v"] == 3
+
+    def test_no_payload_strips_card_without_regenerating(self):
+        """new_payload=None → corta sin re-emitir. Caso defensivo."""
+        msgs = _bernardi_confirmed_history()
+        new_msgs, changed = truncate_history_at_card(
+            msgs,
+            marker_prefix="__DUAL_READ__",
+            new_payload=None,
+        )
+        assert changed is True
+        # brief + ctx card + ctx_confirmed = 3 turns
+        assert len(new_msgs) == 3
+        assert not any(
+            m.get("content", "").startswith("__DUAL_READ__")
+            for m in new_msgs if isinstance(m.get("content"), str)
+        )
+
+    def test_preserves_brief_with_plano_attachment(self):
+        """Brief con content como lista (user subió plano) se preserva
+        tal cual — incluyendo los blocks de image."""
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "cotizar"},
+                    {"type": "image", "source": {"data": "..."}},
+                ],
+            },
+            {"role": "assistant", "content": '__DUAL_READ__{}'},
+        ]
+        new_msgs, changed = truncate_history_at_card(
+            msgs,
+            marker_prefix="__DUAL_READ__",
+            new_payload={"x": 1},
+        )
+        assert changed is True
+        # Brief con image block intacto
+        assert isinstance(new_msgs[0]["content"], list)
+        assert len(new_msgs[0]["content"]) == 2
+
+    def test_idempotent_with_same_payload(self):
+        """Llamar 2 veces con el mismo payload produce el mismo resultado."""
+        msgs = _bernardi_confirmed_history()
+        payload = {"v": "new"}
+        once, _ = truncate_history_at_card(
+            msgs, marker_prefix="__DUAL_READ__", new_payload=payload,
+        )
+        twice, _ = truncate_history_at_card(
+            once, marker_prefix="__DUAL_READ__", new_payload=payload,
+        )
+        assert once == twice
+
+
+class TestResetQuoteToPreContext:
+    def test_clears_verified_context_analysis_and_paso2(self):
+        bd = {
+            "dual_read_result": {"sectores": []},
+            "context_analysis_pending": {"data_known": []},
+            "verified_context_analysis": {"answers": [{"q": 1, "a": "X"}]},
+            "verified_context": "[MEDIDAS...]",
+            "verified_measurements": {"sectores": []},
+            "material_name": "PURASTONE",
+            "total_ars": 797177,
+            "brief_analysis": {"client_name": "Erica Bernardi"},
+        }
+        reset = reset_quote_to_pre_context(bd)
+        # Paso 2 + verified_context_analysis limpio
+        assert "verified_context_analysis" not in reset
+        assert "verified_context" not in reset
+        assert "verified_measurements" not in reset
+        assert "material_name" not in reset
+        assert "total_ars" not in reset
+        # Preservados
+        assert reset["dual_read_result"] == {"sectores": []}
+        assert reset["context_analysis_pending"] == {"data_known": []}
+        assert reset["brief_analysis"] == {"client_name": "Erica Bernardi"}
+
+    def test_preserves_context_analysis_pending(self):
+        """context_analysis_pending es el snapshot de la card original.
+        Es la fuente para regenerarla al reabrir."""
+        bd = {
+            "verified_context_analysis": {"answers": []},
+            "context_analysis_pending": {"data_known": [{"field": "x"}]},
+        }
+        reset = reset_quote_to_pre_context(bd)
+        assert reset["context_analysis_pending"] == {"data_known": [{"field": "x"}]}
+
+    def test_empty_breakdown(self):
+        assert reset_quote_to_pre_context({}) == {}
+        assert reset_quote_to_pre_context(None) == {}
+
+    def test_does_not_mutate_input(self):
+        bd = {
+            "verified_context_analysis": {"answers": []},
+            "verified_context": "X",
+            "context_analysis_pending": {"data_known": []},
+        }
+        snapshot = json.loads(json.dumps(bd))
+        reset_quote_to_pre_context(bd)
+        assert bd == snapshot
+
+    def test_idempotent(self):
+        bd = {
+            "verified_context_analysis": {"answers": []},
+            "verified_context": "X",
+            "context_analysis_pending": {"data_known": []},
+        }
+        once = reset_quote_to_pre_context(bd)
+        twice = reset_quote_to_pre_context(once)
+        assert once == twice
 

--- a/api/tests/test_router.py
+++ b/api/tests/test_router.py
@@ -889,6 +889,280 @@ class TestReopenMeasurements:
         detail = (await client.get(f"/api/quotes/{qid}")).json()
         assert detail["client_name"] == "Erica Bernardi"
 
+    # ── PR #383 — Corte de historial al reopen ──────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_reopen_truncates_chat_from_dual_read(self, client, db_session):
+        """Post-reopen el historial queda cortado desde __DUAL_READ__
+        (inclusive) y la card se regenera con las medidas editadas.
+        Brief + card de contexto + [CONTEXT_CONFIRMED] se preservan;
+        todo lo posterior (Paso 2 markdown, preguntas, confirmación) se
+        descarta."""
+        import json as _json
+        from app.models.quote import Quote
+        from sqlalchemy import update
+
+        qid = await self._make_paso2_quote(client, db_session)
+        # Simular historial Bernardi-style con Paso 2 ya calculado
+        legacy_msgs = [
+            {"role": "user", "content": "cotizar cocina + isla"},
+            {"role": "assistant", "content": '__CONTEXT_ANALYSIS__{"data_known":[]}'},
+            {"role": "user", "content": '[CONTEXT_CONFIRMED]{"answers":[]}'},
+            {"role": "assistant", "content": '__DUAL_READ__{"sectores":[{"id":"cocina","tramos":[{"largo_m":{"valor":1.60}}]}]}'},
+            {"role": "user", "content": '[DUAL_READ_CONFIRMED]{"sectores":[]}'},
+            {"role": "assistant", "content": "## PASO 2 — Validación\nTotal: $797.177"},
+            {"role": "user", "content": "Confirmo"},
+        ]
+        # verified_measurements con las medidas editadas — estas deben
+        # aparecer en la card regenerada.
+        bd_extra = {
+            "verified_measurements": {
+                "sectores": [{"id": "cocina", "tramos": [{"largo_m": {"valor": 2.05}}]}],
+            },
+        }
+        existing = (await client.get(f"/api/quotes/{qid}")).json()["quote_breakdown"]
+        existing.update(bd_extra)
+        await db_session.execute(
+            update(Quote).where(Quote.id == qid).values(
+                messages=legacy_msgs, quote_breakdown=existing,
+            )
+        )
+        await db_session.commit()
+
+        resp = await client.post(f"/api/quotes/{qid}/reopen-measurements")
+        assert resp.status_code == 200, resp.text
+
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        msgs = detail["messages"]
+        # brief + ctx_analysis + ctx_confirmed + card regenerada = 4
+        assert len(msgs) == 4, msgs
+        assert msgs[0]["content"] == "cotizar cocina + isla"
+        assert msgs[1]["content"].startswith("__CONTEXT_ANALYSIS__")
+        assert msgs[2]["content"].startswith("[CONTEXT_CONFIRMED]")
+        # Card regenerada con verified_measurements (editadas)
+        assert msgs[3]["content"].startswith("__DUAL_READ__")
+        parsed = _json.loads(msgs[3]["content"].replace("__DUAL_READ__", "", 1))
+        assert parsed["sectores"][0]["tramos"][0]["largo_m"]["valor"] == 2.05
+
+    @pytest.mark.asyncio
+    async def test_reopen_promotes_verified_to_dual_read_in_breakdown(
+        self, client, db_session,
+    ):
+        """verified_measurements → dual_read_result en el breakdown post-reopen,
+        para que la card regenerada refleje los edits del operador."""
+        import json as _json
+        from app.models.quote import Quote
+        from sqlalchemy import update
+
+        qid = await self._make_paso2_quote(client, db_session)
+        existing = (await client.get(f"/api/quotes/{qid}")).json()["quote_breakdown"]
+        existing["verified_measurements"] = {
+            "sectores": [{"id": "cocina", "tramos": [{"largo_m": {"valor": 2.05}}]}],
+        }
+        await db_session.execute(
+            update(Quote).where(Quote.id == qid).values(quote_breakdown=existing)
+        )
+        await db_session.commit()
+
+        resp = await client.post(f"/api/quotes/{qid}/reopen-measurements")
+        assert resp.status_code == 200
+
+        bd = resp.json()["quote_breakdown"]
+        assert bd["dual_read_result"]["sectores"][0]["tramos"][0]["largo_m"]["valor"] == 2.05
+        assert "verified_measurements" not in bd  # limpiada en el reset
+
+    @pytest.mark.asyncio
+    async def test_reopen_preserves_brief_when_no_card_in_history(
+        self, client, db_session,
+    ):
+        """Si el historial no tiene __DUAL_READ__ por alguna razón
+        (historial corrupto, edge case), el reopen limpia el breakdown
+        igual pero no rompe el chat — queda intacto."""
+        from app.models.quote import Quote
+        from sqlalchemy import update
+
+        qid = await self._make_paso2_quote(client, db_session)
+        sparse_msgs = [
+            {"role": "user", "content": "cotizar"},
+            {"role": "assistant", "content": "Mando el plano por favor."},
+        ]
+        await db_session.execute(
+            update(Quote).where(Quote.id == qid).values(messages=sparse_msgs)
+        )
+        await db_session.commit()
+
+        resp = await client.post(f"/api/quotes/{qid}/reopen-measurements")
+        assert resp.status_code == 200
+
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        # Chat sin cambios (no había card que cortar)
+        assert len(detail["messages"]) == 2
+        assert detail["messages"][0]["content"] == "cotizar"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PR #383 — Endpoint reopen-context (editar card de análisis de contexto)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestReopenContext:
+    """Endpoint que reabre la edición del contexto (card
+    __CONTEXT_ANALYSIS__). Gemelo de /reopen-measurements pero para el
+    paso anterior del flujo."""
+
+    async def _make_context_confirmed_quote(self, client, db_session) -> str:
+        """Quote con verified_context_analysis (contexto confirmado) +
+        historial completo con ambas cards."""
+        from app.models.quote import Quote
+        from sqlalchemy import update
+        create = await client.post("/api/quotes")
+        qid = create.json()["id"]
+        bd = {
+            "dual_read_result": {"sectores": [{"id": "cocina", "tramos": []}]},
+            "context_analysis_pending": {
+                "data_known": [{"field": "Material", "value": "PURASTONE"}],
+                "assumptions": [],
+                "pending_questions": [],
+            },
+            "verified_context_analysis": {"answers": [{"q": 1, "a": "x"}]},
+            "verified_context": "[MEDIDAS VERIFICADAS...]",
+            "verified_measurements": {"sectores": [{"tramos": [{"largo_m": {"valor": 2.05}}]}]},
+            "material_name": "PURASTONE",
+            "total_ars": 797177,
+            "total_usd": 4128,
+            "mo_items": [{"description": "Colocación"}],
+        }
+        msgs = [
+            {"role": "user", "content": "cotizar cocina"},
+            {"role": "assistant", "content": '__CONTEXT_ANALYSIS__{"data_known":[]}'},
+            {"role": "user", "content": '[CONTEXT_CONFIRMED]{"answers":[]}'},
+            {"role": "assistant", "content": '__DUAL_READ__{"sectores":[]}'},
+            {"role": "user", "content": '[DUAL_READ_CONFIRMED]{"sectores":[]}'},
+            {"role": "assistant", "content": "## PASO 2 — Total $797.177"},
+            {"role": "user", "content": "Confirmo"},
+        ]
+        await db_session.execute(
+            update(Quote).where(Quote.id == qid).values(
+                quote_breakdown=bd,
+                messages=msgs,
+                total_ars=797177,
+                total_usd=4128,
+            )
+        )
+        await db_session.commit()
+        return qid
+
+    @pytest.mark.asyncio
+    async def test_reopen_context_clears_paso2_and_context_confirmation(
+        self, client, db_session,
+    ):
+        qid = await self._make_context_confirmed_quote(client, db_session)
+        resp = await client.post(f"/api/quotes/{qid}/reopen-context")
+        assert resp.status_code == 200, resp.text
+
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        bd = detail["quote_breakdown"] or {}
+        # Contexto + Paso 2 limpios
+        assert "verified_context_analysis" not in bd
+        assert "verified_context" not in bd
+        assert "material_name" not in bd
+        assert "mo_items" not in bd
+        # context_analysis_pending preservado (fuente para regenerar card)
+        assert bd.get("context_analysis_pending", {}).get("data_known")
+        # Totales de la tabla también limpios
+        assert detail["total_ars"] is None
+        assert detail["total_usd"] is None
+
+    @pytest.mark.asyncio
+    async def test_reopen_context_truncates_chat_from_context_card(
+        self, client, db_session,
+    ):
+        """Post-reopen el chat queda cortado desde __CONTEXT_ANALYSIS__
+        (inclusive). Solo el brief (y cualquier turn previo a la card de
+        contexto) se preserva."""
+        qid = await self._make_context_confirmed_quote(client, db_session)
+        resp = await client.post(f"/api/quotes/{qid}/reopen-context")
+        assert resp.status_code == 200
+
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        msgs = detail["messages"]
+        # Solo el brief + card regenerada = 2 turns
+        assert len(msgs) == 2, msgs
+        assert msgs[0]["content"] == "cotizar cocina"
+        # Card regenerada con context_analysis_pending preservado
+        assert msgs[1]["content"].startswith("__CONTEXT_ANALYSIS__")
+
+    @pytest.mark.asyncio
+    async def test_reopen_context_404_for_nonexistent_quote(self, client):
+        resp = await client.post(
+            "/api/quotes/00000000-0000-0000-0000-000000000000/reopen-context"
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_reopen_context_400_when_no_context_confirmed(self, client):
+        """Quote sin verified_context_analysis → 400."""
+        create = await client.post("/api/quotes")
+        qid = create.json()["id"]
+        resp = await client.post(f"/api/quotes/{qid}/reopen-context")
+        assert resp.status_code == 400
+        assert "contexto" in resp.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_reopen_context_409_when_validated(self, client, db_session):
+        from app.models.quote import Quote, QuoteStatus
+        from sqlalchemy import update
+        qid = await self._make_context_confirmed_quote(client, db_session)
+        await db_session.execute(
+            update(Quote).where(Quote.id == qid).values(status=QuoteStatus.VALIDATED)
+        )
+        await db_session.commit()
+
+        resp = await client.post(f"/api/quotes/{qid}/reopen-context")
+        assert resp.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_reopen_context_409_when_sent(self, client, db_session):
+        from app.models.quote import Quote, QuoteStatus
+        from sqlalchemy import update
+        qid = await self._make_context_confirmed_quote(client, db_session)
+        await db_session.execute(
+            update(Quote).where(Quote.id == qid).values(status=QuoteStatus.SENT)
+        )
+        await db_session.commit()
+
+        resp = await client.post(f"/api/quotes/{qid}/reopen-context")
+        assert resp.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_reopen_context_idempotent_second_call_returns_400(
+        self, client, db_session,
+    ):
+        """El primer reopen borra verified_context_analysis → el segundo
+        responde 400 (nada que reabrir)."""
+        qid = await self._make_context_confirmed_quote(client, db_session)
+        r1 = await client.post(f"/api/quotes/{qid}/reopen-context")
+        assert r1.status_code == 200
+        r2 = await client.post(f"/api/quotes/{qid}/reopen-context")
+        assert r2.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_reopen_context_preserves_dual_read_and_brief(
+        self, client, db_session,
+    ):
+        """dual_read_result se preserva — el despiece detectado sigue
+        siendo útil post-edit de contexto. Brief del operador intacto."""
+        qid = await self._make_context_confirmed_quote(client, db_session)
+        await client.post(f"/api/quotes/{qid}/reopen-context")
+
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        bd = detail["quote_breakdown"]
+        # El operador puede haber editado medidas — `verified_measurements`
+        # se promueve a `dual_read_result` igual que en /reopen-measurements.
+        assert "dual_read_result" in bd
+        # Brief en el chat intacto
+        assert detail["messages"][0]["content"] == "cotizar cocina"
+
 
 # ═══════════════════════════════════════════════════════════════════════
 # PR #380 — Endpoint rehydrate-history

--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useRouter, useParams } from "next/navigation";
-import { fetchQuote, streamChat, markQuoteAsRead, validateQuote, updateQuote, reopenMeasurements, type QuoteDetail, type QuoteEditablePatch } from "@/lib/api";
+import { fetchQuote, streamChat, markQuoteAsRead, validateQuote, updateQuote, reopenMeasurements, reopenContext, type QuoteDetail, type QuoteEditablePatch } from "@/lib/api";
 import { useQuotes } from "@/lib/quotes-context";
 import MessageBubble from "@/components/chat/MessageBubble";
 import CopyButton from "@/components/chat/CopyButton";
@@ -217,6 +217,11 @@ export default function QuotePage() {
   // Estado { open, busy } para coordinar UI del modal (backdrop bloquea
   // clicks durante el POST + spinner en botón de confirmar).
   const [reopenModal, setReopenModal] = useState<{ open: boolean; busy: boolean }>({
+    open: false, busy: false,
+  });
+  // PR #383 — segundo modal para "Editar contexto". Misma shape que
+  // reopenModal, flujo análogo (POST /reopen-context + refresh del quote).
+  const [contextModal, setContextModal] = useState<{ open: boolean; busy: boolean }>({
     open: false, busy: false,
   });
   const sentFromDetail = useRef(false);
@@ -770,21 +775,37 @@ export default function QuotePage() {
                           Corregir
                         </button>
                       </div>
-                      {/* PR #378 — "Editar despiece" cuando el quote ya
-                          tiene verified_context (Paso 2 calculado). Llama
-                          al endpoint /reopen-measurements que limpia Paso 2
-                          y deja el despiece editable otra vez. Confirmación
-                          obligatoria porque es destructivo: se pierde el
-                          cálculo actual y el operador tiene que re-confirmar
-                          medidas antes de generar PDF. */}
-                      {quote?.quote_breakdown?.verified_context && (
-                        <div className="mt-2 ml-[42px]">
-                          <button
-                            onClick={() => setReopenModal({ open: true, busy: false })}
-                            className="w-full px-4 py-2 rounded-lg text-[12px] font-medium bg-transparent border border-amb/40 text-amb cursor-pointer hover:bg-amb/10 transition"
-                          >
-                            ↩ Editar despiece (invalida el cálculo actual)
-                          </button>
+                      {/* PR #378/#383 — "Editar despiece" + "Editar contexto".
+                          Son acciones paralelas que reabren la edición en
+                          pasos distintos. Cada una corta el chat desde su
+                          card respectiva y regenera el estado:
+                          - "Editar despiece" cuando hay verified_context
+                            (medidas confirmadas) → /reopen-measurements.
+                          - "Editar contexto" cuando hay
+                            verified_context_analysis (contexto confirmado)
+                            → /reopen-context. El primer click invalida
+                            también Paso 2 y cualquier card de despiece
+                            posterior — cambiar contexto puede invalidar
+                            medidas. */}
+                      {(quote?.quote_breakdown?.verified_context
+                        || quote?.quote_breakdown?.verified_context_analysis) && (
+                        <div className="mt-2 ml-[42px] flex flex-col gap-2">
+                          {quote?.quote_breakdown?.verified_context && (
+                            <button
+                              onClick={() => setReopenModal({ open: true, busy: false })}
+                              className="w-full px-4 py-2 rounded-lg text-[12px] font-medium bg-transparent border border-amb/40 text-amb cursor-pointer hover:bg-amb/10 transition"
+                            >
+                              ↩ Editar despiece (invalida el cálculo actual)
+                            </button>
+                          )}
+                          {quote?.quote_breakdown?.verified_context_analysis && (
+                            <button
+                              onClick={() => setContextModal({ open: true, busy: false })}
+                              className="w-full px-4 py-2 rounded-lg text-[12px] font-medium bg-transparent border border-amb/40 text-amb cursor-pointer hover:bg-amb/10 transition"
+                            >
+                              ↩ Editar contexto (invalida Paso 2 y medidas)
+                            </button>
+                          )}
                         </div>
                       )}
                     </>
@@ -866,6 +887,10 @@ export default function QuotePage() {
                     await reopenMeasurements(quoteId);
                     const fresh = await fetchQuote(quoteId);
                     setQuote(fresh);
+                    // PR #383 — el backend ahora corta el historial desde
+                    // la card de despiece y regenera con las medidas
+                    // editadas. Re-parseamos messages para reflejarlo.
+                    setMessages(parseMessages(fresh.messages || []));
                     setReopenModal({ open: false, busy: false });
                     toast(
                       "Despiece reabierto. Editá las medidas y volvé a confirmar.",
@@ -887,6 +912,87 @@ export default function QuotePage() {
                   </>
                 ) : (
                   "↩ Editar despiece"
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* PR #383 — Modal "Editar contexto". Mismo patrón que el modal
+          de despiece, pero el copy aclara que además de Paso 2 se pierden
+          también las medidas confirmadas (cambiar contexto puede
+          invalidar piezas/tramos del dual_read). */}
+      {contextModal.open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+          onClick={() => !contextModal.busy && setContextModal({ open: false, busy: false })}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="context-modal-title"
+        >
+          <div
+            className="w-full max-w-md rounded-2xl border border-b1 bg-s2 p-6 shadow-[0_20px_40px_-20px_rgba(0,0,0,0.5)]"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3
+              id="context-modal-title"
+              className="text-[15px] font-semibold text-t1 mb-2"
+            >
+              Editar contexto
+            </h3>
+            <p className="text-[13px] text-t2 leading-relaxed mb-4">
+              Vas a <strong className="text-t1">invalidar el Paso 2 y las
+              medidas confirmadas</strong> para volver a editar los datos
+              comerciales (material, anafes, ubicación, etc.). Después
+              tenés que reconfirmar contexto y medidas para regenerar el
+              presupuesto.
+            </p>
+            <div className="text-[12px] text-amb bg-amb/[0.08] border border-amb/30 rounded-lg px-3 py-2 mb-5 leading-relaxed">
+              Se pierden totales, MO, material y confirmación de medidas.
+              El plano, el brief y el despiece detectado se mantienen.
+            </div>
+
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={() => setContextModal({ open: false, busy: false })}
+                disabled={contextModal.busy}
+                className="px-4 py-2 rounded-lg text-[13px] font-medium border border-b2 text-t2 hover:text-t1 hover:border-b3 transition disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={async () => {
+                  setContextModal({ open: true, busy: true });
+                  try {
+                    await reopenContext(quoteId);
+                    const fresh = await fetchQuote(quoteId);
+                    setQuote(fresh);
+                    // Re-parsear messages: el backend ya cortó el historial
+                    // desde la card de contexto y la regeneró. Actualizamos
+                    // la vista para reflejarlo sin necesitar un reload.
+                    setMessages(parseMessages(fresh.messages || []));
+                    setContextModal({ open: false, busy: false });
+                    toast(
+                      "Contexto reabierto. Editá los datos y volvé a confirmar.",
+                      "success",
+                    );
+                  } catch (err) {
+                    const msg = err instanceof Error ? err.message : "Error al reabrir edición";
+                    setContextModal({ open: false, busy: false });
+                    toast(msg, "error");
+                  }
+                }}
+                disabled={contextModal.busy}
+                className="px-4 py-2 rounded-lg text-[13px] font-semibold bg-amb hover:brightness-110 text-acc-ink transition disabled:opacity-60 disabled:cursor-not-allowed flex items-center gap-2"
+              >
+                {contextModal.busy ? (
+                  <>
+                    <span className="inline-block w-3 h-3 border-2 border-acc-ink/40 border-t-acc-ink rounded-full animate-spin" />
+                    Reabriendo…
+                  </>
+                ) : (
+                  "↩ Editar contexto"
                 )}
               </button>
             </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -168,6 +168,11 @@ export interface QuoteBreakdown {
    *  Usado por el frontend como flag para lockear edits inline del
    *  despiece y mostrar el botón "Editar despiece". */
   verified_context?: string;
+  /** PR #383 — Presente cuando el operador ya confirmó el contexto
+   *  (card `__CONTEXT_ANALYSIS__`). Se usa como flag para mostrar el
+   *  botón "Editar contexto" (gemelo de "Editar despiece" pero para
+   *  el paso anterior). */
+  verified_context_analysis?: { answers?: unknown[] } | null;
 }
 
 export interface QuoteDetail extends Quote {
@@ -500,6 +505,30 @@ export async function reopenMeasurements(id: string): Promise<void> {
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
     throw new Error(err.detail || "Error al reabrir edición del despiece");
+  }
+}
+
+/**
+ * PR #383 — Reabre la edición del contexto después de haber confirmado
+ * la card de análisis. Limpia Paso 2 + `verified_context_analysis` y
+ * corta el historial desde la card `__CONTEXT_ANALYSIS__` (inclusive),
+ * regenerándola con los data_known + assumptions + pending_questions
+ * que el operador vio en el momento original.
+ *
+ * Errores:
+ *  - 404: quote no existe.
+ *  - 409: status es `validated` o `sent` (PDF ya entregado).
+ *  - 400: no había confirmación de contexto previa.
+ */
+export async function reopenContext(id: string): Promise<void> {
+  const res = await apiFetch(
+    `${API_BASE}/api/quotes/${id}/reopen-context`,
+    { method: "POST", credentials: "include" },
+  );
+  handleAuthError(res);
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || "Error al reabrir edición del contexto");
   }
 }
 


### PR DESCRIPTION
## Contexto

Después del último PR (#382) se destapó un bug de UX: al reabrir la edición del despiece + reconfirmar medidas, las medidas se actualizaban solo en la card del despiece pero el chat seguía mostrando Paso 2 stale + preguntas viejas de Valentina. Valentina además respondía corto pidiendo proyecto de nuevo en lugar de regenerar el Paso 2 con las medidas editadas.

## Cambio

Cuando el operador aprieta **Editar despiece** o **Editar contexto**, el historial se corta desde la card respectiva (inclusive) y se regenera con el estado nuevo del breakdown. Regla del operador: _nunca dejar historial viejo mezclado con estado nuevo; nunca borrar el brief inicial_.

### Backend (`api/`)
- **`card_editor.py`**:
  - Nuevo helper puro `truncate_history_at_card(messages, *, marker_prefix, new_payload)` — encuentra el último turn `assistant` con el marker (e.g. `__DUAL_READ__`), corta desde ahí inclusive, appendea un turn regenerado con `new_payload`.
  - Nuevo helper `reset_quote_to_pre_context` — reset Paso 2 + `verified_context_analysis`, preservando `context_analysis_pending` para regenerar la card.
- **`router.py`**:
  - `/reopen-measurements` extendido: promueve `verified_measurements` → `dual_read_result` (para que la card refleje las medidas editadas), luego corta chat en `__DUAL_READ__` y regenera.
  - `/reopen-context` nuevo endpoint: gate `verified_context_analysis`, mismo shape (200/400/404/409), corta chat en `__CONTEXT_ANALYSIS__` y regenera con `context_analysis_pending`.
- **`agent.py`**:
  - Handler `[CONTEXT_CONFIRMED]` ya no pop-ea `context_analysis_pending` — lo preserva como snapshot para el reopen futuro. El gate "contexto ya confirmado" usa `verified_context_analysis` (no el pending), así que es inofensivo.

### Frontend (`web/`)
- `lib/api.ts`: helper `reopenContext(id)` análogo a `reopenMeasurements`.
- `page.tsx`:
  - Botón **"↩ Editar contexto"** aparece cuando `verified_context_analysis` existe (paralelo a "Editar despiece" cuando existe `verified_context`).
  - Modal styled para confirmar el reopen de contexto, con copy que aclara que se invalidan también las medidas (cambiar contexto puede invalidar piezas del despiece).
  - Ambos modales hacen `setMessages(parseMessages(...))` post-POST para reflejar el corte sin reload.

### Tests
- `test_card_editor.py`: nuevos `TestTruncateHistoryAtCard` (8 tests) + `TestResetQuoteToPreContext` (5 tests).
- `test_router.py`: 3 tests nuevos en `TestReopenMeasurements` (corte de chat, promoción verified→dual_read, historial sin card) + `TestReopenContext` completo (8 tests cubriendo 200/400/404/409 + idempotencia + preservación).

## Test plan

- [x] API: 18/18 tests nuevos pasan (`tests/test_card_editor.py::TestTruncateHistoryAtCard`, `TestResetQuoteToPreContext`; `tests/test_router.py::TestReopenMeasurements`, `TestReopenContext`)
- [x] API: toda la suite API limpia excepto los 16 fallos pre-existentes de evaluación (candidate quality, no tocado en este PR)
- [x] Web: `next lint` sin errores nuevos, `tsc --noEmit` limpio
- [ ] Manual: abrir un quote con Paso 2 confirmado → apretar "Editar despiece" → verificar que el chat queda [brief + card regenerada con medidas editadas], sin Paso 2 stale
- [ ] Manual: abrir un quote con contexto confirmado → apretar "Editar contexto" → verificar que el chat queda [brief + card de contexto regenerada], sin dual_read ni Paso 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)