### PR TITLE
fix(ux): botones reopen visibles siempre que el breakdown los habilite

### DIFF
--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -775,39 +775,6 @@ export default function QuotePage() {
                           Corregir
                         </button>
                       </div>
-                      {/* PR #378/#383 — "Editar despiece" + "Editar contexto".
-                          Son acciones paralelas que reabren la edición en
-                          pasos distintos. Cada una corta el chat desde su
-                          card respectiva y regenera el estado:
-                          - "Editar despiece" cuando hay verified_context
-                            (medidas confirmadas) → /reopen-measurements.
-                          - "Editar contexto" cuando hay
-                            verified_context_analysis (contexto confirmado)
-                            → /reopen-context. El primer click invalida
-                            también Paso 2 y cualquier card de despiece
-                            posterior — cambiar contexto puede invalidar
-                            medidas. */}
-                      {(quote?.quote_breakdown?.verified_context
-                        || quote?.quote_breakdown?.verified_context_analysis) && (
-                        <div className="mt-2 ml-[42px] flex flex-col gap-2">
-                          {quote?.quote_breakdown?.verified_context && (
-                            <button
-                              onClick={() => setReopenModal({ open: true, busy: false })}
-                              className="w-full px-4 py-2 rounded-lg text-[12px] font-medium bg-transparent border border-amb/40 text-amb cursor-pointer hover:bg-amb/10 transition"
-                            >
-                              ↩ Editar despiece (invalida el cálculo actual)
-                            </button>
-                          )}
-                          {quote?.quote_breakdown?.verified_context_analysis && (
-                            <button
-                              onClick={() => setContextModal({ open: true, busy: false })}
-                              className="w-full px-4 py-2 rounded-lg text-[12px] font-medium bg-transparent border border-amb/40 text-amb cursor-pointer hover:bg-amb/10 transition"
-                            >
-                              ↩ Editar contexto (invalida Paso 2 y medidas)
-                            </button>
-                          )}
-                        </div>
-                      )}
                     </>
                   )}
                   {isLastReal && lastFailedMsg && !msg.isStreaming && !sending && msg.content.includes(WARN) && (
@@ -827,6 +794,36 @@ export default function QuotePage() {
           </div>
           {quote?.status === "draft" ? (
             <div className="shrink-0 px-4 md:px-7 pt-3 md:pt-3.5 pb-3 md:pb-[18px] border-t border-b1 bg-s1">
+              {/* PR #378/#383 — Action tray persistente con los reopens.
+                  Antes estos botones vivían dentro del bloque de
+                  "Confirmar/Corregir" (solo visible cuando Valentina
+                  terminaba pidiendo confirmación). Si el operador abría
+                  el quote y el último turn no era una pregunta, el
+                  botón no aparecía — a pesar de que el breakdown decía
+                  que había Paso 2 confirmado. Ahora están siempre
+                  disponibles mientras el quote esté en draft y el
+                  breakdown habilite cada reopen. */}
+              {(quote?.quote_breakdown?.verified_context
+                || quote?.quote_breakdown?.verified_context_analysis) && (
+                <div className="mb-3 flex flex-col gap-2">
+                  {quote?.quote_breakdown?.verified_context && (
+                    <button
+                      onClick={() => setReopenModal({ open: true, busy: false })}
+                      className="w-full px-4 py-2 rounded-lg text-[12px] font-medium bg-transparent border border-amb/40 text-amb cursor-pointer hover:bg-amb/10 transition"
+                    >
+                      ↩ Editar despiece (invalida el cálculo actual)
+                    </button>
+                  )}
+                  {quote?.quote_breakdown?.verified_context_analysis && (
+                    <button
+                      onClick={() => setContextModal({ open: true, busy: false })}
+                      className="w-full px-4 py-2 rounded-lg text-[12px] font-medium bg-transparent border border-amb/40 text-amb cursor-pointer hover:bg-amb/10 transition"
+                    >
+                      ↩ Editar contexto (invalida Paso 2 y medidas)
+                    </button>
+                  )}
+                </div>
+              )}
               <ChatInput input={input} setInput={setInput} files={attachedFiles} setFiles={setAttachedFiles} multiPiece={multiPiece} setMultiPiece={setMultiPiece} dragActive={dragActive} setDragActive={setDragActive} dragCounterRef={dragCounter} sending={sending} send={send} onKey={onKey} fileRef={fileRef} />
               <div className="text-[10px] text-t4 text-center mt-[7px]">{`Enter para enviar ${DOT} Shift+Enter para nueva l${I}nea`}</div>
             </div>


### PR DESCRIPTION
## Contexto

Con el #383 mergeado, Javi abrió el Bernardi (`253825ad-...`) y reportó que no aparece el botón **Editar despiece**. Root cause: los botones seguían dentro del bloque `needsConfirm`, que solo se renderiza cuando el último turn de Valentina es una pregunta tipo "¿Confirmás?". Cualquier otro estado (Valentina pidiendo más datos, chat cerrado por timeout, etc.) dejaba los botones ocultos a pesar de que el breakdown tenía `verified_context` / `verified_context_analysis`.

## Fix

Movemos los dos botones a un action tray persistente, justo arriba del `ChatInput` del quote. Visible siempre que:
- `quote.status === "draft"` (ya era el gate del input).
- El breakdown tenga el marker correspondiente (`verified_context` para despiece, `verified_context_analysis` para contexto).

Nada más. Misma semántica, misma UI de botón, mismos modales.

## Test plan

- [x] `tsc --noEmit` limpio.
- [ ] Abrir `/quote/253825ad-...` (Bernardi) → debería ver "↩ Editar despiece" y "↩ Editar contexto" arriba del input.
- [ ] Apretar "Editar despiece" → modal + POST → chat se re-renderiza con brief + card regenerada.
- [ ] Quote sin confirmaciones (nuevo) → no debe aparecer ningún botón.
- [ ] Quote en `validated` / `sent` → no debe aparecer el ChatInput ni los botones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)