### PR TITLE
feat(trace): instrumentar flow del agente para debug de bugs de flujo

### DIFF
--- a/api/app/modules/agent/_trace.py
+++ b/api/app/modules/agent/_trace.py
@@ -1,0 +1,547 @@
+"""Observability helpers for the agent flow.
+
+Scope (PR #385 — acordado con el operador):
+    1. entrada HTTP del chat
+    2. entrada de stream_chat
+    3. mutaciones de quote_breakdown con diff + snapshot de keys críticas
+    4. tool calls con input y output real
+    5. helpers deterministas críticos (apply_answers, build_commercial_attrs,
+       build_verified_context, build_derived_isla_pieces)
+    6. endpoints reopen-measurements y reopen-context
+    7. persistencia de messages
+    8. SSE chunks estructurales (dual_read_result, action, done, context_analysis —
+       no cada text chunk del stream)
+
+Default: snapshots compactos + hashes + valores numéricos explícitos.
+Full dump de payloads grandes bajo `DEBUG_AGENT_PAYLOADS=1`.
+
+Regla del operador: "Si para entender el bug necesitás preguntarme qué
+botón apreté y en qué orden, entonces primero faltan logs." Este módulo
+existe para que no vuelva a pasar.
+
+Uso:
+    from app.modules.agent._trace import (
+        log_http_enter, log_stream_enter, log_bd_mutation,
+        log_tool_call, log_tool_result, log_helper_io,
+        log_reopen, log_messages_persist, log_sse_structural,
+    )
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger("agent.trace")
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Toggle
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _full_dump_enabled() -> bool:
+    """`DEBUG_AGENT_PAYLOADS=1` → los helpers imprimen los payloads
+    completos, no solo el fingerprint compacto. Se lee cada vez para
+    que el operador pueda prenderlo en prod sin restart."""
+    return os.getenv("DEBUG_AGENT_PAYLOADS", "0") == "1"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Fingerprints / snapshots
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _fp(obj: Any) -> str:
+    """Hash estable + largo para cualquier objeto serializable. Permite
+    comparar dos snapshots sin imprimir el contenido entero."""
+    try:
+        blob = json.dumps(obj, ensure_ascii=False, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        blob = str(obj)
+    h = hashlib.sha256(blob.encode("utf-8")).hexdigest()[:10]
+    return f"sha={h} len={len(blob)}"
+
+
+def _num(field: Any) -> float | None:
+    """Extrae el valor numérico de un FieldValue (dict con 'valor') o
+    número crudo. `None` si no se puede."""
+    if isinstance(field, dict):
+        v = field.get("valor")
+        if v is None:
+            return None
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return None
+    if field is None:
+        return None
+    try:
+        return float(field)
+    except (TypeError, ValueError):
+        return None
+
+
+def snapshot_dual_read(dr: dict | None) -> dict:
+    """Snapshot compacto del dual_read / verified_measurements. Una línea
+    por tramo con (sector_id, tramo_id, largo, ancho, m2).
+
+    Lo que queda fuera del snapshot (pero está en el payload real): status
+    per-field, opus/sonnet valores, zócalos, frentines, alzada, manual
+    flags. Todo visible con `DEBUG_AGENT_PAYLOADS=1`.
+    """
+    if not dr:
+        return {"sectores": 0, "dimensions": []}
+    sectores = dr.get("sectores") or []
+    dims = []
+    for s in sectores:
+        sid = s.get("id", "?")
+        stype = s.get("tipo", "?")
+        for t in s.get("tramos") or []:
+            tid = t.get("id", "?")
+            largo = _num(t.get("largo_m"))
+            ancho = _num(t.get("ancho_m"))
+            m2 = _num(t.get("m2"))
+            dims.append({
+                "sector": sid, "tipo": stype, "tramo": tid,
+                "largo": largo, "ancho": ancho, "m2": m2,
+            })
+    return {
+        "sectores": len(sectores),
+        "tramos_total": len(dims),
+        "dimensions": dims,
+    }
+
+
+def snapshot_commercial_attrs(attrs: dict | None) -> dict:
+    """Extrae los campos clave + source de cada uno. El shape de
+    `commercial_attrs` es `{field: {"value": ..., "source": ...}}`.
+    """
+    if not attrs:
+        return {}
+    keys = (
+        "anafe_count", "pileta_simple_doble", "isla_presence",
+        "isla_profundidad", "isla_patas", "isla_patas_alto",
+        "colocacion", "alzada", "zocalos",
+        "material", "localidad",
+    )
+    out = {}
+    for k in keys:
+        v = attrs.get(k)
+        if isinstance(v, dict):
+            out[k] = {"value": v.get("value"), "source": v.get("source")}
+        elif v is not None:
+            out[k] = {"value": v, "source": "?"}
+    # Divergences si hay
+    divs = attrs.get("divergences")
+    if divs:
+        out["_divergences"] = len(divs)
+    return out
+
+
+def snapshot_derived_pieces(pieces: list | None) -> list[dict]:
+    """Resumen compacto de las piezas derivadas (patas de isla, etc.)."""
+    if not pieces:
+        return []
+    return [
+        {
+            "descripcion": p.get("description") or p.get("descripcion"),
+            "largo": p.get("largo"),
+            "prof": p.get("prof"),
+            "m2": p.get("m2"),
+            "source": p.get("source"),
+        }
+        for p in pieces
+    ]
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Breakdown diff
+# ─────────────────────────────────────────────────────────────────────
+
+# Keys del breakdown que siempre imprimimos explícitamente cuando mutan
+# (resto queda como "added"/"removed" sin valor).
+_CRITICAL_BD_KEYS = (
+    "verified_measurements", "verified_context", "verified_commercial_attrs",
+    "verified_derived_pieces", "verified_context_analysis",
+    "dual_read_result", "context_analysis_pending",
+    "material_name", "total_ars", "total_usd",
+)
+
+
+def _critical_value_snapshot(key: str, value: Any) -> Any:
+    """Para las keys críticas, devolver algo útil en lugar del blob."""
+    if key in ("dual_read_result", "verified_measurements"):
+        return snapshot_dual_read(value)
+    if key == "verified_commercial_attrs":
+        return snapshot_commercial_attrs(value)
+    if key == "verified_derived_pieces":
+        return snapshot_derived_pieces(value)
+    if key == "verified_context":
+        # Texto grande — solo fingerprint.
+        return _fp(value)
+    if key == "context_analysis_pending":
+        return {
+            "data_known": len((value or {}).get("data_known") or []),
+            "pending_questions": len((value or {}).get("pending_questions") or []),
+        }
+    if key == "verified_context_analysis":
+        return {"answers": len((value or {}).get("answers") or [])}
+    return value  # primitives: total_ars, total_usd, material_name
+
+
+def diff_breakdown(pre: dict | None, post: dict | None) -> dict:
+    """Computa qué cambió entre dos breakdowns. Retorna:
+        {
+            "added":    [list of keys nuevas],
+            "removed":  [list of keys borradas],
+            "modified": {key: {"before": ..., "after": ...}, ...}
+        }
+    Para las keys críticas el before/after es un snapshot. Para las demás
+    es un fingerprint (para no inflar logs).
+    """
+    pre = pre or {}
+    post = post or {}
+    pre_keys = set(pre.keys())
+    post_keys = set(post.keys())
+    added = sorted(post_keys - pre_keys)
+    removed = sorted(pre_keys - post_keys)
+    modified = {}
+    for k in sorted(pre_keys & post_keys):
+        if pre[k] != post[k]:
+            if k in _CRITICAL_BD_KEYS:
+                modified[k] = {
+                    "before": _critical_value_snapshot(k, pre[k]),
+                    "after": _critical_value_snapshot(k, post[k]),
+                }
+            else:
+                modified[k] = {"before_fp": _fp(pre[k]), "after_fp": _fp(post[k])}
+    return {"added": added, "removed": removed, "modified": modified}
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Log helpers — entrypoints del flow
+# ─────────────────────────────────────────────────────────────────────
+
+
+def log_http_enter(quote_id: str, endpoint: str, **kwargs) -> None:
+    """Request HTTP entrante al agente (chat, reopen-*, rehydrate-*)."""
+    parts = [f"{k}={v}" for k, v in kwargs.items()]
+    logger.info(f"[trace:http:{quote_id}] {endpoint} {' '.join(parts)}")
+
+
+def log_stream_enter(
+    quote_id: str,
+    user_message: str | None,
+    plan_bytes: bytes | None,
+    extra_files: list | None,
+    bd_pre: dict | None,
+) -> None:
+    """Entrada del loop agéntico: lo que recibe, el estado del breakdown
+    al arrancar (qué confirmaciones ya tiene)."""
+    msg_preview = (user_message or "")[:200].replace("\n", " ")
+    bd = bd_pre or {}
+    bd_state = {
+        "has_dual_read_result": bool(bd.get("dual_read_result")),
+        "has_verified_context": bool(bd.get("verified_context")),
+        "has_verified_context_analysis": bool(bd.get("verified_context_analysis")),
+        "has_context_analysis_pending": bool(bd.get("context_analysis_pending")),
+        "has_verified_measurements": bool(bd.get("verified_measurements")),
+        "has_verified_derived_pieces": bool(bd.get("verified_derived_pieces")),
+        "material_name": bd.get("material_name"),
+        "total_ars": bd.get("total_ars"),
+    }
+    logger.info(
+        f"[trace:stream:{quote_id}] enter "
+        f"msg={msg_preview!r} "
+        f"plan_bytes={len(plan_bytes) if plan_bytes else 0} "
+        f"extra_files={len(extra_files or [])} "
+        f"bd_state={bd_state}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Log helpers — mutación de DB
+# ─────────────────────────────────────────────────────────────────────
+
+
+def log_bd_mutation(
+    quote_id: str,
+    flow: str,
+    pre: dict | None,
+    post: dict | None,
+) -> None:
+    """Diff explícito del breakdown entre pre/post. Sin diff → no log.
+
+    `flow` es un handle para ubicar la mutación en el código:
+    `context-confirmed`, `dual-read-confirmed`, `card-editor`,
+    `calculate-quote`, `reopen-measurements`, `reopen-context`, etc.
+    """
+    diff = diff_breakdown(pre, post)
+    if not diff["added"] and not diff["removed"] and not diff["modified"]:
+        return
+    logger.info(
+        f"[trace:bd-mutation:{quote_id}] flow={flow} "
+        f"added={diff['added']} removed={diff['removed']} "
+        f"modified_keys={list(diff['modified'].keys())}"
+    )
+    for k, change in diff["modified"].items():
+        logger.info(f"[trace:bd-mutation:{quote_id}]   {k}: {change}")
+    if _full_dump_enabled():
+        logger.info(
+            f"[trace:bd-mutation:{quote_id}] FULL pre={pre} post={post}"
+        )
+
+
+def log_messages_persist(
+    quote_id: str,
+    *,
+    flow: str,
+    added_turns: list[dict],
+    total_count: int,
+) -> None:
+    """Cada vez que el backend persiste turns nuevos en `Quote.messages`."""
+    previews = [
+        {
+            "role": t.get("role"),
+            "content_fp": _fp(t.get("content")),
+            "content_preview": (
+                _content_preview(t.get("content"))
+            ),
+        }
+        for t in added_turns
+    ]
+    logger.info(
+        f"[trace:messages-persist:{quote_id}] flow={flow} "
+        f"added={len(added_turns)} total={total_count}"
+    )
+    for p in previews:
+        logger.info(
+            f"[trace:messages-persist:{quote_id}]   "
+            f"role={p['role']} fp={p['content_fp']} preview={p['content_preview']!r}"
+        )
+
+
+def _content_preview(content: Any) -> str:
+    """Primer texto útil del content (str o list de blocks). Max 120 chars."""
+    if isinstance(content, str):
+        return content[:120]
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                return (block.get("text") or "")[:120]
+    return ""
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Log helpers — SSE estructural
+# ─────────────────────────────────────────────────────────────────────
+
+
+# Los tipos de chunk SSE que queremos loguear. NO logueamos "text"
+# (stream char-by-char de Valentina) porque floodearía.
+_STRUCTURAL_SSE = {
+    "dual_read_result", "context_analysis", "zone_selector",
+    "action", "done", "error", "image_tool",
+}
+
+
+def log_sse_structural(quote_id: str, event_type: str, content: Any) -> None:
+    """Log para eventos SSE estructurales (cards emitidas, done, error).
+    El `text` chunk del stream NO pasa por acá — sería ruido."""
+    if event_type not in _STRUCTURAL_SSE:
+        return
+    if event_type == "dual_read_result" and isinstance(content, str):
+        try:
+            parsed = json.loads(content)
+            snap = snapshot_dual_read(parsed)
+            logger.info(
+                f"[trace:sse:{quote_id}] type={event_type} "
+                f"snap={snap} fp={_fp(content)}"
+            )
+            return
+        except (json.JSONDecodeError, ValueError):
+            pass
+    preview = (content if isinstance(content, str) else str(content))[:120]
+    logger.info(
+        f"[trace:sse:{quote_id}] type={event_type} preview={preview!r}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Log helpers — tool I/O
+# ─────────────────────────────────────────────────────────────────────
+
+
+def log_tool_call(quote_id: str, tool_name: str, tool_input: Any) -> None:
+    """Tool call — se loguea el input completo (hasta 2000 chars).
+    Ya existía parcial en agent.py; acá lo centralizamos."""
+    try:
+        blob = json.dumps(tool_input, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        blob = str(tool_input)
+    logger.info(
+        f"[trace:tool-call:{quote_id}] {tool_name} input={blob[:2000]}"
+    )
+
+
+def log_tool_result(
+    quote_id: str,
+    tool_name: str,
+    result: Any,
+) -> None:
+    """Tool result — loguea el output REAL (antes agent.py solo imprimía
+    un subset de keys `ok/total_ars/...` → aparecía `{}` cuando el tool
+    devolvía catálogos o estructuras).
+    """
+    # Dict → imprimir keys + valores primitivos + fingerprint de valores complejos
+    if isinstance(result, dict):
+        flat = {}
+        for k, v in result.items():
+            if isinstance(v, (str, int, float, bool, type(None))):
+                flat[k] = v
+            else:
+                flat[k] = _fp(v)
+        logger.info(
+            f"[trace:tool-result:{quote_id}] {tool_name} keys={list(result.keys())} "
+            f"summary={flat}"
+        )
+        if _full_dump_enabled():
+            try:
+                blob = json.dumps(result, ensure_ascii=False, default=str)
+                logger.info(
+                    f"[trace:tool-result:{quote_id}] {tool_name} FULL={blob[:10000]}"
+                )
+            except (TypeError, ValueError):
+                pass
+    elif isinstance(result, list):
+        logger.info(
+            f"[trace:tool-result:{quote_id}] {tool_name} "
+            f"list_len={len(result)} fp={_fp(result)}"
+        )
+    else:
+        logger.info(
+            f"[trace:tool-result:{quote_id}] {tool_name} "
+            f"value={str(result)[:500]}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Log helpers — helpers deterministas críticos
+# ─────────────────────────────────────────────────────────────────────
+
+
+def log_apply_answers(
+    quote_id: str,
+    *,
+    flow: str,
+    dual_before: dict | None,
+    dual_after: dict | None,
+    answers: list | None,
+) -> None:
+    """`apply_answers(dual_result, answers)` — muestra qué respuesta
+    (id+value) se aplicó y cómo cambió el dual_read."""
+    answers = answers or []
+    logger.info(
+        f"[trace:apply-answers:{quote_id}] flow={flow} "
+        f"answers_count={len(answers)}"
+    )
+    for a in answers:
+        logger.info(
+            f"[trace:apply-answers:{quote_id}]   "
+            f"id={a.get('id')} value={a.get('value')} label={a.get('label')}"
+        )
+    before_snap = snapshot_dual_read(dual_before)
+    after_snap = snapshot_dual_read(dual_after)
+    if before_snap != after_snap:
+        logger.info(
+            f"[trace:apply-answers:{quote_id}] dual_read changed — "
+            f"tramos before={before_snap['tramos_total']} "
+            f"after={after_snap['tramos_total']}"
+        )
+
+
+def log_build_commercial_attrs(
+    quote_id: str,
+    *,
+    flow: str,
+    result: dict,
+) -> None:
+    """Output de `build_commercial_attrs` — los campos con su source."""
+    snap = snapshot_commercial_attrs(result)
+    logger.info(
+        f"[trace:commercial-attrs:{quote_id}] flow={flow} attrs={snap}"
+    )
+
+
+def log_build_derived_isla_pieces(
+    quote_id: str,
+    *,
+    flow: str,
+    pieces: list,
+    warnings: list,
+) -> None:
+    """Output de `build_derived_isla_pieces` — piezas + warnings."""
+    snap = snapshot_derived_pieces(pieces)
+    logger.info(
+        f"[trace:derived-pieces:{quote_id}] flow={flow} "
+        f"count={len(pieces or [])} pieces={snap}"
+    )
+    for w in warnings or []:
+        logger.info(f"[trace:derived-pieces:{quote_id}] warning: {w}")
+
+
+def log_build_verified_context(
+    quote_id: str,
+    *,
+    flow: str,
+    text: str,
+) -> None:
+    """Output de `build_verified_context` — fingerprint del texto inyectado
+    en el system prompt. Full dump con `DEBUG_AGENT_PAYLOADS=1`."""
+    logger.info(
+        f"[trace:verified-context:{quote_id}] flow={flow} "
+        f"chars={len(text or '')} fp={_fp(text)}"
+    )
+    if _full_dump_enabled():
+        logger.info(f"[trace:verified-context:{quote_id}] FULL=\n{text}")
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Log helpers — endpoints reopen
+# ─────────────────────────────────────────────────────────────────────
+
+
+def log_reopen(
+    quote_id: str,
+    *,
+    kind: str,  # "measurements" | "context"
+    bd_pre: dict | None,
+    bd_post: dict | None,
+    msgs_count_pre: int,
+    msgs_count_post: int,
+    truncate_matched: bool,
+) -> None:
+    """Snapshot completo del reopen. Para cada endpoint vemos:
+    - Qué había en el breakdown pre-reset (incluyendo verified_measurements).
+    - Qué quedó post-reset (incluyendo el nuevo dual_read_result).
+    - Cuántos turns se eliminaron del chat.
+    - Si el truncate encontró la card o no (clave: si un quote legacy no
+      tiene el marker `__DUAL_READ__` en DB, el corte no pasa).
+    """
+    diff = diff_breakdown(bd_pre, bd_post)
+    logger.info(
+        f"[trace:reopen:{quote_id}] kind={kind} "
+        f"msgs={msgs_count_pre}→{msgs_count_post} "
+        f"truncate_matched={truncate_matched}"
+    )
+    logger.info(
+        f"[trace:reopen:{quote_id}] breakdown "
+        f"added={diff['added']} removed={diff['removed']} "
+        f"modified={list(diff['modified'].keys())}"
+    )
+    for k, change in diff["modified"].items():
+        logger.info(f"[trace:reopen:{quote_id}]   {k}: {change}")

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1483,6 +1483,34 @@ class AgentService:
         extra_files: Optional[list] = None,
         db: AsyncSession = None,
     ) -> AsyncGenerator[dict, None]:
+        # PR #385 — traza de entrada al loop agéntico. Sabemos qué llega
+        # del frontend (mensaje, adjuntos) y qué estado del breakdown
+        # tenemos al arrancar (gates de flow). Todo lo que pase después
+        # se encadena a este entry point.
+        from app.modules.agent._trace import (
+            log_stream_enter,
+            log_bd_mutation,
+            log_sse_structural,
+            log_tool_call,
+            log_tool_result,
+            log_apply_answers,
+            log_build_commercial_attrs,
+            log_build_derived_isla_pieces,
+            log_build_verified_context,
+            log_messages_persist,
+        )
+        try:
+            _q_enter = await db.execute(select(Quote).where(Quote.id == quote_id))
+            _bd_enter = (_q_enter.scalar_one_or_none() or Quote()).quote_breakdown or {}
+        except Exception:
+            _bd_enter = {}
+        log_stream_enter(
+            quote_id=quote_id,
+            user_message=user_message,
+            plan_bytes=plan_bytes,
+            extra_files=extra_files,
+            bd_pre=_bd_enter,
+        )
 
         # ── Handle CONTEXT_CONFIRMED EARLY (PR G): el operador confirmó la card
         # de análisis de contexto (datos + asunciones + preguntas). Aplicamos
@@ -1493,16 +1521,35 @@ class AgentService:
             try:
                 _ctx_payload = json.loads(user_message[len("[CONTEXT_CONFIRMED]"):])
                 _answers = _ctx_payload.get("answers") or []
+                # PR #385 — payload recibido del frontend. `answers` es la
+                # lista real que el operador respondió en la card de contexto.
+                logging.info(
+                    f"[trace:context-confirmed:{quote_id}] payload answers={len(_answers)}"
+                )
+                for _a in _answers:
+                    logging.info(
+                        f"[trace:context-confirmed:{quote_id}]   "
+                        f"id={_a.get('id')} value={_a.get('value')} label={_a.get('label')}"
+                    )
                 _qr = await db.execute(select(Quote).where(Quote.id == quote_id))
                 _q_ctx = _qr.scalar_one_or_none()
-                _bd_ctx = (_q_ctx.quote_breakdown or {}) if _q_ctx else {}
-                _saved_dual = _bd_ctx.get("dual_read_result") or {}
+                _bd_ctx_pre = dict((_q_ctx.quote_breakdown or {}) if _q_ctx else {})
+                _bd_ctx = dict(_bd_ctx_pre)
+                _saved_dual = dict(_bd_ctx.get("dual_read_result") or {})
+                _dual_before = json.loads(json.dumps(_saved_dual, default=str))
                 # Aplicar las respuestas al dual_read_result
                 if _answers and _saved_dual:
                     from app.modules.quote_engine.pending_questions import apply_answers
                     apply_answers(_saved_dual, _answers)
                     # Limpiar pending_questions ya que están respondidas
                     _saved_dual.pop("pending_questions", None)
+                log_apply_answers(
+                    quote_id,
+                    flow="context-confirmed",
+                    dual_before=_dual_before,
+                    dual_after=_saved_dual,
+                    answers=_answers,
+                )
                 # Guardar verified_context_analysis (gate para no re-preguntar)
                 _bd_ctx["verified_context_analysis"] = _ctx_payload
                 _bd_ctx["dual_read_result"] = _saved_dual
@@ -1519,11 +1566,15 @@ class AgentService:
                         update(Quote).where(Quote.id == quote_id).values(quote_breakdown=_bd_ctx)
                     )
                     await db.commit()
+                log_bd_mutation(quote_id, "context-confirmed", _bd_ctx_pre, _bd_ctx)
                 logging.info(
                     f"[context-confirmed] {quote_id} applied {len(_answers)} answers, "
                     "emitting dual_read_result"
                 )
-                yield {"type": "dual_read_result", "content": json.dumps(_saved_dual, ensure_ascii=False)}
+                _dr_chunk = json.dumps(_saved_dual, ensure_ascii=False)
+                log_sse_structural(quote_id, "dual_read_result", _dr_chunk)
+                yield {"type": "dual_read_result", "content": _dr_chunk}
+                log_sse_structural(quote_id, "done", "")
                 yield {"type": "done", "content": ""}
                 # PR #379 — Persistir el flujo real al DB:
                 # - user turn: el `[CONTEXT_CONFIRMED]<json>` que mandó el
@@ -1545,12 +1596,19 @@ class AgentService:
                         },
                     ]
                     if _q_ctx:
+                        _merged = list(_q_ctx.messages or []) + _turn
                         await db.execute(
                             update(Quote).where(Quote.id == quote_id).values(
-                                messages=list(_q_ctx.messages or []) + _turn
+                                messages=_merged
                             )
                         )
                         await db.commit()
+                        log_messages_persist(
+                            quote_id,
+                            flow="context-confirmed",
+                            added_turns=_turn,
+                            total_count=len(_merged),
+                        )
                 except Exception:
                     pass
                 return
@@ -1569,6 +1627,21 @@ class AgentService:
             _just_confirmed_dual_read = True
             try:
                 _confirmed_json = json.loads(user_message[len("[DUAL_READ_CONFIRMED]"):])
+                # PR #385 — payload crudo que llegó del frontend. Este es el
+                # punto que el usuario ve en la card editable cuando aprieta
+                # "Confirmar medidas". Si aquí el dual_read no refleja lo
+                # editado → bug en el componente. Si aquí está bien pero
+                # downstream Claude usa otro valor → bug en system prompt
+                # injection o derived pieces.
+                from app.modules.agent._trace import snapshot_dual_read as _snap_dr
+                logging.info(
+                    f"[trace:dual-read-confirmed:{quote_id}] payload received: "
+                    f"snap={_snap_dr(_confirmed_json)}"
+                )
+                logging.info(
+                    f"[trace:dual-read-confirmed:{quote_id}] pending_answers="
+                    f"{len(_confirmed_json.get('pending_answers') or [])}"
+                )
                 # Aplicar respuestas de pending_questions (ej: zócalos agregados
                 # determinísticamente cuando el operador eligió la opción default).
                 # El confirmed_json viene con `pending_answers` si el frontend
@@ -1577,10 +1650,14 @@ class AgentService:
                     from app.modules.quote_engine.pending_questions import apply_answers
                     _answers = _confirmed_json.get("pending_answers") or []
                     if _answers:
+                        _dr_before_apply = json.loads(json.dumps(_confirmed_json, default=str))
                         apply_answers(_confirmed_json, _answers)
-                        logging.info(
-                            f"[pending-questions] applied {len(_answers)} answer(s): "
-                            f"{[a.get('id') for a in _answers]}"
+                        log_apply_answers(
+                            quote_id,
+                            flow="dual-read-confirmed/pending",
+                            dual_before=_dr_before_apply,
+                            dual_after=_confirmed_json,
+                            answers=_answers,
                         )
                 except Exception as _e_ans:
                     logging.warning(f"[pending-questions] apply_answers failed: {_e_ans}")
@@ -1597,7 +1674,8 @@ class AgentService:
                 # confirmados" cuando dual_read había detectado 1).
                 _qr0 = await db.execute(select(Quote).where(Quote.id == quote_id))
                 _q0 = _qr0.scalar_one_or_none()
-                _bd0 = dict(_q0.quote_breakdown or {}) if _q0 else {}
+                _bd0_pre = dict(_q0.quote_breakdown or {}) if _q0 else {}
+                _bd0 = dict(_bd0_pre)
                 _saved_dual = _bd0.get("dual_read_result") or {}
                 # Reconstruir el analysis del brief (si está cacheado).
                 # Fallback: diccionario vacío → reconcile se cae al dual_read.
@@ -1610,10 +1688,23 @@ class AgentService:
                 # (frontend las manda dentro del _confirmed_json).
                 _op_answers_turn = _confirmed_json.get("pending_answers") or []
                 _op_answers = list(_op_answers_ctx) + list(_op_answers_turn)
+                # PR #385 — explicitar qué answers entran a los builders.
+                logging.info(
+                    f"[trace:dual-read-confirmed:{quote_id}] operator_answers "
+                    f"ctx={len(_op_answers_ctx)} turn={len(_op_answers_turn)} total={len(_op_answers)}"
+                )
+                for _oa in _op_answers:
+                    logging.info(
+                        f"[trace:dual-read-confirmed:{quote_id}]   "
+                        f"id={_oa.get('id')} value={_oa.get('value')} label={_oa.get('label')}"
+                    )
                 _commercial_attrs = build_commercial_attrs(
                     analysis=_ctx_analysis,
                     dual_result=_saved_dual,
                     operator_answers=_op_answers,
+                )
+                log_build_commercial_attrs(
+                    quote_id, flow="dual-read-confirmed", result=_commercial_attrs,
                 )
                 # PR #377 — Piezas derivadas determinísticas desde las
                 # respuestas del operador (ej: patas de isla). Evita
@@ -1623,12 +1714,19 @@ class AgentService:
                     operator_answers=_op_answers,
                     verified_measurements=_confirmed_json,
                 )
-                for _w in _derived_warnings:
-                    logging.info(f"[derived-pieces] {_w}")
+                log_build_derived_isla_pieces(
+                    quote_id,
+                    flow="dual-read-confirmed",
+                    pieces=_derived_pieces,
+                    warnings=_derived_warnings,
+                )
                 _verified_ctx = build_verified_context(
                     _confirmed_json,
                     commercial_attrs=_commercial_attrs,
                     derived_pieces=_derived_pieces or None,
+                )
+                log_build_verified_context(
+                    quote_id, flow="dual-read-confirmed", text=_verified_ctx,
                 )
                 if _q0:
                     _bd0["verified_measurements"] = _confirmed_json
@@ -1643,6 +1741,7 @@ class AgentService:
                         _bd0["verified_derived_pieces"] = _derived_pieces
                     await db.execute(update(Quote).where(Quote.id == quote_id).values(quote_breakdown=_bd0))
                     await db.commit()
+                    log_bd_mutation(quote_id, "dual-read-confirmed", _bd0_pre, _bd0)
                 logging.info(
                     f"[dual-read] Verified measurements + commercial attrs "
                     f"saved for {quote_id} (early handler). "
@@ -4159,13 +4258,10 @@ class AgentService:
                 if tool_use.name == "list_pieces":
                     _list_pieces_called = True
                 yield {"type": "action", "content": f"⚙️ Ejecutando: {tool_use.name}..."}
-                # Log every tool call with full inputs for debugging
-                logging.info(f"🔧 TOOL CALL [{quote_id}]: {tool_use.name}")
-                try:
-                    import json as _dbg_json
-                    logging.info(f"🔧 TOOL INPUT [{quote_id}]: {_dbg_json.dumps(tool_use.input, ensure_ascii=False, default=str)[:2000]}")
-                except Exception:
-                    logging.info(f"🔧 TOOL INPUT [{quote_id}]: {str(tool_use.input)[:2000]}")
+                # PR #385 — tool call con input estructurado. Ya existía un
+                # log ad-hoc; ahora pasa por `log_tool_call` que normaliza
+                # el prefix + formato.
+                log_tool_call(quote_id, tool_use.name, tool_use.input)
 
                 try:
                     result = await self._execute_tool(
@@ -4181,12 +4277,14 @@ class AgentService:
                     result = {"ok": False, "error": f"Error ejecutando {tool_use.name}: {str(e)}"}
 
                 # Log result summary
+                # PR #385 — tool result REAL. El log anterior filtraba a
+                # un subset de keys (`ok/total_ars/...`) que dejaba en `{}`
+                # los resultados de catalog_batch_lookup, check_architect,
+                # read_plan, etc. → era imposible saber qué devolvió. Ahora
+                # loguea keys + valores primitivos y fingerprint para lo
+                # complejo. Full dump con DEBUG_AGENT_PAYLOADS=1.
                 try:
-                    if isinstance(result, dict):
-                        log_keys = {k: v for k, v in result.items() if k in ("ok", "total_ars", "total_usd", "material", "material_name", "removed", "added", "error", "quote_id")}
-                        logging.info(f"🔧 TOOL RESULT [{quote_id}] {tool_use.name}: {log_keys}")
-                    elif isinstance(result, list):
-                        logging.info(f"🔧 TOOL RESULT [{quote_id}] {tool_use.name}: {len(result)} content blocks")
+                    log_tool_result(quote_id, tool_use.name, result)
                 except Exception:
                     pass
 
@@ -4378,6 +4476,27 @@ class AgentService:
                 .values(**save_values)
             )
             await db.commit()
+            # PR #385 — persistencia final del turn completo (user +
+            # todos los assistants del loop). Loguea la cantidad de turns
+            # nuevos, preview del content y si se modificaron campos
+            # derivados (client_name, material, project) del regex.
+            try:
+                _added_turns = [db_messages[-1]] if db_messages and db_messages[-1].get("role") == "user" else []
+                _added_turns = _added_turns + list(assistant_messages or [])
+                log_messages_persist(
+                    quote_id,
+                    flow="stream_chat-save",
+                    added_turns=_added_turns,
+                    total_count=len(updated_messages),
+                )
+                _extracted_keys = [k for k in ("client_name", "material", "project") if k in save_values]
+                if _extracted_keys:
+                    logging.info(
+                        f"[trace:extract:{quote_id}] extracted fields from user_message: "
+                        f"{ {k: save_values[k] for k in _extracted_keys} }"
+                    )
+            except Exception:
+                pass
         except Exception as e:
             logging.error(f"Error saving conversation to DB: {e}", exc_info=True)
             try:
@@ -4430,6 +4549,7 @@ class AgentService:
             logging.warning(f"Could not save usage record: {e}")
 
         logging.info(f"[stream_chat] Yielding done for quote {quote_id}")
+        log_sse_structural(quote_id, "done", "")
         yield {"type": "done", "content": ""}
 
     async def _execute_tool(self, name: str, inputs: dict, quote_id: str, db: AsyncSession, conversation_history: list | None = None, current_user_message: str = "") -> dict:
@@ -5724,6 +5844,20 @@ class AgentService:
                     )
                     await db.commit()
                     logging.info(f"Saved breakdown for {save_to_qid} after calculate_quote | ARS: {change_entry['total_ars_before']} → {change_entry['total_ars_after']}")
+                    # PR #385 — diff del breakdown post-calculate_quote. Clave
+                    # para detectar qué piezas/totales se persistieron vs qué
+                    # había antes. Si acá el input del tool dice isla=1.80 pero
+                    # el breakdown tiene isla=2.03 → bug en el calculador.
+                    try:
+                        from app.modules.agent._trace import log_bd_mutation
+                        log_bd_mutation(
+                            save_to_qid,
+                            "calculate-quote-save",
+                            old_quote.quote_breakdown if old_quote else {},
+                            _merged_bd,
+                        )
+                    except Exception:
+                        pass
                 except Exception as e:
                     logging.warning(f"Could not save breakdown for {save_to_qid}: {e}")
             calc_result["quote_id"] = save_to_qid

--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -420,6 +420,9 @@ async def reopen_measurements(
         is_paso2_confirmed,
         truncate_history_at_card,
     )
+    from app.modules.agent._trace import log_http_enter, log_reopen
+    log_http_enter(quote_id, "POST /quotes/:id/reopen-measurements")
+
     result = await db.execute(select(Quote).where(Quote.id == quote_id))
     quote = result.scalar_one_or_none()
     if not quote:
@@ -462,8 +465,9 @@ async def reopen_measurements(
         new_bd["dual_read_result"] = verified
 
     # Cortar historial desde la card de despiece + regenerar.
-    new_messages, _ = truncate_history_at_card(
-        list(quote.messages or []),
+    msgs_pre = list(quote.messages or [])
+    new_messages, truncate_matched = truncate_history_at_card(
+        msgs_pre,
         marker_prefix="__DUAL_READ__",
         new_payload=new_bd.get("dual_read_result"),
     )
@@ -482,13 +486,19 @@ async def reopen_measurements(
     )
     await db.commit()
 
+    log_reopen(
+        quote_id,
+        kind="measurements",
+        bd_pre=bd,
+        bd_post=new_bd,
+        msgs_count_pre=len(msgs_pre),
+        msgs_count_post=len(new_messages),
+        truncate_matched=truncate_matched,
+    )
+
     # Refetch para devolver shape consistente con el listado.
     refreshed = await db.execute(select(Quote).where(Quote.id == quote_id))
     q = refreshed.scalar_one()
-    logger.info(
-        f"[reopen-measurements] quote {quote_id} reset to Paso 1; "
-        f"messages: {len(quote.messages or [])} → {len(new_messages)}"
-    )
     return q
 
 
@@ -537,6 +547,9 @@ async def reopen_context(
         reset_quote_to_pre_context,
         truncate_history_at_card,
     )
+    from app.modules.agent._trace import log_http_enter, log_reopen
+    log_http_enter(quote_id, "POST /quotes/:id/reopen-context")
+
     result = await db.execute(select(Quote).where(Quote.id == quote_id))
     quote = result.scalar_one_or_none()
     if not quote:
@@ -568,8 +581,9 @@ async def reopen_context(
     # Cortar historial desde la card de contexto + regenerar con
     # context_analysis_pending (preservado post-#383).
     context_payload = new_bd.get("context_analysis_pending")
-    new_messages, _ = truncate_history_at_card(
-        list(quote.messages or []),
+    msgs_pre = list(quote.messages or [])
+    new_messages, truncate_matched = truncate_history_at_card(
+        msgs_pre,
         marker_prefix="__CONTEXT_ANALYSIS__",
         new_payload=context_payload,
     )
@@ -586,12 +600,18 @@ async def reopen_context(
     )
     await db.commit()
 
+    log_reopen(
+        quote_id,
+        kind="context",
+        bd_pre=bd,
+        bd_post=new_bd,
+        msgs_count_pre=len(msgs_pre),
+        msgs_count_post=len(new_messages),
+        truncate_matched=truncate_matched,
+    )
+
     refreshed = await db.execute(select(Quote).where(Quote.id == quote_id))
     q = refreshed.scalar_one()
-    logger.info(
-        f"[reopen-context] quote {quote_id} reset to pre-context; "
-        f"messages: {len(quote.messages or [])} → {len(new_messages)}"
-    )
     return q
 
 
@@ -1817,7 +1837,17 @@ async def chat(
     db: AsyncSession = Depends(get_db),
 ):
     from app.main import touch_chat_activity
+    from app.modules.agent._trace import log_http_enter
     touch_chat_activity()
+
+    # PR #385 — traza del request HTTP entrante al chat. Lo primero que
+    # vemos en el log cuando se dispara un turn del agente.
+    log_http_enter(
+        quote_id,
+        "POST /quotes/:id/chat",
+        message_preview=(message or "")[:200].replace("\n", " "),
+        plan_files=len(plan_files or []),
+    )
 
     # Budget check — read DIRECTLY from DB (not cached config — multi-worker cache stale)
     try:

--- a/api/tests/test_trace.py
+++ b/api/tests/test_trace.py
@@ -1,0 +1,306 @@
+"""Unit tests para `app.modules.agent._trace`.
+
+El módulo es puro (solo logging + dict transforms), así que los tests
+asertan sobre las salidas de los helpers `snapshot_*` y `diff_breakdown`.
+Los `log_*` helpers (side-effect: logging.info) se ejercitan vía captura
+del caplog para garantizar que no explotan y que el prefijo es estable.
+
+Estos tests son un guard contra regresiones en el formato de logs — si
+algo cambia el shape del snapshot, saltan los tests y revisamos si fue
+intencional (y actualizamos a la vez el log grep de operación).
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from app.modules.agent._trace import (
+    _fp,
+    snapshot_dual_read,
+    snapshot_commercial_attrs,
+    snapshot_derived_pieces,
+    diff_breakdown,
+    log_http_enter,
+    log_stream_enter,
+    log_bd_mutation,
+    log_tool_call,
+    log_tool_result,
+    log_apply_answers,
+    log_build_commercial_attrs,
+    log_build_derived_isla_pieces,
+    log_build_verified_context,
+    log_reopen,
+    log_messages_persist,
+    log_sse_structural,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Helpers puros — snapshots
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _dr_cocina_isla() -> dict:
+    """Shape real de un dual_read con cocina (2 tramos) + isla (1 tramo)."""
+    return {
+        "sectores": [
+            {
+                "id": "cocina", "tipo": "cocina",
+                "tramos": [
+                    {"id": "t1", "largo_m": {"valor": 2.05}, "ancho_m": {"valor": 0.60}, "m2": {"valor": 1.23}},
+                    {"id": "t2", "largo_m": {"valor": 2.95}, "ancho_m": {"valor": 0.60}, "m2": {"valor": 1.77}},
+                ],
+            },
+            {
+                "id": "isla", "tipo": "isla",
+                "tramos": [
+                    {"id": "t3", "largo_m": {"valor": 1.80}, "ancho_m": {"valor": 0.60}, "m2": {"valor": 1.08}},
+                ],
+            },
+        ],
+    }
+
+
+class TestSnapshotDualRead:
+    def test_dimensions_flatten_sectors_and_tramos(self):
+        snap = snapshot_dual_read(_dr_cocina_isla())
+        assert snap["sectores"] == 2
+        assert snap["tramos_total"] == 3
+        assert snap["dimensions"][0] == {
+            "sector": "cocina", "tipo": "cocina", "tramo": "t1",
+            "largo": 2.05, "ancho": 0.60, "m2": 1.23,
+        }
+        assert snap["dimensions"][2] == {
+            "sector": "isla", "tipo": "isla", "tramo": "t3",
+            "largo": 1.80, "ancho": 0.60, "m2": 1.08,
+        }
+
+    def test_empty_returns_zero(self):
+        assert snapshot_dual_read(None) == {"sectores": 0, "dimensions": []}
+        snap = snapshot_dual_read({})
+        assert snap["sectores"] == 0
+        assert snap["dimensions"] == []
+
+    def test_numeric_raw_values_supported(self):
+        """Caso con `largo_m` primitivo en lugar de {"valor": ...}."""
+        dr = {
+            "sectores": [
+                {"id": "cocina", "tipo": "cocina", "tramos": [
+                    {"id": "t1", "largo_m": 2.05, "ancho_m": 0.60, "m2": 1.23},
+                ]},
+            ],
+        }
+        snap = snapshot_dual_read(dr)
+        assert snap["dimensions"][0]["largo"] == 2.05
+
+
+class TestSnapshotCommercialAttrs:
+    def test_extracts_value_and_source(self):
+        attrs = {
+            "anafe_count": {"value": 1, "source": "dual_read"},
+            "isla_presence": {"value": True, "source": "operator_answer"},
+        }
+        snap = snapshot_commercial_attrs(attrs)
+        assert snap == {
+            "anafe_count": {"value": 1, "source": "dual_read"},
+            "isla_presence": {"value": True, "source": "operator_answer"},
+        }
+
+    def test_divergences_counted_not_expanded(self):
+        attrs = {
+            "anafe_count": {"value": 1, "source": "brief"},
+            "divergences": [{"field": "x"}, {"field": "y"}],
+        }
+        snap = snapshot_commercial_attrs(attrs)
+        assert snap["_divergences"] == 2
+
+    def test_none_returns_empty(self):
+        assert snapshot_commercial_attrs(None) == {}
+
+
+class TestSnapshotDerivedPieces:
+    def test_compact_shape(self):
+        pieces = [
+            {"description": "Pata frontal isla", "largo": 2.03, "prof": 0.9, "m2": 1.83, "source": "derived"},
+            {"description": "Pata lateral izq", "largo": 0.6, "prof": 0.9, "m2": 0.54, "source": "derived"},
+        ]
+        snap = snapshot_derived_pieces(pieces)
+        assert len(snap) == 2
+        assert snap[0]["descripcion"] == "Pata frontal isla"
+        assert snap[0]["largo"] == 2.03
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# diff_breakdown
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestDiffBreakdown:
+    def test_added_removed_modified(self):
+        pre = {"total_ars": 100, "material_name": "X"}
+        post = {"total_ars": 200, "dual_read_result": {"sectores": []}}
+        diff = diff_breakdown(pre, post)
+        assert diff["added"] == ["dual_read_result"]
+        assert diff["removed"] == ["material_name"]
+        assert "total_ars" in diff["modified"]
+        assert diff["modified"]["total_ars"] == {"before": 100, "after": 200}
+
+    def test_critical_keys_get_snapshot_not_fingerprint(self):
+        """Para `dual_read_result` el diff imprime el snapshot compacto,
+        no un fingerprint opaco — así el log de Railway es grepeable."""
+        pre = {"dual_read_result": {"sectores": []}}
+        post = {"dual_read_result": _dr_cocina_isla()}
+        diff = diff_breakdown(pre, post)
+        change = diff["modified"]["dual_read_result"]
+        assert change["before"]["tramos_total"] == 0
+        assert change["after"]["tramos_total"] == 3
+        assert change["after"]["dimensions"][0]["sector"] == "cocina"
+
+    def test_non_critical_keys_get_fingerprint(self):
+        """Para keys no-críticas usamos fingerprint para no inflar logs."""
+        pre = {"brief_analysis": {"x": 1}}
+        post = {"brief_analysis": {"x": 2}}
+        diff = diff_breakdown(pre, post)
+        change = diff["modified"]["brief_analysis"]
+        assert "before_fp" in change and "after_fp" in change
+        assert change["before_fp"] != change["after_fp"]
+
+    def test_no_change_returns_empty(self):
+        pre = {"total_ars": 100}
+        post = {"total_ars": 100}
+        diff = diff_breakdown(pre, post)
+        assert diff == {"added": [], "removed": [], "modified": {}}
+
+    def test_none_handled(self):
+        diff = diff_breakdown(None, {"x": 1})
+        assert diff["added"] == ["x"]
+
+
+class TestFingerprint:
+    def test_stable_and_compact(self):
+        fp = _fp({"b": 1, "a": 2})
+        assert fp.startswith("sha=") and "len=" in fp
+
+    def test_same_payload_same_fp(self):
+        assert _fp({"a": 1}) == _fp({"a": 1})
+
+    def test_different_payload_different_fp(self):
+        assert _fp({"a": 1}) != _fp({"a": 2})
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Side-effect helpers (smoke tests: no explotan + logs tienen prefijo)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def trace_caplog(caplog):
+    """Captura logs del logger `agent.trace`."""
+    caplog.set_level(logging.INFO, logger="agent.trace")
+    return caplog
+
+
+class TestLogHelpersSmoke:
+    def test_log_http_enter_has_prefix(self, trace_caplog):
+        log_http_enter("quote-1", "POST /x", foo="bar")
+        assert any("[trace:http:quote-1]" in r.message for r in trace_caplog.records)
+
+    def test_log_stream_enter_includes_bd_state(self, trace_caplog):
+        log_stream_enter(
+            quote_id="q1", user_message="cotizar",
+            plan_bytes=None, extra_files=None,
+            bd_pre={"verified_context": "X", "total_ars": 100},
+        )
+        msg = "\n".join(r.message for r in trace_caplog.records)
+        assert "[trace:stream:q1]" in msg
+        assert "has_verified_context" in msg
+
+    def test_log_bd_mutation_only_when_diff(self, trace_caplog):
+        log_bd_mutation("q1", "test", {"a": 1}, {"a": 1})
+        # Sin diff → sin log
+        assert not any("[trace:bd-mutation:q1]" in r.message for r in trace_caplog.records)
+        log_bd_mutation("q1", "test", {"a": 1}, {"a": 2})
+        assert any("[trace:bd-mutation:q1]" in r.message for r in trace_caplog.records)
+
+    def test_log_tool_call_and_result(self, trace_caplog):
+        log_tool_call("q1", "calculate_quote", {"pieces": []})
+        log_tool_result("q1", "calculate_quote", {"ok": True, "total_ars": 100})
+        msgs = [r.message for r in trace_caplog.records]
+        assert any("[trace:tool-call:q1] calculate_quote" in m for m in msgs)
+        assert any("[trace:tool-result:q1] calculate_quote" in m for m in msgs)
+
+    def test_log_tool_result_with_empty_dict_still_logs(self, trace_caplog):
+        """Antes el código filtraba tanto que imprimía `{}` y dejaba al
+        operador ciego. Ahora al menos las keys aparecen."""
+        log_tool_result("q1", "catalog_batch_lookup", {"material": {"price": 527}})
+        msg = "\n".join(r.message for r in trace_caplog.records)
+        assert "keys=['material']" in msg
+
+    def test_log_apply_answers(self, trace_caplog):
+        log_apply_answers(
+            "q1", flow="ctx",
+            dual_before={"sectores": []},
+            dual_after={"sectores": [{"id": "c", "tramos": []}]},
+            answers=[{"id": "isla_presence", "value": True}],
+        )
+        msg = "\n".join(r.message for r in trace_caplog.records)
+        assert "[trace:apply-answers:q1]" in msg
+        assert "isla_presence" in msg
+
+    def test_log_build_commercial_attrs(self, trace_caplog):
+        log_build_commercial_attrs("q1", flow="dr-confirmed", result={
+            "anafe_count": {"value": 1, "source": "dual_read"},
+        })
+        msg = "\n".join(r.message for r in trace_caplog.records)
+        assert "[trace:commercial-attrs:q1]" in msg
+        assert "anafe_count" in msg
+
+    def test_log_build_derived_isla_pieces(self, trace_caplog):
+        log_build_derived_isla_pieces("q1", flow="dr-confirmed",
+            pieces=[{"description": "Pata frontal", "largo": 2.03, "prof": 0.9}],
+            warnings=[],
+        )
+        msg = "\n".join(r.message for r in trace_caplog.records)
+        assert "[trace:derived-pieces:q1]" in msg
+        assert "count=1" in msg
+
+    def test_log_build_verified_context(self, trace_caplog):
+        log_build_verified_context("q1", flow="dr-confirmed", text="MEDIDAS VERIFICADAS X")
+        msg = "\n".join(r.message for r in trace_caplog.records)
+        assert "[trace:verified-context:q1]" in msg
+        assert "chars=" in msg and "fp=" in msg
+
+    def test_log_reopen(self, trace_caplog):
+        log_reopen(
+            "q1", kind="measurements",
+            bd_pre={"verified_context": "X", "material_name": "Y"},
+            bd_post={"dual_read_result": {"sectores": []}},
+            msgs_count_pre=10, msgs_count_post=4,
+            truncate_matched=True,
+        )
+        msg = "\n".join(r.message for r in trace_caplog.records)
+        assert "[trace:reopen:q1]" in msg
+        assert "msgs=10→4" in msg
+        assert "truncate_matched=True" in msg
+
+    def test_log_messages_persist(self, trace_caplog):
+        log_messages_persist(
+            "q1", flow="stream_chat-save",
+            added_turns=[{"role": "user", "content": "hola"}],
+            total_count=5,
+        )
+        msg = "\n".join(r.message for r in trace_caplog.records)
+        assert "[trace:messages-persist:q1]" in msg
+        assert "added=1" in msg
+        assert "total=5" in msg
+
+    def test_log_sse_structural_filters_non_structural(self, trace_caplog):
+        log_sse_structural("q1", "text", "lorem ipsum...")  # text chunk → NO loguear
+        assert not any("[trace:sse:q1]" in r.message for r in trace_caplog.records)
+
+        log_sse_structural("q1", "dual_read_result", '{"sectores":[]}')
+        assert any("[trace:sse:q1] type=dual_read_result" in r.message for r in trace_caplog.records)
+
+        log_sse_structural("q1", "done", "")
+        assert any("[trace:sse:q1] type=done" in r.message for r in trace_caplog.records)


### PR DESCRIPTION
## Por qué

Regla del operador: _si para entender un bug necesito preguntar qué botón apretó y en qué orden, entonces faltan logs_. El sistema tiene que loguear por sí solo qué pasa en cada paso — el operador no es un "logger humano".

## Qué loguea ahora

Nuevo módulo \`app/modules/agent/_trace.py\` (puro, logging + dict transforms) con helpers que cubren los 8 puntos acordados:

1. **Entrada HTTP del chat + reopen-***: request recibido con preview del mensaje + count de adjuntos.
2. **Entrada de stream_chat**: estado del breakdown al arrancar (has_dual_read_result, has_verified_context, material_name, total_ars, etc.) — así sabemos qué gates estaban activos.
3. **Mutaciones de \`quote_breakdown\`**: diff explícito (added/removed/modified). Para las keys críticas (\`dual_read_result\`, \`verified_measurements\`, \`verified_derived_pieces\`, \`verified_context\`, \`total_ars\`, etc.) el log muestra snapshot compacto con dimensiones por sector/tramo. Para las demás, fingerprint.
4. **Tool calls**: input completo + output REAL. Antes el código filtraba a un subset (\`ok/total_ars/...\`) que dejaba \`catalog_batch_lookup\` / \`check_architect\` / \`read_plan\` mostrando \`{}\`.
5. **Helpers deterministas críticos**: \`apply_answers\` (qué respuesta se aplicó y cómo cambió el dual_read), \`build_commercial_attrs\` (value + source de cada campo), \`build_derived_isla_pieces\` (piezas + warnings), \`build_verified_context\` (fingerprint + largo del texto inyectado).
6. **Endpoints reopen**: snapshot pre/post del breakdown + count de messages antes/después + si el truncate encontró la card (\`truncate_matched=True/False\`).
7. **Persistencia final de \`Quote.messages\`**: cuántos turns nuevos, preview del content, fingerprint.
8. **SSE estructurales**: dual_read_result, context_analysis, action, done, error. Los \`text\` chunks del stream NO se loguean para no floodear.

Default: snapshots compactos + hashes + valores numéricos explícitos. Full dump con \`DEBUG_AGENT_PAYLOADS=1\`.

## Formato

Prefijo estable para \`grep\` en Railway:
- \`[trace:http:<quote_id>] POST /quotes/:id/chat ...\`
- \`[trace:stream:<quote_id>] enter msg=... bd_state={...}\`
- \`[trace:bd-mutation:<quote_id>] flow=dual-read-confirmed modified_keys=[...]\`
- \`[trace:apply-answers:<quote_id>] ...\`
- \`[trace:commercial-attrs:<quote_id>] ...\`
- \`[trace:derived-pieces:<quote_id>] ...\`
- \`[trace:verified-context:<quote_id>] ...\`
- \`[trace:tool-call:<quote_id>] calculate_quote input={...}\`
- \`[trace:tool-result:<quote_id>] calculate_quote keys=[...] summary={...}\`
- \`[trace:reopen:<quote_id>] kind=measurements msgs=10→4 truncate_matched=True\`
- \`[trace:messages-persist:<quote_id>] added=2 total=12\`
- \`[trace:sse:<quote_id>] type=dual_read_result snap={...}\`

## No incluido en este PR (a propósito)

- Full dump del system prompt (solo fingerprint por defecto — 93k chars floodearían).
- Log por iteración de Claude si no aporta al estado.
- Flows no-principales (text-parse brief, card-editor chat-based, building_parent): si aparece un bug en esos flows, instrumentamos después.

## Test plan

- [x] 27 tests unitarios del módulo \`_trace\` (snapshots + diff + smoke de cada \`log_*\`).
- [x] Suite completa API: 1572 passed, 1 pre-existente fail (edificios, no tocado).
- [x] Sin cambios funcionales — solo logs y tests.
- [ ] Después del merge: batería de pruebas del operador; yo leo los logs, no pregunto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)