### PR TITLE
feat(verified-context): emitir frentín + regrueso bajo SECTOR: X

### DIFF
--- a/api/app/modules/quote_engine/dual_reader.py
+++ b/api/app/modules/quote_engine/dual_reader.py
@@ -896,6 +896,38 @@ def build_verified_context(
                 if ml > 0:
                     lines.append(f"  Zócalo {lado}: {ml}ml × {alto}m")
                 # ml=0 → ignorado (operador lo descartó intencionalmente)
+            # PR #387 — emitir frentín / faldón / regrueso de cada tramo
+            # con el mismo formato que los zócalos. Antes estos campos
+            # vivían en `tramo.frentin` / `tramo.regrueso` pero no se
+            # inyectaban al system prompt → Claude tenía que descubrir su
+            # existencia de las descripciones del despiece, y a veces los
+            # omitía del Paso 2. Con esto Claude los ve explícitos bajo
+            # `SECTOR: X` y los replica en `calculate_quote.pieces`
+            # (faldón/frentín) o en MO por ml (regrueso).
+            #
+            # Shape esperado (por analogía con zócalos, salida del parser):
+            #   { "lado": "frente|lateral|...", "ml": <float>, "alto_m": <float?> }
+            # `alto_m` es opcional — si falta no se renderiza la multiplicación.
+            for f in tramo.get("frentin", []) or []:
+                ml = (f.get("ml") or 0) if isinstance(f, dict) else 0
+                if ml <= 0:
+                    continue
+                lado = f.get("lado", "?") if isinstance(f, dict) else "?"
+                alto = f.get("alto_m") if isinstance(f, dict) else None
+                if alto:
+                    lines.append(f"  Frentín {lado}: {ml}ml × {alto}m")
+                else:
+                    lines.append(f"  Frentín {lado}: {ml}ml")
+            for r in tramo.get("regrueso", []) or []:
+                ml = (r.get("ml") or 0) if isinstance(r, dict) else 0
+                if ml <= 0:
+                    continue
+                lado = r.get("lado", "?") if isinstance(r, dict) else "?"
+                alto = r.get("alto_m") if isinstance(r, dict) else None
+                if alto:
+                    lines.append(f"  Regrueso {lado}: {ml}ml × {alto}m")
+                else:
+                    lines.append(f"  Regrueso {lado}: {ml}ml")
         lines.append("")
 
     # ── Atributos comerciales con precedencia explícita ──────────────

--- a/api/tests/test_dual_reader.py
+++ b/api/tests/test_dual_reader.py
@@ -250,6 +250,104 @@ class TestBuildVerifiedContext:
         assert "frontal" in ctx
         assert "1.74" in ctx
 
+    # ───────────────────────────────────────────────────────
+    # PR #387 — frentín + regrueso en verified_context
+    # ───────────────────────────────────────────────────────
+    #
+    # Antes: `tramo.frentin` / `tramo.regrueso` vivían en el dual_read
+    # pero no se inyectaban al system prompt. Claude podía omitirlos del
+    # Paso 2. Ahora se emiten explícitos bajo `SECTOR: X` con el mismo
+    # formato que los zócalos (el agente ya sabe parsear ese formato).
+
+    def _tramo_with_field(self, field: str, items: list) -> dict:
+        """Helper: construye un dual_read con un tramo que tiene `field`
+        (frentin/regrueso) seteado."""
+        dr = _build_single_result(_sample_result(), "SOLO_SONNET")
+        dr["sectores"][0]["tramos"][0][field] = items
+        return dr
+
+    def test_emits_frentin_under_sector(self):
+        dr = self._tramo_with_field(
+            "frentin",
+            [{"lado": "frente", "ml": 6.22, "alto_m": 0.05}],
+        )
+        ctx = build_verified_context(dr)
+        assert "Frentín frente" in ctx
+        assert "6.22ml" in ctx
+        assert "0.05m" in ctx
+
+    def test_emits_regrueso_under_sector(self):
+        dr = self._tramo_with_field(
+            "regrueso",
+            [{"lado": "frente", "ml": 3.5, "alto_m": 0.03}],
+        )
+        ctx = build_verified_context(dr)
+        assert "Regrueso frente" in ctx
+        assert "3.5ml" in ctx
+
+    def test_frentin_without_alto_renders_only_ml(self):
+        """Si no hay alto_m, mostrar solo los ml — no inventar multiplicación."""
+        dr = self._tramo_with_field(
+            "frentin",
+            [{"lado": "frente", "ml": 2.40}],
+        )
+        ctx = build_verified_context(dr)
+        assert "Frentín frente: 2.4ml" in ctx
+        assert "0.4ml × " not in ctx  # no debería haber "× <algo>m"
+
+    def test_empty_frentin_list_noop(self):
+        """Tramo con `frentin: []` no emite nada. El caso más común hoy."""
+        dr = self._tramo_with_field("frentin", [])
+        ctx = build_verified_context(dr)
+        assert "Frentín" not in ctx
+        assert "Regrueso" not in ctx
+
+    def test_zero_ml_items_skipped(self):
+        """Items con `ml=0` se ignoran — mismo criterio que zócalos
+        (operador los descartó intencionalmente)."""
+        dr = self._tramo_with_field(
+            "frentin",
+            [{"lado": "frente", "ml": 0, "alto_m": 0.05}],
+        )
+        ctx = build_verified_context(dr)
+        assert "Frentín" not in ctx
+
+    def test_multiple_items_all_emitted(self):
+        dr = self._tramo_with_field(
+            "frentin",
+            [
+                {"lado": "frente", "ml": 2.50, "alto_m": 0.05},
+                {"lado": "lateral", "ml": 0.60, "alto_m": 0.05},
+            ],
+        )
+        ctx = build_verified_context(dr)
+        assert "Frentín frente" in ctx
+        assert "Frentín lateral" in ctx
+
+    def test_frentin_and_regrueso_coexist(self):
+        """Un tramo puede tener ambos — deben salir los dos."""
+        dr = _build_single_result(_sample_result(), "SOLO_SONNET")
+        dr["sectores"][0]["tramos"][0]["frentin"] = [
+            {"lado": "frente", "ml": 2.00, "alto_m": 0.05},
+        ]
+        dr["sectores"][0]["tramos"][0]["regrueso"] = [
+            {"lado": "frente", "ml": 2.00, "alto_m": 0.03},
+        ]
+        ctx = build_verified_context(dr)
+        assert "Frentín frente" in ctx
+        assert "Regrueso frente" in ctx
+
+    def test_malformed_items_ignored(self):
+        """Si un item no es dict o no tiene ml → skip sin explotar."""
+        dr = self._tramo_with_field(
+            "frentin",
+            [None, "not a dict", {"lado": "frente", "ml": 2.0, "alto_m": 0.05}],
+        )
+        ctx = build_verified_context(dr)
+        # El único item válido se emite
+        assert ctx.count("Frentín") == 1
+        assert "Frentín frente" in ctx
+
 
 # ═══════════════════════════════════════════════════════
 # Compare float helper


### PR DESCRIPTION
## Contexto

Primer PR del plan de unificación de derivados físicos bajo una sola fuente de verdad (el \`dual_read_result\`). Scope chico, bajo riesgo, cero modelado nuevo.

## Bug atacado

\`tramo.frentin\` y \`tramo.regrueso\` viven en el dual_read desde el parser. \`build_verified_context\` los ignoraba al construir el texto que Claude recibe como system prompt. Resultado: Claude tenía que descubrir la existencia de frentín/regrueso de las descripciones libres del despiece — a veces los omitía del Paso 2, generando inconsistencia entre lo que el operador veía y lo que terminaba en PDF.

## Cambio

Emitirlos bajo \`SECTOR: X\` con el mismo formato que ya usa con zócalos:

\`\`\`
SECTOR: COCINA
  Mesada cocina: 1.55m × 0.60m = 0.93 m²
  Zócalo frontal: 1.55ml × 0.07m
  Frentín frente: 2.00ml × 0.05m
  Regrueso frente: 3.50ml × 0.03m
\`\`\`

- Si no hay \`alto_m\` → se renderiza solo \`Xml\` (no inventamos multiplicación).
- Items con \`ml=0\` se skipean — mismo criterio que zócalos (el operador los descartó).
- Items malformados (None, no dict, sin \`ml\`) se ignoran sin explotar.

## Sin cambios en

- Frontend (la card ya renderiza \`tramo.frentin\` / \`tramo.regrueso\`).
- Calculator (sigue detectando frentín/faldón por keywords en descripción — compat total).
- Shape del breakdown o dual_read (solo texto de presentación al LLM).

## Test plan

- [x] 11 tests de \`TestBuildVerifiedContext\` (los originales + 7 nuevos):
  - frentín bajo sector ✓
  - regrueso bajo sector ✓
  - sin \`alto_m\` renderiza solo ml ✓
  - lista vacía no emite ✓
  - \`ml=0\` se skipea ✓
  - múltiples items del mismo tipo ✓
  - frentín + regrueso coexisten ✓
  - items malformados no explotan ✓
- [x] Suite completa API: 1597 passed, 1 pre-existente (edificios, no tocado).
- [ ] **Manual post-merge**: operador hace retest end-to-end con un quote con frentín en isla o regrueso. Con el trace de #385, si Claude lo omite a pesar de que está en verified_context → bug es del LLM, no del helper.

## Próximo

Después de este retest end-to-end: #388 alzada como tramos derivados. Ahí sí hay decisión de modelado (1 tramo por sector con \`largo = perímetro_visible\` × \`alto_alzada\`). Lo abrimos con mini diseño previo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)