### PR TITLE
feat(despiece): alzada como tramo derivado por sector

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1560,6 +1560,7 @@ class AgentService:
                     from app.modules.quote_engine.dual_reader import (
                         build_derived_isla_pieces,
                         merge_derived_pieces_into_dual_read,
+                        merge_alzada_tramos_into_dual_read,
                     )
                     _ctx_derived, _ctx_derived_warn = build_derived_isla_pieces(
                         operator_answers=_answers,
@@ -1573,6 +1574,24 @@ class AgentService:
                     )
                     _saved_dual = merge_derived_pieces_into_dual_read(
                         _saved_dual, _ctx_derived,
+                    )
+                    # PR #388 — materializar alzada como tramo por sector
+                    # (1 tramo: "Alzada cocina" largo=perímetro × alto).
+                    # `apply_alzada_answer` ya escribió los campos top-level
+                    # `alzada` / `alzada_alto_m` sobre `_saved_dual`. Este
+                    # merge los lleva al despiece visible. Si el operador
+                    # respondió "no" → `alzada=False` → el helper solo limpia
+                    # alzadas previas (idempotencia al reconfirmar).
+                    _alzada_active = bool(_saved_dual.get("alzada"))
+                    _alzada_alto = _saved_dual.get("alzada_alto_m")
+                    _saved_dual = merge_alzada_tramos_into_dual_read(
+                        _saved_dual,
+                        alto_m=_alzada_alto,
+                        active=_alzada_active,
+                    )
+                    logging.info(
+                        f"[trace:context-confirmed:{quote_id}] alzada "
+                        f"active={_alzada_active} alto_m={_alzada_alto}"
                     )
                 except Exception as _e_merge:
                     logging.warning(

--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -578,17 +578,18 @@ async def reopen_context(
 
     new_bd = reset_quote_to_pre_context(bd)
 
-    # PR #386 — quitar tramos `_derived:true` del sector isla del dual_read.
-    # Esos tramos (patas) se materializan en `[CONTEXT_CONFIRMED]` a partir
-    # de las respuestas del operador. Si reabre contexto, esas respuestas
-    # podrían cambiar → las viejas patas quedan stale. La re-confirmación
-    # del contexto las regenera con los valores nuevos.
+    # PR #386/#388 — quitar TODOS los tramos `_derived:true` del dual_read,
+    # de cualquier kind (patas de isla `isla_pata`, alzadas `alzada`, y los
+    # que se agreguen a futuro). Se materializan en `[CONTEXT_CONFIRMED]` a
+    # partir de las respuestas del operador. Si reabre contexto, esas
+    # respuestas podrían cambiar → los derivados viejos quedan stale. La
+    # re-confirmación del contexto los regenera con los valores nuevos.
     if new_bd.get("dual_read_result"):
         from app.modules.quote_engine.dual_reader import (
-            merge_derived_pieces_into_dual_read,
+            clear_all_derived_tramos,
         )
-        new_bd["dual_read_result"] = merge_derived_pieces_into_dual_read(
-            new_bd["dual_read_result"], [],
+        new_bd["dual_read_result"] = clear_all_derived_tramos(
+            new_bd["dual_read_result"],
         )
 
     # Cortar historial desde la card de contexto + regenerar con

--- a/api/app/modules/quote_engine/dual_reader.py
+++ b/api/app/modules/quote_engine/dual_reader.py
@@ -1256,20 +1256,27 @@ def build_derived_isla_pieces(
 def merge_derived_pieces_into_dual_read(
     dual_read: dict | None,
     derived_pieces: list[dict] | None,
+    *,
+    kind: str = "isla_pata",
 ) -> dict:
-    """Sincroniza los tramos `_derived:true` del sector `isla` del
+    """Sincroniza los tramos derivados del sector `isla` del
     `dual_read_result` con la lista `derived_pieces` (output de
     `build_derived_isla_pieces`).
 
     Comportamiento:
-    - **Idempotente**: remueve TODOS los tramos con flag `_derived:true`
-      antes de agregar los nuevos. Reconfirmar contexto no duplica patas.
-    - `derived_pieces=None` o `[]` → solo limpieza (remueve los existentes,
-      no agrega nada). Usado por `/reopen-context` y para el caso en que
-      el operador cambió la respuesta "¿hay patas?" a "no".
-    - Si no hay sector `isla` en el dual_read y hay piezas derivadas → no
-      crea sector (las patas no tienen sentido sin isla detectada).
+    - **Idempotente**: remueve los tramos con `_derived_kind == kind`
+      antes de agregar los nuevos. Reconfirmar contexto no duplica patas
+      ni mezcla kinds (alzada vs patas pueden coexistir en sectores
+      distintos — cada helper limpia solo lo suyo).
+    - `derived_pieces=None` o `[]` → solo limpieza de `kind` (remueve los
+      existentes de ese kind, no agrega nada). Cambiar "¿hay patas?" a
+      "no" dispara este path.
+    - Si no hay sector `isla` en el dual_read → no-op (las patas no
+      tienen sentido sin isla detectada).
     - **No muta el input** — devuelve una copia nueva.
+
+    Para borrar **todos** los tramos derivados de cualquier kind (usado
+    por /reopen-context), usar `clear_all_derived_tramos(dual_read)`.
 
     Shape del tramo resultante:
         {
@@ -1280,6 +1287,7 @@ def merge_derived_pieces_into_dual_read(
             "m2":      {"valor": 1.22, "status": "CONFIRMADO"},
             "zocalos": [],
             "_derived": True,
+            "_derived_kind": "isla_pata",
             "_derived_source": "derived_from_operator_answers",
         }
     """
@@ -1297,9 +1305,14 @@ def merge_derived_pieces_into_dual_read(
     if isla_sector is None:
         return new_dr  # Sin sector isla, nada que mergear.
 
-    # Filtrar tramos existentes: preservar los que NO son derivados.
+    # Filtrar tramos existentes: preservar los que NO son de este `kind`.
+    # Los derivados de OTRO kind quedan (ej: si mañana hay alzada en isla
+    # también, no se pisan). Los no-derivados siempre se preservan.
     existing_tramos = isla_sector.get("tramos") or []
-    preserved = [t for t in existing_tramos if not t.get("_derived")]
+    preserved = [
+        t for t in existing_tramos
+        if not (t.get("_derived") and t.get("_derived_kind", "isla_pata") == kind)
+    ]
 
     # Construir tramos nuevos desde las piezas derivadas.
     new_tramos: list[dict] = []
@@ -1316,10 +1329,158 @@ def merge_derived_pieces_into_dual_read(
             "m2":      {"valor": m2, "status": "CONFIRMADO"},
             "zocalos": [],
             "_derived": True,
+            "_derived_kind": kind,
             "_derived_source": piece.get("source") or "derived_from_operator_answers",
         })
 
     isla_sector["tramos"] = preserved + new_tramos
+    return new_dr
+
+
+# ─────────────────────────────────────────────────────────────────────
+# PR #388 — Alzada como tramo derivado por sector
+# ─────────────────────────────────────────────────────────────────────
+#
+# La alzada (tira vertical contra pared que sube detrás de la mesada)
+# venía viviendo solo como dos campos top-level del dual_read:
+# `dual_result["alzada"] = True/False` y `dual_result["alzada_alto_m"]`.
+# El operador confirmaba "sí, 10cm" en la card de contexto pero NO veía
+# la alzada en el despiece. Claude tenía que "inventar" la pieza en
+# Paso 2 leyendo el brief y el system prompt.
+#
+# Ahora materializamos la alzada como un tramo por sector (no por cada
+# tramo interno — más legible, consistente con cómo se cotiza):
+#   SECTOR: COCINA
+#     Alzada cocina: 5.00m × 0.10m = 0.50 m²
+#
+# Decisión de modelado (acordada con el operador):
+# - 1 tramo por sector, no 1 por cada tramo interno.
+# - `descripcion = "Alzada <sector_id>"`.
+# - `largo = perímetro visible` = suma de `largo_m.valor` de los tramos
+#   NO-derivados del sector (mesadas originales, no patas ni alzadas
+#   previas).
+# - `ancho = alzada_alto_m` (tipicamente 0.05, 0.10 o custom).
+# - Scope: sectores cuyo tipo NO es `isla` (la isla es central sin pared
+#   de fondo, no lleva alzada). Cocinas, baños, lavaderos: sí.
+
+
+# Sectores que NO llevan alzada nunca. La isla es central — no tiene
+# pared de fondo contra la cual apoyarla.
+_NO_ALZADA_SECTOR_TIPOS = {"isla"}
+
+
+def _sector_visible_perimeter(sector: dict | None) -> float:
+    """Suma de `largo_m.valor` de los tramos NO-derivados del sector.
+
+    Usado para dimensionar la alzada: la tira vertical corre por todo
+    el perímetro visible de mesadas contra pared. Excluye tramos
+    derivados (patas de isla, alzadas previas) — solo cuenta el despiece
+    original del dual_read.
+    """
+    if not sector:
+        return 0.0
+    total = 0.0
+    for t in sector.get("tramos") or []:
+        if t.get("_derived"):
+            continue
+        largo = t.get("largo_m")
+        v = largo.get("valor") if isinstance(largo, dict) else largo
+        try:
+            if v is not None:
+                total += float(v)
+        except (TypeError, ValueError):
+            continue
+    return round(total, 2)
+
+
+def merge_alzada_tramos_into_dual_read(
+    dual_read: dict | None,
+    alto_m: float | None,
+    *,
+    active: bool = True,
+) -> dict:
+    """Sincroniza tramos `_derived_kind="alzada"` en todos los sectores
+    NO-isla del dual_read, según las respuestas confirmadas del operador.
+
+    Comportamiento:
+    - **Idempotente**: remueve tramos `_derived_kind="alzada"` previos
+      antes de agregar los nuevos. Reconfirmar contexto no duplica.
+    - `active=False` o `alto_m<=0` o `alto_m=None` → solo limpieza
+      (remueve alzadas existentes, no agrega). Cambiar "¿lleva alzada?"
+      a "no" dispara este path.
+    - Para cada sector NO-isla cuyo perímetro visible > 0 → agrega
+      **un solo tramo**: `"Alzada <sector_id>"` con
+      `largo = perímetro`, `ancho = alto_m`.
+    - Si un sector no tiene tramos no-derivados (perímetro=0) → skip
+      ese sector (no hay mesada original contra la cual apoyar alzada).
+    - **No muta el input** — devuelve una copia nueva.
+    - No pisa tramos `_derived_kind="isla_pata"` (patas de isla) —
+      usa el mismo filtro por kind que el helper de patas.
+    """
+    if not dual_read:
+        return {}
+    import copy as _copy
+    new_dr = _copy.deepcopy(dual_read)
+
+    try:
+        alto_val = float(alto_m) if alto_m is not None else 0.0
+    except (TypeError, ValueError):
+        alto_val = 0.0
+
+    should_emit = bool(active) and alto_val > 0
+
+    for sector in new_dr.get("sectores") or []:
+        # Limpiar tramos alzada previos en TODOS los sectores (incluso
+        # isla — defensivo, por si alguna vez un handler anterior los
+        # agregó por error).
+        tramos = sector.get("tramos") or []
+        sector["tramos"] = [
+            t for t in tramos
+            if not (t.get("_derived") and t.get("_derived_kind") == "alzada")
+        ]
+
+        if not should_emit:
+            continue
+
+        sector_tipo = (sector.get("tipo") or "").lower()
+        if sector_tipo in _NO_ALZADA_SECTOR_TIPOS:
+            continue
+
+        perimeter = _sector_visible_perimeter(sector)
+        if perimeter <= 0:
+            continue
+
+        sector_id = sector.get("id") or sector_tipo or "sector"
+        desc = f"Alzada {sector_id}"
+        m2 = round(perimeter * alto_val, 2)
+        sector["tramos"].append({
+            "id": _derived_piece_id(desc),
+            "descripcion": desc,
+            "largo_m": {"valor": round(perimeter, 2), "status": "CONFIRMADO"},
+            "ancho_m": {"valor": round(alto_val, 2), "status": "CONFIRMADO"},
+            "m2":      {"valor": m2, "status": "CONFIRMADO"},
+            "zocalos": [],
+            "_derived": True,
+            "_derived_kind": "alzada",
+            "_derived_source": "alzada_answer",
+        })
+
+    return new_dr
+
+
+def clear_all_derived_tramos(dual_read: dict | None) -> dict:
+    """Remueve TODOS los tramos `_derived:true` (cualquier kind) del
+    dual_read. Usado por `/reopen-context` que quiere borrar cualquier
+    pieza derivada (patas + alzadas) antes de la re-confirmación.
+
+    **No muta el input** — devuelve copia nueva."""
+    if not dual_read:
+        return {}
+    import copy as _copy
+    new_dr = _copy.deepcopy(dual_read)
+    for sector in new_dr.get("sectores") or []:
+        tramos = sector.get("tramos") or []
+        sector["tramos"] = [t for t in tramos if not t.get("_derived")]
     return new_dr
 
 

--- a/api/app/modules/quote_engine/pending_questions.py
+++ b/api/app/modules/quote_engine/pending_questions.py
@@ -368,12 +368,38 @@ def _detect_isla_presence_question(brief: str, dual_result: dict) -> dict | None
     }
 
 
+def _has_non_isla_sector(dual_result: dict) -> bool:
+    """True si el despiece tiene al menos un sector que NO es isla.
+    La alzada solo tiene sentido en sectores apoyados contra pared
+    (cocina, baño, lavadero) — la isla es central sin pared de fondo.
+    """
+    for s in dual_result.get("sectores") or []:
+        tipo = (s.get("tipo") or "").lower()
+        if tipo and tipo != "isla":
+            return True
+    return False
+
+
 def _detect_alzada_question(brief: str, dual_result: dict) -> dict | None:
     """Alzada: típicamente el operador la olvida o no está en el plano.
-    Preguntar siempre en cocina salvo que brief sea explícito."""
-    if not _is_cocina_work(dual_result, brief or ""):
-        return None
+
+    PR #388 — se pregunta para cualquier trabajo con al menos un sector
+    NO-isla (cocina, baño, lavadero). Antes el gate era `_is_cocina_work`
+    que dejaba afuera baños y lavaderos puros — se omitía la pregunta
+    aunque pudieran llevar alzada.
+
+    Skip cuando:
+    - El único sector detectado es isla (no tiene pared de fondo).
+    - El dual_read está vacío y el brief no menciona cocina (fallback
+      conservador — no preguntar a ciegas).
+    - El brief ya menciona alzada explícitamente (con/sin/alto).
+    """
     b = brief or ""
+    has_non_isla = _has_non_isla_sector(dual_result)
+    # Si no hay sectores detectados, caer al legacy gate (brief cocina o
+    # sectores vacíos sin evidencia de baño/lavadero).
+    if not has_non_isla and not _is_cocina_work(dual_result, b):
+        return None
     if _ALZADA.search(b) or _ALZADA_NO.search(b):
         return None
     return {

--- a/api/tests/test_derived_pieces_merge.py
+++ b/api/tests/test_derived_pieces_merge.py
@@ -20,9 +20,12 @@ import pytest
 
 from app.modules.quote_engine.dual_reader import (
     merge_derived_pieces_into_dual_read,
+    merge_alzada_tramos_into_dual_read,
+    clear_all_derived_tramos,
     dual_read_has_derived_pieces,
     build_derived_isla_pieces,
     build_verified_context,
+    _sector_visible_perimeter,
 )
 
 
@@ -245,7 +248,287 @@ class TestNoDoubleCountingInVerifiedContext:
         # NO debe aparecer.
         assert "PIEZAS DERIVADAS DE RESPUESTAS DEL OPERADOR" not in ctx
 
-    def test_would_double_count_if_both_sources_passed(self):
+    def test_would_double_count_if_both_sources_passed(self):  # noqa: E501
+        pass
+
+    # Placeholder para la refactor de kind — ver tests más abajo en la
+    # clase TestMergeAlzadaTramos que cubre el split por kind.
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PR #388 — Alzada como tramo derivado por sector
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _dr_cocina_L_and_bano() -> dict:
+    """Dual_read con cocina en L (2 tramos) + baño vanitory (1 tramo).
+    Ambos NO-isla → deberían recibir alzada."""
+    return {
+        "sectores": [
+            {
+                "id": "cocina", "tipo": "cocina",
+                "tramos": [
+                    {"id": "c1", "descripcion": "Cocina 1",
+                     "largo_m": {"valor": 2.05}, "ancho_m": {"valor": 0.60}, "m2": {"valor": 1.23}},
+                    {"id": "c2", "descripcion": "Cocina 2",
+                     "largo_m": {"valor": 2.95}, "ancho_m": {"valor": 0.60}, "m2": {"valor": 1.77}},
+                ],
+            },
+            {
+                "id": "bano", "tipo": "baño",
+                "tramos": [
+                    {"id": "b1", "descripcion": "Vanitory",
+                     "largo_m": {"valor": 1.20}, "ancho_m": {"valor": 0.50}, "m2": {"valor": 0.60}},
+                ],
+            },
+        ],
+    }
+
+
+def _dr_isla_only() -> dict:
+    return {
+        "sectores": [
+            {
+                "id": "isla", "tipo": "isla",
+                "tramos": [
+                    {"id": "i1", "descripcion": "Mesada isla",
+                     "largo_m": {"valor": 2.03}, "ancho_m": {"valor": 0.60}, "m2": {"valor": 1.22}},
+                ],
+            },
+        ],
+    }
+
+
+class TestSectorVisiblePerimeter:
+    def test_sums_largos_of_non_derived_tramos(self):
+        sector = {
+            "id": "cocina", "tipo": "cocina",
+            "tramos": [
+                {"largo_m": {"valor": 2.05}},
+                {"largo_m": {"valor": 2.95}},
+            ],
+        }
+        assert _sector_visible_perimeter(sector) == 5.00
+
+    def test_skips_derived_tramos(self):
+        sector = {
+            "id": "cocina", "tipo": "cocina",
+            "tramos": [
+                {"largo_m": {"valor": 2.05}},
+                {"largo_m": {"valor": 1.80}, "_derived": True, "_derived_kind": "alzada"},
+            ],
+        }
+        # Solo el 2.05, la alzada previa se ignora (no se usa para derivar nueva).
+        assert _sector_visible_perimeter(sector) == 2.05
+
+    def test_handles_primitive_largo(self):
+        """Si `largo_m` es número crudo (no dict con valor), también funciona."""
+        sector = {"tramos": [{"largo_m": 1.50}, {"largo_m": 2.00}]}
+        assert _sector_visible_perimeter(sector) == 3.50
+
+    def test_empty_sector(self):
+        assert _sector_visible_perimeter(None) == 0.0
+        assert _sector_visible_perimeter({}) == 0.0
+        assert _sector_visible_perimeter({"tramos": []}) == 0.0
+
+
+class TestMergeAlzadaTramos:
+    def test_adds_one_tramo_per_non_isla_sector(self):
+        dr = _dr_cocina_L_and_bano()
+        result = merge_alzada_tramos_into_dual_read(dr, alto_m=0.10, active=True)
+        cocina = next(s for s in result["sectores"] if s["tipo"] == "cocina")
+        bano = next(s for s in result["sectores"] if s["tipo"] == "baño")
+
+        # Cocina: 2 tramos originales + 1 alzada
+        assert len(cocina["tramos"]) == 3
+        alz_cocina = cocina["tramos"][-1]
+        assert alz_cocina["descripcion"] == "Alzada cocina"
+        assert alz_cocina["largo_m"]["valor"] == 5.00  # 2.05 + 2.95
+        assert alz_cocina["ancho_m"]["valor"] == 0.10
+        assert alz_cocina["m2"]["valor"] == 0.50
+        assert alz_cocina["_derived"] is True
+        assert alz_cocina["_derived_kind"] == "alzada"
+
+        # Baño: 1 tramo original + 1 alzada
+        assert len(bano["tramos"]) == 2
+        alz_bano = bano["tramos"][-1]
+        assert alz_bano["descripcion"] == "Alzada bano"  # id es "bano"
+        assert alz_bano["largo_m"]["valor"] == 1.20
+        assert alz_bano["ancho_m"]["valor"] == 0.10
+
+    def test_skips_isla_sector(self):
+        dr = _dr_isla_only()
+        result = merge_alzada_tramos_into_dual_read(dr, alto_m=0.10, active=True)
+        isla = result["sectores"][0]
+        # La isla no recibe alzada — sigue con su único tramo de mesada.
+        assert len(isla["tramos"]) == 1
+        assert not any(t.get("_derived_kind") == "alzada" for t in isla["tramos"])
+
+    def test_active_false_only_cleans(self):
+        """Si el operador responde 'no' a alzada, se limpian las previas
+        sin agregar nuevas."""
+        dr = _dr_cocina_L_and_bano()
+        with_alzada = merge_alzada_tramos_into_dual_read(dr, 0.10, active=True)
+        cleaned = merge_alzada_tramos_into_dual_read(with_alzada, 0.10, active=False)
+        # Cocina vuelve a sus 2 tramos originales
+        cocina = next(s for s in cleaned["sectores"] if s["tipo"] == "cocina")
+        assert len(cocina["tramos"]) == 2
+        assert not any(t.get("_derived_kind") == "alzada" for t in cocina["tramos"])
+
+    def test_zero_alto_only_cleans(self):
+        """alto_m=0 o None equivale a active=False."""
+        dr = _dr_cocina_L_and_bano()
+        result = merge_alzada_tramos_into_dual_read(dr, alto_m=0, active=True)
+        cocina = next(s for s in result["sectores"] if s["tipo"] == "cocina")
+        assert len(cocina["tramos"]) == 2
+
+        result2 = merge_alzada_tramos_into_dual_read(dr, alto_m=None, active=True)
+        cocina2 = next(s for s in result2["sectores"] if s["tipo"] == "cocina")
+        assert len(cocina2["tramos"]) == 2
+
+    def test_idempotent_same_alto(self):
+        """Llamar 2 veces con el mismo alto no duplica."""
+        dr = _dr_cocina_L_and_bano()
+        step1 = merge_alzada_tramos_into_dual_read(dr, 0.10, active=True)
+        step2 = merge_alzada_tramos_into_dual_read(step1, 0.10, active=True)
+        cocina = next(s for s in step2["sectores"] if s["tipo"] == "cocina")
+        assert len(cocina["tramos"]) == 3  # 2 originales + 1 alzada (no 2 alzadas)
+
+    def test_idempotent_different_alto_replaces(self):
+        """Cambiar el alto de 10cm a 5cm reemplaza (no agrega)."""
+        dr = _dr_cocina_L_and_bano()
+        step1 = merge_alzada_tramos_into_dual_read(dr, 0.10, active=True)
+        step2 = merge_alzada_tramos_into_dual_read(step1, 0.05, active=True)
+        cocina = next(s for s in step2["sectores"] if s["tipo"] == "cocina")
+        assert len(cocina["tramos"]) == 3
+        alz = next(t for t in cocina["tramos"] if t.get("_derived_kind") == "alzada")
+        assert alz["ancho_m"]["valor"] == 0.05
+        assert alz["m2"]["valor"] == 0.25  # 5.00 × 0.05
+
+    def test_does_not_mutate_input(self):
+        dr = _dr_cocina_L_and_bano()
+        snapshot = copy.deepcopy(dr)
+        merge_alzada_tramos_into_dual_read(dr, 0.10, active=True)
+        assert dr == snapshot
+
+    def test_empty_dual_read(self):
+        assert merge_alzada_tramos_into_dual_read(None, 0.10) == {}
+        assert merge_alzada_tramos_into_dual_read({}, 0.10) == {}
+
+    def test_sector_with_no_visible_tramos_skipped(self):
+        """Si un sector solo tiene tramos derivados (no mesada original),
+        no se le agrega alzada."""
+        dr = {
+            "sectores": [
+                {"id": "cocina", "tipo": "cocina", "tramos": [
+                    # Solo un tramo ficticio ya derivado (edge case):
+                    {"largo_m": {"valor": 1.0}, "_derived": True, "_derived_kind": "foo"},
+                ]},
+            ],
+        }
+        result = merge_alzada_tramos_into_dual_read(dr, 0.10, active=True)
+        cocina = result["sectores"][0]
+        # No se agregó alzada (perímetro=0 porque el único tramo es derivado)
+        assert not any(t.get("_derived_kind") == "alzada" for t in cocina["tramos"])
+
+    def test_coexists_with_isla_patas(self):
+        """Alzada en cocina + patas en isla → ambos kinds coexisten."""
+        dr = {
+            "sectores": [
+                {"id": "cocina", "tipo": "cocina", "tramos": [
+                    {"largo_m": {"valor": 2.00}, "ancho_m": {"valor": 0.60}, "m2": {"valor": 1.20}},
+                ]},
+                {"id": "isla", "tipo": "isla", "tramos": [
+                    {"largo_m": {"valor": 1.80}, "ancho_m": {"valor": 0.60}, "m2": {"valor": 1.08}},
+                ]},
+            ],
+        }
+        patas = [
+            {"description": "Pata frontal isla", "largo": 1.80, "prof": 0.90, "m2": 1.62, "source": "x"},
+        ]
+        with_patas = merge_derived_pieces_into_dual_read(dr, patas)
+        with_both = merge_alzada_tramos_into_dual_read(with_patas, 0.10, active=True)
+
+        isla = next(s for s in with_both["sectores"] if s["tipo"] == "isla")
+        cocina = next(s for s in with_both["sectores"] if s["tipo"] == "cocina")
+        # Isla tiene mesada + pata (no alzada — es isla)
+        assert len(isla["tramos"]) == 2
+        assert any(t.get("_derived_kind") == "isla_pata" for t in isla["tramos"])
+        assert not any(t.get("_derived_kind") == "alzada" for t in isla["tramos"])
+        # Cocina tiene mesada + alzada (no patas)
+        assert len(cocina["tramos"]) == 2
+        assert any(t.get("_derived_kind") == "alzada" for t in cocina["tramos"])
+
+    def test_merge_patas_does_not_pisa_alzada_in_same_sector(self):
+        """Guard: si por alguna razón hubiera alzada y luego corremos el
+        helper de patas (kind='isla_pata') sobre el mismo dual_read, la
+        alzada debe sobrevivir (solo se pisan los de kind='isla_pata')."""
+        dr = {
+            "sectores": [
+                {"id": "isla", "tipo": "isla", "tramos": [
+                    {"largo_m": {"valor": 1.80}, "ancho_m": {"valor": 0.60}, "m2": {"valor": 1.08}},
+                    # Hipotético: alguien puso alzada en isla (no deberíamos
+                    # pero el helper no debería borrarlo al reconfirmar patas)
+                    {"largo_m": {"valor": 1.80}, "_derived": True, "_derived_kind": "alzada"},
+                ]},
+            ],
+        }
+        new_patas = [{"description": "Pata frontal isla", "largo": 1.80, "prof": 0.90, "m2": 1.62}]
+        result = merge_derived_pieces_into_dual_read(dr, new_patas)
+        isla = result["sectores"][0]
+        # La alzada sigue, la pata se agregó
+        assert any(t.get("_derived_kind") == "alzada" for t in isla["tramos"])
+        assert any(t.get("_derived_kind") == "isla_pata" for t in isla["tramos"])
+
+
+class TestClearAllDerivedTramos:
+    def test_removes_all_kinds(self):
+        dr = _dr_cocina_L_and_bano()
+        dr["sectores"].append({
+            "id": "isla", "tipo": "isla",
+            "tramos": [
+                {"id": "i1", "largo_m": {"valor": 1.80}, "ancho_m": {"valor": 0.60}, "m2": {"valor": 1.08}},
+            ],
+        })
+        # Agregar patas + alzadas
+        with_patas = merge_derived_pieces_into_dual_read(dr, [
+            {"description": "Pata frontal isla", "largo": 1.80, "prof": 0.90, "m2": 1.62},
+        ])
+        with_both = merge_alzada_tramos_into_dual_read(with_patas, 0.10, active=True)
+        # Limpiar todo
+        cleaned = clear_all_derived_tramos(with_both)
+        for sector in cleaned["sectores"]:
+            assert not any(t.get("_derived") for t in sector["tramos"])
+
+    def test_preserves_non_derived(self):
+        dr = _dr_cocina_L_and_bano()
+        cleaned = clear_all_derived_tramos(dr)
+        # Sin cambios: no había nada derivado
+        cocina = next(s for s in cleaned["sectores"] if s["tipo"] == "cocina")
+        assert len(cocina["tramos"]) == 2
+
+    def test_empty_input(self):
+        assert clear_all_derived_tramos(None) == {}
+        assert clear_all_derived_tramos({}) == {}
+
+
+class TestAlzadaAppearsInVerifiedContext:
+    """Integración: post-merge, verified_context muestra la alzada como
+    tramo bajo SECTOR: X. Claude la ve ahí sin bloque aparte."""
+
+    def test_alzada_tramo_emitted(self):
+        dr = _dr_cocina_L_and_bano()
+        with_alzada = merge_alzada_tramos_into_dual_read(dr, 0.10, active=True)
+        ctx = build_verified_context(with_alzada, commercial_attrs=None, derived_pieces=None)
+        assert "Alzada cocina" in ctx
+        assert "5.0m × 0.1m" in ctx  # perímetro × alto
+        assert "Alzada bano" in ctx
+
+    def test_no_alzada_when_only_isla(self):
+        dr = _dr_isla_only()
+        with_alzada = merge_alzada_tramos_into_dual_read(dr, 0.10, active=True)
+        ctx = build_verified_context(with_alzada, commercial_attrs=None, derived_pieces=None)
+        assert "Alzada" not in ctx
         """Contra-ejemplo: si el handler accidentalmente pasara
         derived_pieces a build_verified_context TAMBIÉN con los tramos
         mergeados, las patas aparecen DOS veces. Este test documenta la

--- a/api/tests/test_pending_questions.py
+++ b/api/tests/test_pending_questions.py
@@ -565,6 +565,57 @@ class TestDetectAlzada:
         qs = detect_pending_questions("sin alzada", _make_dual_result())
         assert all(q["id"] != "alzada" for q in qs)
 
+    # PR #388 — la pregunta se relajó: antes solo se preguntaba si
+    # `_is_cocina_work=True`. Ahora se pregunta si hay al menos un
+    # sector NO-isla (cocina, baño, lavadero).
+
+    def test_emits_in_bano(self):
+        """Baño puro (sin cocina) → antes no se preguntaba alzada. Ahora sí."""
+        dr = {
+            "sectores": [
+                {"id": "s1", "tipo": "baño", "tramos": [
+                    {"id": "t1", "descripcion": "Vanitory",
+                     "largo_m": {"valor": 1.20, "status": "CONFIRMADO"},
+                     "ancho_m": {"valor": 0.50, "status": "CONFIRMADO"},
+                     "m2": {"valor": 0.60, "status": "CONFIRMADO"},
+                     "zocalos": [], "frentin": [], "regrueso": []},
+                ]},
+            ],
+        }
+        qs = detect_pending_questions("vanitory mármol", dr)
+        assert any(q["id"] == "alzada" for q in qs)
+
+    def test_emits_in_lavadero(self):
+        dr = {
+            "sectores": [
+                {"id": "s1", "tipo": "lavadero", "tramos": [
+                    {"id": "t1", "descripcion": "Lavadero",
+                     "largo_m": {"valor": 1.80, "status": "CONFIRMADO"},
+                     "ancho_m": {"valor": 0.55, "status": "CONFIRMADO"},
+                     "m2": {"valor": 0.99, "status": "CONFIRMADO"},
+                     "zocalos": [], "frentin": [], "regrueso": []},
+                ]},
+            ],
+        }
+        qs = detect_pending_questions("lavadero granito", dr)
+        assert any(q["id"] == "alzada" for q in qs)
+
+    def test_skips_when_only_isla(self):
+        """Isla sola (sin cocina/baño/lavadero) → no preguntar alzada."""
+        dr = {
+            "sectores": [
+                {"id": "s1", "tipo": "isla", "tramos": [
+                    {"id": "t1", "descripcion": "Mesada isla",
+                     "largo_m": {"valor": 2.00, "status": "CONFIRMADO"},
+                     "ancho_m": {"valor": 0.60, "status": "CONFIRMADO"},
+                     "m2": {"valor": 1.20, "status": "CONFIRMADO"},
+                     "zocalos": [], "frentin": [], "regrueso": []},
+                ]},
+            ],
+        }
+        qs = detect_pending_questions("isla central granito", dr)
+        assert all(q["id"] != "alzada" for q in qs)
+
 
 class TestApplyAlzada:
     def test_preset_10cm(self):

--- a/api/tests/test_router.py
+++ b/api/tests/test_router.py
@@ -1147,6 +1147,43 @@ class TestReopenContext:
         assert r2.status_code == 400
 
     @pytest.mark.asyncio
+    async def test_reopen_context_clears_alzada_derived_tramos(
+        self, client, db_session,
+    ):
+        """PR #388 — reopen-context debe quitar tramos `_derived_kind='alzada'`
+        además de los de patas. Una alzada con distinto alto después
+        requiere regenerar desde cero con la nueva respuesta."""
+        from app.models.quote import Quote
+        from sqlalchemy import update
+        qid = await self._make_context_confirmed_quote(client, db_session)
+        existing = (await client.get(f"/api/quotes/{qid}")).json()["quote_breakdown"]
+        existing["dual_read_result"] = {
+            "sectores": [
+                {"id": "cocina", "tipo": "cocina", "tramos": [
+                    {"id": "c1", "descripcion": "Cocina",
+                     "largo_m": {"valor": 2.05}, "ancho_m": {"valor": 0.60}, "m2": {"valor": 1.23}},
+                    {"id": "derived_alzada_cocina", "descripcion": "Alzada cocina",
+                     "largo_m": {"valor": 2.05}, "ancho_m": {"valor": 0.10}, "m2": {"valor": 0.21},
+                     "zocalos": [], "_derived": True, "_derived_kind": "alzada"},
+                ]},
+            ],
+        }
+        await db_session.execute(
+            update(Quote).where(Quote.id == qid).values(quote_breakdown=existing)
+        )
+        await db_session.commit()
+
+        resp = await client.post(f"/api/quotes/{qid}/reopen-context")
+        assert resp.status_code == 200, resp.text
+
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        cocina = detail["quote_breakdown"]["dual_read_result"]["sectores"][0]
+        # Solo la mesada original queda — la alzada derivada se limpió
+        assert len(cocina["tramos"]) == 1
+        assert cocina["tramos"][0]["descripcion"] == "Cocina"
+        assert not any(t.get("_derived") for t in cocina["tramos"])
+
+    @pytest.mark.asyncio
     async def test_reopen_context_clears_derived_pieces_from_isla(
         self, client, db_session,
     ):


### PR DESCRIPTION
## Bug atacado

La alzada vivía como dos campos top-level del dual_read (\`alzada\` boolean + \`alzada_alto_m\` float). El operador respondía "sí, 10cm" en la card de contexto y **NO veía la alzada en el despiece**. Claude tenía que inventar la pieza en Paso 2 leyendo brief + system prompt. Riesgo: omisión, mal dimensionado o gate de toma corriente que no se dispara.

Es el último bug grande del patrón "derivado confirmado en contexto que no llega al despiece visible" (ya cerramos patas de isla en #386, frentín/regrueso en #387).

## Modelado acordado

**1 tramo por sector** (no 1 por cada tramo interno):

\`\`\`
SECTOR: COCINA
  Mesada cocina 1: 2.05m × 0.60m = 1.23 m²
  Mesada cocina 2: 2.95m × 0.60m = 1.77 m²
  Alzada cocina:   5.00m × 0.10m = 0.50 m²
\`\`\`

- \`descripcion = "Alzada <sector_id>"\` (ej: "Alzada cocina", "Alzada bano").
- \`largo = perímetro visible\` = suma de \`largo_m.valor\` de los tramos **NO-derivados** del sector (mesadas originales, sin incluir patas ni alzadas previas).
- \`ancho = alzada_alto_m\` (tipicamente 0.05, 0.10, o custom).
- Sectores tipo \`isla\` se skipean — son centrales, sin pared de fondo.

## Cambios

### \`dual_reader.py\`

1. **\`merge_alzada_tramos_into_dual_read(dr, alto_m, active)\`** — helper nuevo. Idempotente, no muta. \`active=False\` o \`alto<=0\` → solo limpieza.
2. **\`merge_derived_pieces_into_dual_read(dr, pieces, kind="isla_pata")\`** — refactor: filtra solo su kind al preservar. Alzada + patas coexisten en el mismo dual_read sin pisarse.
3. **\`clear_all_derived_tramos(dr)\`** — helper nuevo, remueve TODOS los derivados. Usado por \`/reopen-context\`.
4. **\`_sector_visible_perimeter(sector)\`** — suma \`largo_m\` de tramos no-derivados.

### \`agent.py\` \`[CONTEXT_CONFIRMED]\`
Llama \`merge_alzada_tramos_into_dual_read\` post-merge-patas. Lee \`dual_result.alzada\` / \`alzada_alto_m\` (ya setteados por \`apply_alzada_answer\`).

### \`router.py\` \`/reopen-context\`
Usa \`clear_all_derived_tramos\` (antes limpiaba solo patas con el helper viejo).

### \`pending_questions._detect_alzada_question\`
Gate relajado de \`_is_cocina_work\` → "al menos un sector NO-isla". Antes no se preguntaba alzada en baños/lavaderos puros aunque aplica. Ahora sí.

## No se rompe

- \`_has_alzada_piece(pieces)\` en calculator.py sigue funcionando: las pieces llegan con descripción que arranca con "Alzada" desde los tramos. Gate de toma corriente mantiene comportamiento.
- Compat legacy: \`merge_derived_pieces_into_dual_read\` sigue como primer argumento-posicional + \`kind\` kwarg default "isla_pata" → callers viejos siguen andando.
- Tramos \`_derived_kind="alzada"\` no se pisan cuando se agregan patas (coexistencia probada en test).

## Test plan

- [x] **Unit (16 tests nuevos)**: perímetro visible + alzada en sectores no-isla + idempotencia same/different alto + active=False + zero/None alto + coexistencia con patas + clear_all_derived_tramos.
- [x] **Pending questions (3 nuevos)**: alzada se pregunta en baño, lavadero, pero no si solo hay isla.
- [x] **E2E router**: reopen-context limpia tramos \`_derived_kind="alzada"\` (no solo patas).
- [x] **Integración verified_context**: "Alzada cocina" aparece bajo \`SECTOR: COCINA\`, no como bloque separado.
- [x] Suite completa API: 1621 passed, 1 pre-existente fail (edificios, no tocado).
- [ ] **Manual post-merge**: operador hace retest con cocina + alzada 10cm → verifica que aparece "Alzada cocina: 5.00m × 0.10m" en la card del despiece → confirmar medidas → Paso 2 usa esa alzada (no una inventada).

## Criterio general

Con este PR el patrón queda establecido para los 3 derivados físicos: **patas de isla → frentín/regrueso → alzada**. La regla:

> Si un dato confirmado en contexto genera pieza física / ml / m² / costo material, debe vivir en el despiece visible antes de \`[DUAL_READ_CONFIRMED]\`. La fuente única de verdad es el \`dual_read_result\`, no bloques paralelos en el system prompt.

## Próximo

#389 — productores de frentín/regrueso (preguntas + apply_answer). Abriré después del retest end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)