### PR TITLE
fix(auth): sliding session refresh + detección de 401 expirado

### DIFF
--- a/api/app/core/auth.py
+++ b/api/app/core/auth.py
@@ -24,8 +24,20 @@ logger = logging.getLogger(__name__)
 # ── Config ───────────────────────────────────────────────────────────────────
 
 ALGORITHM = "HS256"
-TOKEN_EXPIRY_HOURS = 72  # 3 days
+TOKEN_EXPIRY_HOURS = 72  # 3 days — absolute lifetime of each issued token.
 COOKIE_NAME = "auth_token"
+
+# PR #389 — sliding refresh: cuando al token activo le quedan menos de
+# este umbral, la siguiente request autenticada emite un nuevo token
+# (cookie + header `X-Refreshed-Token`). Efecto: un operador que usa
+# la app cualquier rato dentro de (TOKEN_EXPIRY - REFRESH_THRESHOLD)
+# **nunca ve 401**. Si deja el navegador inactivo más que ese margen
+# la sesión vence naturalmente y el próximo click lo manda a /login.
+#
+# Umbral actual: 24h. Balance entre "no molestar al activo" (cualquier
+# click extiende 72h) y "cerrar sesiones abandonadas en tiempo
+# razonable" (~1 día de idle disponible antes del corte).
+REFRESH_THRESHOLD_HOURS = 24
 
 
 # ── Rate Limiter (in-memory, no Redis) ─────────────────────────────────────
@@ -267,4 +279,39 @@ async def auth_middleware(request: Request, call_next):
     # Attach user info to request state
     request.state.user_email = payload.get("sub")
 
-    return await call_next(request)
+    response = await call_next(request)
+
+    # PR #389 — sliding refresh. Si al token le quedan menos de
+    # REFRESH_THRESHOLD_HOURS de vida y la request autenticada completó
+    # con éxito, emitir token nuevo en la response. Mientras el operador
+    # use la app regularmente la sesión nunca vence.
+    #
+    # Side-effects solo en el success path (call_next completó sin
+    # raise). Si hubo excepción que se propaga al ASGI handler, no
+    # tocamos cookies — el error viaja limpio.
+    try:
+        exp_ts = payload.get("exp")
+        sub = payload.get("sub")
+        if exp_ts and sub:
+            exp_dt = datetime.fromtimestamp(int(exp_ts), tz=timezone.utc)
+            now_dt = datetime.now(timezone.utc)
+            remaining = exp_dt - now_dt
+            if timedelta(0) < remaining < timedelta(hours=REFRESH_THRESHOLD_HOURS):
+                new_token = create_token(sub)
+                # Re-emitir cookie (path desktop + el primario aún).
+                set_auth_cookie(response, new_token)
+                # Header fallback para clientes sin cookie cross-origin
+                # (iOS Safari ITP). El frontend captura `X-Refreshed-Token`
+                # en `apiFetch` y lo guarda en localStorage para próximos
+                # requests vía Authorization header.
+                response.headers["X-Refreshed-Token"] = new_token
+                logger.info(
+                    f"[auth] sliding refresh for {sub} — "
+                    f"remaining={remaining.total_seconds() / 3600:.1f}h, "
+                    f"new exp=+{TOKEN_EXPIRY_HOURS}h"
+                )
+    except Exception as _e_refresh:
+        # No romper la response del usuario si algo raro pasa en el refresh.
+        logger.warning(f"[auth] sliding refresh failed: {_e_refresh}")
+
+    return response

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -124,6 +124,12 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    # PR #389 — sliding session refresh: el middleware de auth emite un
+    # nuevo JWT en cookie + `X-Refreshed-Token` cuando al token activo le
+    # quedan <24h de vida. El header queda expuesto al JS del frontend
+    # para que el fallback de localStorage (iOS Safari con ITP bloqueando
+    # cookies cross-origin) también se actualice y la sesión deslice.
+    expose_headers=["X-Refreshed-Token"],
 )
 
 app.include_router(auth_router, prefix="/api")

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -1,8 +1,19 @@
 """Tests for auth endpoints — create-user protection, username strip."""
 
 import os
+from datetime import datetime, timedelta, timezone
+
 import pytest
-from app.core.auth import create_token, COOKIE_NAME
+from jose import jwt
+
+from app.core.auth import (
+    create_token,
+    COOKIE_NAME,
+    ALGORITHM,
+    TOKEN_EXPIRY_HOURS,
+    REFRESH_THRESHOLD_HOURS,
+)
+from app.core.config import settings
 
 
 class TestCreateUserProtection:
@@ -341,3 +352,118 @@ class TestTypedPatch:
         quote_id = create_res.json()["id"]
         res = await client.patch(f"/api/quotes/{quote_id}", json={"client_name": "A" * 501})
         assert res.status_code == 422
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PR #389 — Sliding session refresh
+# ═══════════════════════════════════════════════════════════════════════
+#
+# Al token activo le quedan <24h de vida → la siguiente request
+# autenticada emite un token nuevo (cookie + header `X-Refreshed-Token`).
+# Al activo le quedan >=24h → no se emite refresh (evita spam).
+#
+# Helpers para simular tokens con `exp` arbitrario sin tener que esperar
+# días reales ni monkeypatchear `datetime.now` global.
+
+
+def _make_token_with_remaining(email: str, remaining_hours: float) -> str:
+    """Emite un JWT con `exp = now + remaining_hours`. Usado para simular
+    tokens cerca/lejos de vencer sin tocar el reloj."""
+    exp = datetime.now(timezone.utc) + timedelta(hours=remaining_hours)
+    payload = {
+        "sub": email,
+        "exp": exp,
+        "iat": datetime.now(timezone.utc),
+    }
+    return jwt.encode(payload, settings.SECRET_KEY, algorithm=ALGORITHM)
+
+
+def _decode_exp_hours(token: str) -> float:
+    """Calcula horas restantes hasta `exp` del JWT."""
+    payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
+    exp_dt = datetime.fromtimestamp(int(payload["exp"]), tz=timezone.utc)
+    return (exp_dt - datetime.now(timezone.utc)).total_seconds() / 3600
+
+
+class TestSlidingSessionRefresh:
+    @pytest.mark.asyncio
+    async def test_refresh_fires_when_under_threshold(self, client_no_auth):
+        """Token con <24h de vida → el middleware emite uno nuevo en la
+        response (cookie + header `X-Refreshed-Token`)."""
+        # Token a punto de vencer: 2h de vida (umbral: 24h → debe refrescar).
+        old_token = _make_token_with_remaining("test@test.com", remaining_hours=2)
+
+        res = await client_no_auth.get(
+            "/api/quotes",
+            headers={"Authorization": f"Bearer {old_token}"},
+        )
+        assert res.status_code != 401
+        # El header expuesto debe tener el token fresco.
+        refreshed = res.headers.get("X-Refreshed-Token") or res.headers.get("x-refreshed-token")
+        assert refreshed, "esperaba X-Refreshed-Token en la response"
+        assert refreshed != old_token, "el token nuevo debe diferir del viejo"
+        # Y debe tener ~72h de vida (TOKEN_EXPIRY_HOURS).
+        remaining = _decode_exp_hours(refreshed)
+        assert remaining > TOKEN_EXPIRY_HOURS - 1  # tolerancia 1h
+        # La cookie también se re-emite.
+        assert COOKIE_NAME in res.cookies
+
+    @pytest.mark.asyncio
+    async def test_no_refresh_when_above_threshold(self, client_no_auth):
+        """Token fresco (ej: acabado de emitir, ~72h) → no refresh — evita
+        spam de Set-Cookie/header en cada request cuando la sesión está
+        lejos de vencer."""
+        fresh_token = create_token("test@test.com")
+        res = await client_no_auth.get(
+            "/api/quotes",
+            headers={"Authorization": f"Bearer {fresh_token}"},
+        )
+        assert res.status_code != 401
+        assert res.headers.get("X-Refreshed-Token") is None
+        assert res.headers.get("x-refreshed-token") is None
+
+    @pytest.mark.asyncio
+    async def test_expired_token_returns_401_no_refresh(self, client_no_auth):
+        """Token ya vencido (remaining < 0) → 401 con 'Sesión expirada'.
+        No refresh (no podemos re-emitir en un token que no es válido)."""
+        expired = _make_token_with_remaining("test@test.com", remaining_hours=-1)
+        res = await client_no_auth.get(
+            "/api/quotes",
+            headers={"Authorization": f"Bearer {expired}"},
+        )
+        assert res.status_code == 401
+        assert res.json()["detail"] == "Sesión expirada"
+        assert res.headers.get("X-Refreshed-Token") is None
+
+    @pytest.mark.asyncio
+    async def test_no_token_returns_401_no_authenticado(self, client_no_auth):
+        """Sin token ni cookie → 401 con 'No autenticado'. El string es
+        el contract que el frontend matchea para el redirect a /login."""
+        res = await client_no_auth.get("/api/quotes")
+        assert res.status_code == 401
+        assert res.json()["detail"] == "No autenticado"
+
+    @pytest.mark.asyncio
+    async def test_refresh_at_threshold_boundary(self, client_no_auth):
+        """Token con exactamente REFRESH_THRESHOLD_HOURS - 0.1h de vida
+        (apenas bajo el umbral) → sí refresh.
+        Token con exactamente REFRESH_THRESHOLD_HOURS + 0.1h → no refresh."""
+        just_under = _make_token_with_remaining(
+            "test@test.com",
+            remaining_hours=REFRESH_THRESHOLD_HOURS - 0.1,
+        )
+        res1 = await client_no_auth.get(
+            "/api/quotes",
+            headers={"Authorization": f"Bearer {just_under}"},
+        )
+        assert res1.headers.get("X-Refreshed-Token"), "justo bajo umbral debe refrescar"
+
+        just_over = _make_token_with_remaining(
+            "test@test.com",
+            remaining_hours=REFRESH_THRESHOLD_HOURS + 0.1,
+        )
+        res2 = await client_no_auth.get(
+            "/api/quotes",
+            headers={"Authorization": f"Bearer {just_over}"},
+        )
+        assert res2.headers.get("X-Refreshed-Token") is None, "justo sobre umbral NO debe refrescar"

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,21 +1,48 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useEffect, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { login } from "@/lib/auth";
 import clsx from "clsx";
 
+// Next.js 14 requiere que cualquier componente que use `useSearchParams`
+// esté dentro de un `<Suspense>` boundary para que la prerender estática
+// no falle. Lo envolvemos al nivel del export default y el componente
+// real queda con toda la lógica adentro.
 export default function LoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginForm />
+    </Suspense>
+  );
+}
+
+function LoginForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [showPw, setShowPw] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  // PR #389 — banner informativo cuando caemos acá por sesión vencida.
+  // `handleAuthError` en `lib/api.ts` agrega `?reason=expired` al redirect.
+  const expiredReason = searchParams?.get("reason") === "expired";
+  const [showExpiredBanner, setShowExpiredBanner] = useState(expiredReason);
+
+  useEffect(() => {
+    // Limpiar el flag de redirecting al aterrizar en /login — si no,
+    // un refresh manual de esta misma página dejaría el flag vivo y el
+    // próximo 401 post-login no podría redirigir.
+    try {
+      window.sessionStorage.removeItem("dangelo:redirecting");
+    } catch { /* ignore */ }
+  }, []);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
+    setShowExpiredBanner(false);
     setLoading(true);
     try {
       await login(username, password);
@@ -53,6 +80,18 @@ export default function LoginPage() {
             Sistema de presupuestos
           </div>
         </div>
+
+        {/* PR #389 — banner de sesión expirada. Aparece cuando
+            `handleAuthError` redirige con ?reason=expired. Se oculta al
+            intentar login o al mostrar un error de credenciales. */}
+        {showExpiredBanner && !error && (
+          <div className="flex items-center gap-2 px-3.5 py-2.5 bg-amb/[0.08] border border-amb/[0.25] rounded-lg text-[13px] text-amb mb-4 animate-[fadeUp_0.2s_ease]">
+            <svg className="shrink-0" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
+            </svg>
+            <span>Tu sesión expiró. Iniciá sesión de nuevo para seguir.</span>
+          </div>
+        )}
 
         {/* Error */}
         {error && (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -21,23 +21,49 @@ function resolveApiBase(): string {
 const API_BASE = resolveApiBase();
 
 /**
- * Antes: cualquier 401 redirigía automáticamente a /login. Problema: si
- * un SOLO fetch secundario (ej: una de las 3 requests que hace /config
- * al montar) devolvía 401 por cualquier motivo transiente (cross-origin
- * cookie issue, redirect chain, expired token en un endpoint pero no en
- * otros), el usuario era pateado a login sin ver el error real.
+ * Historia: PR antiguo redirigía a /login en CUALQUIER 401 → bug con
+ * 401 transientes (cross-origin cookie issues, expired token en un
+ * endpoint pero no en otros). Desde entonces era no-op: ningún 401 se
+ * atendía y el user quedaba en UI zombi cuando la sesión vencía.
  *
- * Ahora: NO redirigimos automáticamente. Dejamos que el error burbujee
- * como cualquier otro — el caller muestra toast o inline error. El
- * usuario mantiene su sesión y puede decidir si volver a loguearse
- * manualmente. Si la cookie realmente expiró todas las siguientes
- * requests fallarán con 401, pero al menos ve QUÉ está pasando en vez
- * de un rebote misterioso a /login.
+ * PR #389: detectar solo los 401 **determinísticos del backend** (los
+ * strings exactos que emite `auth.py` del middleware cuando el token
+ * no existe o expiró) y en ese caso limpiar + redirigir. Cualquier otro
+ * 401 (rutas privadas que devuelven 401 por otra razón, 401 transiente
+ * cross-origin raro) sigue siendo no-op → preserva la robustez
+ * histórica contra falsos positivos.
  *
- * El flujo de login/logout explícito sigue funcionando (auth.ts).
+ * Side-effect: el backend con sliding refresh ahora extiende la sesión
+ * en cada request mientras el token esté vivo. Solo vas a llegar a
+ * `handleAuthError` si DE VERDAD dejaste el navegador inactivo >24h
+ * después del último refresh.
  */
-function handleAuthError(_res: Response): void {
-  // no-op intentional — ver doc arriba
+const AUTH_EXPIRED_DETAILS = new Set([
+  "Sesión expirada",
+  "No autenticado",
+]);
+
+function handleAuthError(res: Response): void {
+  if (res.status !== 401) return;
+  if (typeof window === "undefined") return;
+  // Evitar que 3 fetchs concurrentes (ej: /quotes + /quotes/check + /usage)
+  // disparen 3 redirects en paralelo. sessionStorage dura lo que la pestaña.
+  try {
+    if (window.sessionStorage.getItem("dangelo:redirecting") === "1") return;
+  } catch { /* storage inaccessible — seguir igual */ }
+
+  // Clonar para no consumir el body del caller. Sin await: fire-and-forget.
+  res.clone().json().then((body) => {
+    const detail = typeof body?.detail === "string" ? body.detail : "";
+    if (!AUTH_EXPIRED_DETAILS.has(detail)) return;
+    try { window.sessionStorage.setItem("dangelo:redirecting", "1"); } catch {}
+    try { localStorage.removeItem("dangelo:token"); } catch {}
+    // Si ya estamos en /login no hace falta navegar — evita loops cuando
+    // el propio /api/auth/check durante el login devuelve 401.
+    const path = window.location?.pathname || "";
+    if (path.startsWith("/login")) return;
+    window.location.href = "/login?reason=expired";
+  }).catch(() => { /* body no parseable — no redirigir por las dudas */ });
 }
 
 /**
@@ -73,8 +99,9 @@ export function withAuthHeader(init?: RequestInit): RequestInit {
  * Uso: `apiFetch(url, init)` en lugar de `fetch(url, init)`.
  */
 export async function apiFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  let res: Response;
   try {
-    return await fetch(input, withAuthHeader(init));
+    res = await fetch(input, withAuthHeader(init));
   } catch (err: any) {
     // TypeError: Failed to fetch (Chrome/Safari) / NetworkError (Firefox)
     if (err instanceof TypeError || err?.name === "NetworkError") {
@@ -82,6 +109,19 @@ export async function apiFetch(input: RequestInfo | URL, init?: RequestInit): Pr
     }
     throw err;
   }
+  // PR #389 — sliding session refresh. Si al token le quedaban <24h, el
+  // backend emite un JWT nuevo en el header `X-Refreshed-Token` (además
+  // de Set-Cookie). Sincronizamos el fallback de localStorage — es lo
+  // que usa `withAuthHeader` cuando la cookie cross-origin no viaja
+  // (iOS Safari con ITP). Sin esto, el fallback se quedaba con el token
+  // viejo post-expiración y recién al vencer el fallback iba a /login.
+  try {
+    const refreshed = res.headers.get("X-Refreshed-Token");
+    if (refreshed && typeof window !== "undefined") {
+      localStorage.setItem("dangelo:token", refreshed);
+    }
+  } catch { /* ignore storage errors */ }
+  return res;
 }
 
 export interface ResumenObraRecord {
@@ -663,6 +703,17 @@ export async function* streamChat(
     throw new Error("No se pudo conectar con Valentina. Intentá de nuevo.");
   }
   clearTimeout(connectTimeout);
+
+  // PR #389 — mismo capture de refresh token + detección 401 que apiFetch.
+  // streamChat hace fetch directo (sin apiFetch) porque el body es un
+  // ReadableStream (SSE), pero igual participa en el sliding session flow.
+  try {
+    const refreshed = res.headers.get("X-Refreshed-Token");
+    if (refreshed && typeof window !== "undefined") {
+      localStorage.setItem("dangelo:token", refreshed);
+    }
+  } catch { /* ignore */ }
+  handleAuthError(res);
 
   if (!res.ok) {
     if (res.status === 400) {


### PR DESCRIPTION
## Problema

Dos bugs encadenados:

1. **Backend**: JWT con TTL absoluto de 72h, sin mecanismo de refresh. El token nace con \`exp\` fijo y muere a las 72h sin importar actividad. Operador activo → mismo corte abrupto que un operador abandonado.
2. **Frontend**: \`handleAuthError\` era literalmente \`// no-op\` (decisión histórica por 401 transientes cross-origin). Cuando la sesión vence, el polling de \`/api/quotes\` y \`/api/quotes/check\` tira 401 silenciosamente y el user queda en **UI zombi**. Errors en consola, interacciones muertas.

Síntoma reportado: dejar el navegador abierto varias horas → consola llena de \`401 (Unauthorized)\`, la app no redirige a login.

## Solución (causa raíz en dos frentes)

### Backend — sliding refresh

\`api/app/core/auth.py\`:

- Nueva constante \`REFRESH_THRESHOLD_HOURS = 24\`.
- En \`auth_middleware\`, después de validar el token y completar la request, si quedan <24h de vida:
  - Emitir token nuevo con \`exp = now + 72h\`.
  - Re-set cookie \`auth_token\`.
  - Agregar header \`X-Refreshed-Token: <new_jwt>\` a la response.
- CORS expone \`X-Refreshed-Token\` (para que el JS pueda leerlo en cross-origin).

**Efecto**: un operador que hace cualquier click dentro de las ~48h (72h - 24h de margen) nunca vende sesión. Si deja la app quieta >24h, al próximo click el token vigente tendrá <24h → refresh silencioso. Si deja >72h idle desde la última request, ahí sí vence y el próximo click devuelve 401.

### Frontend — detectar 401 real + redirigir

\`web/src/lib/api.ts\`:

- \`handleAuthError\` detecta:
  - \`res.status === 401\`
  - body con \`{detail: "Sesión expirada" | "No autenticado"}\` (los strings exactos que emite \`auth.py\` en el middleware).
- Si matchea → \`localStorage.removeItem("dangelo:token")\` + \`window.location.href = "/login?reason=expired"\`.
- 401 con otro \`detail\` (401 transientes, otros endpoints): **siguen siendo no-op**. Preserva la robustez histórica contra falsos positivos.
- Flag \`sessionStorage["dangelo:redirecting"]\` evita que N fetchs concurrentes disparen N redirects.
- \`apiFetch\` + \`streamChat\` capturan \`X-Refreshed-Token\` y sincronizan \`localStorage\` (fallback iOS Safari ITP).

\`/login\` page:
- Banner amber "Tu sesión expiró. Iniciá sesión de nuevo para seguir." cuando \`?reason=expired\`.
- Limpia el flag \`redirecting\` al montar (para poder reaccionar a próximos 401 post-login).
- \`useSearchParams\` envuelto en \`<Suspense>\` (requisito de Next 14).

## Cómo ataca la causa raíz

| Caso | Antes | Ahora |
|---|---|---|
| User activo llegando a las 72h | Corte abrupto, 401s en polling | Token se refresca automáticamente en cada request mientras le queden <24h |
| User inactivo >72h | 401s silenciosos + UI zombi | Redirect a /login con banner explicativo |
| 401 transiente en 1 endpoint (cross-origin, expired en un endpoint pero no otro) | No-op (correcto) | No-op (se mantiene — solo redirige si el detail matchea "Sesión expirada" o "No autenticado") |

## Test plan

- [x] **Backend** — 5 tests nuevos (\`TestSlidingSessionRefresh\`):
  - Token con <24h emite \`X-Refreshed-Token\` + cookie nueva.
  - Token con >24h NO emite.
  - Token expirado → 401 "Sesión expirada" sin header nuevo.
  - Sin token → 401 "No autenticado".
  - Boundary test: 23.9h sí / 24.1h no.
- [x] Suite API full: 1626 passed, 1 pre-existente (edificios).
- [x] **Frontend** — \`tsc --noEmit\` + \`next lint\` + \`next build\` limpios.
- [ ] **Manual post-merge**:
  - Login → hacer 1 request → ver cookie nueva en DevTools (si el token estaba fresco, ignorar; si venía de una sesión vieja <24h, esperar el \`X-Refreshed-Token\` en response headers).
  - Forzar expiración (dev: bajar \`TOKEN_EXPIRY_HOURS\` a minutos) → esperar → ver redirect a \`/login?reason=expired\` con banner.
  - Verificar que no haya loops en el redirect si el propio \`/login\` tira 401.

## Alcance

- 2 archivos backend (\`auth.py\`, \`main.py\`) + 1 test (\`test_auth.py\`).
- 2 archivos frontend (\`lib/api.ts\`, \`app/login/page.tsx\`).
- Ningún otro caller afectado. \`apiFetch\`/\`streamChat\` son puntos únicos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)