### PR TITLE
fix(ux): reopen links visibles — amber + 11px + separador

### DIFF
--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -806,13 +806,23 @@ export default function QuotePage() {
                            gritones. Al click el modal da el warning
                            destructivo completo. */}
               <ChatInput input={input} setInput={setInput} files={attachedFiles} setFiles={setAttachedFiles} multiPiece={multiPiece} setMultiPiece={setMultiPiece} dragActive={dragActive} setDragActive={setDragActive} dragCounterRef={dragCounter} sending={sending} send={send} onKey={onKey} fileRef={fileRef} />
-              <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 mt-[7px]">
+              {/* PR #391 — ajuste de visibilidad sobre #390. Los links quedaron
+                  en 10px + color t3 (gris genérico) → se camuflaban con el
+                  hint del teclado. Ahora: 11px, color amb/80 (amber tenue —
+                  diferenciable del gris del hint), separador vertical `|`
+                  para cortar visualmente. Siguen sutiles, pero se leen como
+                  acción. */}
+              <div className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 mt-[7px]">
                 <span className="text-[10px] text-t4">{`Enter para enviar ${DOT} Shift+Enter para nueva l${I}nea`}</span>
+                {(quote?.quote_breakdown?.verified_context
+                  || quote?.quote_breakdown?.verified_context_analysis) && (
+                  <span className="text-[10px] text-b2" aria-hidden="true">|</span>
+                )}
                 {quote?.quote_breakdown?.verified_context && (
                   <button
                     type="button"
                     onClick={() => setReopenModal({ open: true, busy: false })}
-                    className="text-[10px] text-t3 hover:text-amb transition underline-offset-2 hover:underline"
+                    className="text-[11px] text-amb/80 hover:text-amb transition underline-offset-2 hover:underline font-medium"
                     title="Invalida el cálculo actual y vuelve a edición del despiece"
                   >
                     ↩ Editar despiece
@@ -822,7 +832,7 @@ export default function QuotePage() {
                   <button
                     type="button"
                     onClick={() => setContextModal({ open: true, busy: false })}
-                    className="text-[10px] text-t3 hover:text-amb transition underline-offset-2 hover:underline"
+                    className="text-[11px] text-amb/80 hover:text-amb transition underline-offset-2 hover:underline font-medium"
                     title="Invalida Paso 2 y medidas; vuelve a edición del contexto"
                   >
                     ↩ Editar contexto


### PR DESCRIPTION
## Contexto

#390 movió los reopen buttons abajo del input como links ghost. Pero me pasé de ghost: quedaron en \`text-[10px] text-t3\` — exactamente el mismo tamaño y color genérico gris que el hint "Enter para enviar". Visualmente se camuflaron como un solo bloque de metadata gris.

Feedback del operador tras refresh sobre un quote post-confirmación:

> no veo como editar el despiece

## Cambio

Mantener posición y espíritu del #390, pero ajustar para que se lean como **acción** y no como más texto pasivo:

| | Antes (#390) | Ahora (#391) |
|---|---|---|
| Tamaño | 10px (= hint) | 11px (+1 vs hint) |
| Color | \`text-t3\` (gris genérico) | \`text-amb/80\` (amber tenue) |
| Peso | regular | \`font-medium\` |
| Separador del hint | \`·\` (mismo que el hint usa internamente) | \`\|\` (separador visual explícito) |
| Hover | \`text-amb\` + underline | \`text-amb\` + underline (igual) |

## Por qué esta combinación

- **11px vs 10px**: diferencia mínima pero perceptible. Los ojos escanean jerarquía por tamaño primero.
- **amber/80**: mismo color family que el "Medidas verificadas ✅" pill, coherente con el rol "action sobre el estado del quote". \`/80\` = semi-opaco, no grita.
- **\`font-medium\`**: los links pasivos tienden a regular; los links accionables tienen peso. Diferencia sutil pero importante.
- **Separador \`|\`**: corta visualmente el bloque "metadata del input" de las "acciones secundarias". El \`·\` ya está dentro del hint (entre "Enter para enviar" y "Shift+Enter") — reusarlo diluye el corte.

Los 3 cambios juntos hacen que sea imposible perderlos de vista aunque sigan siendo 11px + ghost.

## Qué no cambia

- Posición: debajo del input, misma fila que el hint.
- Copy corto (sin "invalida el cálculo actual" en el label).
- Modal destructivo al click (warning completo vive ahí).
- Gates: solo aparecen si el quote está en \`draft\` + tiene \`verified_context\` / \`verified_context_analysis\`.

## Test plan

- [x] \`tsc --noEmit\` limpio.
- [ ] **Manual**: quote con medidas confirmadas → los links deberían saltar como amber claro, diferenciables del "Enter para enviar" gris.
- [ ] Hover → full amber + underline.
- [ ] Click → modal existente.

## Si después del deploy sigue sin verse

Señal de que la opción "link debajo del input" no es el lugar correcto. El feedback original del operador mencionaba una alternativa: **barra de acciones arriba del chat cerca del estado del quote** (junto al pill "Medidas verificadas ✅"). En ese caso lo movería ahí en un PR siguiente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)