### PR TITLE
fix(derivados): re-aplicar answers del contexto sobre dual_read final en DUAL_READ_CONFIRMED

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1754,44 +1754,78 @@ class AgentService:
                 log_build_commercial_attrs(
                     quote_id, flow="dual-read-confirmed", result=_commercial_attrs,
                 )
-                # PR #386 — Fuente única de verdad para las patas de isla:
-                # el despiece (`_confirmed_json`) viene con los tramos
-                # `_derived:true` del `[CONTEXT_CONFIRMED]` y posiblemente
-                # editados por el operador en la card. Skipeamos el
-                # re-cálculo para respetar esos edits. Si por alguna razón
-                # los tramos derivados no están (caso legacy o
-                # flow text-only pre-#386), caemos al cálculo determinístico
-                # y los agregamos como tramos antes de emitir.
+                # PR #393 — Re-aplicar answers del contexto sobre el
+                # `_confirmed_json` final. Caso Bernardi 2026-04-24: el
+                # parser dejó R1/R2 sin medir; el operador los editó en la
+                # card; al confirmar medidas los derivados (alzada, frentín,
+                # regrueso) quedaban con los ml/perímetros viejos (null).
+                #
+                # Orden acordado con el operador:
+                #   1. apply_answers — rescribe frentin[]/regrueso[] con
+                #      ml=largo_actual; re-escribe alzada/alzada_alto_m.
+                #   2. merge_alzada_tramos_into_dual_read — regenera tramos
+                #      "Alzada <sector>" con perímetro actual (no-derivados).
+                #   3. build_derived_isla_pieces + merge — regenera patas
+                #      con el largo de isla actual.
+                #   4. build_verified_context — texto con todo materializado.
+                #
+                # "Replace, no merge blando": cada helper pisa el kind
+                # correspondiente. Ninguno hace append. Answers son fuente
+                # de verdad; si el operador editó item derivado (ej: alto
+                # de pata), ese cambio se pierde — debe editar la answer
+                # vía reopen-context.
                 from app.modules.quote_engine.dual_reader import (
-                    dual_read_has_derived_pieces,
                     merge_derived_pieces_into_dual_read,
+                    merge_alzada_tramos_into_dual_read,
                 )
-                if dual_read_has_derived_pieces(_confirmed_json):
-                    # Ya están como tramos — no recalcular. Claude los ve
-                    # como parte del SECTOR: ISLA del verified_context.
-                    _derived_pieces = []
-                    _derived_warnings = []
-                    logging.info(
-                        f"[trace:dual-read-confirmed:{quote_id}] "
-                        "derived pieces already materialized as tramos in dual_read — skipping recompute"
-                    )
-                else:
-                    _derived_pieces, _derived_warnings = build_derived_isla_pieces(
-                        operator_answers=_op_answers,
-                        verified_measurements=_confirmed_json,
-                    )
-                    log_build_derived_isla_pieces(
-                        quote_id,
-                        flow="dual-read-confirmed",
-                        pieces=_derived_pieces,
-                        warnings=_derived_warnings,
-                    )
-                    if _derived_pieces:
-                        # Backfill para quotes legacy: mergear al despiece
-                        # para que Paso 2 y PDF lean de una sola fuente.
-                        _confirmed_json = merge_derived_pieces_into_dual_read(
-                            _confirmed_json, _derived_pieces,
+                if _op_answers_ctx:
+                    try:
+                        _dr_before_re = json.loads(json.dumps(_confirmed_json, default=str))
+                        apply_answers(_confirmed_json, _op_answers_ctx)
+                        log_apply_answers(
+                            quote_id,
+                            flow="dual-read-confirmed/re-apply-ctx",
+                            dual_before=_dr_before_re,
+                            dual_after=_confirmed_json,
+                            answers=_op_answers_ctx,
                         )
+                    except Exception as _e_re:
+                        logging.warning(
+                            f"[dual-read-confirmed:{quote_id}] re-apply ctx "
+                            f"answers failed: {_e_re}"
+                        )
+
+                # Materializar alzada con los largos finales (replace por
+                # `_derived_kind="alzada"`).
+                _alzada_active_final = bool(_confirmed_json.get("alzada"))
+                _alzada_alto_final = _confirmed_json.get("alzada_alto_m")
+                _confirmed_json = merge_alzada_tramos_into_dual_read(
+                    _confirmed_json,
+                    alto_m=_alzada_alto_final,
+                    active=_alzada_active_final,
+                )
+                logging.info(
+                    f"[trace:dual-read-confirmed:{quote_id}] re-materialized "
+                    f"alzada active={_alzada_active_final} alto_m={_alzada_alto_final}"
+                )
+
+                # Materializar patas de isla con el largo actual de la isla
+                # y las answers finales (replace por `_derived_kind="isla_pata"`).
+                # Llamamos siempre — incluso con _derived_pieces=[] el merge
+                # limpia las patas viejas si el operador cambió a "no patas".
+                _derived_pieces, _derived_warnings = build_derived_isla_pieces(
+                    operator_answers=_op_answers,
+                    verified_measurements=_confirmed_json,
+                )
+                log_build_derived_isla_pieces(
+                    quote_id,
+                    flow="dual-read-confirmed",
+                    pieces=_derived_pieces,
+                    warnings=_derived_warnings,
+                )
+                _confirmed_json = merge_derived_pieces_into_dual_read(
+                    _confirmed_json, _derived_pieces,
+                )
                 # PR #386 — NO pasar `derived_pieces` a build_verified_context.
                 # Las patas ya están como tramos del sector isla y se renderizan
                 # naturalmente bajo `SECTOR: ISLA` en el verified_context text.

--- a/api/tests/test_derived_pieces_merge.py
+++ b/api/tests/test_derived_pieces_merge.py
@@ -27,6 +27,8 @@ from app.modules.quote_engine.dual_reader import (
     build_verified_context,
     _sector_visible_perimeter,
 )
+from app.modules.quote_engine.pending_questions import apply_answers
+import json
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -546,3 +548,300 @@ class TestAlzadaAppearsInVerifiedContext:
         # La pata frontal aparece 2 veces (tramos + bloque derivado).
         assert ctx_bad.count("Pata frontal isla") == 2
         assert "PIEZAS DERIVADAS" in ctx_bad
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PR #393 — Re-aplicar derivados en [DUAL_READ_CONFIRMED]
+# ═══════════════════════════════════════════════════════════════════════
+#
+# Bug raíz: si el operador edita largos en la card post-CONTEXT_CONFIRMED,
+# los derivados materializados en context-confirmed quedan stale (alzada
+# con perímetro viejo, frentín/regrueso con ml=0 si el parser había
+# dejado null).
+#
+# Fix: en DUAL_READ_CONFIRMED, re-aplicar answers del contexto sobre el
+# _confirmed_json final + re-materializar alzada/patas con las medidas
+# actuales. Replace, no merge blando.
+#
+# Estos tests reproducen la composición del handler sin tocar DB. Si
+# alguno se rompe, el handler debe sincronizarse con el nuevo contrato.
+
+
+def _simulate_dual_read_confirmed_pipeline(
+    confirmed_json: dict,
+    op_answers_ctx: list[dict],
+) -> dict:
+    """Simula el pipeline del handler [DUAL_READ_CONFIRMED] post-#393
+    sobre un dict puro. Útil para tests sin DB.
+
+    Orden:
+      1. apply_answers(op_answers_ctx) → rescribe frentin/regrueso/alzada
+      2. merge_alzada_tramos_into_dual_read → tramos "Alzada <sector>"
+      3. build_derived_isla_pieces + merge → tramos patas isla
+    """
+    out = json.loads(json.dumps(confirmed_json, default=str))
+    if op_answers_ctx:
+        apply_answers(out, op_answers_ctx)
+    out = merge_alzada_tramos_into_dual_read(
+        out,
+        alto_m=out.get("alzada_alto_m"),
+        active=bool(out.get("alzada")),
+    )
+    derived_pieces, _ = build_derived_isla_pieces(op_answers_ctx, out)
+    out = merge_derived_pieces_into_dual_read(out, derived_pieces)
+    return out
+
+
+class TestReapplyDerivadosBernardiNullEditado:
+    """Caso real Bernardi 2026-04-24: el parser dejó R1/R2 sin medir.
+    El operador edita los largos en la card. Al confirmar medidas, los
+    derivados deben materializarse con esos largos."""
+
+    def _confirmed_with_null_cocinas(self) -> dict:
+        """Shape post-CONTEXT_CONFIRMED (pre-edit): R1/R2 con largo=None,
+        isla R3 con valores. Alzada ya seteada por context-confirmed
+        (pero sin tramo alzada porque perímetro=0)."""
+        return {
+            "sectores": [
+                {
+                    "id": "sector_cocina", "tipo": "cocina",
+                    "tramos": [
+                        {"id": "R1", "descripcion": "Mesada (con anafe, pileta)",
+                         "largo_m": {"valor": None}, "ancho_m": {"valor": None},
+                         "m2": {"valor": None},
+                         "zocalos": [], "frentin": [], "regrueso": []},
+                        {"id": "R2", "descripcion": "Mesada 2",
+                         "largo_m": {"valor": None}, "ancho_m": {"valor": None},
+                         "m2": {"valor": None},
+                         "zocalos": [], "frentin": [], "regrueso": []},
+                    ],
+                },
+                {
+                    "id": "sector_isla", "tipo": "isla",
+                    "tramos": [
+                        {"id": "R3", "descripcion": "Mesada isla",
+                         "largo_m": {"valor": 1.60}, "ancho_m": {"valor": 0.70},
+                         "m2": {"valor": 1.12},
+                         "zocalos": [], "frentin": [], "regrueso": []},
+                    ],
+                },
+            ],
+            "alzada": True,
+            "alzada_alto_m": 0.05,
+        }
+
+    def _answers_bernardi(self) -> list[dict]:
+        return [
+            {"id": "alzada", "value": "5"},
+            {"id": "frentin", "value": "no"},
+            {"id": "regrueso", "value": "2"},
+            {"id": "isla_patas", "value": "no"},
+        ]
+
+    def test_after_edit_alzada_cocina_has_correct_perimeter(self):
+        """Operador edita R1=2.05 y R2=2.95. Post DUAL_READ_CONFIRMED la
+        alzada cocina debe tener perímetro = 5.00m."""
+        confirmed = self._confirmed_with_null_cocinas()
+        cocina = confirmed["sectores"][0]
+        cocina["tramos"][0]["largo_m"] = {"valor": 2.05}
+        cocina["tramos"][0]["ancho_m"] = {"valor": 0.60}
+        cocina["tramos"][0]["m2"] = {"valor": 1.23}
+        cocina["tramos"][1]["largo_m"] = {"valor": 2.95}
+        cocina["tramos"][1]["ancho_m"] = {"valor": 0.60}
+        cocina["tramos"][1]["m2"] = {"valor": 1.77}
+
+        out = _simulate_dual_read_confirmed_pipeline(confirmed, self._answers_bernardi())
+
+        cocina_out = next(s for s in out["sectores"] if s["tipo"] == "cocina")
+        alzada = next(
+            (t for t in cocina_out["tramos"] if t.get("_derived_kind") == "alzada"),
+            None,
+        )
+        assert alzada is not None, "esperaba tramo Alzada cocina post-edit"
+        assert alzada["descripcion"] == "Alzada sector_cocina"
+        assert alzada["largo_m"]["valor"] == 5.00
+        assert alzada["ancho_m"]["valor"] == 0.05
+        assert alzada["m2"]["valor"] == 0.25
+
+    def test_after_edit_regrueso_ml_matches_new_largos(self):
+        """Regrueso=2cm. ml debe ser el largo editado (2.05 y 2.95), no 0."""
+        confirmed = self._confirmed_with_null_cocinas()
+        cocina = confirmed["sectores"][0]
+        cocina["tramos"][0]["largo_m"] = {"valor": 2.05}
+        cocina["tramos"][0]["ancho_m"] = {"valor": 0.60}
+        cocina["tramos"][1]["largo_m"] = {"valor": 2.95}
+        cocina["tramos"][1]["ancho_m"] = {"valor": 0.60}
+
+        out = _simulate_dual_read_confirmed_pipeline(confirmed, self._answers_bernardi())
+
+        cocina_out = next(s for s in out["sectores"] if s["tipo"] == "cocina")
+        no_derived = [t for t in cocina_out["tramos"] if not t.get("_derived")]
+        assert no_derived[0]["regrueso"] == [
+            {"lado": "frente", "ml": 2.05, "alto_m": 0.02}
+        ]
+        assert no_derived[1]["regrueso"] == [
+            {"lado": "frente", "ml": 2.95, "alto_m": 0.02}
+        ]
+
+    def test_after_edit_isla_no_alzada(self):
+        """Sector isla nunca recibe alzada. Con edits en cocina, la isla
+        sigue con 1 tramo (su mesada original)."""
+        confirmed = self._confirmed_with_null_cocinas()
+        confirmed["sectores"][0]["tramos"][0]["largo_m"] = {"valor": 2.05}
+        confirmed["sectores"][0]["tramos"][0]["ancho_m"] = {"valor": 0.60}
+
+        out = _simulate_dual_read_confirmed_pipeline(confirmed, self._answers_bernardi())
+
+        isla = next(s for s in out["sectores"] if s["tipo"] == "isla")
+        alzadas_isla = [
+            t for t in isla["tramos"] if t.get("_derived_kind") == "alzada"
+        ]
+        assert len(alzadas_isla) == 0
+        # La isla debe tener solo su mesada original (no answers de patas).
+        assert len(isla["tramos"]) == 1
+
+
+class TestReapplyDerivadosEditParserDetected:
+    """El parser detectó un largo, el operador lo corrige en la card
+    (ej: 2.00 → 2.10). Los derivados deben recalcularse con el valor
+    corregido."""
+
+    def test_edited_largo_propagates_to_alzada_perimeter(self):
+        confirmed = {
+            "sectores": [
+                {"id": "cocina", "tipo": "cocina", "tramos": [
+                    {"id": "R1", "descripcion": "Cocina",
+                     "largo_m": {"valor": 2.00}, "ancho_m": {"valor": 0.60},
+                     "m2": {"valor": 1.20},
+                     "zocalos": [], "frentin": [], "regrueso": []},
+                ]},
+            ],
+            "alzada": True,
+            "alzada_alto_m": 0.10,
+        }
+        answers = [
+            {"id": "alzada", "value": "10"},
+            {"id": "frentin", "value": "5"},
+            {"id": "regrueso", "value": "no"},
+            {"id": "isla_patas", "value": "no"},
+        ]
+
+        # Simular context-confirmed: alzada con perímetro=2.00
+        with_ctx = merge_alzada_tramos_into_dual_read(
+            json.loads(json.dumps(confirmed, default=str)),
+            alto_m=0.10, active=True,
+        )
+        alzada_ctx = next(
+            t for t in with_ctx["sectores"][0]["tramos"]
+            if t.get("_derived_kind") == "alzada"
+        )
+        assert alzada_ctx["largo_m"]["valor"] == 2.00
+
+        # Operador edita R1 largo=2.00 → 2.10.
+        with_ctx["sectores"][0]["tramos"][0]["largo_m"] = {"valor": 2.10}
+        # Frentín pre-edit tenía ml=2.00 (stale).
+        with_ctx["sectores"][0]["tramos"][0]["frentin"] = [
+            {"lado": "frente", "ml": 2.00, "alto_m": 0.05},
+        ]
+
+        # Pipeline DUAL_READ_CONFIRMED post-#393.
+        out = _simulate_dual_read_confirmed_pipeline(with_ctx, answers)
+
+        # Alzada: perímetro recalculado con largo nuevo.
+        tramos = out["sectores"][0]["tramos"]
+        alzada_new = next(t for t in tramos if t.get("_derived_kind") == "alzada")
+        assert alzada_new["largo_m"]["valor"] == 2.10
+
+        # Frentín: ml recalculado con largo nuevo (replace, no append).
+        mesada = next(t for t in tramos if not t.get("_derived"))
+        assert mesada["frentin"] == [{"lado": "frente", "ml": 2.10, "alto_m": 0.05}]
+
+
+class TestReapplyDerivadosDobleConfirmSinDup:
+    """Doble DUAL_READ_CONFIRMED seguido no debe duplicar tramos derivados
+    ni items de frentín/regrueso."""
+
+    def test_two_passes_same_tramo_counts(self):
+        confirmed = {
+            "sectores": [
+                {"id": "cocina", "tipo": "cocina", "tramos": [
+                    {"id": "R1", "descripcion": "Cocina",
+                     "largo_m": {"valor": 2.00}, "ancho_m": {"valor": 0.60},
+                     "m2": {"valor": 1.20},
+                     "zocalos": [], "frentin": [], "regrueso": []},
+                    {"id": "R2", "descripcion": "Cocina 2",
+                     "largo_m": {"valor": 3.00}, "ancho_m": {"valor": 0.60},
+                     "m2": {"valor": 1.80},
+                     "zocalos": [], "frentin": [], "regrueso": []},
+                ]},
+            ],
+            "alzada": True,
+            "alzada_alto_m": 0.05,
+        }
+        answers = [
+            {"id": "alzada", "value": "5"},
+            {"id": "frentin", "value": "5"},
+            {"id": "regrueso", "value": "2"},
+            {"id": "isla_patas", "value": "no"},
+        ]
+
+        pass1 = _simulate_dual_read_confirmed_pipeline(confirmed, answers)
+        pass2 = _simulate_dual_read_confirmed_pipeline(pass1, answers)
+
+        cocina1 = next(s for s in pass1["sectores"] if s["tipo"] == "cocina")
+        cocina2 = next(s for s in pass2["sectores"] if s["tipo"] == "cocina")
+
+        assert len(cocina1["tramos"]) == len(cocina2["tramos"])
+
+        # Exactamente 1 tramo alzada — no 2.
+        alzadas2 = [t for t in cocina2["tramos"] if t.get("_derived_kind") == "alzada"]
+        assert len(alzadas2) == 1
+
+        # Cada mesada tiene exactamente 1 frentín y 1 regrueso.
+        mesadas = [t for t in cocina2["tramos"] if not t.get("_derived")]
+        assert len(mesadas) == 2
+        for m in mesadas:
+            assert len(m["frentin"]) == 1
+            assert len(m["regrueso"]) == 1
+
+
+class TestReapplyDerivadosLimpiezaPatasCambiadas:
+    """Si el operador reabre contexto y cambia `isla_patas` de 'sí' a
+    'no', las patas materializadas en el context-confirmed anterior se
+    deben limpiar en el siguiente DUAL_READ_CONFIRMED."""
+
+    def test_patas_cleaned_when_answer_changes_to_no(self):
+        # Pre-condición: isla con mesada + 3 patas ya materializadas.
+        confirmed = {
+            "sectores": [
+                {"id": "isla", "tipo": "isla", "tramos": [
+                    {"id": "R3", "descripcion": "Mesada isla",
+                     "largo_m": {"valor": 1.80}, "ancho_m": {"valor": 0.60},
+                     "m2": {"valor": 1.08},
+                     "zocalos": [], "frentin": [], "regrueso": []},
+                    {"id": "derived_pata_frontal_isla",
+                     "descripcion": "Pata frontal isla",
+                     "largo_m": {"valor": 1.80}, "ancho_m": {"valor": 0.90},
+                     "m2": {"valor": 1.62},
+                     "zocalos": [],
+                     "_derived": True, "_derived_kind": "isla_pata",
+                     "_derived_source": "old"},
+                ]},
+            ],
+        }
+        # Nuevo answer: operador cambió a "sin patas".
+        answers = [
+            {"id": "alzada", "value": "no"},
+            {"id": "frentin", "value": "no"},
+            {"id": "regrueso", "value": "no"},
+            {"id": "isla_patas", "value": "no"},
+        ]
+
+        out = _simulate_dual_read_confirmed_pipeline(confirmed, answers)
+
+        isla = out["sectores"][0]
+        # Solo la mesada original, sin patas viejas.
+        assert len(isla["tramos"]) == 1
+        assert not any(
+            t.get("_derived_kind") == "isla_pata" for t in isla["tramos"]
+        )


### PR DESCRIPTION
## Bug raíz (caso real Bernardi, 2026-04-24)

Cadena de 3 eslabones que dejaba el despiece sin alzada ni regrueso cuando el parser no medía todos los tramos:

1. **Parser falló en R1/R2**: multi_crop dejó \`largo_m=null\` en las 2 mesadas de cocina (no logró alinear las cotas del plano con los bbox de las regiones).
2. **CONTEXT_CONFIRMED corrió OK pero con largos null**:
   - merge_alzada calculó perímetro=0 (suma de largos null) → skip sector cocina → no se agregó "Alzada cocina".
   - apply_regrueso_answer intentó escribir items con \`ml = tramo.largo_m.valor = None → 0\` → \`_ml_for_lado\` retornó 0 → skip (\`if ml <= 0: continue\`).
3. **El operador editó R1/R2 en la card con los largos reales** (2.05, 2.95), pero **DUAL_READ_CONFIRMED no recalculaba derivados** → alzada ausente + regrueso sin items para R1/R2.

Los logs del trace del #385 mostraron exactamente esto:
\`\`\`
[trace:derived-pieces:...] count=0 pieces=[]
[trace:context-confirmed:...] alzada active=True alto_m=0.05
[trace:bd-mutation:...] dual_read_result:
  before: R1 largo=None, R2 largo=None, R3 largo=1.6
  after:  R1 largo=None, R2 largo=None, R3 largo=1.6  ← mismo, sin alzada
\`\`\`

Aunque R1/R2 hubieran sido detectados por el parser, el mismo bug aparece si el operador **edita** una medida entre CONTEXT_CONFIRMED y DUAL_READ_CONFIRMED. El flow asumía implícitamente "medidas finales al confirmar contexto"; no siempre es cierto.

## Fix (3 condiciones acordadas con el operador)

### 1. Orden correcto en \`[DUAL_READ_CONFIRMED]\` (\`agent.py\`)

\`\`\`
apply_answers(_confirmed_json, _op_answers_ctx)   # rescribe frentin/regrueso con ml=largo_actual
  ↓
merge_alzada_tramos_into_dual_read               # perímetro actualizado → tramos Alzada <sector>
  ↓
build_derived_isla_pieces + merge_derived_pieces # patas con largo de isla actual
  ↓
build_verified_context                           # texto con todo materializado
\`\`\`

### 2. Replace, no merge blando

- Removido el skip \`if dual_read_has_derived_pieces(_confirmed_json)\` (heredado de #386 que respetaba edits manuales). Ahora **siempre recalcular**.
- \`merge_alzada_tramos_into_dual_read\`: borra \`_derived_kind="alzada"\` antes de agregar.
- \`apply_frentin/regrueso_answer\`: reescriben arrays completos por tramo.
- \`merge_derived_pieces_into_dual_read\` llamado siempre (incluso con \`pieces=[]\` para limpiar patas viejas cuando operador cambia a "sin patas").
- **Answers son fuente de verdad**. Si el operador editó un item derivado en la card (ej: alto de pata), ese cambio se pisa → debe editar la answer vía \`reopen-context\`.

### 3. Tests con casos reales (6 nuevos)

\`TestReapplyDerivadosBernardiNullEditado\`:
- \`test_after_edit_alzada_cocina_has_correct_perimeter\` — R1/R2 null → operador edita 2.05 y 2.95 → alzada con perímetro 5.00m.
- \`test_after_edit_regrueso_ml_matches_new_largos\` — regrueso=2cm escribe items con ml={2.05, 2.95}, no 0.
- \`test_after_edit_isla_no_alzada\` — la isla no recibe alzada aunque se edite cocina.

\`TestReapplyDerivadosEditParserDetected\`:
- \`test_edited_largo_propagates_to_alzada_perimeter\` — parser detectó 2.00, operador lo corrige a 2.10 → alzada y frentín recalculados.

\`TestReapplyDerivadosDobleConfirmSinDup\`:
- \`test_two_passes_same_tramo_counts\` — 2 pipelines seguidos producen el mismo shape (no acumulación).

\`TestReapplyDerivadosLimpiezaPatasCambiadas\`:
- \`test_patas_cleaned_when_answer_changes_to_no\` — reconfirmar con \`isla_patas="no"\` limpia patas viejas.

## Qué no cambia

- No se toca el parser (\`multi_crop_reader\`). El fix trata el síntoma del flow, no la detección visual.
- No hay cambios en frontend ni modales.
- Helpers puros (\`merge_alzada_tramos_into_dual_read\`, \`merge_derived_pieces_into_dual_read\`, \`apply_*_answer\`) ya eran idempotentes — solo se compone de forma distinta en el handler.
- \`verified_context\` se construye al final (con todos los derivados ya materializados) — sin doble conteo con \`derived_pieces=None\`.

## Alcance

- 1 archivo backend: \`agent.py\` (~30 líneas extra en handler DUAL_READ_CONFIRMED, ~20 líneas removidas del skip).
- 1 archivo de tests: \`test_derived_pieces_merge.py\` (~300 líneas).
- Suite completa API: 1657 passed, 1 pre-existente (edificios, no tocado).

## Test plan manual post-merge

- [ ] Quote nuevo con plano Bernardi (o cualquiera con cocinas que el parser no resuelve).
- [ ] Confirmar contexto con alzada + frentín + regrueso.
- [ ] Card del despiece mostrará tramos vacíos si el parser no los resolvió.
- [ ] Editar largos en la card manualmente.
- [ ] Confirmar medidas → verificar en el chat/PDF:
  - Aparece "Alzada <sector>" con perímetro correcto.
  - Frentín/regrueso tienen ml correcto (no 0).
  - Si hay isla con patas, las patas tienen las dimensiones de la isla editada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)