### PR TITLE
feat(web-api): skip auto-estimate si source=web + archivo adjunto

### DIFF
--- a/api/app/modules/quote_engine/router.py
+++ b/api/app/modules/quote_engine/router.py
@@ -1,5 +1,6 @@
 """Public API endpoint for quote generation — no LLM, pure calculation."""
 
+import asyncio
 import uuid
 import logging
 from fastapi import APIRouter, Depends, UploadFile, File, HTTPException, Header
@@ -285,129 +286,206 @@ async def upload_source_files(
     await db.execute(upd(Quote).where(Quote.id == quote_id).values(source_files=existing))
     await db.commit()
 
+    # PR #394 — Web API rule: quotes originados desde el chatbot externo
+    # (`source="web"`) que traigan al menos 1 archivo guardado válido NO
+    # deben recibir presupuesto pre-calculado. El operador revisa el
+    # archivo + datos manualmente desde la UI interna antes de devolver
+    # números al cliente.
+    #
+    # Criterio del operador (2026-04-24): gate por presencia de archivo
+    # adjunto en este endpoint, no por intención ni por tipo de archivo.
+    # Flujos internos (operador con JWT vía /api/quotes/*) no pasan por
+    # acá — intactos.
+    _is_web_source = (quote.source or "").lower() == "web"
+    _skip_auto_estimate = _is_web_source and bool(saved)
+
+    if _skip_auto_estimate:
+        logging.info(
+            f"[web-api] skipping auto-estimate for {quote_id}: "
+            f"source=web, {len(saved)} file(s) saved. Operator will review."
+        )
+
     # If quote has no breakdown yet and we just saved files, trigger agent processing
-    # in the background so the API responds immediately to the chatbot
-    if saved and not quote.quote_breakdown:
-        import asyncio
+    # in the background so the API responds immediately to the chatbot.
+    # PR #394 — gate: web+archivo NO dispara. Otros sources mantienen comportamiento.
+    if saved and not quote.quote_breakdown and not _skip_auto_estimate:
+        _schedule_agent_background_processing(quote_id, quote, saved[0])
 
+    response = {"ok": True, "saved": len(saved), "errors": errors, "files": existing}
+    # PR #394 — aviso explícito al chatbot externo cuando el estimate no
+    # se genera automáticamente (source=web + archivo adjunto). Campos
+    # aditivos: clientes viejos que no los miren siguen andando.
+    if _skip_auto_estimate:
+        response["estimate_skipped"] = True
+        response["estimate_skip_reason"] = "web_upload_manual_review"
+        response["message"] = (
+            "Archivo recibido. Un operador revisará la información antes de cotizar."
+        )
+    return response
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Background agent processing
+# ─────────────────────────────────────────────────────────────────────
+#
+# PR #394 — extraído de upload_source_files para que el scheduler sea
+# mockeable en tests. El closure anidado dentro del endpoint volvía
+# imposible verificar la invocación del bg task sin parchar
+# `asyncio.create_task` a nivel global (con side-effects sobre el
+# resto del event loop).
+
+
+def _schedule_agent_background_processing(quote_id: str, quote: Quote, first_file: dict) -> None:
+    """Programa la corrida asíncrona de Valentina sobre un archivo recién
+    subido (lee plano → extrae piezas → `calculate_quote` → persiste
+    breakdown). Fire-and-forget: la response del endpoint sale inmediata
+    al chatbot externo.
+
+    Usado solo cuando `source != "web"` (regla del PR #394): quotes
+    web con archivo quedan para revisión manual del operador.
+    """
+    import json as _json
+    from pathlib import Path
+
+    try:
+        _cfg = _json.loads(
+            (Path(__file__).parent.parent.parent / "catalog" / "config.json").read_text()
+        )
+        _default_plazo = _cfg.get("delivery_days", {}).get(
+            "display", "30 dias desde la toma de medidas"
+        )
+    except Exception:
+        _default_plazo = "30 dias desde la toma de medidas"
+
+    async def _process_plan_background(qid: str, q: Quote, file_info: dict):
+        """Run Valentina in background to read plan, extract pieces, calculate quote."""
         try:
-            import json as _json
-            _cfg = _json.loads((Path(__file__).parent.parent.parent / "catalog" / "config.json").read_text())
-            _default_plazo = _cfg.get("delivery_days", {}).get("display", "30 dias desde la toma de medidas")
-        except Exception:
-            _default_plazo = "30 dias desde la toma de medidas"
+            from app.modules.agent.agent import AgentService
+            from app.core.database import AsyncSessionLocal
 
-        async def _process_plan_background(qid: str, q: Quote, first_file: dict):
-            """Run Valentina in background to read plan, extract pieces, calculate quote."""
-            try:
-                from app.modules.agent.agent import AgentService
-                from app.core.database import AsyncSessionLocal
+            # Build context message from quote data
+            parts = []
+            if q.client_name:
+                parts.append(f"Cliente: {q.client_name}")
+            if q.project:
+                parts.append(f"Proyecto: {q.project}")
+            if q.material:
+                parts.append(f"Material: {q.material}")
+            localidad = getattr(q, "localidad", None)
+            if localidad:
+                parts.append(f"Localidad: {localidad}")
+            colocacion = getattr(q, "colocacion", None)
+            if colocacion is not None:
+                parts.append(f"{'Con' if colocacion else 'Sin'} colocación")
+            pileta_val = getattr(q, "pileta", None)
+            if pileta_val:
+                parts.append(f"Pileta: {pileta_val}")
+            anafe_val = getattr(q, "anafe", None)
+            if anafe_val:
+                parts.append(f"Con anafe")
+            sink_type_val = getattr(q, "sink_type", None)
+            if sink_type_val:
+                bc = sink_type_val.get("basin_count", "").capitalize()
+                mt = (
+                    "Pegada de " + sink_type_val.get("mount_type", "")
+                    if sink_type_val.get("mount_type")
+                    else ""
+                )
+                parts.append(f"Tipo de bacha: {bc} · {mt}".strip(" ·"))
+            parts.append(f"Plazo: {_default_plazo}")
+            if q.notes:
+                parts.append(f"Notas del cliente: {q.notes}")
+            parts.append(
+                "Adjunto el plano. Es un procesamiento automático — calculá el "
+                "presupuesto completo y guardá el breakdown. NO generar documentos "
+                "(PDF/Excel/Drive). NO pedir confirmación. Solo calcular y guardar."
+            )
 
-                # Build context message from quote data
-                parts = []
-                if q.client_name:
-                    parts.append(f"Cliente: {q.client_name}")
-                if q.project:
-                    parts.append(f"Proyecto: {q.project}")
-                if q.material:
-                    parts.append(f"Material: {q.material}")
-                localidad = getattr(q, "localidad", None)
-                if localidad:
-                    parts.append(f"Localidad: {localidad}")
-                colocacion = getattr(q, "colocacion", None)
-                if colocacion is not None:
-                    parts.append(f"{'Con' if colocacion else 'Sin'} colocación")
-                pileta_val = getattr(q, "pileta", None)
-                if pileta_val:
-                    parts.append(f"Pileta: {pileta_val}")
-                anafe_val = getattr(q, "anafe", None)
-                if anafe_val:
-                    parts.append(f"Con anafe")
-                sink_type_val = getattr(q, "sink_type", None)
-                if sink_type_val:
-                    bc = sink_type_val.get("basin_count", "").capitalize()
-                    mt = "Pegada de " + sink_type_val.get("mount_type", "") if sink_type_val.get("mount_type") else ""
-                    parts.append(f"Tipo de bacha: {bc} · {mt}".strip(" ·"))
-                parts.append(f"Plazo: {_default_plazo}")
-                if q.notes:
-                    parts.append(f"Notas del cliente: {q.notes}")
-                parts.append("Adjunto el plano. Es un procesamiento automático — calculá el presupuesto completo y guardá el breakdown. NO generar documentos (PDF/Excel/Drive). NO pedir confirmación. Solo calcular y guardar.")
+            auto_message = "\n".join(parts)
 
-                auto_message = "\n".join(parts)
+            # Read file from disk — check both OUTPUT_DIR and /tmp fallback, retry once
+            from app.core.static import OUTPUT_DIR as _OUTDIR
 
-                # Read file from disk — check both OUTPUT_DIR and /tmp fallback, retry once
-                from app.core.static import OUTPUT_DIR as _OUTDIR
-                plan_data = None
-                for _attempt in range(2):
-                    file_path = _OUTDIR / qid / "sources" / first_file["filename"]
-                    if not file_path.exists():
-                        file_path = Path("/tmp/output") / qid / "sources" / first_file["filename"]
-                    if file_path.exists():
-                        plan_data = file_path.read_bytes()
-                        break
-                    if _attempt == 0:
-                        logging.warning(f"File not found for {qid}, retrying in 2s: {first_file['filename']}")
-                        await asyncio.sleep(2)
-                if plan_data is None:
-                    logging.error(f"File NOT FOUND after retry for {qid}: {first_file['filename']}. Skipping background processing.")
-                    return
+            plan_data = None
+            for _attempt in range(2):
+                file_path = _OUTDIR / qid / "sources" / file_info["filename"]
+                if not file_path.exists():
+                    file_path = Path("/tmp/output") / qid / "sources" / file_info["filename"]
+                if file_path.exists():
+                    plan_data = file_path.read_bytes()
+                    break
+                if _attempt == 0:
+                    logging.warning(
+                        f"File not found for {qid}, retrying in 2s: {file_info['filename']}"
+                    )
+                    await asyncio.sleep(2)
+            if plan_data is None:
+                logging.error(
+                    f"File NOT FOUND after retry for {qid}: {file_info['filename']}. "
+                    "Skipping background processing."
+                )
+                return
 
-                agent = AgentService()
-                async with AsyncSessionLocal() as bg_db:
-                    async for _ in agent.stream_chat(
-                        quote_id=qid,
-                        messages=q.messages or [],
-                        user_message=auto_message,
-                        plan_bytes=plan_data,
-                        plan_filename=first_file["filename"] if plan_data else None,
-                        db=bg_db,
-                    ):
-                        pass  # Consume stream — only care about side effects (DB updates)
+            agent = AgentService()
+            async with AsyncSessionLocal() as bg_db:
+                async for _ in agent.stream_chat(
+                    quote_id=qid,
+                    messages=q.messages or [],
+                    user_message=auto_message,
+                    plan_bytes=plan_data,
+                    plan_filename=file_info["filename"] if plan_data else None,
+                    db=bg_db,
+                ):
+                    pass  # Consume stream — only care about side effects (DB updates)
 
-                # Verify breakdown was saved — if Valentina extracted pieces
-                # but didn't call calculate_quote, call it explicitly
-                async with AsyncSessionLocal() as verify_db:
-                    from sqlalchemy import select as _sel
-                    _r = await verify_db.execute(_sel(Quote).where(Quote.id == qid))
-                    _updated = _r.scalar_one_or_none()
-                    if _updated and not _updated.quote_breakdown:
-                        logging.warning(f"Breakdown not saved after stream_chat for {qid} — attempting fallback calculate")
-                        # Try to build calc input from quote data + any pieces in messages
-                        try:
-                            # Extract pieces from Valentina's messages if available
-                            pieces_from_msgs = _updated.pieces  # raw pieces if saved
-                            if pieces_from_msgs:
-                                calc_input = {
-                                    "client_name": _updated.client_name,
-                                    "project": _updated.project,
-                                    "material": _updated.material,
-                                    "pieces": pieces_from_msgs,
-                                    "localidad": getattr(_updated, "localidad", "rosario"),
-                                    "colocacion": getattr(_updated, "colocacion", True),
-                                    "pileta": getattr(_updated, "pileta", None),
-                                    "anafe": getattr(_updated, "anafe", False),
-                                    "plazo": _default_plazo,
-                                }
-                                from app.modules.quote_engine.calculator import calculate_quote as _calc
-                                fallback_result = _calc(calc_input)
-                                if fallback_result.get("ok"):
-                                    from sqlalchemy import update as _upd
-                                    await verify_db.execute(
-                                        _upd(Quote).where(Quote.id == qid).values(
-                                            quote_breakdown=fallback_result,
-                                            total_ars=fallback_result.get("total_ars"),
-                                            total_usd=fallback_result.get("total_usd"),
-                                        )
+            # Verify breakdown was saved — if Valentina extracted pieces
+            # but didn't call calculate_quote, call it explicitly
+            async with AsyncSessionLocal() as verify_db:
+                from sqlalchemy import select as _sel
+
+                _r = await verify_db.execute(_sel(Quote).where(Quote.id == qid))
+                _updated = _r.scalar_one_or_none()
+                if _updated and not _updated.quote_breakdown:
+                    logging.warning(
+                        f"Breakdown not saved after stream_chat for {qid} — "
+                        "attempting fallback calculate"
+                    )
+                    try:
+                        pieces_from_msgs = _updated.pieces
+                        if pieces_from_msgs:
+                            calc_input = {
+                                "client_name": _updated.client_name,
+                                "project": _updated.project,
+                                "material": _updated.material,
+                                "pieces": pieces_from_msgs,
+                                "localidad": getattr(_updated, "localidad", "rosario"),
+                                "colocacion": getattr(_updated, "colocacion", True),
+                                "pileta": getattr(_updated, "pileta", None),
+                                "anafe": getattr(_updated, "anafe", False),
+                                "plazo": _default_plazo,
+                            }
+                            from app.modules.quote_engine.calculator import (
+                                calculate_quote as _calc,
+                            )
+
+                            fallback_result = _calc(calc_input)
+                            if fallback_result.get("ok"):
+                                from sqlalchemy import update as _upd
+
+                                await verify_db.execute(
+                                    _upd(Quote).where(Quote.id == qid).values(
+                                        quote_breakdown=fallback_result,
+                                        total_ars=fallback_result.get("total_ars"),
+                                        total_usd=fallback_result.get("total_usd"),
                                     )
-                                    await verify_db.commit()
-                                    logging.info(f"Fallback calculate_quote succeeded for {qid}")
-                        except Exception as fb_err:
-                            logging.error(f"Fallback calculate failed for {qid}: {fb_err}")
+                                )
+                                await verify_db.commit()
+                                logging.info(f"Fallback calculate_quote succeeded for {qid}")
+                    except Exception as fb_err:
+                        logging.error(f"Fallback calculate failed for {qid}: {fb_err}")
 
-                logging.info(f"Auto-processed plan for web quote {qid}")
-            except Exception as e:
-                logging.error(f"Failed to auto-process plan for {qid}: {e}", exc_info=True)
+            logging.info(f"Auto-processed plan for web quote {qid}")
+        except Exception as e:
+            logging.error(f"Failed to auto-process plan for {qid}: {e}", exc_info=True)
 
-        asyncio.create_task(_process_plan_background(quote_id, quote, saved[0]))
-
-    return {"ok": True, "saved": len(saved), "errors": errors, "files": existing}
+    asyncio.create_task(_process_plan_background(quote_id, quote, first_file))

--- a/api/tests/test_web_api_upload_gate.py
+++ b/api/tests/test_web_api_upload_gate.py
@@ -1,0 +1,305 @@
+"""Tests para PR #394 — Gate de auto-estimate en `/api/v1/quote/{id}/files`.
+
+Regla acordada con el operador:
+    Si el quote tiene `source="web"` Y se guardó al menos 1 archivo
+    válido en la request, NO se dispara el `_process_plan_background`
+    (agente Valentina calculando estimate). El response incluye los 3
+    campos aditivos: `estimate_skipped=True`,
+    `estimate_skip_reason="web_upload_manual_review"`, `message` en
+    español.
+
+Alcance testeado:
+    - Gate activo: source=web + ≥1 archivo válido guardado.
+    - Gate inactivo: source != web (operador manual / flujos internos).
+    - Gate inactivo: source=web pero 0 archivos válidos (ej: todos
+      rechazados por tipo o tamaño).
+    - File storage funciona idéntico en ambos casos (saved + source_files
+      se escriben en DB).
+    - Campos aditivos del response no rompen clientes viejos (ok, saved,
+      errors, files siguen presentes).
+"""
+from __future__ import annotations
+
+import io
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from app.models.quote import Quote
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────
+
+
+async def _insert_quote(db_session, *, source: str | None = "web") -> str:
+    """Inserta un quote limpio sin breakdown, con el `source` dado.
+    Simula el quote creado por `POST /api/v1/quote` antes del upload
+    de archivos."""
+    import uuid
+    from app.models.quote import QuoteStatus
+
+    qid = f"web-{uuid.uuid4()}"
+    q = Quote(
+        id=qid,
+        client_name="Test Client",
+        project="Cocina test",
+        material="Silestone Blanco Norte",
+        status=QuoteStatus.DRAFT,
+        source=source,
+        is_read=False,
+    )
+    db_session.add(q)
+    await db_session.commit()
+    return qid
+
+
+def _dummy_pdf_bytes() -> bytes:
+    """Bytes mínimos válidos como PDF (header %PDF-1.4 + trailer)."""
+    return b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF\n"
+
+
+def _upload_payload_pdf(name: str = "plano.pdf") -> dict:
+    """Payload multipart válido para un solo PDF."""
+    return {
+        "files": (name, io.BytesIO(_dummy_pdf_bytes()), "application/pdf"),
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Gate activo: source=web + archivo válido
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestGateActive:
+    """Web + archivo válido → skip auto-estimate + response con flags."""
+
+    @pytest.mark.asyncio
+    async def test_skips_background_processing(self, client, db_session):
+        """El `asyncio.create_task(_process_plan_background)` NO debe
+        invocarse. Mock del bg task + assert en el número de calls."""
+        qid = await _insert_quote(db_session, source="web")
+
+        with patch(
+            "app.modules.quote_engine.router._schedule_agent_background_processing",
+        ) as mock_schedule, patch(
+            "app.modules.agent.tools.drive_tool.upload_single_file_to_drive",
+            new_callable=AsyncMock,
+            return_value={"ok": False},
+        ):
+            res = await client.post(
+                f"/api/v1/quote/{qid}/files",
+                files=_upload_payload_pdf(),
+            )
+
+        assert res.status_code == 200, res.text
+        # El gate corta ANTES de asyncio.create_task → 0 invocaciones.
+        assert mock_schedule.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_response_includes_skip_flags(self, client, db_session):
+        """Response con los 3 campos aditivos."""
+        qid = await _insert_quote(db_session, source="web")
+
+        with patch(
+            "app.modules.agent.tools.drive_tool.upload_single_file_to_drive",
+            new_callable=AsyncMock,
+            return_value={"ok": False},
+        ):
+            res = await client.post(
+                f"/api/v1/quote/{qid}/files",
+                files=_upload_payload_pdf(),
+            )
+
+        body = res.json()
+        assert body["ok"] is True
+        assert body["estimate_skipped"] is True
+        assert body["estimate_skip_reason"] == "web_upload_manual_review"
+        assert body["message"] == (
+            "Archivo recibido. Un operador revisará la información antes de cotizar."
+        )
+
+    @pytest.mark.asyncio
+    async def test_file_storage_unchanged(self, client, db_session):
+        """El gate NO toca la lógica de storage: saved, source_files,
+        response.files siguen iguales."""
+        qid = await _insert_quote(db_session, source="web")
+
+        with patch(
+            "app.modules.agent.tools.drive_tool.upload_single_file_to_drive",
+            new_callable=AsyncMock,
+            return_value={"ok": False},
+        ):
+            res = await client.post(
+                f"/api/v1/quote/{qid}/files",
+                files=_upload_payload_pdf("plano-cocina.pdf"),
+            )
+
+        body = res.json()
+        assert body["saved"] == 1
+        assert len(body["files"]) == 1
+        assert body["files"][0]["filename"] == "plano-cocina.pdf"
+        assert body["files"][0]["type"] == "application/pdf"
+
+        # Persistencia: source_files del quote se actualizó.
+        result = await db_session.execute(select(Quote).where(Quote.id == qid))
+        q = result.scalar_one()
+        assert q.source_files
+        assert q.source_files[0]["filename"] == "plano-cocina.pdf"
+        # Y el quote sigue sin breakdown (gate cortó el bg task).
+        assert not q.quote_breakdown
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Gate inactivo: otros sources
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestGateInactive:
+    """Fuera de `source=web` el flujo auto-estimate sigue intacto."""
+
+    @pytest.mark.asyncio
+    async def test_source_none_triggers_background(self, client, db_session):
+        """Quote con `source=None` (legacy / operador manual creando
+        desde la UI) → sigue disparando el background task."""
+        qid = await _insert_quote(db_session, source=None)
+
+        with patch(
+            "app.modules.quote_engine.router._schedule_agent_background_processing",
+        ) as mock_schedule, patch(
+            "app.modules.agent.tools.drive_tool.upload_single_file_to_drive",
+            new_callable=AsyncMock,
+            return_value={"ok": False},
+        ):
+            res = await client.post(
+                f"/api/v1/quote/{qid}/files",
+                files=_upload_payload_pdf(),
+            )
+
+        assert res.status_code == 200
+        # source != "web" → NO skipea → create_task se invoca.
+        assert mock_schedule.call_count == 1
+        body = res.json()
+        # Response sin los campos aditivos.
+        assert "estimate_skipped" not in body
+        assert "estimate_skip_reason" not in body
+
+    @pytest.mark.asyncio
+    async def test_source_manual_triggers_background(self, client, db_session):
+        """Quote con `source="manual"` (u otro valor no-web) también
+        dispara el auto-estimate."""
+        qid = await _insert_quote(db_session, source="manual")
+
+        with patch(
+            "app.modules.quote_engine.router._schedule_agent_background_processing",
+        ) as mock_schedule, patch(
+            "app.modules.agent.tools.drive_tool.upload_single_file_to_drive",
+            new_callable=AsyncMock,
+            return_value={"ok": False},
+        ):
+            res = await client.post(
+                f"/api/v1/quote/{qid}/files",
+                files=_upload_payload_pdf(),
+            )
+
+        assert res.status_code == 200
+        assert mock_schedule.call_count == 1
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Gate depende de archivos VÁLIDOS guardados, no de la request
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestGateRequiresValidSavedFile:
+    """El gate se activa por `bool(saved)`, NO por `files` del request.
+    Si todos los archivos fueron rechazados (tipo / tamaño / empty), el
+    gate queda inactivo y el quote sigue sin auto-estimate igual
+    (porque el `if saved and not quote_breakdown` sin skip también
+    requiere archivos)."""
+
+    @pytest.mark.asyncio
+    async def test_web_with_invalid_file_does_not_set_skip_flag(
+        self, client, db_session,
+    ):
+        """Archivo con MIME no soportado → rechazado por validación →
+        `saved=0` → gate NO se activa → response SIN `estimate_skipped`."""
+        qid = await _insert_quote(db_session, source="web")
+
+        with patch(
+            "app.modules.agent.tools.drive_tool.upload_single_file_to_drive",
+            new_callable=AsyncMock,
+            return_value={"ok": False},
+        ):
+            res = await client.post(
+                f"/api/v1/quote/{qid}/files",
+                files={"files": (
+                    "archivo.xyz",
+                    io.BytesIO(b"algo"),
+                    "application/octet-stream",
+                )},
+            )
+
+        body = res.json()
+        assert res.status_code == 200
+        assert body["saved"] == 0
+        assert len(body["errors"]) == 1
+        # Sin archivos válidos, el gate no se activa → response sin
+        # campos aditivos (coherente: no hay nada que "skipear"
+        # porque no hay input que generara estimate).
+        assert "estimate_skipped" not in body
+        assert "estimate_skip_reason" not in body
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Quote con breakdown pre-existente: gate no interfiere
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestGateDoesNotTouchExistingBreakdowns:
+    @pytest.mark.asyncio
+    async def test_web_upload_when_breakdown_already_exists(
+        self, client, db_session,
+    ):
+        """Quote web con breakdown YA calculado (ej: subieron archivo
+        complementario post-estimate). El gate y el `if not
+        quote.quote_breakdown` ambos cortan el bg task; lo importante es
+        que tampoco se dispara — y que saved sigue escribiendo archivos."""
+        import uuid
+        from app.models.quote import QuoteStatus
+
+        qid = f"web-{uuid.uuid4()}"
+        q = Quote(
+            id=qid,
+            client_name="X",
+            project="Y",
+            status=QuoteStatus.PENDING,
+            source="web",
+            is_read=False,
+            quote_breakdown={"material_name": "SILESTONE", "total_ars": 100},
+        )
+        db_session.add(q)
+        await db_session.commit()
+
+        with patch(
+            "app.modules.quote_engine.router._schedule_agent_background_processing",
+        ) as mock_schedule, patch(
+            "app.modules.agent.tools.drive_tool.upload_single_file_to_drive",
+            new_callable=AsyncMock,
+            return_value={"ok": False},
+        ):
+            res = await client.post(
+                f"/api/v1/quote/{qid}/files",
+                files=_upload_payload_pdf(),
+            )
+
+        assert res.status_code == 200
+        # Nunca se dispara (el breakdown ya existía + el gate también corta).
+        assert mock_schedule.call_count == 0
+        body = res.json()
+        # Pero el flag estimate_skipped SÍ sale porque source=web + archivo
+        # fueron las condiciones del gate (independiente del breakdown).
+        assert body["estimate_skipped"] is True
+        assert body["saved"] == 1


### PR DESCRIPTION
## Regla de negocio

Acordada con el operador (2026-04-24):

> Si la request viene desde web y trae cualquier archivo adjunto, el API externo NO debe pre-generar presupuesto. Guardar el quote + archivo + datos, dejar todo listo para revisión manual.

Gate simple por presencia de archivo. Sin evaluar tipo ni intención.

## Flow afectado (único)

Endpoint **\`POST /api/v1/quote/{quote_id}/files\`** (API externa pública con X-API-Key). Antes disparaba un background task con el agente Valentina que calculaba estimate automáticamente. Ahora se bloquea cuando:

\`\`\`python
_is_web_source = (quote.source or "").lower() == "web"
_skip_auto_estimate = _is_web_source and bool(saved)
\`\`\`

Cuando se activa:
- ✅ Archivos siguen guardándose (disco + Drive + DB).
- ✅ \`quote.source_files\` se actualiza normal.
- ❌ \`_schedule_agent_background_processing\` NO se invoca.
- ✅ Response incluye flags aditivos informando al chatbot.

## Response shape

**Sin cambios** cuando el gate NO se activa (otros sources o sin archivos):
\`\`\`json
{"ok": true, "saved": 1, "errors": [], "files": [...]}
\`\`\`

**Con flags** cuando se activa (source=web + archivo):
\`\`\`json
{
  "ok": true,
  "saved": 1,
  "errors": [],
  "files": [...],
  "estimate_skipped": true,
  "estimate_skip_reason": "web_upload_manual_review",
  "message": "Archivo recibido. Un operador revisará la información antes de cotizar."
}
\`\`\`

Clientes viejos que no lean los campos extras siguen andando — los 3 nuevos son **aditivos**.

## Refactor mínimo

Extraí \`_schedule_agent_background_processing\` como función de módulo (antes era un closure anidado en \`upload_source_files\`). Comportamiento funcional idéntico; el único motivo es poder mockear en tests sin parchar \`asyncio.create_task\` a nivel global (side-effects sobre el event loop).

## Lo que NO cambia

- **\`POST /api/v1/quote\`** (JSON sin archivos): sigue calculando y devolviendo estimate.
- **\`/api/quotes/*\`** endpoints internos del operador (JWT): intactos.
- **Agente Valentina** invocado desde la UI interna: intacto.
- **Quotes con \`source != "web"\`** al subir archivos: siguen disparando el bg task como hoy.
- **File storage + Drive upload**: idénticos.
- **Data extraction** del endpoint \`/v1/quote\` (pieces + notas): idéntica.

## Test plan

- [x] 7 tests nuevos en \`test_web_api_upload_gate.py\`:
  - Gate activo: bg NO se dispara + response con flags + storage intacto.
  - Gate inactivo: source=None / source="manual" siguen disparando.
  - Gate inactivo por archivos inválidos (saved=0) → sin flags.
  - Quote con breakdown preexistente: gate + guard funcionan juntos.
- [x] Suite completa API: 1664 passed, 1 pre-existente (edificios, no tocado).
- [ ] **Manual post-merge**: chatbot externo sube plano → response incluye \`estimate_skipped: true\` y \`message\` en español. Quote queda en DB con \`source_files\` pero sin \`quote_breakdown\` — operador lo procesa desde la UI interna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)