### PR TITLE
feat(web-quotes): botón 'Procesar plano y contexto' para disparar flow manual

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1512,6 +1512,37 @@ class AgentService:
             bd_pre=_bd_enter,
         )
 
+        # ── PR #395 — Handle [SYSTEM_TRIGGER:process_saved_plan]
+        # EARLY: reemplazamos el mensaje por un brief sintético armado
+        # desde las columnas del Quote (client_name, material, localidad,
+        # pileta, anafe, notes, etc.) ANTES de que el flow normal lo
+        # procese. Efecto: el agente ve ese "brief" como si el operador
+        # lo hubiera escrito + el plan_bytes ya fue restaurado desde
+        # `source_files` por el endpoint `/chat` → multi_crop + context
+        # analyzer corren normal → card de contexto sale llena.
+        #
+        # Sin este handler, el operador tendría que retipear los datos
+        # que el chatbot web ya dejó en columnas para que el brief
+        # analyzer los capture. Acá los sintetizamos.
+        if user_message.startswith("[SYSTEM_TRIGGER:process_saved_plan]"):
+            try:
+                _q_ps_res = await db.execute(select(Quote).where(Quote.id == quote_id))
+                _q_ps = _q_ps_res.scalar_one_or_none()
+                if _q_ps is not None:
+                    from app.modules.agent.synthetic_brief import (
+                        build_brief_from_quote_columns,
+                    )
+                    user_message = build_brief_from_quote_columns(_q_ps)
+                    logging.info(
+                        f"[trace:process-saved-plan:{quote_id}] trigger replaced "
+                        f"with synthetic brief ({len(user_message)} chars)"
+                    )
+            except Exception as _e_ps:
+                logging.warning(
+                    f"[process-saved-plan:{quote_id}] synthetic brief build failed: "
+                    f"{_e_ps}. Falling back to raw trigger → flow puede no activarse."
+                )
+
         # ── Handle CONTEXT_CONFIRMED EARLY (PR G): el operador confirmó la card
         # de análisis de contexto (datos + asunciones + preguntas). Aplicamos
         # las respuestas al dual_read_result guardado, emitimos el chunk de

--- a/api/app/modules/agent/synthetic_brief.py
+++ b/api/app/modules/agent/synthetic_brief.py
@@ -1,0 +1,97 @@
+"""Construcción de brief sintético desde las columnas del Quote.
+
+PR #395 — cuando el chatbot externo crea un quote vía `POST /api/v1/quote`
+y sube un plano, el gate #394 bloquea el auto-estimate. El operador
+necesita disparar el flow del agente manualmente desde la UI interna.
+Para que la card de contexto salga llena con los datos del chatbot,
+reconstruimos un "brief sintético" desde las columnas del Quote que
+el brief_analyzer sabe parsear:
+
+    Cliente: Erica Bernardi
+    Proyecto: Cocina
+    Material: Puraprima Onix White Mate
+    Localidad: Rosario
+    Con colocación
+    Pileta: empotrada
+    Con anafe
+
+El operador aprieta "Procesar plano y contexto" en la UI → frontend
+manda `[SYSTEM_TRIGGER:process_saved_plan]` → el handler en `stream_chat`
+llama a este helper para reemplazar el trigger por el brief → el flow
+normal corre con plan_bytes restaurado de `source_files`.
+
+Este mismo shape de mensaje es el que usaba el bg task de
+`_schedule_agent_background_processing` (antes del gate #394) — mantenerlo
+coherente evita divergencia de wording.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_brief_from_quote_columns(quote: Any) -> str:
+    """Construye un brief natural desde las columnas del Quote que el
+    chatbot web haya llenado. No inventa nada: si una columna está en
+    None / vacía, se omite la línea.
+
+    Shape esperado del `quote`: ORM `app.models.quote.Quote` o cualquier
+    objeto con atributos equivalentes (`getattr` seguro).
+
+    Returns:
+        String multi-línea con los campos presentes + línea final que
+        indica al agente que es procesamiento inicial con plano adjunto
+        (equivalente al user_message del bg task en `_process_plan_background`
+        del router).
+    """
+    parts: list[str] = []
+
+    client_name = getattr(quote, "client_name", None)
+    if client_name:
+        parts.append(f"Cliente: {client_name}")
+
+    project = getattr(quote, "project", None)
+    if project:
+        parts.append(f"Proyecto: {project}")
+
+    material = getattr(quote, "material", None)
+    if material:
+        parts.append(f"Material: {material}")
+
+    localidad = getattr(quote, "localidad", None)
+    if localidad:
+        parts.append(f"Localidad: {localidad}")
+
+    colocacion = getattr(quote, "colocacion", None)
+    if colocacion is True:
+        parts.append("Con colocación")
+    elif colocacion is False:
+        parts.append("Sin colocación")
+
+    pileta_val = getattr(quote, "pileta", None)
+    if pileta_val:
+        parts.append(f"Pileta: {pileta_val}")
+
+    anafe_val = getattr(quote, "anafe", None)
+    if anafe_val:
+        parts.append("Con anafe")
+
+    sink_type_val = getattr(quote, "sink_type", None)
+    if isinstance(sink_type_val, dict):
+        bc = (sink_type_val.get("basin_count") or "").capitalize()
+        mt = sink_type_val.get("mount_type") or ""
+        pieces_bacha = " · ".join(p for p in (bc, f"Pegada de {mt}" if mt else "") if p)
+        if pieces_bacha:
+            parts.append(f"Tipo de bacha: {pieces_bacha}")
+
+    notes = getattr(quote, "notes", None)
+    if notes:
+        notes_clean = str(notes).strip()
+        if notes_clean:
+            parts.append(f"Notas del cliente: {notes_clean}")
+
+    # Línea final que aclara al agente el origen del flujo. No usa los
+    # imperativos del bg task ("NO generar documentos") porque acá sí
+    # queremos el flujo completo (el operador lo dispara a propósito).
+    parts.append("Adjunto el plano cargado desde el chatbot web.")
+
+    return "\n".join(parts)

--- a/api/tests/test_synthetic_brief.py
+++ b/api/tests/test_synthetic_brief.py
@@ -1,0 +1,125 @@
+"""Tests para PR #395 — `build_brief_from_quote_columns`.
+
+El helper toma un Quote de DB con datos del chatbot externo y arma un
+brief natural (texto plano) que el `brief_analyzer` LLM sabe parsear
+cuando el operador aprieta "Procesar plano y contexto". Equivalente al
+user_message que usaba el bg task pre-#394.
+
+Regla de no-invención: si una columna del Quote está `None` o vacía,
+NO aparece línea en el brief. Nunca rellena con defaults.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.modules.agent.synthetic_brief import build_brief_from_quote_columns
+
+
+def _q(**fields) -> SimpleNamespace:
+    """Factory de fake-Quote con getattr-equivalent."""
+    defaults = {
+        "client_name": None,
+        "project": None,
+        "material": None,
+        "localidad": None,
+        "colocacion": None,
+        "pileta": None,
+        "anafe": None,
+        "sink_type": None,
+        "notes": None,
+    }
+    defaults.update(fields)
+    return SimpleNamespace(**defaults)
+
+
+class TestBuildBrief:
+    def test_bernardi_style_full(self):
+        """Quote típico del chatbot con varios datos presentes."""
+        q = _q(
+            client_name="Erica Bernardi",
+            project="Cocina",
+            material="Puraprima Onix White Mate",
+            localidad="Rosario",
+            colocacion=True,
+            pileta="empotrada",
+            anafe=True,
+            notes="Sin zócalos, pileta Johnson LUXOR",
+        )
+        out = build_brief_from_quote_columns(q)
+        lines = out.split("\n")
+        assert "Cliente: Erica Bernardi" in lines
+        assert "Proyecto: Cocina" in lines
+        assert "Material: Puraprima Onix White Mate" in lines
+        assert "Localidad: Rosario" in lines
+        assert "Con colocación" in lines
+        assert "Pileta: empotrada" in lines
+        assert "Con anafe" in lines
+        assert "Notas del cliente: Sin zócalos, pileta Johnson LUXOR" in lines
+        assert lines[-1] == "Adjunto el plano cargado desde el chatbot web."
+
+    def test_empty_quote_has_only_final_line(self):
+        """Quote sin ningún dato → solo la línea final que indica al
+        agente que el plano está adjunto."""
+        q = _q()
+        out = build_brief_from_quote_columns(q)
+        assert out == "Adjunto el plano cargado desde el chatbot web."
+
+    def test_colocacion_false_emits_sin(self):
+        q = _q(client_name="X", colocacion=False)
+        out = build_brief_from_quote_columns(q)
+        assert "Sin colocación" in out
+        assert "Con colocación" not in out
+
+    def test_colocacion_none_omitted(self):
+        q = _q(client_name="X", colocacion=None)
+        out = build_brief_from_quote_columns(q)
+        assert "colocación" not in out  # ninguna línea
+
+    def test_anafe_false_or_none_omitted(self):
+        """`anafe=False` no emite 'Sin anafe' — el helper omite. Si el
+        chatbot no aclaró, no inventamos negación."""
+        q1 = _q(client_name="X", anafe=False)
+        q2 = _q(client_name="X", anafe=None)
+        assert "anafe" not in build_brief_from_quote_columns(q1).lower()
+        assert "anafe" not in build_brief_from_quote_columns(q2).lower()
+
+    def test_sink_type_dict_rendered(self):
+        q = _q(
+            client_name="X",
+            sink_type={"basin_count": "doble", "mount_type": "empotrada"},
+        )
+        out = build_brief_from_quote_columns(q)
+        assert "Tipo de bacha:" in out
+        assert "Doble" in out
+        assert "Pegada de empotrada" in out
+
+    def test_sink_type_empty_dict_omitted(self):
+        q = _q(client_name="X", sink_type={"basin_count": "", "mount_type": ""})
+        out = build_brief_from_quote_columns(q)
+        assert "Tipo de bacha" not in out
+
+    def test_notes_whitespace_only_omitted(self):
+        q = _q(client_name="X", notes="   \n  \t ")
+        out = build_brief_from_quote_columns(q)
+        assert "Notas del cliente" not in out
+
+    def test_does_not_invent_fields_not_present(self):
+        """Lo que no está en el Quote NO aparece, ni como default."""
+        q = _q(client_name="X")
+        out = build_brief_from_quote_columns(q)
+        # Solo 2 líneas: cliente + adjunto el plano.
+        assert out.count("\n") == 1
+        assert "Cliente: X" in out
+        assert "Proyecto" not in out
+        assert "Material" not in out
+        assert "Localidad" not in out
+
+    def test_output_is_llm_parseable_shape(self):
+        """Sanity: el shape del output coincide con el que espera
+        `brief_analyzer` (líneas `Clave: valor`)."""
+        q = _q(client_name="Juan", material="Silestone Blanco Norte")
+        out = build_brief_from_quote_columns(q)
+        # Cada línea relevante matchea "Clave: valor" excepto la final.
+        data_lines = [l for l in out.split("\n") if l != "Adjunto el plano cargado desde el chatbot web."]
+        for line in data_lines:
+            assert ":" in line, f"Línea sin formato 'clave: valor': {line!r}"

--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -17,7 +17,7 @@ import ContextAnalysis from "@/components/chat/ContextAnalysis";
 import HomeHero from "@/components/chat/HomeHero";
 import { useToast } from "@/lib/toast-context";
 import clsx from "clsx";
-import { A, I, O, N, DOT, SUP2, DASH, ITEM, WARN, CIRCLE, ARROW, XMARK, CLOUD, WAVE, PAGE, PICTURE, CLIP, RULER, TAG, FOLDER, CHART } from "@/lib/chars";
+import { A, E, I, O, N, DOT, SUP2, DASH, ITEM, WARN, CIRCLE, ARROW, XMARK, CLOUD, WAVE, PAGE, PICTURE, CLIP, RULER, TAG, FOLDER, CHART } from "@/lib/chars";
 import { VALID_FILE_TYPES as PARENT_VALID_TYPES, MAX_FILE_SIZE as PARENT_MAX_SIZE, MAX_FILES as PARENT_MAX_FILES } from "@/lib/constants";
 
 export interface UIMessage {
@@ -591,10 +591,64 @@ export default function QuotePage() {
           )}
           <div className="flex-1 overflow-y-auto px-4 md:px-7 pt-5 md:pt-7 pb-4 flex flex-col gap-4 md:gap-5">
             {messages.length === 0 && (
-              <HomeHero
-                onPickFile={() => fileRef.current?.click()}
-                onFocusText={() => { const ta = document.querySelector("textarea"); if (ta) (ta as HTMLTextAreaElement).focus(); }}
-              />
+              (() => {
+                // PR #395 — Quote creado por chatbot externo con archivo
+                // subido (gate del #394 bloqueó el auto-estimate). El
+                // operador necesita disparar manualmente el análisis. Este
+                // CTA reemplaza el HomeHero genérico en ese caso: el plano
+                // ya existe, no hace falta pedir "pegá tu plano".
+                const hasSavedPlanFromWeb = (
+                  quote?.source === "web"
+                  && !!quote?.source_files
+                  && quote.source_files.length > 0
+                  && !quote?.quote_breakdown
+                  && (quote?.status === "draft" || quote?.status === "pending")
+                );
+                if (!hasSavedPlanFromWeb) {
+                  return (
+                    <HomeHero
+                      onPickFile={() => fileRef.current?.click()}
+                      onFocusText={() => { const ta = document.querySelector("textarea"); if (ta) (ta as HTMLTextAreaElement).focus(); }}
+                    />
+                  );
+                }
+                const files = quote!.source_files!;
+                const filesLabel = files.length === 1
+                  ? files[0].filename
+                  : `${files.length} archivos`;
+                return (
+                  <div className="flex flex-col items-center justify-center text-center px-6 py-10">
+                    <div className="mb-4 w-12 h-12 rounded-xl bg-acc/10 border border-acc/20 flex items-center justify-center text-acc text-[22px]">
+                      {PAGE}
+                    </div>
+                    <div className="text-[15px] font-semibold text-t1 mb-1.5">
+                      {`Archivos recibidos del chatbot`}
+                    </div>
+                    <div className="text-[13px] text-t3 mb-5 max-w-md leading-relaxed">
+                      {`${filesLabel} ya est${A} guardado. Cuando est${E}s listo, proces${A} el plano para que Valentina arme el an${A}lisis de contexto con los datos del cliente.`}
+                    </div>
+                    <button
+                      onClick={() => send("[SYSTEM_TRIGGER:process_saved_plan]")}
+                      disabled={sending}
+                      className="inline-flex items-center gap-2 px-6 py-2.5 rounded-lg text-[13px] font-semibold text-white bg-acc border-none cursor-pointer hover:brightness-110 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {sending ? (
+                        <>
+                          <span className="inline-block w-3 h-3 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+                          {`Procesando${DOT}${DOT}${DOT}`}
+                        </>
+                      ) : (
+                        <>
+                          {ARROW} Procesar plano y contexto
+                        </>
+                      )}
+                    </button>
+                    <div className="text-[11px] text-t4 mt-3 max-w-sm">
+                      {`Tambi${E}n pod${E}s escribir un mensaje al chat para darle m${A}s instrucciones a Valentina.`}
+                    </div>
+                  </div>
+                );
+              })()
             )}
             {messages.map((msg, idx) => {
               // Find last REAL assistant message (not dots or empty)


### PR DESCRIPTION
## Complemento de #394

El gate del #394 bloquea el auto-estimate cuando un quote web sube un archivo. Pero el operador necesitaba disparar el flow del agente manualmente y no había CTA explícito — hoy sólo funciona si escribe "procesá" al chat. Este PR agrega un botón claro en la UI.

## Flujo end-to-end cerrado

\`\`\`
chatbot web → POST /api/v1/quote + /files
  → gate #394: quote guardado con source_files pero sin breakdown
  → operador abre el quote
  → Chat muestra "Archivos recibidos del chatbot" + botón ➤ Procesar plano y contexto
  → click → [SYSTEM_TRIGGER:process_saved_plan]
  → backend: handler reemplaza trigger por brief sintético desde columnas del Quote
  → /chat restaura plan_bytes desde source_files (lógica pre-existente)
  → multi_crop + context_analyzer → card de contexto LLENA con datos del chatbot
    + detecciones del plano
  → confirma contexto → despiece → medidas → Paso 2 → PDF
\`\`\`

## 3 capas

### Backend helper — \`synthetic_brief.py\`

\`\`\`python
build_brief_from_quote_columns(quote) -> str
\`\`\`

Construye un brief natural tipo:

\`\`\`
Cliente: Erica Bernardi
Proyecto: Cocina
Material: Puraprima Onix White Mate
Localidad: Rosario
Con colocación
Pileta: empotrada
Con anafe
Notas del cliente: Sin zócalos
Adjunto el plano cargado desde el chatbot web.
\`\`\`

**No inventa**: si una columna es \`None\` o vacía, la línea se omite. Formato "Clave: valor" parseable por el \`brief_analyzer\` existente.

### Handler — \`agent.py\` \`stream_chat\`

Early handler (antes de \`[CONTEXT_CONFIRMED]\` / \`[DUAL_READ_CONFIRMED]\`):

\`\`\`python
if user_message.startswith("[SYSTEM_TRIGGER:process_saved_plan]"):
    quote = await db.execute(...).scalar_one_or_none()
    if quote:
        user_message = build_brief_from_quote_columns(quote)
\`\`\`

El flow normal continúa: \`/chat\` ya restaura \`plan_bytes\` desde \`source_files\` (router.py:2013, pre-existente), el agente corre multi_crop + context_analyzer con el brief sintético como si el operador lo hubiera escrito.

### Frontend CTA — \`page.tsx\`

En el empty state del chat, si:
- \`quote.source === "web"\`
- \`quote.source_files.length > 0\`
- \`!quote.quote_breakdown\`
- status draft/pending

→ Botón claro **"➤ Procesar plano y contexto"** que reemplaza al \`HomeHero\` genérico. Click → \`send("[SYSTEM_TRIGGER:process_saved_plan]")\` → spinner mientras \`sending\`.

Debajo un hint sutil: _"También podés escribir un mensaje al chat para darle más instrucciones a Valentina."_ — el botón no es la única forma de arrancar.

## Lo que NO cambia

- Gate #394 sigue: el endpoint \`/files\` NO genera auto-estimate para \`source=web\`.
- Operador con flow interno (sin \`source=web\`): sin cambios.
- El chat con plano nuevo adjunto (operador sube archivo directamente por el chat): sin cambios.
- \`brief_analyzer\` + \`multi_crop_reader\`: sin cambios.

## Test plan

- [x] \`test_synthetic_brief.py\` — 10 tests:
  - Shape tipo "Clave: valor".
  - Omisión de campos \`None\` / vacíos.
  - \`colocacion=True/False/None\` diferenciado.
  - \`sink_type\` dict renderizado + dict vacío omitido.
  - \`notes\` whitespace-only omitido.
  - No inventa campos ausentes.
- [x] Suite API completa: 1674 passed, 1 pre-existente.
- [x] Web \`tsc --noEmit\` + \`next build\` limpios.
- [ ] **Manual post-merge**: chatbot externo sube plano → operador abre quote → ve botón → click → card de contexto aparece llena con datos del Quote (cliente, material, localidad, pileta, anafe) + detecciones del plano (R1/R2/R3) + preguntas bloqueantes pendientes. Flow continúa normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)