### PR TITLE
fix(web-api): resolver pileta desde sink_type + pileta_sku (Bug A)

### DIFF
--- a/api/app/modules/quote_engine/router.py
+++ b/api/app/modules/quote_engine/router.py
@@ -36,6 +36,33 @@ async def create_quote_api(body: QuoteInput, db: AsyncSession = Depends(get_db))
     # Normalize material to list
     materials = body.material if isinstance(body.material, list) else [body.material]
 
+    # PR #397 — Resolver `pileta` desde sink_type / pileta_sku ANTES de
+    # cualquier persistencia o cálculo. Aplica tanto al path no-pieces
+    # (quote DRAFT/PENDING guardado para revisión del operador) como al
+    # path con-pieces (corrida de calculate_quote). Así la DB y el
+    # cálculo ven el mismo valor de pileta resuelto.
+    #
+    # Reglas (acordadas con operador, 2026-04-24):
+    #   1. body.pileta seteado → respetar.
+    #   2. body.pileta_sku presente → empotrada_johnson (SKU implica
+    #      que D'Angelo provee la pileta).
+    #   3. body.sink_type presente:
+    #        - mount_type=arriba → apoyo.
+    #        - mount_type=abajo  → empotrada_cliente.
+    #   4. Nada de lo anterior → None (no se cotiza MO pileta).
+    #
+    # basin_count NO multiplica qty (mesada doble sigue siendo 1
+    # PEGADOPILETA — regla del negocio).
+    _resolved_pileta: Optional[PiletaType] = body.pileta
+    if _resolved_pileta is None:
+        if body.pileta_sku:
+            _resolved_pileta = PiletaType.EMPOTRADA_JOHNSON
+        elif body.sink_type is not None:
+            if body.sink_type.mount_type == "arriba":
+                _resolved_pileta = PiletaType.APOYO
+            else:
+                _resolved_pileta = PiletaType.EMPOTRADA_CLIENTE
+
     # Default plazo from config.json if not provided
     if not body.plazo:
         try:
@@ -88,7 +115,9 @@ async def create_quote_api(body: QuoteInput, db: AsyncSession = Depends(get_db))
                 notes=body.notes,
                 localidad=body.localidad,
                 colocacion=body.colocacion,
-                pileta=body.pileta.value if body.pileta else None,
+                # PR #397 — persistir el pileta resuelto (no el body raw)
+                # para que la DB refleje lo que el calculator usaría.
+                pileta=_resolved_pileta.value if _resolved_pileta else None,
                 sink_type=body.sink_type.model_dump() if body.sink_type else None,
                 anafe=body.anafe,
             )
@@ -122,7 +151,11 @@ async def create_quote_api(body: QuoteInput, db: AsyncSession = Depends(get_db))
             "pieces": [p.model_dump() for p in body.pieces],
             "localidad": body.localidad,
             "colocacion": body.colocacion,
-            "pileta": body.pileta.value if body.pileta else None,
+            "pileta": _resolved_pileta.value if _resolved_pileta else None,
+            # pileta_sku: si el chatbot mandó uno (o si el body.pileta_sku
+            # coexiste con pileta=empotrada_johnson), el calculator lo usa
+            # para lookup en sinks.json y agregar el producto físico.
+            "pileta_sku": body.pileta_sku or None,
             "anafe": body.anafe,
             "frentin": body.frentin,
             "pulido": body.pulido,
@@ -171,7 +204,9 @@ async def create_quote_api(body: QuoteInput, db: AsyncSession = Depends(get_db))
             notes=quote_notes,
             localidad=body.localidad,
             colocacion=body.colocacion,
-            pileta=body.pileta.value if body.pileta else None,
+            # PR #397 — persistir el pileta resuelto (puede venir de
+            # body.pileta directo o derivado de sink_type / pileta_sku).
+            pileta=_resolved_pileta.value if _resolved_pileta else None,
             sink_type=body.sink_type.model_dump() if body.sink_type else None,
             anafe=body.anafe,
             pieces=[p.model_dump() for p in body.pieces] if body.pieces else None,

--- a/api/app/modules/quote_engine/schemas.py
+++ b/api/app/modules/quote_engine/schemas.py
@@ -33,6 +33,12 @@ class QuoteInput(BaseModel):
     colocacion: bool = Field(default=True)
     pileta: Optional[PiletaType] = Field(default=None)
     sink_type: Optional[SinkTypeInput] = Field(default=None, description="Tipo de bacha: basin_count (simple/doble), mount_type (arriba/abajo)")
+    # PR #397 — SKU específico de pileta Johnson (ej: "LUXOR171", "ON30A").
+    # Si se envía, se intenta matchear contra `sinks.json` y se agrega como
+    # producto físico a la cotización (además del MO PEGADOPILETA). Si no
+    # matchea, el quote se crea igual con warning. Si no se envía, el
+    # comportamiento actual se mantiene (solo MO, sin producto).
+    pileta_sku: Optional[str] = Field(default=None, max_length=64, description="SKU de pileta Johnson del catálogo (opcional)")
     anafe: bool = Field(default=False)
     frentin: bool = Field(default=False)
     pulido: bool = Field(default=False)

--- a/api/tests/test_sink_type.py
+++ b/api/tests/test_sink_type.py
@@ -181,3 +181,200 @@ class TestSinkTypeListResponse:
         matched = [q for q in quotes if q["id"] == qid]
         assert len(matched) == 1
         assert matched[0]["sink_type"]["basin_count"] == "doble"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PR #397 — Defaults de pileta desde sink_type / pileta_sku
+# ═══════════════════════════════════════════════════════════════════════
+#
+# Regla acordada con operador (2026-04-24):
+#   1. body.pileta seteado → respetar.
+#   2. body.pileta_sku presente → pileta=empotrada_johnson.
+#   3. body.sink_type presente:
+#        - mount_type=arriba → apoyo.
+#        - mount_type=abajo  → empotrada_cliente.
+#   4. Nada → None (comportamiento actual).
+# basin_count NO multiplica pileta_qty (1 PEGADOPILETA, siempre).
+
+
+class TestSinkTypeDefaultsPileta:
+    """Sin body.pileta explícito, el router debe inferirlo desde
+    sink_type / pileta_sku, y el calculator cotiza MO de pileta según."""
+
+    async def _post_and_get_breakdown(self, client, **body_fields):
+        """Helper: POST /api/v1/quote con los campos pedidos + un
+        despiece mínimo. Retorna `quote_breakdown` del quote creado."""
+        from unittest.mock import patch
+        payload = {
+            "client_name": "Test Pileta Resolver",
+            "project": "Cocina",
+            "material": "Silestone Blanco Norte",
+            "pieces": [{"description": "Mesada", "largo": 2.0, "prof": 0.6}],
+            "localidad": "Rosario",
+            "plazo": "30 dias",
+            **body_fields,
+        }
+        with patch(
+            "app.modules.quote_engine.router.upload_to_drive",
+            return_value={"ok": True, "drive_url": "https://drive.test"},
+        ):
+            resp = await client.post("/api/v1/quote", json=payload)
+        assert resp.status_code == 200, resp.text
+        qid = resp.json()["quotes"][0]["quote_id"]
+        detail = await client.get(f"/api/quotes/{qid}")
+        return detail.json(), resp.json()["quotes"][0]
+
+    @pytest.mark.asyncio
+    async def test_sink_type_abajo_without_pileta_defaults_to_empotrada_cliente(
+        self, client,
+    ):
+        """sink_type.mount_type=abajo sin pileta → empotrada_cliente.
+        El calculator agrega PEGADOPILETA qty=1."""
+        q, item = await self._post_and_get_breakdown(
+            client,
+            sink_type={"basin_count": "simple", "mount_type": "abajo"},
+        )
+        assert q["pileta"] == "empotrada_cliente"
+        mo_descs = [mo["description"].lower() for mo in item["mo_items"]]
+        assert any("pegado pileta" in d for d in mo_descs)
+
+    @pytest.mark.asyncio
+    async def test_sink_type_arriba_without_pileta_defaults_to_apoyo(
+        self, client,
+    ):
+        """sink_type.mount_type=arriba sin pileta → apoyo.
+        El calculator agrega AGUJERO PILETA APOYO (no PEGADOPILETA)."""
+        q, item = await self._post_and_get_breakdown(
+            client,
+            sink_type={"basin_count": "simple", "mount_type": "arriba"},
+        )
+        assert q["pileta"] == "apoyo"
+        mo_descs = [mo["description"].lower() for mo in item["mo_items"]]
+        assert any("pileta apoyo" in d for d in mo_descs)
+
+    @pytest.mark.asyncio
+    async def test_pileta_sku_without_enum_defaults_to_empotrada_johnson(
+        self, client,
+    ):
+        """pileta_sku sin pileta enum → empotrada_johnson.
+        La bacha entra como producto si el SKU matchea sinks.json."""
+        q, item = await self._post_and_get_breakdown(
+            client,
+            pileta_sku="Z52",  # existe en sinks.json
+        )
+        assert q["pileta"] == "empotrada_johnson"
+        # El item físico pileta entra al breakdown via sinks[]
+        assert q["quote_breakdown"].get("sinks"), (
+            "esperaba que la bacha entre como producto cuando pileta_sku matchea"
+        )
+        sinks = q["quote_breakdown"]["sinks"]
+        assert any("JOHNSON" in (s.get("name") or "").upper() for s in sinks)
+        # MO de PEGADOPILETA también presente.
+        mo_descs = [mo["description"].lower() for mo in item["mo_items"]]
+        assert any("pegado pileta" in d for d in mo_descs)
+
+    @pytest.mark.asyncio
+    async def test_pileta_sku_with_explicit_pileta_respects_explicit(
+        self, client,
+    ):
+        """Si el cliente manda ambos, body.pileta gana sobre la
+        inferencia por sku (prioridad 1 de la regla)."""
+        q, item = await self._post_and_get_breakdown(
+            client,
+            pileta="apoyo",  # explícito
+            pileta_sku="Z52",
+        )
+        assert q["pileta"] == "apoyo"
+        # Nota: con pileta=apoyo el calculator NO agrega sink product
+        # (la rama de sinks[] requiere empotrada_johnson).
+        mo_descs = [mo["description"].lower() for mo in item["mo_items"]]
+        assert any("pileta apoyo" in d for d in mo_descs)
+
+    @pytest.mark.asyncio
+    async def test_basin_count_doble_does_not_multiply_qty(self, client):
+        """Regla del operador: doble sigue siendo 1 PEGADOPILETA, no 2.
+        basin_count es dato comercial/contextual, no multiplicador."""
+        q, item = await self._post_and_get_breakdown(
+            client,
+            sink_type={"basin_count": "doble", "mount_type": "abajo"},
+        )
+        # Un solo item de pegado pileta (no 2).
+        pegado_items = [
+            mo for mo in item["mo_items"]
+            if "pegado pileta" in mo["description"].lower()
+        ]
+        assert len(pegado_items) == 1
+        assert pegado_items[0]["quantity"] == 1
+
+    @pytest.mark.asyncio
+    async def test_no_pileta_no_sink_type_no_mo(self, client):
+        """Sin pileta, sin sink_type, sin pileta_sku → comportamiento
+        actual: el calculator no cotiza MO de pileta."""
+        q, item = await self._post_and_get_breakdown(client)
+        assert q["pileta"] is None
+        mo_descs = [mo["description"].lower() for mo in item["mo_items"]]
+        assert not any("pileta" in d for d in mo_descs)
+
+    @pytest.mark.asyncio
+    async def test_explicit_pileta_respected_over_sink_type(self, client):
+        """body.pileta explícito (apoyo) + sink_type.mount_type=abajo
+        (que inferiría empotrada_cliente) → gana el explícito."""
+        q, item = await self._post_and_get_breakdown(
+            client,
+            pileta="apoyo",
+            sink_type={"basin_count": "simple", "mount_type": "abajo"},
+        )
+        assert q["pileta"] == "apoyo"
+
+    @pytest.mark.asyncio
+    async def test_pileta_sku_not_found_still_adds_mo(self, client):
+        """Si pileta_sku se envía pero no existe en sinks.json → MO
+        PEGADOPILETA sí entra (regla #5: 'si no hay pileta_sku, igual
+        tiene que entrar la MO correspondiente')."""
+        q, item = await self._post_and_get_breakdown(
+            client,
+            pileta_sku="INEXISTENTE_XYZ123",
+        )
+        assert q["pileta"] == "empotrada_johnson"
+        mo_descs = [mo["description"].lower() for mo in item["mo_items"]]
+        assert any("pegado pileta" in d for d in mo_descs), (
+            "MO debe entrar aunque el SKU del producto no matchee"
+        )
+
+
+class TestSinkTypeDefaultsNoPiecesPath:
+    """Path no-pieces: el default se aplica antes de persistir el
+    quote DRAFT/PENDING. La DB refleja el pileta resuelto."""
+
+    @pytest.mark.asyncio
+    async def test_no_pieces_sink_type_resolves_pileta(self, client):
+        """Sin pieces + sink_type abajo sin pileta → persiste
+        empotrada_cliente en Quote.pileta (para que el operador vea el
+        estado correcto al abrir el quote)."""
+        resp = await client.post("/api/v1/quote", json={
+            "client_name": "Web No Pieces",
+            "project": "Cocina",
+            "material": "Silestone Blanco Norte",
+            "localidad": "Rosario",
+            "sink_type": {"basin_count": "simple", "mount_type": "abajo"},
+            "notes": "Mesada con bacha simple",
+        })
+        assert resp.status_code == 200
+        qid = resp.json()["quotes"][0]["quote_id"]
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        assert detail["pileta"] == "empotrada_cliente"
+
+    @pytest.mark.asyncio
+    async def test_no_pieces_pileta_sku_defaults_johnson(self, client):
+        resp = await client.post("/api/v1/quote", json={
+            "client_name": "Web SKU",
+            "project": "Cocina",
+            "material": "Silestone Blanco Norte",
+            "localidad": "Rosario",
+            "pileta_sku": "LUXOR171",
+            "notes": "Cliente pidió Johnson",
+        })
+        assert resp.status_code == 200
+        qid = resp.json()["quotes"][0]["quote_id"]
+        detail = (await client.get(f"/api/quotes/{qid}")).json()
+        assert detail["pileta"] == "empotrada_johnson"


### PR DESCRIPTION
## Bug raíz

Antes de este PR, el endpoint público \`/api/v1/quote\` tenía dos fugas:

1. **\`sink_type\` se persistía pero NO entraba al cálculo.** Si el chatbot externo mandaba \`sink_type: {basin_count, mount_type}\` sin setear \`body.pileta\`, el calculator veía \`pileta=None\` → **no cotizaba PEGADOPILETA ni la bacha**. La info quedaba solo en \`Quote.sink_type\` como dato decorativo.
2. **\`pileta_sku\` no existía en el schema público.** El calculator soportaba el campo internamente (usado por el agente Valentina) pero el chatbot externo no podía especificar modelo → la bacha **nunca** entraba como producto vía API pública.

## Fix (Opción 1 + \`pileta_sku\` opcional)

### \`schemas.py\`

\`\`\`python
class QuoteInput(BaseModel):
    ...
    pileta_sku: Optional[str] = Field(default=None, max_length=64)
\`\`\`

### \`router.py\` — resolver \`pileta\` antes de persistir/calcular

\`\`\`python
_resolved_pileta: Optional[PiletaType] = body.pileta
if _resolved_pileta is None:
    if body.pileta_sku:
        _resolved_pileta = PiletaType.EMPOTRADA_JOHNSON
    elif body.sink_type is not None:
        if body.sink_type.mount_type == "arriba":
            _resolved_pileta = PiletaType.APOYO
        else:  # "abajo"
            _resolved_pileta = PiletaType.EMPOTRADA_CLIENTE
\`\`\`

- Ambos paths (con-pieces → calculator; no-pieces → DRAFT/PENDING) usan el mismo valor resuelto.
- \`calc_input\` ahora incluye \`pileta\` resuelto + \`pileta_sku\`.
- \`Quote.pileta\` en DB refleja lo que se usó para cotizar (ya no el body raw).

## Regla de negocio confirmada

\`basin_count=doble\` **NO multiplica** \`pileta_qty\`. "Doble" = 1 mesada con doble seno conectado = 1 PEGADOPILETA. Si en el futuro hay 2 piletas físicamente separadas, se soporta con un \`pileta_qty\` explícito en el payload (no cubierto en este PR).

## Tabla de resolución

| body.pileta | body.pileta_sku | body.sink_type.mount_type | → pileta resuelto |
|---|---|---|---|
| \`apoyo\` | — | — | \`apoyo\` (respetado) |
| \`empotrada_johnson\` | \`LUXOR171\` | — | \`empotrada_johnson\` + bacha en sinks[] |
| \`null\` | \`LUXOR171\` | — | \`empotrada_johnson\` + bacha en sinks[] |
| \`null\` | \`null\` | \`abajo\` | \`empotrada_cliente\` |
| \`null\` | \`null\` | \`arriba\` | \`apoyo\` |
| \`null\` | \`null\` | \`null\` | \`null\` (no cotiza MO pileta) |
| \`null\` | \`INEXISTENTE\` | — | \`empotrada_johnson\` + **MO sí, producto no** (warning) |

## Alcance

- **Solo** \`schemas.py\` + \`router.py\` (endpoint público).
- **No toca** calculator, tools del agente, chat interno, frontend.
- **No cambia** el comportamiento del operador con JWT.

## Test plan

- [x] **9 tests nuevos** en \`test_sink_type.py\`:
  - \`sink_type\` abajo sin pileta → empotrada_cliente + PEGADOPILETA.
  - \`sink_type\` arriba sin pileta → apoyo + AGUJEROAPOYO.
  - \`pileta_sku\` sin enum → empotrada_johnson + bacha en sinks[].
  - \`body.pileta\` explícito gana sobre sink_type/pileta_sku.
  - \`basin_count=doble\` → qty=1 (no multiplica).
  - Sin nada → no cotiza MO pileta.
  - \`pileta_sku\` inexistente → MO igual entra, sin producto.
  - Path no-pieces también persiste pileta resuelto en DB.
- [x] Suite completa API: 1740 passed, 1 pre-existente (edificios).
- [ ] **Manual post-merge**: POST \`/api/v1/quote\` con solo \`sink_type: {basin_count: "simple", mount_type: "abajo"}\` → quote incluye MO PEGADOPILETA. POST con \`pileta_sku: "Z52"\` → quote_breakdown.sinks tiene la bacha Johnson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)