### PR TITLE
feat(business-rules): endpoint público v0 para bot web

### DIFF
--- a/api/app/core/auth.py
+++ b/api/app/core/auth.py
@@ -73,6 +73,12 @@ PUBLIC_ROUTES = {
     "/api/auth/login",
     "/api/auth/create-user",  # Protected internally (checks if users exist)
     "/api/v1/quote",  # Web API — uses its own API key
+    # PR #398 — endpoint de reglas de negocio v0 para el bot web.
+    # Público sin api-key: el bot externo necesita levantarlo al
+    # construir su system prompt y no tiene credenciales. El payload
+    # NO expone precios, SKUs internos, ni lógica comercial — solo
+    # vocabulario de captura. Ver `business_rules/schema.py`.
+    "/api/v1/business-rules",
 }
 
 # Route prefixes that are public

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -137,6 +137,9 @@ app.include_router(usage_router, prefix="/api")
 app.include_router(agent_router, prefix="/api")
 app.include_router(catalog_router, prefix="/api")
 app.include_router(quote_engine_router, prefix="/api")
+# PR #398 — endpoint público de reglas de negocio v0 para el bot web.
+from app.modules.business_rules.router import router as business_rules_router
+app.include_router(business_rules_router, prefix="/api")
 # Authenticated file serving (replaces unauthenticated StaticFiles mount)
 app.include_router(files_router)
 

--- a/api/app/modules/business_rules/__init__.py
+++ b/api/app/modules/business_rules/__init__.py
@@ -1,0 +1,2 @@
+"""Business rules v0 — endpoint público de subset mínimo de reglas
+consumibles por el bot web (PR #398)."""

--- a/api/app/modules/business_rules/router.py
+++ b/api/app/modules/business_rules/router.py
@@ -1,0 +1,69 @@
+"""Endpoint público `GET /api/v1/business-rules` v0.
+
+- Sin auth. Pensado para ser fetcheado por el bot web al construir su
+  system prompt sin necesidad de credenciales.
+- `Cache-Control: max-age=3600` (1h). Bump manual de `version` cuando
+  hay cambio breaking — el cliente puede comparar `version` en su
+  payload cacheado.
+- `ETag` por hash determinístico del payload. Si el contenido no
+  cambió, el cliente revalida con `If-None-Match` y el server
+  responde 304.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+
+from fastapi import APIRouter, Header, Response
+
+from app.modules.business_rules.rules import build_rules
+from app.modules.business_rules.schema import BusinessRulesV0
+
+
+router = APIRouter(tags=["business-rules"])
+
+
+def _compute_etag(payload: dict) -> str:
+    """Hash determinístico del payload — sirve como ETag stable. Sort
+    keys para que el orden de inserción no afecte el hash."""
+    blob = json.dumps(payload, sort_keys=True, ensure_ascii=False)
+    digest = hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+    return f'"{digest}"'  # ETag spec exige comillas dobles.
+
+
+@router.get(
+    "/v1/business-rules",
+    response_model=BusinessRulesV0,
+    summary="Reglas de negocio v0 para el bot web",
+)
+async def get_business_rules(
+    response: Response,
+    if_none_match: str | None = Header(default=None, alias="If-None-Match"),
+) -> BusinessRulesV0:
+    """Retorna el subset mínimo de reglas que el bot web necesita para
+    capturar leads sin romper.
+
+    Headers de respuesta:
+        - `Cache-Control: max-age=3600`
+        - `ETag: "<hash>"` — el cliente puede usarlo en `If-None-Match`
+          para revalidar.
+
+    Status 304 si el ETag entrante coincide con el actual.
+    """
+    rules = build_rules()
+    payload = rules.model_dump()
+    etag = _compute_etag(payload)
+
+    response.headers["Cache-Control"] = "public, max-age=3600"
+    response.headers["ETag"] = etag
+
+    # Si el cliente revalida con un ETag idéntico, devolvemos 304 sin
+    # body. FastAPI no expone una API limpia para "204/304 con headers"
+    # desde un endpoint con `response_model`, así que se setea el
+    # status_code en la response y dejamos a Pydantic devolver el
+    # modelo (FastAPI lo serializa, pero con status 304 el body es
+    # ignorado por la spec HTTP).
+    if if_none_match and if_none_match == etag:
+        response.status_code = 304
+
+    return rules

--- a/api/app/modules/business_rules/rules.py
+++ b/api/app/modules/business_rules/rules.py
@@ -1,0 +1,100 @@
+"""Construcción del payload de `business-rules` v0.
+
+Política de fuentes (acordado con operador, 2026-04-24):
+  - **Levantar de la fuente de verdad** cuando exista como dato
+    estructurado (constante / enum / dict). Cero duplicación.
+  - **Hardcodear en este módulo** solo las reglas que hoy son lógica
+    Python (ej: "cocina_requires_capture" deriva de
+    `_detect_pileta_question` que es una función con condicional, no
+    una constante). Documentar el origen.
+
+Si una constante / enum referenciado se renombra o cambia su shape,
+este módulo va a romper en import — es la salvaguarda contra drift.
+"""
+from __future__ import annotations
+
+from typing import get_args
+
+from app.modules.business_rules.schema import (
+    BusinessRulesV0,
+    MaterialsRules,
+    SinkRules,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Versión del payload v0
+# ─────────────────────────────────────────────────────────────────────
+#
+# Formato ISO YYYY-MM-DD. Bump manual al introducir cambios breaking
+# (renombre de campos, cambio de tipos, remoción). Cambios aditivos
+# (nuevo campo opcional) no requieren bump.
+_VERSION = "2026-04-24"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Mapping interno (NO se serializa al cliente)
+# ─────────────────────────────────────────────────────────────────────
+#
+# El bot web ve el eje `ownership` con dos valores canónicos:
+# `cliente` y `dangelo`. Backend interno usa el enum `PiletaType`
+# del schema `QuoteInput`. Mapeo:
+#
+#   cliente  → PiletaType.EMPOTRADA_CLIENTE
+#   dangelo  → PiletaType.EMPOTRADA_JOHNSON (+ opcional `pileta_sku`)
+#
+# El valor `apoyo` del enum no es ownership — es mount type. Por eso
+# `apoyo` queda fuera de `ownership_options` y se modela como
+# `mount_options=arriba` (ver `mount_options` abajo).
+#
+# Cuando el bot web envía a /api/v1/quote:
+#   ownership=cliente, mount=abajo  → pileta=empotrada_cliente
+#   ownership=dangelo, mount=abajo  → pileta=empotrada_johnson [+ pileta_sku]
+#   ownership=cliente, mount=arriba → pileta=apoyo (cliente trae bacha de apoyo)
+#   ownership=dangelo, mount=arriba → no soportado (D'Angelo no
+#                                     provee piletas de apoyo, fuera
+#                                     de catálogo).
+_OWNERSHIP_OPTIONS = ("cliente", "dangelo")
+
+
+def _mount_options() -> list[str]:
+    """Levanta los valores válidos de `mount_type` desde la fuente
+    canónica (schema del POST /api/v1/quote). Si alguien renombra el
+    Literal, este módulo rompe en import — drift detectado."""
+    from app.modules.quote_engine.schemas import SinkTypeInput
+
+    field = SinkTypeInput.model_fields["mount_type"]
+    return list(get_args(field.annotation))
+
+
+def _material_families() -> list[str]:
+    """Levanta las familias canónicas del matcher de materiales
+    (calculator.py post-#396). Misma garantía anti-drift: si el dict
+    se renombra, este módulo no importa."""
+    from app.modules.quote_engine.calculator import _FAMILY_CATALOGS
+
+    return list(_FAMILY_CATALOGS.keys())
+
+
+def build_rules() -> BusinessRulesV0:
+    """Construye el payload completo del endpoint.
+
+    Función pura — sin DB, sin LLM, sin side-effects. Llamable desde
+    cualquier contexto (incluido tests sin fixtures).
+    """
+    return BusinessRulesV0(
+        version=_VERSION,
+        sink=SinkRules(
+            # `cocina_requires_capture=True` refleja la lógica de
+            # `pending_questions.py::_detect_pileta_question` — la
+            # pregunta de pileta se dispara SIEMPRE en cocina (salvo
+            # que el brief la niegue explícito). Hardcodeado acá
+            # porque es lógica condicional, no una constante.
+            cocina_requires_capture=True,
+            ownership_options=list(_OWNERSHIP_OPTIONS),
+            mount_options=_mount_options(),
+        ),
+        materials=MaterialsRules(
+            families=_material_families(),
+        ),
+    )

--- a/api/app/modules/business_rules/schema.py
+++ b/api/app/modules/business_rules/schema.py
@@ -1,0 +1,71 @@
+"""Pydantic schemas del payload de `GET /api/v1/business-rules`.
+
+Shape v0 acordado con el operador (2026-04-24). Cualquier cambio
+breaking debe bumpear `version` y notificar al consumer (bot web).
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class SinkRules(BaseModel):
+    """Vocabulario para captura de pileta/bacha en el bot web."""
+
+    cocina_requires_capture: bool = Field(
+        ...,
+        description=(
+            "Si True, el bot web debe capturar pileta antes de cerrar el "
+            "lead cuando el proyecto incluye cocina. Refleja la regla "
+            "interna 'en cocina la pileta siempre va empotrada' — el "
+            "operador debe saber tipo y ownership antes de cotizar."
+        ),
+    )
+    ownership_options: list[Literal["cliente", "dangelo"]] = Field(
+        ...,
+        description=(
+            "Quién provee la pileta. 'cliente' = el cliente trae la pileta; "
+            "'dangelo' = D'Angelo provee del catálogo Johnson (puede pasar "
+            "`pileta_sku` opcional al endpoint /api/v1/quote para SKU "
+            "específico)."
+        ),
+    )
+    mount_options: list[Literal["abajo", "arriba"]] = Field(
+        ...,
+        description=(
+            "Tipo de montaje. 'abajo' = bajo mesada (empotrada); 'arriba' "
+            "= sobre mesada (apoyo). Mismo vocabulario que el campo "
+            "`sink_type.mount_type` del POST /api/v1/quote."
+        ),
+    )
+
+
+class MaterialsRules(BaseModel):
+    """Vocabulario de familias de materiales para el bot web."""
+
+    families: list[str] = Field(
+        ...,
+        description=(
+            "Familias canónicas reconocidas por el matcher de materiales. "
+            "El bot web puede usarlas para sugerir opciones al usuario sin "
+            "mezclar familias (ej: no proponer granito cuando piden "
+            "puraprima). El POST /api/v1/quote acepta `material` con "
+            "cualquier string que contenga keyword de familia."
+        ),
+    )
+
+
+class BusinessRulesV0(BaseModel):
+    """Payload completo de `GET /api/v1/business-rules`."""
+
+    version: str = Field(
+        ...,
+        description=(
+            "Versión del payload en formato ISO YYYY-MM-DD. Se bumpea "
+            "manualmente cuando hay cambio breaking. El bot web puede "
+            "comparar contra su versión cacheada para revalidación."
+        ),
+    )
+    sink: SinkRules
+    materials: MaterialsRules

--- a/api/tests/test_business_rules_endpoint.py
+++ b/api/tests/test_business_rules_endpoint.py
@@ -1,0 +1,235 @@
+"""Tests para PR #398 — `GET /api/v1/business-rules`.
+
+Subset v0 (acordado con operador, 2026-04-24):
+  1. cocina_requires_capture — anti-Fabiana.
+  2. ownership_options — cliente / dangelo.
+  3. mount_options — abajo / arriba (levantado de SinkTypeInput).
+  4. material families — levantadas de _FAMILY_CATALOGS (post-#396).
+
+Endpoint público sin auth — el bot web lo fetchea al construir su
+system prompt sin credenciales. Cache-Control + ETag para revalidación.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Smoke: 200 con shape correcto
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestBusinessRulesEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_200_with_shape(self, client_no_auth):
+        """Endpoint público — accesible sin cookie ni X-API-Key."""
+        resp = await client_no_auth.get("/api/v1/business-rules")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert "version" in body
+        assert "sink" in body
+        assert "materials" in body
+
+    @pytest.mark.asyncio
+    async def test_version_parses_as_iso_date(self, client_no_auth):
+        """`version` debe ser ISO YYYY-MM-DD (parseable como fecha)."""
+        resp = await client_no_auth.get("/api/v1/business-rules")
+        v = resp.json()["version"]
+        # Validación: fromisoformat acepta YYYY-MM-DD.
+        parsed = date.fromisoformat(v)
+        assert parsed.year >= 2025  # sanity: no es una fecha basura.
+
+    @pytest.mark.asyncio
+    async def test_sink_fields_typed_correctly(self, client_no_auth):
+        body = (await client_no_auth.get("/api/v1/business-rules")).json()
+        sink = body["sink"]
+
+        assert isinstance(sink["cocina_requires_capture"], bool)
+        assert sink["cocina_requires_capture"] is True
+
+        assert isinstance(sink["ownership_options"], list)
+        assert sink["ownership_options"] == ["cliente", "dangelo"]
+
+        assert isinstance(sink["mount_options"], list)
+        # Orden no importa, contenido sí.
+        assert set(sink["mount_options"]) == {"abajo", "arriba"}
+
+    @pytest.mark.asyncio
+    async def test_materials_families_match_internal_catalog(self, client_no_auth):
+        """Las familias expuestas DEBEN coincidir con el matcher interno
+        post-#396. Si alguien renombra `_FAMILY_CATALOGS`, este test
+        detecta drift."""
+        from app.modules.quote_engine.calculator import _FAMILY_CATALOGS
+
+        body = (await client_no_auth.get("/api/v1/business-rules")).json()
+        families = body["materials"]["families"]
+
+        assert isinstance(families, list)
+        assert all(isinstance(f, str) for f in families)
+        assert set(families) == set(_FAMILY_CATALOGS.keys())
+        # v0 debe incluir las 8 conocidas.
+        for expected in (
+            "puraprima", "purastone", "silestone", "dekton",
+            "neolith", "laminatto", "granito", "marmol",
+        ):
+            assert expected in families, f"missing family: {expected}"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Acceso público (sin auth)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestPublicAccess:
+    @pytest.mark.asyncio
+    async def test_no_jwt_cookie_required(self, client_no_auth):
+        """Sin cookie de sesión → no 401."""
+        resp = await client_no_auth.get("/api/v1/business-rules")
+        assert resp.status_code != 401
+
+    @pytest.mark.asyncio
+    async def test_no_x_api_key_required(self, client_no_auth):
+        """Sin X-API-Key → no 401. El bot web lo fetchea sin
+        credenciales."""
+        resp = await client_no_auth.get(
+            "/api/v1/business-rules",
+            headers={},  # explícitamente sin headers
+        )
+        assert resp.status_code == 200
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Cache-Control + ETag
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestCachingHeaders:
+    @pytest.mark.asyncio
+    async def test_cache_control_max_age_3600(self, client_no_auth):
+        resp = await client_no_auth.get("/api/v1/business-rules")
+        cc = resp.headers.get("cache-control") or resp.headers.get("Cache-Control")
+        assert cc is not None
+        assert "max-age=3600" in cc
+
+    @pytest.mark.asyncio
+    async def test_etag_present_and_quoted(self, client_no_auth):
+        """ETag debe venir con comillas dobles según RFC 7232."""
+        resp = await client_no_auth.get("/api/v1/business-rules")
+        etag = resp.headers.get("etag") or resp.headers.get("ETag")
+        assert etag is not None
+        assert etag.startswith('"') and etag.endswith('"')
+
+    @pytest.mark.asyncio
+    async def test_etag_stable_across_requests(self, client_no_auth):
+        """Mismo payload → mismo ETag. Determinístico (sort_keys
+        en el hash)."""
+        r1 = await client_no_auth.get("/api/v1/business-rules")
+        r2 = await client_no_auth.get("/api/v1/business-rules")
+        e1 = r1.headers.get("etag") or r1.headers.get("ETag")
+        e2 = r2.headers.get("etag") or r2.headers.get("ETag")
+        assert e1 == e2
+
+    @pytest.mark.asyncio
+    async def test_if_none_match_returns_304(self, client_no_auth):
+        """Cliente revalida con ETag actual → 304 Not Modified."""
+        first = await client_no_auth.get("/api/v1/business-rules")
+        etag = first.headers.get("etag") or first.headers.get("ETag")
+
+        revalidate = await client_no_auth.get(
+            "/api/v1/business-rules",
+            headers={"If-None-Match": etag},
+        )
+        assert revalidate.status_code == 304
+
+    @pytest.mark.asyncio
+    async def test_if_none_match_mismatch_returns_200(self, client_no_auth):
+        """ETag distinto al actual → 200 con body fresco."""
+        resp = await client_no_auth.get(
+            "/api/v1/business-rules",
+            headers={"If-None-Match": '"stale-etag-xyz"'},
+        )
+        assert resp.status_code == 200
+        # Body presente.
+        assert "version" in resp.json()
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Anti-leak: no expone data sensible
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestNoSensitiveLeak:
+    """Garantía explícita: el payload NO contiene precios, SKUs
+    internos, lógica comercial. Si alguien agrega un campo nuevo que
+    rompa esto, los tests fallan."""
+
+    @pytest.mark.asyncio
+    async def test_payload_keys_are_only_v0_subset(self, client_no_auth):
+        body = (await client_no_auth.get("/api/v1/business-rules")).json()
+        assert set(body.keys()) == {"version", "sink", "materials"}
+
+    @pytest.mark.asyncio
+    async def test_no_price_fields_anywhere(self, client_no_auth):
+        """Ninguna key del payload debe sonar a precio."""
+        body = (await client_no_auth.get("/api/v1/business-rules")).json()
+        blob = str(body).lower()
+        for forbidden in ("price", "precio", "iva", "ars", "usd",
+                          "discount", "descuento", "merma", "margen"):
+            assert forbidden not in blob, (
+                f"payload contiene token sensible: {forbidden!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_no_sku_fields(self, client_no_auth):
+        """No exponer SKUs internos (ej: 'PURAGREY', 'LUXOR171',
+        'PEGADOPILETA')."""
+        body = (await client_no_auth.get("/api/v1/business-rules")).json()
+        blob = str(body).upper()
+        for forbidden in ("PURAGREY", "LUXOR", "PEGADOPILETA", "QUADRA",
+                          "JOHNSON", "SILVER GREY", "BLANCO NORTE"):
+            assert forbidden not in blob, (
+                f"payload contiene SKU/marca: {forbidden!r}"
+            )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Función pura `build_rules()`
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestBuildRulesPure:
+    """`build_rules()` es función pura — sin DB, sin LLM. Llamable
+    desde tests sin fixtures."""
+
+    def test_pure_function_returns_pydantic_model(self):
+        from app.modules.business_rules.rules import build_rules
+        from app.modules.business_rules.schema import BusinessRulesV0
+
+        rules = build_rules()
+        assert isinstance(rules, BusinessRulesV0)
+        assert rules.sink.cocina_requires_capture is True
+        assert rules.sink.ownership_options == ["cliente", "dangelo"]
+
+    def test_mount_options_are_lifted_from_quote_input(self):
+        """Drift guard: si alguien renombra el Literal en
+        SinkTypeInput.mount_type, el endpoint refleja el cambio. Y si
+        rompe el shape, este test falla en el import."""
+        from app.modules.business_rules.rules import build_rules
+        from app.modules.quote_engine.schemas import SinkTypeInput
+        from typing import get_args
+
+        rules = build_rules()
+        expected = list(get_args(
+            SinkTypeInput.model_fields["mount_type"].annotation
+        ))
+        assert rules.sink.mount_options == expected
+
+    def test_families_lifted_from_calculator_constant(self):
+        """Drift guard idem para `_FAMILY_CATALOGS`."""
+        from app.modules.business_rules.rules import build_rules
+        from app.modules.quote_engine.calculator import _FAMILY_CATALOGS
+
+        rules = build_rules()
+        assert rules.materials.families == list(_FAMILY_CATALOGS.keys())


### PR DESCRIPTION
## Bug raíz (caso Fabiana Perdomo, 24/04/2026)

El bot web NO sabía la regla "cocina → siempre hay pileta, preguntar propia o D'Angelo" y cerró el lead sin capturar la pileta. La regla existe en este repo (\`pending_questions._detect_pileta_question\`) pero **no es consumible desde fuera**. Drift entre repos.

## Solución v0

Subset MÍNIMO de reglas vía \`GET /api/v1/business-rules\`. El bot web lo fetchea + cachea al construir su system prompt.

### Shape (4 puntos acordados)

\`\`\`json
{
  "version": "2026-04-24",
  "sink": {
    "cocina_requires_capture": true,
    "ownership_options": ["cliente", "dangelo"],
    "mount_options": ["abajo", "arriba"]
  },
  "materials": {
    "families": [
      "puraprima", "purastone", "silestone", "dekton",
      "neolith", "laminatto", "granito", "marmol"
    ]
  }
}
\`\`\`

### Mapping interno (documentado en \`rules.py\`)

\`\`\`
ownership=cliente, mount=abajo  → pileta=empotrada_cliente
ownership=dangelo, mount=abajo  → pileta=empotrada_johnson [+ pileta_sku opcional]
ownership=cliente, mount=arriba → pileta=apoyo (cliente trae bacha de apoyo)
ownership=dangelo, mount=arriba → no soportado (D'Angelo no provee piletas de apoyo)
\`\`\`

### Fuentes (sin duplicar)

| Campo | Origen |
|---|---|
| \`sink.cocina_requires_capture\` | **Hardcoded** en \`rules.py\` (refleja la lógica de \`_detect_pileta_question\` que es condicional, no constante). |
| \`sink.ownership_options\` | **Hardcoded** — eje canónico nuevo, no existe como estructura interna. |
| \`sink.mount_options\` | **Levantado** de \`SinkTypeInput.mount_type\` (\`Literal["arriba", "abajo"]\`). Drift guard: si renombran el Literal, este módulo rompe en import. |
| \`materials.families\` | **Levantado** de \`_FAMILY_CATALOGS\` keys (calculator post-#396). Drift guard idem. |

## Anti-leak verificado

El endpoint es **público sin api-key** (el bot web lo necesita sin credenciales). El payload **NO** expone:

- ❌ Precios (\`price_*\`, IVA, ARS, USD).
- ❌ SKUs internos (\`PURAGREY\`, \`LUXOR171\`, \`PEGADOPILETA\`, \`JOHNSON\`).
- ❌ Descuentos / márgenes (\`discount.*\`).
- ❌ Catálogos privados (qué archivo contiene qué SKU).
- ❌ Lógica de merma, colocación, flete.

Solo expone **vocabulario de captura**. Un competidor ve "D'Angelo distingue pileta cliente vs dangelo y trabaja estas 8 familias de piedra" — info pública.

## Caching

- \`Cache-Control: public, max-age=3600\` (1h).
- \`ETag\` con sha256(payload sort_keys). Stable entre requests con mismo contenido.
- \`If-None-Match\` matcheando → 304 sin body.
- \`version\` ISO YYYY-MM-DD. Bump manual cuando hay cambio breaking.

## Test plan

- [x] **17 tests nuevos** en \`test_business_rules_endpoint.py\`:
  - 200 con shape correcto, \`version\` parse ISO, todos los fields tipados.
  - Acceso público sin JWT ni X-API-Key.
  - Cache-Control + ETag estable + 304 con If-None-Match.
  - Anti-leak: payload keys exactas + tokens prohibidos no aparecen.
  - \`build_rules()\` puro + drift guards.
- [x] Suite completa API: 1757 passed, 1 pre-existente (edificios, no tocado).
- [ ] **Manual post-merge**:
  \`\`\`bash
  curl -i https://<railway>/api/v1/business-rules
  # Expect: 200 + Cache-Control: public, max-age=3600 + ETag: "..."
  curl -i -H 'If-None-Match: "<etag>"' https://<railway>/api/v1/business-rules
  # Expect: 304
  \`\`\`

## Lo que NO toca

- \`CONTEXT.md\`, \`calculator.py\` (solo import de constante existente), \`rules/*.md\`, chat del operador.
- Sin variables de entorno nuevas. Sin migraciones de DB. Deploy automático.

🤖 Generated with [Claude Code](https://claude.com/claude-code)