### PR TITLE
feat(business-rules): rework v0 con X-API-Key + shape prescriptivo

### DIFF
--- a/api/app/modules/business_rules/router.py
+++ b/api/app/modules/business_rules/router.py
@@ -1,31 +1,32 @@
-"""Endpoint público `GET /api/v1/business-rules` v0.
+"""Endpoint `GET /api/v1/business-rules` v0 (PR #399 rework).
 
-- Sin auth. Pensado para ser fetcheado por el bot web al construir su
-  system prompt sin necesidad de credenciales.
-- `Cache-Control: max-age=3600` (1h). Bump manual de `version` cuando
-  hay cambio breaking — el cliente puede comparar `version` en su
-  payload cacheado.
-- `ETag` por hash determinístico del payload. Si el contenido no
-  cambió, el cliente revalida con `If-None-Match` y el server
-  responde 304.
+- **Auth**: `X-API-Key` requerido (mismo esquema que `POST /api/v1/quote`).
+  Reusa `verify_api_key` del `quote_engine.router` — no duplica
+  middleware. Si `QUOTE_API_KEY` no está seteada en el env (dev),
+  el check se skipea para backward-compat con desarrollo local.
+- **Cache-Control: max-age=3600** (1h). Bump manual de `version` cuando
+  hay cambio breaking — el cliente compara con su payload cacheado.
+- **ETag** por hash determinístico. `If-None-Match` matcheando → 304
+  sin body.
 """
 from __future__ import annotations
 
 import hashlib
 import json
 
-from fastapi import APIRouter, Header, Response
+from fastapi import APIRouter, Depends, Header, Response
 
 from app.modules.business_rules.rules import build_rules
 from app.modules.business_rules.schema import BusinessRulesV0
+from app.modules.quote_engine.router import verify_api_key
 
 
 router = APIRouter(tags=["business-rules"])
 
 
 def _compute_etag(payload: dict) -> str:
-    """Hash determinístico del payload — sirve como ETag stable. Sort
-    keys para que el orden de inserción no afecte el hash."""
+    """Hash determinístico del payload — ETag estable. `sort_keys` para
+    que el orden de inserción no afecte el hash."""
     blob = json.dumps(payload, sort_keys=True, ensure_ascii=False)
     digest = hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
     return f'"{digest}"'  # ETag spec exige comillas dobles.
@@ -34,19 +35,21 @@ def _compute_etag(payload: dict) -> str:
 @router.get(
     "/v1/business-rules",
     response_model=BusinessRulesV0,
-    summary="Reglas de negocio v0 para el bot web",
+    summary="Reglas de negocio v0 para el bot web (X-API-Key requerido)",
+    dependencies=[Depends(verify_api_key)],
 )
 async def get_business_rules(
     response: Response,
     if_none_match: str | None = Header(default=None, alias="If-None-Match"),
 ) -> BusinessRulesV0:
-    """Retorna el subset mínimo de reglas que el bot web necesita para
+    """Retorna el subset de reglas que el bot web necesita para
     capturar leads sin romper.
 
+    Auth: header `X-API-Key: <key>` (mismo esquema que `/api/v1/quote`).
+
     Headers de respuesta:
-        - `Cache-Control: max-age=3600`
-        - `ETag: "<hash>"` — el cliente puede usarlo en `If-None-Match`
-          para revalidar.
+        - `Cache-Control: public, max-age=3600`
+        - `ETag: "<hash>"` — usable en `If-None-Match` para revalidar.
 
     Status 304 si el ETag entrante coincide con el actual.
     """
@@ -57,12 +60,6 @@ async def get_business_rules(
     response.headers["Cache-Control"] = "public, max-age=3600"
     response.headers["ETag"] = etag
 
-    # Si el cliente revalida con un ETag idéntico, devolvemos 304 sin
-    # body. FastAPI no expone una API limpia para "204/304 con headers"
-    # desde un endpoint con `response_model`, así que se setea el
-    # status_code en la response y dejamos a Pydantic devolver el
-    # modelo (FastAPI lo serializa, pero con status 304 el body es
-    # ignorado por la spec HTTP).
     if if_none_match and if_none_match == etag:
         response.status_code = 304
 

--- a/api/app/modules/business_rules/rules.py
+++ b/api/app/modules/business_rules/rules.py
@@ -1,76 +1,84 @@
-"""Construcción del payload de `business-rules` v0.
+"""Construcción del payload de `business-rules` v0 prescriptivo.
 
-Política de fuentes (acordado con operador, 2026-04-24):
-  - **Levantar de la fuente de verdad** cuando exista como dato
-    estructurado (constante / enum / dict). Cero duplicación.
-  - **Hardcodear en este módulo** solo las reglas que hoy son lógica
-    Python (ej: "cocina_requires_capture" deriva de
-    `_detect_pileta_question` que es una función con condicional, no
-    una constante). Documentar el origen.
+PR #399 — rework del shape original (#398) a versión copy-paste para
+prompt del bot web. El bot web no usa los strings como vocabulario
+abstracto: los inserta literal en su system prompt para asegurar que
+las preguntas al cliente final salgan idénticas a la convención del
+operador.
 
-Si una constante / enum referenciado se renombra o cambia su shape,
-este módulo va a romper en import — es la salvaguarda contra drift.
+Política de fuentes:
+  - Strings literales (question, notes) — hardcoded acá. Son contenido
+    de prompt, no derivable de constantes.
+  - `families` — levantado de `_FAMILY_CATALOGS` (calculator post-#396).
+    Drift guard: si renombran el dict, este módulo no importa.
+  - Flags booleanas (requires_clarification, marble_not_recommended,
+    purastone_one_word, etc.) — hardcoded reflejando reglas de negocio
+    documentadas en `rules/quote-process-general.md` y CONTEXT.md.
+
+Mapping interno (no se serializa al cliente — vive como descripción
+del field `payload_mapping`):
+
+    bot web manda → /api/v1/quote recibe
+    "propia"      → pileta="empotrada_cliente"
+    "dangelo"     → pileta="empotrada_johnson" (+ pileta_sku opcional)
+    "apoyo"       → pileta="apoyo"
 """
 from __future__ import annotations
 
-from typing import get_args
-
 from app.modules.business_rules.schema import (
+    BachaRules,
     BusinessRulesV0,
     MaterialsRules,
-    SinkRules,
+    NamingRules,
+    RulesPayload,
 )
 
 
 # ─────────────────────────────────────────────────────────────────────
-# Versión del payload v0
+# Versión del payload
 # ─────────────────────────────────────────────────────────────────────
 #
-# Formato ISO YYYY-MM-DD. Bump manual al introducir cambios breaking
+# Formato `YYYY-MM-DD-vN`. Bump manual al introducir cambios breaking
 # (renombre de campos, cambio de tipos, remoción). Cambios aditivos
-# (nuevo campo opcional) no requieren bump.
-_VERSION = "2026-04-24"
+# (nuevo campo opcional) no requieren bump pero conviene actualizar
+# la fecha si el cambio es significativo.
+_VERSION = "2026-04-24-v1"
 
 
 # ─────────────────────────────────────────────────────────────────────
-# Mapping interno (NO se serializa al cliente)
+# Strings literales — copy-paste del prompt del bot web
 # ─────────────────────────────────────────────────────────────────────
-#
-# El bot web ve el eje `ownership` con dos valores canónicos:
-# `cliente` y `dangelo`. Backend interno usa el enum `PiletaType`
-# del schema `QuoteInput`. Mapeo:
-#
-#   cliente  → PiletaType.EMPOTRADA_CLIENTE
-#   dangelo  → PiletaType.EMPOTRADA_JOHNSON (+ opcional `pileta_sku`)
-#
-# El valor `apoyo` del enum no es ownership — es mount type. Por eso
-# `apoyo` queda fuera de `ownership_options` y se modela como
-# `mount_options=arriba` (ver `mount_options` abajo).
-#
-# Cuando el bot web envía a /api/v1/quote:
-#   ownership=cliente, mount=abajo  → pileta=empotrada_cliente
-#   ownership=dangelo, mount=abajo  → pileta=empotrada_johnson [+ pileta_sku]
-#   ownership=cliente, mount=arriba → pileta=apoyo (cliente trae bacha de apoyo)
-#   ownership=dangelo, mount=arriba → no soportado (D'Angelo no
-#                                     provee piletas de apoyo, fuera
-#                                     de catálogo).
-_OWNERSHIP_OPTIONS = ("cliente", "dangelo")
 
+_BACHA_QUESTION = "¿La pileta ya la tenés, o la comprás con nosotros?"
 
-def _mount_options() -> list[str]:
-    """Levanta los valores válidos de `mount_type` desde la fuente
-    canónica (schema del POST /api/v1/quote). Si alguien renombra el
-    Literal, este módulo rompe en import — drift detectado."""
-    from app.modules.quote_engine.schemas import SinkTypeInput
+_BACHA_DO_NOT_ASK = [
+    "simple/doble",
+    "arriba/abajo",
+]
 
-    field = SinkTypeInput.model_fields["mount_type"]
-    return list(get_args(field.annotation))
+_BACHA_PAYLOAD_MAPPING = {
+    "propia": "empotrada_cliente",
+    "dangelo": "empotrada_johnson",
+    "apoyo": "apoyo",
+}
+
+_BACHA_NOTES = [
+    (
+        "Si el cliente menciona pileta, bacha, agujero para pileta o dice "
+        "que no tiene la pileta, aclarar si la trae o la compra en "
+        "D'Angelo antes de cerrar."
+    ),
+    (
+        "No preguntar detalle fino de bacha como simple/doble o pegada "
+        "arriba/abajo."
+    ),
+]
 
 
 def _material_families() -> list[str]:
     """Levanta las familias canónicas del matcher de materiales
-    (calculator.py post-#396). Misma garantía anti-drift: si el dict
-    se renombra, este módulo no importa."""
+    (calculator.py post-#396). Si el dict se renombra, este módulo
+    rompe en import — drift guard."""
     from app.modules.quote_engine.calculator import _FAMILY_CATALOGS
 
     return list(_FAMILY_CATALOGS.keys())
@@ -84,17 +92,22 @@ def build_rules() -> BusinessRulesV0:
     """
     return BusinessRulesV0(
         version=_VERSION,
-        sink=SinkRules(
-            # `cocina_requires_capture=True` refleja la lógica de
-            # `pending_questions.py::_detect_pileta_question` — la
-            # pregunta de pileta se dispara SIEMPRE en cocina (salvo
-            # que el brief la niegue explícito). Hardcodeado acá
-            # porque es lógica condicional, no una constante.
-            cocina_requires_capture=True,
-            ownership_options=list(_OWNERSHIP_OPTIONS),
-            mount_options=_mount_options(),
-        ),
-        materials=MaterialsRules(
-            families=_material_families(),
+        rules=RulesPayload(
+            bacha=BachaRules(
+                requires_clarification_when_mentioned=True,
+                question=_BACHA_QUESTION,
+                do_not_ask=list(_BACHA_DO_NOT_ASK),
+                payload_mapping=dict(_BACHA_PAYLOAD_MAPPING),
+                notes=list(_BACHA_NOTES),
+            ),
+            materials=MaterialsRules(
+                marble_not_recommended_for_kitchen=True,
+                silestone_purastone_not_for_exterior=True,
+                families=_material_families(),
+            ),
+            naming=NamingRules(
+                purastone_one_word=True,
+                puraprima_one_word=True,
+            ),
         ),
     )

--- a/api/app/modules/business_rules/schema.py
+++ b/api/app/modules/business_rules/schema.py
@@ -1,7 +1,13 @@
 """Pydantic schemas del payload de `GET /api/v1/business-rules`.
 
-Shape v0 acordado con el operador (2026-04-24). Cualquier cambio
-breaking debe bumpear `version` y notificar al consumer (bot web).
+Shape v0 prescriptivo (PR #399, rework de #398): el bot web copia
+estos strings literal en su system prompt. Por eso los campos son
+copy-paste-into-prompt (question literal, notes literales, flags
+booleanas), no vocabulario abstracto.
+
+Cualquier cambio breaking debe bumpear `version` y notificar al
+consumer (bot web). El formato de version es `YYYY-MM-DD-vN` —
+permite múltiples versiones el mismo día si hace falta.
 """
 from __future__ import annotations
 
@@ -10,50 +16,109 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 
-class SinkRules(BaseModel):
-    """Vocabulario para captura de pileta/bacha en el bot web."""
+class BachaRules(BaseModel):
+    """Reglas de captura de pileta/bacha para el bot web."""
 
-    cocina_requires_capture: bool = Field(
+    requires_clarification_when_mentioned: bool = Field(
         ...,
         description=(
-            "Si True, el bot web debe capturar pileta antes de cerrar el "
-            "lead cuando el proyecto incluye cocina. Refleja la regla "
-            "interna 'en cocina la pileta siempre va empotrada' — el "
-            "operador debe saber tipo y ownership antes de cotizar."
+            "Si True, cuando el cliente mencione pileta/bacha/agujero "
+            "para pileta o diga que no tiene la pileta, el bot debe "
+            "preguntar si la trae o la compra en D'Angelo antes de "
+            "cerrar el lead."
         ),
     )
-    ownership_options: list[Literal["cliente", "dangelo"]] = Field(
+    question: str = Field(
         ...,
         description=(
-            "Quién provee la pileta. 'cliente' = el cliente trae la pileta; "
-            "'dangelo' = D'Angelo provee del catálogo Johnson (puede pasar "
-            "`pileta_sku` opcional al endpoint /api/v1/quote para SKU "
-            "específico)."
+            "Texto literal que el bot debe usar para preguntar. "
+            "Copy-paste exacto."
         ),
     )
-    mount_options: list[Literal["abajo", "arriba"]] = Field(
+    do_not_ask: list[str] = Field(
         ...,
         description=(
-            "Tipo de montaje. 'abajo' = bajo mesada (empotrada); 'arriba' "
-            "= sobre mesada (apoyo). Mismo vocabulario que el campo "
-            "`sink_type.mount_type` del POST /api/v1/quote."
+            "Topics que el bot NO debe preguntar al cliente — son "
+            "detalles internos que el operador resuelve después."
+        ),
+    )
+    payload_mapping: dict[
+        Literal["propia", "dangelo", "apoyo"],
+        Literal["empotrada_cliente", "empotrada_johnson", "apoyo"],
+    ] = Field(
+        ...,
+        description=(
+            "Mapping de la respuesta del cliente al valor del enum "
+            "`pileta` que se manda en POST /api/v1/quote. "
+            "'propia' = cliente la trae; 'dangelo' = D'Angelo la "
+            "provee; 'apoyo' = pileta sobre mesada."
+        ),
+    )
+    notes: list[str] = Field(
+        ...,
+        description=(
+            "Notas adicionales que el bot puede usar como contexto en "
+            "el prompt. Texto literal en español."
         ),
     )
 
 
 class MaterialsRules(BaseModel):
-    """Vocabulario de familias de materiales para el bot web."""
+    """Reglas y vocabulario de materiales para el bot web."""
 
+    marble_not_recommended_for_kitchen: bool = Field(
+        ...,
+        description=(
+            "Si True, el bot debe desaconsejar mármol para cocina (es "
+            "poroso, se mancha con ácidos). Sugerir alternativas "
+            "(granito / sintéticos)."
+        ),
+    )
+    silestone_purastone_not_for_exterior: bool = Field(
+        ...,
+        description=(
+            "Si True, el bot debe desaconsejar Silestone y Purastone "
+            "para exterior (no resistentes a UV / temperatura). "
+            "Sugerir Dekton / Neolith."
+        ),
+    )
     families: list[str] = Field(
         ...,
         description=(
-            "Familias canónicas reconocidas por el matcher de materiales. "
-            "El bot web puede usarlas para sugerir opciones al usuario sin "
-            "mezclar familias (ej: no proponer granito cuando piden "
-            "puraprima). El POST /api/v1/quote acepta `material` con "
-            "cualquier string que contenga keyword de familia."
+            "Familias canónicas de material reconocidas por el matcher "
+            "interno. Útil para que el bot sugiera opciones sin mezclar "
+            "familias incompatibles. Subordinado al shape rules.* — "
+            "vocabulario, no endpoint paralelo."
         ),
     )
+
+
+class NamingRules(BaseModel):
+    """Reglas de ortografía / naming que el bot debe seguir."""
+
+    purastone_one_word: bool = Field(
+        ...,
+        description=(
+            "Si True, escribir 'Purastone' como una sola palabra "
+            "(no 'Pura Stone')."
+        ),
+    )
+    puraprima_one_word: bool = Field(
+        ...,
+        description=(
+            "Si True, escribir 'Puraprima' como una sola palabra "
+            "(no 'Pura Prima')."
+        ),
+    )
+
+
+class RulesPayload(BaseModel):
+    """Wrapper de las reglas v0. El bot web itera por sub-secciones
+    (bacha / materials / naming) para construir su prompt."""
+
+    bacha: BachaRules
+    materials: MaterialsRules
+    naming: NamingRules
 
 
 class BusinessRulesV0(BaseModel):
@@ -62,10 +127,9 @@ class BusinessRulesV0(BaseModel):
     version: str = Field(
         ...,
         description=(
-            "Versión del payload en formato ISO YYYY-MM-DD. Se bumpea "
+            "Versión del payload en formato `YYYY-MM-DD-vN`. Se bumpea "
             "manualmente cuando hay cambio breaking. El bot web puede "
             "comparar contra su versión cacheada para revalidación."
         ),
     )
-    sink: SinkRules
-    materials: MaterialsRules
+    rules: RulesPayload

--- a/api/tests/test_business_rules_endpoint.py
+++ b/api/tests/test_business_rules_endpoint.py
@@ -1,103 +1,197 @@
-"""Tests para PR #398 — `GET /api/v1/business-rules`.
+"""Tests para `GET /api/v1/business-rules` v0 (PR #399 rework de #398).
 
-Subset v0 (acordado con operador, 2026-04-24):
-  1. cocina_requires_capture — anti-Fabiana.
-  2. ownership_options — cliente / dangelo.
-  3. mount_options — abajo / arriba (levantado de SinkTypeInput).
-  4. material families — levantadas de _FAMILY_CATALOGS (post-#396).
+Shape prescriptivo (copy-paste-into-prompt). Auth con `X-API-Key`
+(mismo esquema que `/api/v1/quote`).
 
-Endpoint público sin auth — el bot web lo fetchea al construir su
-system prompt sin credenciales. Cache-Control + ETag para revalidación.
+Cobertura:
+  - 401 sin api-key.
+  - 401 con api-key inválida.
+  - 200 con api-key válida.
+  - Shape correcto (rules.bacha.question, payload_mapping, etc.).
+  - Endpoint NO requiere cookie/sesión del operador (X-API-Key alcanza).
+  - Cache-Control + ETag + If-None-Match → 304.
+  - Anti-leak: no precios, no SKUs internos.
 """
 from __future__ import annotations
 
-from datetime import date
-
 import pytest
 
+from app.core import auth as _auth_mod
+from app.modules.quote_engine import router as _qe_router_mod
+
+
+_TEST_API_KEY = "test-marble-api-key-396"
+
+
+@pytest.fixture
+def with_api_key(monkeypatch):
+    """Setea `QUOTE_API_KEY` en ambos lugares donde se lee desde
+    `settings`: el del agent middleware (auth.py) y el del verify_api_key
+    del quote_engine router. Sin esto, el check se skipea (dev mode)."""
+    monkeypatch.setattr(_auth_mod.settings, "QUOTE_API_KEY", _TEST_API_KEY)
+    monkeypatch.setattr(_qe_router_mod.settings, "QUOTE_API_KEY", _TEST_API_KEY)
+    return _TEST_API_KEY
+
 
 # ═══════════════════════════════════════════════════════════════════════
-# Smoke: 200 con shape correcto
+# Auth con X-API-Key
 # ═══════════════════════════════════════════════════════════════════════
 
 
-class TestBusinessRulesEndpoint:
+class TestAuth:
     @pytest.mark.asyncio
-    async def test_returns_200_with_shape(self, client_no_auth):
-        """Endpoint público — accesible sin cookie ni X-API-Key."""
+    async def test_no_api_key_returns_401(self, client_no_auth, with_api_key):
+        """Sin header X-API-Key → 401 con mensaje del verify_api_key."""
         resp = await client_no_auth.get("/api/v1/business-rules")
-        assert resp.status_code == 200, resp.text
-        body = resp.json()
-        assert "version" in body
-        assert "sink" in body
-        assert "materials" in body
+        assert resp.status_code == 401
+        # Mensaje del helper (ver quote_engine/router.py::verify_api_key).
+        assert "API key" in resp.json().get("detail", "")
 
     @pytest.mark.asyncio
-    async def test_version_parses_as_iso_date(self, client_no_auth):
-        """`version` debe ser ISO YYYY-MM-DD (parseable como fecha)."""
-        resp = await client_no_auth.get("/api/v1/business-rules")
-        v = resp.json()["version"]
-        # Validación: fromisoformat acepta YYYY-MM-DD.
-        parsed = date.fromisoformat(v)
-        assert parsed.year >= 2025  # sanity: no es una fecha basura.
-
-    @pytest.mark.asyncio
-    async def test_sink_fields_typed_correctly(self, client_no_auth):
-        body = (await client_no_auth.get("/api/v1/business-rules")).json()
-        sink = body["sink"]
-
-        assert isinstance(sink["cocina_requires_capture"], bool)
-        assert sink["cocina_requires_capture"] is True
-
-        assert isinstance(sink["ownership_options"], list)
-        assert sink["ownership_options"] == ["cliente", "dangelo"]
-
-        assert isinstance(sink["mount_options"], list)
-        # Orden no importa, contenido sí.
-        assert set(sink["mount_options"]) == {"abajo", "arriba"}
-
-    @pytest.mark.asyncio
-    async def test_materials_families_match_internal_catalog(self, client_no_auth):
-        """Las familias expuestas DEBEN coincidir con el matcher interno
-        post-#396. Si alguien renombra `_FAMILY_CATALOGS`, este test
-        detecta drift."""
-        from app.modules.quote_engine.calculator import _FAMILY_CATALOGS
-
-        body = (await client_no_auth.get("/api/v1/business-rules")).json()
-        families = body["materials"]["families"]
-
-        assert isinstance(families, list)
-        assert all(isinstance(f, str) for f in families)
-        assert set(families) == set(_FAMILY_CATALOGS.keys())
-        # v0 debe incluir las 8 conocidas.
-        for expected in (
-            "puraprima", "purastone", "silestone", "dekton",
-            "neolith", "laminatto", "granito", "marmol",
-        ):
-            assert expected in families, f"missing family: {expected}"
-
-
-# ═══════════════════════════════════════════════════════════════════════
-# Acceso público (sin auth)
-# ═══════════════════════════════════════════════════════════════════════
-
-
-class TestPublicAccess:
-    @pytest.mark.asyncio
-    async def test_no_jwt_cookie_required(self, client_no_auth):
-        """Sin cookie de sesión → no 401."""
-        resp = await client_no_auth.get("/api/v1/business-rules")
-        assert resp.status_code != 401
-
-    @pytest.mark.asyncio
-    async def test_no_x_api_key_required(self, client_no_auth):
-        """Sin X-API-Key → no 401. El bot web lo fetchea sin
-        credenciales."""
+    async def test_wrong_api_key_returns_401(self, client_no_auth, with_api_key):
+        """Con X-API-Key incorrecta → 401."""
         resp = await client_no_auth.get(
             "/api/v1/business-rules",
-            headers={},  # explícitamente sin headers
+            headers={"X-API-Key": "wrong-key-xyz"},
+        )
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_valid_api_key_returns_200(self, client_no_auth, with_api_key):
+        resp = await client_no_auth.get(
+            "/api/v1/business-rules",
+            headers={"X-API-Key": _TEST_API_KEY},
+        )
+        assert resp.status_code == 200, resp.text
+
+    @pytest.mark.asyncio
+    async def test_no_cookie_session_required(self, client_no_auth, with_api_key):
+        """El endpoint NO requiere cookie del operador. Con X-API-Key
+        sola alcanza, sin importar que el cliente no tenga JWT."""
+        resp = await client_no_auth.get(
+            "/api/v1/business-rules",
+            headers={"X-API-Key": _TEST_API_KEY},
         )
         assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_lowercase_header_accepted(self, client_no_auth, with_api_key):
+        """`x-api-key` lowercase también — los headers HTTP son
+        case-insensitive."""
+        resp = await client_no_auth.get(
+            "/api/v1/business-rules",
+            headers={"x-api-key": _TEST_API_KEY},
+        )
+        assert resp.status_code == 200
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Shape del payload
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestPayloadShape:
+    async def _get(self, client, with_api_key):
+        resp = await client.get(
+            "/api/v1/business-rules",
+            headers={"X-API-Key": _TEST_API_KEY},
+        )
+        assert resp.status_code == 200
+        return resp.json()
+
+    @pytest.mark.asyncio
+    async def test_top_level_has_version_and_rules(self, client_no_auth, with_api_key):
+        body = await self._get(client_no_auth, with_api_key)
+        assert set(body.keys()) == {"version", "rules"}
+
+    @pytest.mark.asyncio
+    async def test_version_format(self, client_no_auth, with_api_key):
+        """`version` con formato `YYYY-MM-DD-vN`."""
+        import re
+        body = await self._get(client_no_auth, with_api_key)
+        v = body["version"]
+        assert re.match(r"^\d{4}-\d{2}-\d{2}-v\d+$", v), f"version inválida: {v!r}"
+
+    # ── Bacha ────────────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_rules_bacha_question_present(self, client_no_auth, with_api_key):
+        body = await self._get(client_no_auth, with_api_key)
+        bacha = body["rules"]["bacha"]
+        assert isinstance(bacha["question"], str)
+        # El copy literal debe incluir las opciones del cliente.
+        assert "tenés" in bacha["question"] or "tienes" in bacha["question"]
+        assert "comprás" in bacha["question"] or "compras" in bacha["question"]
+
+    @pytest.mark.asyncio
+    async def test_rules_bacha_requires_clarification_when_mentioned(
+        self, client_no_auth, with_api_key,
+    ):
+        body = await self._get(client_no_auth, with_api_key)
+        assert body["rules"]["bacha"]["requires_clarification_when_mentioned"] is True
+
+    @pytest.mark.asyncio
+    async def test_rules_bacha_do_not_ask(self, client_no_auth, with_api_key):
+        body = await self._get(client_no_auth, with_api_key)
+        do_not_ask = body["rules"]["bacha"]["do_not_ask"]
+        assert isinstance(do_not_ask, list)
+        # Topics que el bot NO debe preguntar (regla del operador).
+        assert "simple/doble" in do_not_ask
+        assert "arriba/abajo" in do_not_ask
+
+    @pytest.mark.asyncio
+    async def test_rules_bacha_payload_mapping(self, client_no_auth, with_api_key):
+        body = await self._get(client_no_auth, with_api_key)
+        mapping = body["rules"]["bacha"]["payload_mapping"]
+        # Mapping de la respuesta del cliente al enum `pileta` de
+        # POST /api/v1/quote (#397).
+        assert mapping == {
+            "propia": "empotrada_cliente",
+            "dangelo": "empotrada_johnson",
+            "apoyo": "apoyo",
+        }
+
+    @pytest.mark.asyncio
+    async def test_rules_bacha_notes_non_empty(self, client_no_auth, with_api_key):
+        body = await self._get(client_no_auth, with_api_key)
+        notes = body["rules"]["bacha"]["notes"]
+        assert isinstance(notes, list)
+        assert len(notes) >= 1
+        # Cada nota es un string de prompt.
+        assert all(isinstance(n, str) and n for n in notes)
+        # Al menos una nota cubre el escenario clave (anti-Fabiana).
+        joined = " ".join(notes).lower()
+        assert "pileta" in joined or "bacha" in joined
+        assert "d'angelo" in joined or "dangelo" in joined.replace("'", "")
+
+    # ── Materials ────────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_rules_materials_flags(self, client_no_auth, with_api_key):
+        body = await self._get(client_no_auth, with_api_key)
+        m = body["rules"]["materials"]
+        assert m["marble_not_recommended_for_kitchen"] is True
+        assert m["silestone_purastone_not_for_exterior"] is True
+
+    @pytest.mark.asyncio
+    async def test_rules_materials_families_present(self, client_no_auth, with_api_key):
+        """`families` queda subordinado al shape `rules.materials.*` —
+        no como endpoint paralelo. Levantado de _FAMILY_CATALOGS."""
+        from app.modules.quote_engine.calculator import _FAMILY_CATALOGS
+
+        body = await self._get(client_no_auth, with_api_key)
+        families = body["rules"]["materials"]["families"]
+        assert isinstance(families, list)
+        assert set(families) == set(_FAMILY_CATALOGS.keys())
+
+    # ── Naming ───────────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_rules_naming_flags(self, client_no_auth, with_api_key):
+        body = await self._get(client_no_auth, with_api_key)
+        n = body["rules"]["naming"]
+        assert n["purastone_one_word"] is True
+        assert n["puraprima_one_word"] is True
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -107,129 +201,108 @@ class TestPublicAccess:
 
 class TestCachingHeaders:
     @pytest.mark.asyncio
-    async def test_cache_control_max_age_3600(self, client_no_auth):
-        resp = await client_no_auth.get("/api/v1/business-rules")
+    async def test_cache_control(self, client_no_auth, with_api_key):
+        resp = await client_no_auth.get(
+            "/api/v1/business-rules",
+            headers={"X-API-Key": _TEST_API_KEY},
+        )
         cc = resp.headers.get("cache-control") or resp.headers.get("Cache-Control")
         assert cc is not None
         assert "max-age=3600" in cc
 
     @pytest.mark.asyncio
-    async def test_etag_present_and_quoted(self, client_no_auth):
-        """ETag debe venir con comillas dobles según RFC 7232."""
-        resp = await client_no_auth.get("/api/v1/business-rules")
-        etag = resp.headers.get("etag") or resp.headers.get("ETag")
-        assert etag is not None
-        assert etag.startswith('"') and etag.endswith('"')
-
-    @pytest.mark.asyncio
-    async def test_etag_stable_across_requests(self, client_no_auth):
-        """Mismo payload → mismo ETag. Determinístico (sort_keys
-        en el hash)."""
-        r1 = await client_no_auth.get("/api/v1/business-rules")
-        r2 = await client_no_auth.get("/api/v1/business-rules")
+    async def test_etag_stable(self, client_no_auth, with_api_key):
+        h = {"X-API-Key": _TEST_API_KEY}
+        r1 = await client_no_auth.get("/api/v1/business-rules", headers=h)
+        r2 = await client_no_auth.get("/api/v1/business-rules", headers=h)
         e1 = r1.headers.get("etag") or r1.headers.get("ETag")
         e2 = r2.headers.get("etag") or r2.headers.get("ETag")
-        assert e1 == e2
+        assert e1 and e2 and e1 == e2
 
     @pytest.mark.asyncio
-    async def test_if_none_match_returns_304(self, client_no_auth):
-        """Cliente revalida con ETag actual → 304 Not Modified."""
-        first = await client_no_auth.get("/api/v1/business-rules")
+    async def test_if_none_match_returns_304(self, client_no_auth, with_api_key):
+        h = {"X-API-Key": _TEST_API_KEY}
+        first = await client_no_auth.get("/api/v1/business-rules", headers=h)
         etag = first.headers.get("etag") or first.headers.get("ETag")
-
         revalidate = await client_no_auth.get(
             "/api/v1/business-rules",
-            headers={"If-None-Match": etag},
+            headers={**h, "If-None-Match": etag},
         )
         assert revalidate.status_code == 304
 
-    @pytest.mark.asyncio
-    async def test_if_none_match_mismatch_returns_200(self, client_no_auth):
-        """ETag distinto al actual → 200 con body fresco."""
-        resp = await client_no_auth.get(
-            "/api/v1/business-rules",
-            headers={"If-None-Match": '"stale-etag-xyz"'},
-        )
-        assert resp.status_code == 200
-        # Body presente.
-        assert "version" in resp.json()
-
 
 # ═══════════════════════════════════════════════════════════════════════
-# Anti-leak: no expone data sensible
+# Anti-leak — no expone data sensible
 # ═══════════════════════════════════════════════════════════════════════
 
 
 class TestNoSensitiveLeak:
-    """Garantía explícita: el payload NO contiene precios, SKUs
-    internos, lógica comercial. Si alguien agrega un campo nuevo que
-    rompa esto, los tests fallan."""
+    @pytest.mark.asyncio
+    async def test_no_price_tokens(self, client_no_auth, with_api_key):
+        resp = await client_no_auth.get(
+            "/api/v1/business-rules",
+            headers={"X-API-Key": _TEST_API_KEY},
+        )
+        blob = str(resp.json()).lower()
+        for forbidden in (
+            "price", "precio", "ars", "usd", "iva", "discount", "merma",
+            "margen", "$",
+        ):
+            assert forbidden not in blob, f"token sensible: {forbidden!r}"
 
     @pytest.mark.asyncio
-    async def test_payload_keys_are_only_v0_subset(self, client_no_auth):
-        body = (await client_no_auth.get("/api/v1/business-rules")).json()
-        assert set(body.keys()) == {"version", "sink", "materials"}
+    async def test_no_internal_skus(self, client_no_auth, with_api_key):
+        """Ningún SKU interno (PEGADOPILETA, PURAGREY, LUXOR, etc.)
+        debe filtrarse al payload del bot web.
 
-    @pytest.mark.asyncio
-    async def test_no_price_fields_anywhere(self, client_no_auth):
-        """Ninguna key del payload debe sonar a precio."""
-        body = (await client_no_auth.get("/api/v1/business-rules")).json()
-        blob = str(body).lower()
-        for forbidden in ("price", "precio", "iva", "ars", "usd",
-                          "discount", "descuento", "merma", "margen"):
-            assert forbidden not in blob, (
-                f"payload contiene token sensible: {forbidden!r}"
-            )
-
-    @pytest.mark.asyncio
-    async def test_no_sku_fields(self, client_no_auth):
-        """No exponer SKUs internos (ej: 'PURAGREY', 'LUXOR171',
-        'PEGADOPILETA')."""
-        body = (await client_no_auth.get("/api/v1/business-rules")).json()
-        blob = str(body).upper()
-        for forbidden in ("PURAGREY", "LUXOR", "PEGADOPILETA", "QUADRA",
-                          "JOHNSON", "SILVER GREY", "BLANCO NORTE"):
-            assert forbidden not in blob, (
-                f"payload contiene SKU/marca: {forbidden!r}"
-            )
+        Nota sobre 'JOHNSON': el string aparece intencionalmente como
+        parte de `empotrada_johnson` — valor del enum `PiletaType` que
+        es **contrato público** de POST /api/v1/quote (el bot lo manda
+        de vuelta en `pileta`). Por eso no se chequea acá: no es un
+        SKU interno, es vocabulario de la API."""
+        resp = await client_no_auth.get(
+            "/api/v1/business-rules",
+            headers={"X-API-Key": _TEST_API_KEY},
+        )
+        blob = str(resp.json()).upper()
+        for forbidden in (
+            "PURAGREY", "PEGADOPILETA", "LUXOR", "QUADRA",
+            "SILVER GREY", "BLANCO NORTE", "ENKEL",
+        ):
+            assert forbidden not in blob, f"SKU interno filtrado: {forbidden!r}"
 
 
 # ═══════════════════════════════════════════════════════════════════════
-# Función pura `build_rules()`
+# build_rules() puro — drift guards
 # ═══════════════════════════════════════════════════════════════════════
 
 
 class TestBuildRulesPure:
-    """`build_rules()` es función pura — sin DB, sin LLM. Llamable
-    desde tests sin fixtures."""
-
-    def test_pure_function_returns_pydantic_model(self):
+    def test_returns_pydantic_model(self):
         from app.modules.business_rules.rules import build_rules
         from app.modules.business_rules.schema import BusinessRulesV0
 
         rules = build_rules()
         assert isinstance(rules, BusinessRulesV0)
-        assert rules.sink.cocina_requires_capture is True
-        assert rules.sink.ownership_options == ["cliente", "dangelo"]
 
-    def test_mount_options_are_lifted_from_quote_input(self):
-        """Drift guard: si alguien renombra el Literal en
-        SinkTypeInput.mount_type, el endpoint refleja el cambio. Y si
-        rompe el shape, este test falla en el import."""
-        from app.modules.business_rules.rules import build_rules
-        from app.modules.quote_engine.schemas import SinkTypeInput
-        from typing import get_args
-
-        rules = build_rules()
-        expected = list(get_args(
-            SinkTypeInput.model_fields["mount_type"].annotation
-        ))
-        assert rules.sink.mount_options == expected
-
-    def test_families_lifted_from_calculator_constant(self):
-        """Drift guard idem para `_FAMILY_CATALOGS`."""
+    def test_families_lifted_from_calculator(self):
         from app.modules.business_rules.rules import build_rules
         from app.modules.quote_engine.calculator import _FAMILY_CATALOGS
 
         rules = build_rules()
-        assert rules.materials.families == list(_FAMILY_CATALOGS.keys())
+        assert rules.rules.materials.families == list(_FAMILY_CATALOGS.keys())
+
+    def test_payload_mapping_keys_match_quote_input_enum(self):
+        """El mapping `payload_mapping` debe tener las 3 keys canónicas
+        que el bot web envía. Los valores deben ser parseables como
+        `PiletaType` enum del POST /api/v1/quote."""
+        from app.modules.business_rules.rules import build_rules
+        from app.modules.quote_engine.schemas import PiletaType
+
+        rules = build_rules()
+        mapping = rules.rules.bacha.payload_mapping
+        assert set(mapping.keys()) == {"propia", "dangelo", "apoyo"}
+        for v in mapping.values():
+            # Si el valor no es parseable como PiletaType, esto rompe
+            # (drift guard contra renombre del enum).
+            PiletaType(v)


### PR DESCRIPTION
## Summary

Rework completo del endpoint `GET /api/v1/business-rules` introducido en #398.

**Triggers del rework:**
- El bot web intentó consumir el endpoint con `X-API-Key: sk-marble-...` asumiendo mismo esquema que `POST /api/v1/quote`. #398 lo dejó público sin auth.
- El shape genérico (sink/materials.families) no era directamente copy-paste al system prompt del bot. Resultado: caso Fabiana — cerraba leads sin clarificar la pileta.

## Cambios

### 1. Auth con X-API-Key
- Reusa `verify_api_key` del `quote_engine.router` vía `dependencies=[Depends(verify_api_key)]`.
- Sin middleware nuevo. Mismo patrón que `/api/v1/quote`.
- En dev (sin `QUOTE_API_KEY` seteada) el check se skipea — backward compat con desarrollo local.

### 2. Shape prescriptivo (copy-paste-into-prompt)
```jsonc
{
  "version": "2026-04-24-v1",
  "rules": {
    "bacha": {
      "requires_clarification_when_mentioned": true,
      "question": "¿La pileta ya la tenés, o la comprás con nosotros?",
      "do_not_ask": ["simple/doble", "arriba/abajo"],
      "payload_mapping": {
        "propia": "empotrada_cliente",
        "dangelo": "empotrada_johnson",
        "apoyo": "apoyo"
      },
      "notes": ["Si el cliente menciona pileta...", "..."]
    },
    "materials": {
      "marble_not_recommended_for_kitchen": true,
      "silestone_purastone_not_for_exterior": true,
      "families": ["...lifted from _FAMILY_CATALOGS..."]
    },
    "naming": {
      "purastone_one_word": true,
      "puraprima_one_word": true
    }
  }
}
```

### 3. Tests (23 casos en `tests/test_business_rules_endpoint.py`)
- **Auth**: 401 sin/wrong key, 200 con key, lowercase header, no requiere cookie del operador.
- **Shape**: version regex `YYYY-MM-DD-vN`, bacha/materials/naming completos.
- **Caching**: `Cache-Control: max-age=3600`, ETag estable, `If-None-Match` → 304.
- **Anti-leak**: no precios, no SKUs internos (PURAGREY, PEGADOPILETA, LUXOR, etc.).
- **Drift guards**: `families` lifted de `_FAMILY_CATALOGS`; `payload_mapping` values parseables como `PiletaType`.

### 4. Removido
- `mount_options` (la regla nueva es `do_not_ask: ["arriba/abajo"]`).
- `sink/materials.families` paralelo (queda subordinado a `rules.materials.families`).

## Versión
Bump a `2026-04-24-v1` (breaking change del shape).

## Test plan

- [x] `pytest tests/test_business_rules_endpoint.py -v` → 23/23 verde.
- [x] Suite full (`pytest --ignore=tests/evaluation -q`) → 1763/1764 verde (1 fail preexistente en `test_edificio_render`, no relacionado).
- [ ] CI Backend Tests verde.
- [ ] CI Frontend Build verde.
- [ ] Post-deploy: `curl -s -H "X-API-Key: sk-marble-..." https://...railway.app/api/v1/business-rules | jq .` → 200 con shape esperado.
- [ ] Post-deploy: `curl -s https://...railway.app/api/v1/business-rules` (sin key) → 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)