### PR TITLE
feat(web-quote): persistir body raw del bot + botón 'Copiar solicitud'

### DIFF
--- a/api/app/core/database.py
+++ b/api/app/core/database.py
@@ -71,6 +71,11 @@ async def init_db():
             "ALTER TABLE quotes ADD COLUMN IF NOT EXISTS email_draft JSON",
             # PR #24 — Condiciones de Contratación PDF para edificios.
             "ALTER TABLE quotes ADD COLUMN IF NOT EXISTS condiciones_pdf JSON",
+            # PR #400 — Snapshot raw del body POST /api/v1/quote para quotes
+            # source="web". Permite auditar el caso Fabiana y similares
+            # (qué mandó el bot vs qué derivó el backend). NULL para quotes
+            # web pre-#400 (no hay backfill posible — el body original se perdió).
+            "ALTER TABLE quotes ADD COLUMN IF NOT EXISTS web_input JSON",
             # PR #19 — backfill is_building para quotes que tenían is_edificio=true
             # solo en el JSON breakdown. Idempotente (UPDATE WHERE).
             "UPDATE quotes SET is_building = TRUE "

--- a/api/app/models/quote.py
+++ b/api/app/models/quote.py
@@ -67,6 +67,14 @@ class Quote(Base):
     # Raw pieces input (as submitted, before calculation)
     pieces: Mapped[list | None] = mapped_column(JSON, nullable=True)
 
+    # PR #400 — Raw payload completo del POST /api/v1/quote (source="web").
+    # Snapshot literal del body que mandó el bot externo, antes de cualquier
+    # derivación (resolve_pileta, parse_measurements, fuzzy correction, etc.).
+    # Útil para auditar bugs del bot vs bugs del backend: si el campo `pileta`
+    # del quote difiere del que llega acá, sabemos en qué capa está el problema.
+    # NULL para quotes operator (Valentina) y para quotes web pre-#400.
+    web_input: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+
     # Conversation link (web sessions)
     conversation_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
 

--- a/api/app/modules/agent/schemas.py
+++ b/api/app/modules/agent/schemas.py
@@ -59,6 +59,10 @@ class QuoteDetailResponse(QuoteListResponse):
     # PR #24 — PDF de Condiciones (solo edificios). Frontend lo muestra
     # como card debajo del PDF principal cuando is_building=True.
     condiciones_pdf: Optional[dict] = None
+    # PR #400 — Payload crudo del POST /api/v1/quote (solo source="web").
+    # El frontend lo usa para el botón "Copiar solicitud web" — dump literal
+    # de lo que mandó el bot externo, útil para debug del bot vs backend.
+    web_input: Optional[dict] = None
 
 
 class QuoteCompareItem(BaseModel):

--- a/api/app/modules/quote_engine/router.py
+++ b/api/app/modules/quote_engine/router.py
@@ -33,6 +33,17 @@ async def create_quote_api(body: QuoteInput, db: AsyncSession = Depends(get_db))
     No LLM involved — pure Python calculation.
     Returns quotes with PDF/Excel links.
     """
+    # PR #400 — Snapshot raw del body ANTES de cualquier derivación. Se
+    # persiste literal en `quote.web_input` para que el operador pueda
+    # auditar exactamente qué mandó el bot (sink_type, pileta_sku,
+    # conversation, plazo, etc.) sin pasar por las normalizaciones que
+    # vienen abajo (resolve_pileta, parse_measurements, etc.).
+    #
+    # mode="json" para que enums (PiletaType) y datetimes serialicen a
+    # primitivos JSON-safe; sino el INSERT tira `Object of type ... is not
+    # JSON serializable`.
+    _raw_web_input = body.model_dump(mode="json")
+
     # Normalize material to list
     materials = body.material if isinstance(body.material, list) else [body.material]
 
@@ -120,6 +131,8 @@ async def create_quote_api(body: QuoteInput, db: AsyncSession = Depends(get_db))
                 pileta=_resolved_pileta.value if _resolved_pileta else None,
                 sink_type=body.sink_type.model_dump() if body.sink_type else None,
                 anafe=body.anafe,
+                # PR #400 — payload crudo del bot. Ver bloque _raw_web_input arriba.
+                web_input=_raw_web_input,
             )
             db.add(quote)
             await db.commit()
@@ -210,6 +223,8 @@ async def create_quote_api(body: QuoteInput, db: AsyncSession = Depends(get_db))
             sink_type=body.sink_type.model_dump() if body.sink_type else None,
             anafe=body.anafe,
             pieces=[p.model_dump() for p in body.pieces] if body.pieces else None,
+            # PR #400 — payload crudo del bot. Ver bloque _raw_web_input arriba.
+            web_input=_raw_web_input,
         )
         db.add(quote)
         await db.commit()

--- a/api/tests/test_web_input_persistence.py
+++ b/api/tests/test_web_input_persistence.py
@@ -1,0 +1,179 @@
+"""Tests para persistencia de `web_input` (PR #400).
+
+Cuando el bot externo hace `POST /api/v1/quote`, el body crudo se
+guarda en `Quote.web_input` para que el operador pueda auditar
+exactamente qué llegó vs qué derivó el backend (resolve_pileta,
+parse_measurements, fuzzy material correction).
+
+Cubre:
+  - Path con-pieces: el body se persiste cuando hay pieces.
+  - Path sin-pieces (DRAFT/PENDING): el body se persiste igual.
+  - Schema response: `GET /api/quotes/:id` expone `web_input`.
+  - Enum serialization: `pileta` (PiletaType) sale como string, no
+    como `PiletaType.EMPOTRADA_JOHNSON` (sino el JSON column rompe).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+
+from app.models.quote import Quote
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# POST /api/v1/quote → web_input persistido en DB
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestWebInputPersistedOnPost:
+    @pytest.mark.asyncio
+    async def test_with_pieces_persists_body(self, client, db_session):
+        """Path con-pieces: body crudo se guarda en quote.web_input."""
+        body = {
+            "client_name": "Perdomo Fabiana",
+            "project": "Cocina",
+            "material": "Silestone Blanco Norte",
+            "pieces": [
+                {"description": "Mesada", "largo": 2.30, "prof": 0.60},
+            ],
+            "localidad": "Rosario",
+            "plazo": "30 días",
+            "sink_type": {"basin_count": "simple", "mount_type": "abajo"},
+            "pileta_sku": "JOHNSON-LAVANDA",
+            "notes": "Compra la bacha en D'Angelo",
+        }
+        with patch(
+            "app.modules.quote_engine.router.upload_to_drive",
+            return_value={"ok": True, "drive_url": "https://drive.test"},
+        ):
+            resp = await client.post("/api/v1/quote", json=body)
+        assert resp.status_code == 200, resp.text
+
+        quote_id = resp.json()["quotes"][0]["quote_id"]
+        result = await db_session.execute(select(Quote).where(Quote.id == quote_id))
+        quote = result.scalar_one()
+        assert quote.web_input is not None, "web_input debería persistirse"
+        # Campos clave del body llegan literal (no derivados).
+        assert quote.web_input["client_name"] == "Perdomo Fabiana"
+        assert quote.web_input["pileta_sku"] == "JOHNSON-LAVANDA"
+        assert quote.web_input["notes"] == "Compra la bacha en D'Angelo"
+        assert quote.web_input["sink_type"] == {
+            "basin_count": "simple",
+            "mount_type": "abajo",
+        }
+        # Drift guard: si alguien rompe model_dump(mode="json") y los
+        # enums vuelven como objetos, el JSON column tira al insertar.
+        # Acá ya pasó la persistencia → si llegamos hasta acá, está OK.
+
+    @pytest.mark.asyncio
+    async def test_without_pieces_persists_body(self, client, db_session):
+        """Path sin-pieces (PENDING/DRAFT): body crudo igual se guarda.
+        Este es el path crítico — sin pieces es donde más data hay que
+        capturar (notas, sink_type, conversation, etc.)."""
+        body = {
+            "client_name": "Cliente Sin Piezas",
+            "project": "Cocina",
+            "material": "Silestone Blanco Norte",
+            "localidad": "Rosario",
+            "plazo": "30 días",
+            "notes": "Mesada de 2 metros aprox, todavía no tengo plano",
+            "sink_type": {"basin_count": "doble", "mount_type": "arriba"},
+        }
+        with patch(
+            "app.modules.quote_engine.text_parser.parse_measurements",
+            return_value=None,  # forzar path sin pieces
+        ):
+            resp = await client.post("/api/v1/quote", json=body)
+        assert resp.status_code == 200, resp.text
+
+        quote_id = resp.json()["quotes"][0]["quote_id"]
+        result = await db_session.execute(select(Quote).where(Quote.id == quote_id))
+        quote = result.scalar_one()
+        assert quote.web_input is not None
+        assert quote.web_input["client_name"] == "Cliente Sin Piezas"
+        assert quote.web_input["notes"].startswith("Mesada de 2 metros")
+        assert quote.web_input["sink_type"]["basin_count"] == "doble"
+
+    @pytest.mark.asyncio
+    async def test_pileta_enum_serializes_to_string(self, client, db_session):
+        """`pileta` (PiletaType enum) debe serializar como string en
+        web_input. Si `model_dump()` sin mode="json" se cuela, los
+        enums quedan como objetos no JSON-serializables y rompe el
+        INSERT en SQLite/Postgres."""
+        body = {
+            "client_name": "Test Enum",
+            "project": "Cocina",
+            "material": "Silestone Blanco Norte",
+            "pieces": [{"description": "Mesada", "largo": 2.0, "prof": 0.6}],
+            "localidad": "Rosario",
+            "plazo": "30 días",
+            "pileta": "empotrada_johnson",
+        }
+        with patch(
+            "app.modules.quote_engine.router.upload_to_drive",
+            return_value={"ok": True, "drive_url": "https://drive.test"},
+        ):
+            resp = await client.post("/api/v1/quote", json=body)
+        assert resp.status_code == 200, resp.text
+
+        quote_id = resp.json()["quotes"][0]["quote_id"]
+        result = await db_session.execute(select(Quote).where(Quote.id == quote_id))
+        quote = result.scalar_one()
+        # Si el enum no serializó bien, web_input sería None o
+        # contendría algo como `"pileta": "PiletaType.EMPOTRADA_JOHNSON"`.
+        assert quote.web_input is not None
+        assert quote.web_input["pileta"] == "empotrada_johnson"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# GET /api/quotes/:id expone web_input
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestQuoteDetailExposesWebInput:
+    @pytest.mark.asyncio
+    async def test_response_includes_web_input(self, client):
+        """El detalle del quote debe traer web_input para que el
+        frontend lo use en el botón 'Copiar solicitud'."""
+        # Crear quote vía POST /api/v1/quote.
+        body = {
+            "client_name": "Detail Test",
+            "project": "Cocina",
+            "material": "Silestone Blanco Norte",
+            "pieces": [{"description": "Mesada", "largo": 2.0, "prof": 0.6}],
+            "localidad": "Rosario",
+            "plazo": "30 días",
+            "notes": "Notita",
+        }
+        with patch(
+            "app.modules.quote_engine.router.upload_to_drive",
+            return_value={"ok": True, "drive_url": "https://drive.test"},
+        ):
+            create_resp = await client.post("/api/v1/quote", json=body)
+        quote_id = create_resp.json()["quotes"][0]["quote_id"]
+
+        # Leer el detalle.
+        detail_resp = await client.get(f"/api/quotes/{quote_id}")
+        assert detail_resp.status_code == 200
+        data = detail_resp.json()
+        assert "web_input" in data, "QuoteDetailResponse debe incluir web_input"
+        assert data["web_input"] is not None
+        assert data["web_input"]["client_name"] == "Detail Test"
+        assert data["web_input"]["notes"] == "Notita"
+
+    @pytest.mark.asyncio
+    async def test_operator_quote_has_null_web_input(self, client):
+        """Quotes creados por el operador (no por el bot web) no tienen
+        web_input — solo el path POST /v1/quote lo persiste."""
+        # Crear quote vía operator endpoint.
+        create_resp = await client.post("/api/quotes")
+        assert create_resp.status_code == 200
+        quote_id = create_resp.json()["id"]
+
+        detail_resp = await client.get(f"/api/quotes/{quote_id}")
+        assert detail_resp.status_code == 200
+        data = detail_resp.json()
+        # web_input debe estar presente en el schema pero null para operator.
+        assert data.get("web_input") is None

--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -130,6 +130,73 @@ function buildFullSnapshot(quote: QuoteDetail | null, messages: UIMessage[]): st
   return parts.join("\n").trim();
 }
 
+// PR #400 — Snapshot enfocado en debug de quotes WEB. Vuelca:
+//   1. Meta básica del quote (id, cliente, proyecto, source, fecha).
+//   2. `web_input` raw: el body literal del POST /api/v1/quote (tal cual
+//      lo mandó el bot externo, antes de derivaciones del backend).
+//   3. Lo que el backend derivó: pileta resuelto, sink_type persistido,
+//      notes (con la corrección fuzzy si aplicó), totales, m².
+//   4. Conversación tal cual (reusa buildFullSnapshot para no duplicar
+//      el formateo de mensajes).
+// Útil para mandarle a un compañero / al dev del bot cuando un quote
+// salió raro y hay que comparar input vs output sin abrir la DB.
+function buildWebRequestSnapshot(quote: QuoteDetail | null, messages: UIMessage[]): string {
+  if (!quote) return "";
+  const lines: string[] = [];
+
+  lines.push(`# SOLICITUD WEB — ${quote.client_name || "(sin cliente)"} / ${quote.project || "(sin proyecto)"}`);
+  lines.push("");
+  lines.push(`- Quote ID: ${quote.id}`);
+  lines.push(`- Source: ${quote.source || "operator"}`);
+  lines.push(`- Status: ${quote.status}`);
+  lines.push(`- Fecha: ${new Date(quote.created_at).toLocaleString("es-AR")}`);
+  if (quote.material) lines.push(`- Material persistido: ${quote.material}`);
+  lines.push("");
+
+  lines.push("## 1. Body crudo del POST /api/v1/quote");
+  lines.push("");
+  if (quote.web_input) {
+    lines.push("```json");
+    lines.push(JSON.stringify(quote.web_input, null, 2));
+    lines.push("```");
+  } else {
+    // Quote web pre-#400 (no había persistencia del body) o quote operator.
+    // Indicamos por qué falta para que el lector no asuma un bug nuevo.
+    lines.push("_(no disponible — quote previo a la persistencia de web_input, o source=operator)_");
+  }
+  lines.push("");
+
+  lines.push("## 2. Derivación del backend");
+  lines.push("");
+  if (quote.pileta) lines.push(`- pileta resuelto: \`${quote.pileta}\``);
+  if (quote.sink_type) {
+    lines.push(`- sink_type: \`${JSON.stringify(quote.sink_type)}\``);
+  }
+  if (quote.localidad) lines.push(`- localidad: ${quote.localidad}`);
+  if (quote.colocacion != null) lines.push(`- colocación: ${quote.colocacion ? "sí" : "no"}`);
+  if (quote.anafe != null) lines.push(`- anafe: ${quote.anafe ? "sí" : "no"}`);
+  if (quote.total_ars != null) lines.push(`- total ARS: ${quote.total_ars}`);
+  if (quote.total_usd != null) lines.push(`- total USD: ${quote.total_usd}`);
+  if (quote.notes) {
+    lines.push("");
+    lines.push("Notas (incluye corrección fuzzy si aplicó):");
+    lines.push("```");
+    lines.push(quote.notes);
+    lines.push("```");
+  }
+  lines.push("");
+
+  // 3. Conversación / mensajes — solo si hay algo. Reuse buildFullSnapshot
+  // para no duplicar el filtrado de markers internos.
+  if (messages.length > 0) {
+    lines.push("## 3. Conversación");
+    lines.push("");
+    lines.push(buildFullSnapshot(quote, messages));
+  }
+
+  return lines.join("\n").trim();
+}
+
 const STATUS_CLASS: Record<string, { label: string; cls: string; text: string; dotColor: string }> = {
   draft:     { label: "Borrador",  cls: "bg-amb-bg text-amb", text: "text-amb",          dotColor: "var(--amb)" },
   pending:   { label: "Pendiente", cls: "bg-acc-bg text-acc", text: "text-[#b299ff]",    dotColor: "#b299ff" },
@@ -512,7 +579,18 @@ export default function QuotePage() {
                 <span className="w-[7px] h-[7px] rounded-full shrink-0" style={{ background: st.dotColor }} />
                 {st.label}
               </span>
-              {quote?.source === "web" && <span className="text-[9px] font-semibold font-mono tracking-wider px-1.5 py-[2px] rounded border border-[#b48fe0]/30 text-[#b48fe0] shrink-0 not-italic">WEB</span>}
+              {quote?.source === "web" && (
+                <>
+                  <span className="text-[9px] font-semibold font-mono tracking-wider px-1.5 py-[2px] rounded border border-[#b48fe0]/30 text-[#b48fe0] shrink-0 not-italic">WEB</span>
+                  {/* PR #400 — Botón de debug: dump del body raw + derivaciones
+                      + conversación. Solo visible en quotes web (al lado del badge). */}
+                  <CopyButton
+                    text={buildWebRequestSnapshot(quote, messages)}
+                    label="Copiar solicitud"
+                    className="not-italic shrink-0"
+                  />
+                </>
+              )}
             </div>
             <div className="text-xs text-t3 mt-1 truncate max-w-[600px] font-sans">
               {quote?.project}{quote?.material ? ` ${DOT} ${quote.material}` : ""}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -156,6 +156,13 @@ export interface Quote {
   is_read: boolean;
   notes: string | null;
   sink_type: { basin_count: "simple" | "doble"; mount_type: "arriba" | "abajo" } | null;
+  // PR #400 — campos que el backend ya devuelve en QuoteListResponse pero
+  // no estaban tipados en el cliente. Se usan en `buildWebRequestSnapshot`
+  // para volcar la derivación del backend (pileta resuelto, etc.).
+  pileta?: string | null;
+  localidad?: string | null;
+  colocacion?: boolean | null;
+  anafe?: boolean | null;
   resumen_obra?: ResumenObraRecord | null;
   condiciones_pdf?: {
     pdf_url: string;
@@ -220,6 +227,11 @@ export interface QuoteDetail extends Quote {
   quote_breakdown: QuoteBreakdown | null;
   source_files: SourceFile[] | null;
   children?: Quote[];  // building_child_material quotes for building_parent
+  /** PR #400 — Snapshot raw del body POST /api/v1/quote (solo source="web").
+   *  Usado por el botón "Copiar solicitud web" en el detalle: dump literal
+   *  de lo que mandó el bot externo, antes de derivaciones del backend.
+   *  Null para quotes operator y para web pre-#400. */
+  web_input?: Record<string, unknown> | null;
 }
 
 export interface Message {


### PR DESCRIPTION
## Summary

- Persiste el body raw del POST `/api/v1/quote` en `Quote.web_input` para auditar el caso Fabiana (¿qué mandó el bot vs qué derivó el backend?).
- Expone botón **"Copiar solicitud"** al lado del badge `WEB` en el detalle del quote — copia un dump markdown con body crudo + derivación + conversación.

## Problema que resuelve

Hoy, cuando un quote del bot web sale raro (ej: `pileta=cliente` en vez de `empotrada_johnson`), no podemos saber si el bot mandó algo mal o si el backend derivó mal — el body original del POST se pierde apenas se desarma en columnas. Imposible debuggear sin reproducir.

Con `web_input` persistido + el botón, el operador puede copiar todo en un click y mandárselo al dev del bot.

## Cambios

### Backend
- `Quote.web_input` (JSON, nullable). Migración `ADD COLUMN IF NOT EXISTS` idempotente.
- POST `/v1/quote` persiste `body.model_dump(mode="json")` en ambos paths (con-pieces y sin-pieces). `mode="json"` evita el `Object of type ... is not JSON serializable` con enums tipo `PiletaType`.
- `QuoteDetailResponse.web_input` expuesto en GET `/api/quotes/:id`.

### Frontend
- `QuoteDetail.web_input?` tipado.
- Tipados `pileta`, `localidad`, `colocacion`, `anafe` (el backend ya los devolvía pero no estaban en el TS).
- `buildWebRequestSnapshot(quote, messages)`: dump markdown con (1) meta, (2) body crudo formateado en bloque ```json```, (3) derivación del backend, (4) conversación (reusa `buildFullSnapshot`).
- `<CopyButton>` reusado, label "Copiar solicitud", visible solo si `source === "web"`.

### Tests
5 casos en `tests/test_web_input_persistence.py`:
- web_input persiste con/sin pieces.
- Drift guard: enum serializa como string.
- GET response incluye web_input.
- Operator quotes → null.

## Caveat

Quotes web pre-#400 quedan con `web_input=NULL` (el body se perdió). El frontend lo indica explícitamente en el snapshot.

## Test plan

- [x] `pytest tests/test_web_input_persistence.py -v` → 5/5 verde.
- [x] Suite full → 1768/1769 (1 fail preexistente en `test_edificio_render`, no relacionado).
- [x] `tsc --noEmit` + `npm run build` verde.
- [ ] CI Backend Tests verde.
- [ ] CI Frontend Build verde.
- [ ] Post-deploy: abrir un quote `source=web` en producción, verificar botón visible al lado del badge `WEB`, click → clipboard contiene markdown con body raw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
