### PR TITLE
fix(flow): texto con despiece completo NO re-emite card post-context

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1463,6 +1463,15 @@ RETRY_DELAYS = [5, 10, 15, 20, 30]
 MAX_ITERATIONS = 15  # Safety limit — prevent infinite tool loops
 
 
+# PR #402 — sentinel exception para escape limpio del bloque de merges
+# en el handler de [CONTEXT_CONFIRMED] cuando el dual_read viene de
+# texto (`source="TEXT"`). Evita corromper el despiece textual con
+# merges de patas de isla / alzada que no aplican.
+class _PR402SkipMerges(Exception):
+    """Sentinel — no es un error, control de flow."""
+    pass
+
+
 # ── AGENT SERVICE ─────────────────────────────────────────────────────────────
 
 class AgentService:
@@ -1568,11 +1577,34 @@ class AgentService:
                 _bd_ctx = dict(_bd_ctx_pre)
                 _saved_dual = dict(_bd_ctx.get("dual_read_result") or {})
                 _dual_before = json.loads(json.dumps(_saved_dual, default=str))
-                # Aplicar las respuestas al dual_read_result
-                if _answers and _saved_dual:
+                # PR #402 — Despiece desde texto: el brief lo cerró el
+                # operador, los tramos están explícitos y completos. Las
+                # mutaciones que vienen abajo (`apply_answers` para
+                # frentin/regrueso/zocalos, merges de patas/alzada)
+                # corromperían el despiece — pisarían los sectores
+                # textuales con valores derivados o vacíos.
+                #
+                # Las respuestas top-level del contexto (localidad,
+                # material, etc.) se preservan en `verified_context_analysis`
+                # más abajo y el agente las consume desde ahí cuando arma
+                # `calc_input` para `calculate_quote`. No se pierden.
+                #
+                # Detección: `parsed_pieces_to_card()` setea `source="TEXT"`
+                # al top-level del dual_read (text_parser.py:202). Solo
+                # tagueado por esa función — duals interactivos (Dual Read
+                # del plano) traen otro source o nada.
+                _is_text_dispiece = _saved_dual.get("source") == "TEXT"
+
+                # Aplicar las respuestas al dual_read_result — solo para
+                # duals interactivos. TEXT salta este bloque.
+                if _answers and _saved_dual and not _is_text_dispiece:
                     from app.modules.quote_engine.pending_questions import apply_answers
                     apply_answers(_saved_dual, _answers)
                     # Limpiar pending_questions ya que están respondidas
+                    _saved_dual.pop("pending_questions", None)
+                elif _is_text_dispiece:
+                    # Limpieza defensiva: si por alguna razón el dual TEXT
+                    # tiene pending_questions (no debería), las descartamos.
                     _saved_dual.pop("pending_questions", None)
                 log_apply_answers(
                     quote_id,
@@ -1587,7 +1619,17 @@ class AgentService:
                 # prompt → el operador no las veía en la card. Ahora aparecen
                 # como tramos del sector isla, editables, con flag `_derived`.
                 # Idempotente: reconfirmar contexto reemplaza las viejas.
+                #
+                # PR #402 — Skip merges para despiece TEXT por la misma razón
+                # que `apply_answers`: pisarían los sectores textuales.
+                if _is_text_dispiece:
+                    logging.info(
+                        f"[trace:context-confirmed:{quote_id}] "
+                        "skipping derived-merge (source=TEXT)"
+                    )
                 try:
+                    if _is_text_dispiece:
+                        raise _PR402SkipMerges()
                     from app.modules.quote_engine.dual_reader import (
                         build_derived_isla_pieces,
                         merge_derived_pieces_into_dual_read,
@@ -1624,6 +1666,9 @@ class AgentService:
                         f"[trace:context-confirmed:{quote_id}] alzada "
                         f"active={_alzada_active} alto_m={_alzada_alto}"
                     )
+                except _PR402SkipMerges:
+                    # Path TEXT — escape limpio, no warn.
+                    pass
                 except Exception as _e_merge:
                     logging.warning(
                         f"[context-confirmed:{quote_id}] derived-merge failed: {_e_merge}",
@@ -1650,6 +1695,48 @@ class AgentService:
                     f"[context-confirmed] {quote_id} applied {len(_answers)} answers, "
                     "emitting dual_read_result"
                 )
+                # PR #402 — Despiece desde texto: NO re-emit del chunk
+                # `dual_read_result`. La card original se emitió cuando
+                # el operador pegó el brief (paso inicial del flow text)
+                # y sigue visible en el chat. Re-emitirla acá causaba
+                # que apareciera una "card fantasma" con los tramos
+                # mutados destructivamente por apply_answers/merges.
+                if _is_text_dispiece:
+                    logging.info(
+                        f"[trace:context-confirmed:{quote_id}] "
+                        "skip dual_read_result emit (source=TEXT)"
+                    )
+                    log_sse_structural(quote_id, "done", "")
+                    yield {"type": "done", "content": ""}
+                    # Persistir solo el user turn `[CONTEXT_CONFIRMED]`
+                    # (sin assistant __DUAL_READ__ adicional). El
+                    # __DUAL_READ__ original ya está en messages del
+                    # primer emit cuando el operador pegó el brief.
+                    try:
+                        _turn = [
+                            {
+                                "role": "user",
+                                "content": [{"type": "text", "text": user_message}],
+                            },
+                        ]
+                        if _q_ctx:
+                            _merged = list(_q_ctx.messages or []) + _turn
+                            await db.execute(
+                                update(Quote).where(Quote.id == quote_id).values(
+                                    messages=_merged
+                                )
+                            )
+                            await db.commit()
+                            log_messages_persist(
+                                quote_id,
+                                flow="context-confirmed-text",
+                                added_turns=_turn,
+                                total_count=len(_merged),
+                            )
+                    except Exception:
+                        pass
+                    return
+
                 _dr_chunk = json.dumps(_saved_dual, ensure_ascii=False)
                 log_sse_structural(quote_id, "dual_read_result", _dr_chunk)
                 yield {"type": "dual_read_result", "content": _dr_chunk}

--- a/api/tests/test_text_dispiece_skips_card.py
+++ b/api/tests/test_text_dispiece_skips_card.py
@@ -1,0 +1,337 @@
+"""Tests para PR #402 — texto con despiece completo NO debe re-emitir
+la card de Dual Read post-`[CONTEXT_CONFIRMED]`.
+
+**Bug:** cuando el operador pega un brief con despiece textual completo
+(`text_parser.parsed_pieces_to_card` → `dual_read_result.source="TEXT"`)
+y después confirma contexto, el handler de `[CONTEXT_CONFIRMED]` corre
+`apply_answers()` y los merges de patas/alzada sobre el dual textual,
+corrompiendo los sectores. Al re-emitir el chunk, el frontend renderiza
+una "card fantasma" con tramos pisados (típicamente "Regrueso 60,68 × 1"
+solo, sin los sectores originales).
+
+**Fix:** detectar `source == "TEXT"` en el handler y:
+  1. Skip `apply_answers` (preserva tramos textuales).
+  2. Skip merges de patas/alzada.
+  3. Skip emit del chunk `dual_read_result`.
+  4. Skip persistencia del assistant turn `__DUAL_READ__` (la card
+     original ya está en messages del primer emit).
+
+**Lo que NO toca este PR:**
+  - El cálculo (calculator.py).
+  - El path Dual Read interactivo (source != "TEXT") — comportamiento
+    intacto.
+  - `verified_context_analysis` se sigue persistiendo igual.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+from sqlalchemy import select, update as sql_update
+
+from app.models.quote import Quote, QuoteStatus
+from app.modules.agent.agent import AgentService
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _build_completed_dual(source: str) -> dict:
+    """Dual read 'cerrado' — un sector con un tramo con todos los
+    fields confirmed. Igual al output de parsed_pieces_to_card() o de
+    una Dual Read confirmada, según el `source`."""
+    return {
+        "sectores": [
+            {
+                "id": "sector_1",
+                "tipo": "cocina",
+                "tramos": [
+                    {
+                        "id": "t1",
+                        "descripcion": "Mesada",
+                        "largo_m": {"opus": None, "sonnet": None, "valor": 2.30, "status": "CONFIRMADO"},
+                        "ancho_m": {"opus": None, "sonnet": None, "valor": 0.60, "status": "CONFIRMADO"},
+                        "m2": {"opus": None, "sonnet": None, "valor": 1.38, "status": "CONFIRMADO"},
+                        "zocalos": [],
+                        "frentin": [],
+                        "regrueso": [],
+                        "_manual": True,
+                    },
+                ],
+                "m2_total": {"opus": None, "sonnet": None, "valor": 1.38, "status": "CONFIRMADO"},
+                "ambiguedades": [],
+                "_manual": True,
+            },
+        ],
+        "requires_human_review": False,
+        "conflict_fields": [],
+        "source": source,
+        "view_type": "texto" if source == "TEXT" else "plano",
+        "view_type_reason": "test fixture",
+        "m2_warning": None,
+        "_retry": True,
+    }
+
+
+async def _create_quote_with_dual(db_session, source: str) -> str:
+    """Crea un quote con un dual_read_result cerrado del `source` dado.
+    El quote ya tiene el primer emit de la card (en messages) y un
+    `context_analysis_pending` del paso anterior."""
+    qid = f"test-text-dispiece-{uuid.uuid4()}"
+    quote = Quote(
+        id=qid,
+        client_name="Cliente Texto",
+        project="Cocina",
+        material="Silestone Blanco Norte",
+        localidad="Rosario",
+        messages=[
+            # Mensaje user con el brief.
+            {"role": "user", "content": [{"type": "text", "text": "cocina 2.30 × 0.60"}]},
+            # Mensaje assistant con la card original (primer emit).
+            {
+                "role": "assistant",
+                "content": f"__DUAL_READ__{json.dumps(_build_completed_dual(source))}",
+            },
+            # Mensaje assistant con la card de contexto.
+            {
+                "role": "assistant",
+                "content": '__CONTEXT_ANALYSIS__{"data_known":[],"assumptions":[],"pending_questions":[]}',
+            },
+        ],
+        status=QuoteStatus.DRAFT,
+    )
+    db_session.add(quote)
+    await db_session.commit()
+
+    breakdown = {
+        "dual_read_result": _build_completed_dual(source),
+        # context_analysis_pending: gate del flow normal — el handler
+        # de `[CONTEXT_CONFIRMED]` lo lee al cargar `_bd_ctx`.
+        "context_analysis_pending": {
+            "data_known": [],
+            "assumptions": [],
+            "pending_questions": [],
+        },
+    }
+    await db_session.execute(
+        sql_update(Quote).where(Quote.id == qid).values(quote_breakdown=breakdown)
+    )
+    await db_session.commit()
+    return qid
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Tests
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestTextDispieceSkipsCard:
+    """Path TEXT — despiece textual cerrado, NO debe re-emitir card."""
+
+    @pytest.mark.asyncio
+    async def test_text_source_skips_dual_read_chunk(self, db_session):
+        """`source="TEXT"` + `[CONTEXT_CONFIRMED]` → NO emit chunk
+        `dual_read_result`. Solo emit `done`."""
+        qid = await _create_quote_with_dual(db_session, source="TEXT")
+
+        agent = AgentService()
+        chunks = []
+        async for chunk in agent.stream_chat(
+            quote_id=qid,
+            messages=[],
+            user_message='[CONTEXT_CONFIRMED]{"answers":[]}',
+            plan_bytes=None,
+            plan_filename=None,
+            db=db_session,
+        ):
+            chunks.append(chunk)
+
+        chunk_types = [c.get("type") for c in chunks]
+        assert "dual_read_result" not in chunk_types, (
+            f"Regresión: TEXT no debe re-emitir dual_read_result. "
+            f"Chunks emitidos: {chunk_types}"
+        )
+        assert "done" in chunk_types, f"Falta el emit done. Chunks: {chunks}"
+
+    @pytest.mark.asyncio
+    async def test_text_source_preserves_dual_read_in_db(self, db_session):
+        """`source="TEXT"` debe preservar el dual_read_result en DB
+        sin mutar los sectores. apply_answers no debe correr."""
+        qid = await _create_quote_with_dual(db_session, source="TEXT")
+        original_dual = _build_completed_dual("TEXT")
+
+        agent = AgentService()
+        async for _ in agent.stream_chat(
+            quote_id=qid,
+            messages=[],
+            # Answers no triviales — si apply_answers corriera,
+            # mutaría el dual.
+            user_message='[CONTEXT_CONFIRMED]{"answers":[{"id":"regrueso","value":"5"}]}',
+            plan_bytes=None,
+            plan_filename=None,
+            db=db_session,
+        ):
+            pass
+
+        # Re-leer el quote: el dual_read_result debe estar igual.
+        await db_session.commit()
+        result = await db_session.execute(select(Quote).where(Quote.id == qid))
+        quote = result.scalar_one()
+        persisted_dual = quote.quote_breakdown.get("dual_read_result")
+
+        # Sectores preservados (apply_answers NO corrió).
+        assert persisted_dual["sectores"] == original_dual["sectores"], (
+            "Regresión: apply_answers corrió sobre TEXT y mutó los sectores. "
+            f"Esperaba {original_dual['sectores']}, "
+            f"encontré {persisted_dual['sectores']}"
+        )
+        # source preservado.
+        assert persisted_dual["source"] == "TEXT"
+
+    @pytest.mark.asyncio
+    async def test_text_source_persists_context_confirmed_user_turn(self, db_session):
+        """El user turn `[CONTEXT_CONFIRMED]<json>` se persiste en
+        messages para que el frontend lo renderice como pill verde."""
+        qid = await _create_quote_with_dual(db_session, source="TEXT")
+
+        agent = AgentService()
+        async for _ in agent.stream_chat(
+            quote_id=qid,
+            messages=[],
+            user_message='[CONTEXT_CONFIRMED]{"answers":[]}',
+            plan_bytes=None,
+            plan_filename=None,
+            db=db_session,
+        ):
+            pass
+
+        await db_session.commit()
+        result = await db_session.execute(select(Quote).where(Quote.id == qid))
+        quote = result.scalar_one()
+        msg_texts = [
+            m["content"][0]["text"] if isinstance(m.get("content"), list) else m.get("content")
+            for m in (quote.messages or [])
+        ]
+        # Debe haber al menos un msg con `[CONTEXT_CONFIRMED]`.
+        assert any(
+            isinstance(t, str) and t.startswith("[CONTEXT_CONFIRMED]")
+            for t in msg_texts
+        ), f"Falta persistencia del user turn `[CONTEXT_CONFIRMED]`. Msgs: {msg_texts}"
+
+    @pytest.mark.asyncio
+    async def test_text_source_does_not_persist_extra_dual_read_assistant(self, db_session):
+        """En TEXT NO debe agregarse un assistant turn `__DUAL_READ__`
+        nuevo — la card original ya está en messages del primer emit."""
+        qid = await _create_quote_with_dual(db_session, source="TEXT")
+
+        # Snapshot inicial: 1 user + 1 assistant DUAL_READ + 1 assistant CONTEXT_ANALYSIS.
+        result_pre = await db_session.execute(select(Quote).where(Quote.id == qid))
+        msgs_pre = result_pre.scalar_one().messages or []
+        assistant_dual_pre = sum(
+            1 for m in msgs_pre
+            if m.get("role") == "assistant"
+            and isinstance(m.get("content"), str)
+            and m["content"].startswith("__DUAL_READ__")
+        )
+        assert assistant_dual_pre == 1  # baseline
+
+        agent = AgentService()
+        async for _ in agent.stream_chat(
+            quote_id=qid,
+            messages=[],
+            user_message='[CONTEXT_CONFIRMED]{"answers":[]}',
+            plan_bytes=None,
+            plan_filename=None,
+            db=db_session,
+        ):
+            pass
+
+        await db_session.commit()
+        result_post = await db_session.execute(select(Quote).where(Quote.id == qid))
+        msgs_post = result_post.scalar_one().messages or []
+        assistant_dual_post = sum(
+            1 for m in msgs_post
+            if m.get("role") == "assistant"
+            and isinstance(m.get("content"), str)
+            and m["content"].startswith("__DUAL_READ__")
+        )
+        assert assistant_dual_post == 1, (
+            f"Regresión: TEXT no debe agregar un assistant __DUAL_READ__ extra. "
+            f"Antes: {assistant_dual_pre}, después: {assistant_dual_post}"
+        )
+
+
+class TestInteractiveDualReadStillEmits:
+    """Path interactivo — el comportamiento del Dual Read del plano
+    no se toca. Regresión guard."""
+
+    @pytest.mark.asyncio
+    async def test_non_text_source_emits_dual_read_chunk(self, db_session):
+        """`source != "TEXT"` (Dual Read del plano) → DEBE emitir
+        chunk `dual_read_result` como hoy."""
+        qid = await _create_quote_with_dual(db_session, source="OPUS")
+
+        agent = AgentService()
+        chunks = []
+        async for chunk in agent.stream_chat(
+            quote_id=qid,
+            messages=[],
+            user_message='[CONTEXT_CONFIRMED]{"answers":[]}',
+            plan_bytes=None,
+            plan_filename=None,
+            db=db_session,
+        ):
+            chunks.append(chunk)
+
+        chunk_types = [c.get("type") for c in chunks]
+        assert "dual_read_result" in chunk_types, (
+            f"Regresión: Dual Read interactivo (source!=TEXT) debe seguir "
+            f"emitiendo chunk dual_read_result. Chunks: {chunk_types}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_source_emits_dual_read_chunk(self, db_session):
+        """Quote sin `source` definido (legacy / plano antiguo) →
+        comportamiento default = emit (no skip)."""
+        qid = f"test-no-source-{uuid.uuid4()}"
+        quote = Quote(
+            id=qid,
+            client_name="Test Legacy",
+            project="Cocina",
+            material="Silestone Blanco Norte",
+            localidad="Rosario",
+            messages=[],
+            status=QuoteStatus.DRAFT,
+        )
+        db_session.add(quote)
+        await db_session.commit()
+        # dual sin `source` field.
+        dual_no_source = _build_completed_dual("OPUS")
+        dual_no_source.pop("source")
+        await db_session.execute(
+            sql_update(Quote).where(Quote.id == qid).values(
+                quote_breakdown={"dual_read_result": dual_no_source}
+            )
+        )
+        await db_session.commit()
+
+        agent = AgentService()
+        chunks = []
+        async for chunk in agent.stream_chat(
+            quote_id=qid,
+            messages=[],
+            user_message='[CONTEXT_CONFIRMED]{"answers":[]}',
+            plan_bytes=None,
+            plan_filename=None,
+            db=db_session,
+        ):
+            chunks.append(chunk)
+
+        chunk_types = [c.get("type") for c in chunks]
+        assert "dual_read_result" in chunk_types, (
+            f"Regresión: dual sin `source` (legacy) debe emitir chunk. "
+            f"Chunks: {chunk_types}"
+        )


### PR DESCRIPTION
## Summary

PR 1 del par prometido (PR 2 ya cerró en #401). **Cero cambios en cálculo** — solo gate de orquestación/render.

**Bug:** operador pega un brief con despiece textual completo. El sistema arma Paso 1 OK con todas las piezas (primer emit OK). Después confirma contexto y aparece una card de Dual Read **artificial** con UN solo ítem ("Regrueso 60,68 × 1") pisando los sectores originales.

## Causa raíz

En el handler `[CONTEXT_CONFIRMED]` (`agent.py:1551+`), tras cargar `_saved_dual` desde DB:
1. Corre `apply_answers()` — `apply_regrueso_answer` muta los tramos con valores derivados.
2. Corre merges de patas de isla / alzada — pisan sectores con derivados.
3. Re-emite chunk `dual_read_result` → frontend renderiza card mutada.

PR #392 introdujo el flow de regrueso asumiendo Dual Read interactivo del plano; no consideró el path texto donde `parsed_pieces_to_card()` ya cierra el despiece.

## Fix

Detectar `_saved_dual.get("source") == "TEXT"` (que `text_parser.py:202` ya setea) y, si es texto:

| Acción | Antes (bug) | Después (#402) |
|---|---|---|
| `apply_answers` | corre y muta tramos | **skip** |
| Merges patas/alzada | corren y pisan sectores | **skip** |
| Emit chunk `dual_read_result` | re-emite card mutada | **skip** |
| Persiste assistant `__DUAL_READ__` | duplica en messages | **skip** |
| Persiste `verified_context_analysis` | sí | **sí (igual)** |
| Persiste user `[CONTEXT_CONFIRMED]` (pill) | sí | **sí (igual)** |

**Las answers top-level del contexto** (localidad, material, anafe_count, etc.) **no se pierden** — quedan en `verified_context_analysis` y el agente las consume desde ahí cuando arma `calc_input` para `calculate_quote`.

## Lo que NO toca

- `apply_answers`, merges, `apply_regrueso_answer` — intactos para el path interactivo del plano.
- Calculator (#401 ya cerró el regrueso).
- Cualquier otro path del agente.

## Tests

6 casos en `tests/test_text_dispiece_skips_card.py`:

✅ TEXT + `[CONTEXT_CONFIRMED]` → no emit chunk.
✅ TEXT + answers no-triviales → sectores preservados.
✅ TEXT → user turn persistido (pill).
✅ TEXT → no duplica assistant `__DUAL_READ__`.
✅ **Regression guard:** `source="OPUS"` → emit chunk como hoy.
✅ **Regression guard:** dual sin `source` (legacy) → emit chunk default.

Suite full: **1781 passing** (1 fail preexistente en `test_edificio_render`, no relacionado).

## Test plan

- [x] `pytest tests/test_text_dispiece_skips_card.py -v` → 6/6.
- [x] Suite full → 1781 passing.
- [ ] CI Backend Tests verde.
- [ ] CI Frontend Build verde.
- [ ] Post-deploy: caso reportado (texto con "M.O. REGRUESO frente 1x60,68ml") → tras "Confirmar contexto" la card original sigue visible (no aparece la fantasma con regrueso solo) + `mo_items` del Paso 2 incluye el regrueso (gracias a #401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
