### PR TITLE
fix(calculator): label canónico 'Mano de obra regrueso x ml' (hotfix #401)

### DIFF
--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -1177,8 +1177,14 @@ def calculate_quote(input_data: dict) -> dict:
     if regrueso and regrueso_ml > 0:
         price, base = _get_mo_price("REGRUESO")
         ml = round(regrueso_ml, 2)
+        # PR #403 — label canónico del repo. El ejemplo validado
+        # `examples/quote-030-juan-carlos-negro-brasil.md:49` usa
+        # "Mano de obra regrueso x ml" como description del row de
+        # MO. PR #401 (yo) había puesto "Regrueso frente" calcando
+        # mal del frentín — el "frente" del brief era ubicación
+        # ("regrueso del frente, h:5cm"), no parte del nombre.
         mo_items.append({
-            "description": "Regrueso frente",
+            "description": "Mano de obra regrueso x ml",
             "quantity": ml,
             "unit_price": price,
             "base_price": base,

--- a/api/tests/test_regrueso_mo.py
+++ b/api/tests/test_regrueso_mo.py
@@ -61,6 +61,15 @@ class TestRegruesoMoItem:
             f"{[m['description'] for m in result['mo_items']]}"
         )
         item = regrueso_items[0]
+        # PR #403 — label canónico del repo (ver
+        # `examples/quote-030-juan-carlos-negro-brasil.md:49`).
+        # PR #401 había puesto "Regrueso frente" calcando mal del
+        # frentín — el "frente" del brief era ubicación, no parte
+        # del nombre. El operador lo señaló al revisar un quote.
+        assert item["description"] == "Mano de obra regrueso x ml", (
+            f"Label canónico distinto: {item['description']!r}. "
+            f"Esperado: 'Mano de obra regrueso x ml' (ver ejemplo #030)."
+        )
         assert item["quantity"] == 60.68
         # Precio del catálogo labor.json — 13810.06 ARS por ml (sin IVA).
         # El calculator aplica IVA ×1.21 → round(13810.06 * 1.21) = 16710


### PR DESCRIPTION
## Summary

Hotfix corto del label visible al operador/cliente. **Cero cambios en lógica/qty/pricing.**

## Bug

PR #401 puso `"Regrueso frente"` como description del `mo_item` del regrueso, calcando mal del frentín ("Armado frentín"). El operador lo señaló al revisar un quote real (caso Dyscon S.A.):

```
| Regrueso frente | 60,68 ml | $13.810 | ✓ | $965.662 |
```

El "frente" del brief era **ubicación** ("regrueso del frente, h:5cm"), no parte del nombre del item.

## Fix

Cambio único:

```diff
- "description": "Regrueso frente",
+ "description": "Mano de obra regrueso x ml",
```

Label canónico del ejemplo validado del repo `examples/quote-030-juan-carlos-negro-brasil.md:49`:

```
| Mano de obra regrueso x ml | REGRUESO | 6.27 | $15.331 | $96.125 |
```

## Tests

- Test principal ahora asserta sobre la description exacta para evitar regresión futura.
- 7/7 verde en `test_regrueso_mo.py`.
- Suite full: 1781 passing (1 fail preexistente en `test_edificio_render`).

## Test plan

- [x] `pytest tests/test_regrueso_mo.py -v` → 7/7.
- [x] Suite full → 1781 passing.
- [ ] CI verde.
- [ ] Post-deploy: re-cotizar caso Dyscon — la línea de MO debe leer "Mano de obra regrueso x ml — 60.68 ml".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
