### PR TITLE
fix(text-parser): respetar quantity (×N) en despiece textual

### DIFF
--- a/api/app/modules/quote_engine/dual_reader.py
+++ b/api/app/modules/quote_engine/dual_reader.py
@@ -888,14 +888,42 @@ def build_verified_context(
             largo_v = largo.get("valor", 0) if isinstance(largo, dict) else largo
             ancho_v = ancho.get("valor", 0) if isinstance(ancho, dict) else ancho
             m2_v = m2.get("valor", 0) if isinstance(m2, dict) else m2
-            lines.append(f"  {desc}: {largo_v}m × {ancho_v}m = {m2_v} m²")
+            # PR #405 — render quantity cuando > 1 (path TEXT con
+            # tipologías repetidas, ej: edificio con 24 mesadas idénticas).
+            # `m2_v` ya viene multiplicado por quantity desde el parser
+            # text_parser.parsed_pieces_to_card. La línea `× quantity =`
+            # le indica a Claude que debe pasar `quantity=N` al
+            # `calculate_quote.pieces[]` (NO un m²_override) — el
+            # calculator multiplica por su cuenta y NO puede recibir
+            # ambos sin doblar el cobro.
+            t_qty = tramo.get("quantity", 1) or 1
+            try:
+                t_qty = int(t_qty)
+            except (TypeError, ValueError):
+                t_qty = 1
+            if t_qty > 1:
+                lines.append(
+                    f"  {desc}: {largo_v}m × {ancho_v}m × {t_qty} = {m2_v} m²"
+                )
+            else:
+                lines.append(f"  {desc}: {largo_v}m × {ancho_v}m = {m2_v} m²")
             for z in tramo.get("zocalos", []):
                 ml = z.get("ml", 0) or 0
                 alto = z.get("alto_m", _default_zocalo_alto())
                 lado = z.get("lado", "?")
-                if ml > 0:
+                if ml <= 0:
+                    continue  # ml=0 → operador lo descartó intencionalmente
+                # PR #405 — zócalo también lleva quantity (heredada del
+                # tramo padre en el adapter). Mismo formato.
+                z_qty = z.get("quantity", 1) or 1
+                try:
+                    z_qty = int(z_qty)
+                except (TypeError, ValueError):
+                    z_qty = 1
+                if z_qty > 1:
+                    lines.append(f"  Zócalo {lado}: {ml}ml × {alto}m × {z_qty}")
+                else:
                     lines.append(f"  Zócalo {lado}: {ml}ml × {alto}m")
-                # ml=0 → ignorado (operador lo descartó intencionalmente)
             # PR #387 — emitir frentín / faldón / regrueso de cada tramo
             # con el mismo formato que los zócalos. Antes estos campos
             # vivían en `tramo.frentin` / `tramo.regrueso` pero no se

--- a/api/app/modules/quote_engine/text_parser.py
+++ b/api/app/modules/quote_engine/text_parser.py
@@ -28,6 +28,18 @@ Reglas de medidas:
 - Frentín: largo × alto (generalmente 0.02m o 0.03m)
 - Si dice "zócalo atrás 5cm" en una mesada de 2m → zócalo largo=2.0, alto=0.05
 
+Cantidad (`quantity`) — PR #405:
+- Por DEFECTO `quantity=1` (cocinas particulares, una mesada por pieza).
+- Si el texto declara cantidad multiplicada explícita ("× 24", "×2",
+  "(×N)", "×24 unidades", "= 27.60 m²" cuando dice "1.15 m²/u × 24"),
+  extraer ese N como `quantity` entero ≥1.
+- El zócalo de una pieza con `quantity=N` también lleva `quantity=N`
+  (24 mesadas → 24 zócalos). NO inventar zócalos extra; solo replicar
+  la cantidad de la mesada padre.
+- NO multiplicar `largo`/`prof`/`alto`. Esos quedan por unidad.
+  El cálculo `m² total = largo × prof × quantity` lo hace el calculator
+  downstream — vos solo extraés la cantidad como número aparte.
+
 Detectar también:
 - pileta: "Johnson" o "johnson" → "empotrada_johnson", "empotrada" o "bajo mesada" → "empotrada_cliente", "apoyo" → "apoyo"
 - anafe: si menciona anafe/hornalla → true
@@ -37,8 +49,9 @@ Detectar también:
 Respondé SOLO con JSON válido, sin markdown ni explicaciones:
 {{
   "pieces": [
-    {{"description": "Mesada cocina", "largo": 2.0, "prof": {depth}}},
-    {{"description": "Zócalo trasero", "largo": 2.0, "alto": {zocalo}}}
+    {{"description": "M1 mesada", "largo": 1.92, "prof": {depth}, "quantity": 24}},
+    {{"description": "M1 zócalo atrás", "largo": 1.92, "alto": 0.10, "quantity": 24}},
+    {{"description": "M2 mesada", "largo": 1.70, "prof": {depth}, "quantity": 1}}
   ],
   "pileta": "empotrada_johnson" | "empotrada_cliente" | "apoyo" | null,
   "anafe": false,
@@ -138,19 +151,36 @@ def parsed_pieces_to_card(parsed: dict) -> dict | None:
             continue
         prof = p.get("prof")
         alto = p.get("alto")
+        # PR #405 — cantidad multiplicada (default 1). El parser LLM la
+        # extrae cuando ve "×24", "×2", etc. en el brief. Casos sin
+        # quantity (cocina particular) quedan en 1 y no cambian.
+        try:
+            quantity = int(p.get("quantity") or 1)
+        except (TypeError, ValueError):
+            quantity = 1
+        if quantity < 1:
+            quantity = 1
 
         if prof is not None and isinstance(prof, (int, float)) and prof > 0:
-            # Es una mesada
-            m2 = round(largo * prof, 2)
+            # Es una mesada. m2.valor = largo × prof × quantity (m² total
+            # del tramo). Calculator downstream NO debe re-multiplicar:
+            # se le pasa `quantity` separado y `largo/prof` por unidad.
+            m2_per_unit = round(largo * prof, 2)
+            m2 = round(m2_per_unit * quantity, 2)
+            base_desc = p.get("description") or f"Mesada {len(tramos) + 1}"
+            descripcion = f"{base_desc} (×{quantity})" if quantity > 1 else base_desc
             tramo = {
                 "id": f"t{len(tramos) + 1}",
-                "descripcion": p.get("description") or f"Mesada {len(tramos) + 1}",
+                "descripcion": descripcion,
                 "largo_m": _field(largo),
                 "ancho_m": _field(prof),
                 "m2": _field(m2),
                 "zocalos": [],
                 "frentin": [],
                 "regrueso": [],
+                # PR #405 — cantidad propagada al tramo. El handoff a
+                # calculator usa este campo para `pieces[].quantity`.
+                "quantity": quantity,
                 "_manual": True,
             }
             # Si hay zócalos pendientes sin tramo previo, asignarlos al primer tramo
@@ -159,7 +189,10 @@ def parsed_pieces_to_card(parsed: dict) -> dict | None:
                 pending_zocalos = []
             tramos.append(tramo)
         elif alto is not None and isinstance(alto, (int, float)) and alto > 0:
-            # Es un zócalo — asignar al último tramo, o dejarlo pendiente
+            # Es un zócalo — asignar al último tramo, o dejarlo pendiente.
+            # El zócalo hereda la quantity del tramo padre (24 mesadas →
+            # 24 zócalos). Si el LLM ya pasó `quantity` para el zócalo,
+            # respetarla; si no, heredar del tramo previo en el final.
             zocalo = {
                 "lado": (p.get("description") or "trasero").replace("Zócalo ", "").replace("Zócalo", "").strip() or "trasero",
                 "ml": float(largo),
@@ -167,6 +200,9 @@ def parsed_pieces_to_card(parsed: dict) -> dict | None:
                 "status": "CONFIRMADO",
                 "opus_ml": None,
                 "sonnet_ml": None,
+                # PR #405 — quantity del zócalo. Si el LLM no lo extrajo,
+                # se hereda del tramo padre más abajo (resolución en 2 pasos).
+                "quantity": quantity,
             }
             if tramos:
                 tramos[-1]["zocalos"].append(zocalo)
@@ -180,9 +216,30 @@ def parsed_pieces_to_card(parsed: dict) -> dict | None:
     if pending_zocalos:
         tramos[0]["zocalos"].extend(pending_zocalos)
 
+    # PR #405 — herencia de quantity para zócalos del último tramo.
+    # Si el LLM no extrajo quantity para un zócalo (ej: solo dice
+    # "zócalo 5cm" después de la mesada con ×24), el zócalo arranca con
+    # quantity=1 (el default del parser). Lo sobrescribimos con la
+    # quantity del tramo padre — caso DYSCON: 24 mesadas → 24 zócalos.
+    # Si el zócalo trae quantity > 1 explícita del LLM, respetarla.
+    for t in tramos:
+        t_qty = t.get("quantity", 1)
+        if t_qty <= 1:
+            continue
+        for z in t["zocalos"]:
+            if z.get("quantity", 1) <= 1:
+                z["quantity"] = t_qty
+
+    # PR #405 — total m² del sector, ya con cantidades aplicadas:
+    #   - tramo.m2.valor ya viene multiplicado por tramo.quantity.
+    #   - zocalo: ml × alto_m × quantity.
     m2_total_valor = round(
         sum(t["m2"]["valor"] for t in tramos)
-        + sum(z["ml"] * z["alto_m"] for t in tramos for z in t["zocalos"]),
+        + sum(
+            z["ml"] * z["alto_m"] * z.get("quantity", 1)
+            for t in tramos
+            for z in t["zocalos"]
+        ),
         2,
     )
 

--- a/api/tests/test_text_parser_quantity.py
+++ b/api/tests/test_text_parser_quantity.py
@@ -1,0 +1,224 @@
+"""Tests para PR #405 — `quantity` en el parser textual.
+
+Bug: cuando el operador pega un brief con piezas que declaran cantidad
+multiplicada explícita ("× 24", "×2", etc.), el parser textual extraía
+solo medidas por unidad y el dual_read mostraba `m² total = sum(m²/u)`
+sin multiplicar. Caso real (DYSCON S.A. / Unidad Penal N°8 — Piñero,
+quote 17052eac): operador declara 14 piezas con quantities `[24, 24,
+1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2]` para total 42.39 m². El sistema
+mostró 9.43 m² (suma de m²/u sin multiplicar).
+
+Cobertura:
+  - parsed_pieces_to_card respeta `quantity` del parser (default 1).
+  - m2 del tramo = largo × prof × quantity.
+  - Zócalo hereda quantity del tramo padre cuando el LLM no la pasa.
+  - Zócalo respeta quantity propia si el LLM la pasó.
+  - Total m² del sector = suma con quantities aplicadas.
+  - Descripción del tramo lleva sufijo "(×N)" cuando quantity > 1.
+  - Caso DYSCON exacto: 14 piezas → 42.39 m² total.
+  - build_verified_context renderiza "× quantity = m² total" cuando >1.
+  - Default (quantity=1 implícito): comportamiento idéntico a pre-#405.
+
+NO se toca:
+  - Calculator (ya respeta `quantity` cuando llega).
+  - Path Dual Read del plano (sin quantity por diseño actual).
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.modules.quote_engine.text_parser import parsed_pieces_to_card
+from app.modules.quote_engine.dual_reader import build_verified_context
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# parsed_pieces_to_card — propagación y multiplicación
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestQuantityPropagation:
+    def test_quantity_default_1_no_change(self):
+        """Brief simple sin quantity → comportamiento idéntico a pre-#405.
+        m2 = largo × prof; no aparece sufijo (×N) en descripción."""
+        parsed = {
+            "pieces": [
+                {"description": "Mesada cocina", "largo": 2.0, "prof": 0.6},
+                {"description": "Zócalo trasero", "largo": 2.0, "alto": 0.05},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        tramo = card["sectores"][0]["tramos"][0]
+        assert tramo["quantity"] == 1
+        assert tramo["m2"]["valor"] == round(2.0 * 0.6, 2)  # 1.2
+        assert "(×" not in tramo["descripcion"]
+        # Zócalo hereda quantity=1.
+        assert tramo["zocalos"][0]["quantity"] == 1
+
+    def test_quantity_multiplies_m2(self):
+        """quantity=24 → m2 = largo × prof × 24."""
+        parsed = {
+            "pieces": [
+                {"description": "M1 mesada", "largo": 1.92, "prof": 0.6, "quantity": 24},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        tramo = card["sectores"][0]["tramos"][0]
+        assert tramo["quantity"] == 24
+        # 1.92 × 0.60 = 1.152 → round 2 = 1.15. × 24 = 27.60.
+        assert tramo["m2"]["valor"] == 27.6
+        assert "(×24)" in tramo["descripcion"]
+        # largo y ancho quedan POR UNIDAD (no multiplicados).
+        assert tramo["largo_m"]["valor"] == 1.92
+        assert tramo["ancho_m"]["valor"] == 0.6
+
+    def test_zocalo_inherits_quantity_from_tramo(self):
+        """Si el LLM extrajo quantity para la mesada pero no para el
+        zócalo, el zócalo hereda la cantidad del tramo padre.
+        Caso DYSCON: 24 mesadas → 24 zócalos."""
+        parsed = {
+            "pieces": [
+                {"description": "M1 mesada", "largo": 1.92, "prof": 0.6, "quantity": 24},
+                # zócalo SIN quantity → debe heredar 24.
+                {"description": "M1 zócalo atrás", "largo": 1.92, "alto": 0.10},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        tramo = card["sectores"][0]["tramos"][0]
+        assert tramo["quantity"] == 24
+        assert len(tramo["zocalos"]) == 1
+        assert tramo["zocalos"][0]["quantity"] == 24
+
+    def test_zocalo_respects_explicit_quantity(self):
+        """Si el LLM pasó quantity para el zócalo, respetarla (no
+        sobrescribir con la del tramo padre)."""
+        parsed = {
+            "pieces": [
+                {"description": "M1 mesada", "largo": 1.92, "prof": 0.6, "quantity": 24},
+                # zócalo con quantity propia (raro pero posible).
+                {"description": "M1 zócalo atrás", "largo": 1.92, "alto": 0.10, "quantity": 12},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        tramo = card["sectores"][0]["tramos"][0]
+        assert tramo["zocalos"][0]["quantity"] == 12
+
+    def test_invalid_quantity_falls_back_to_1(self):
+        """Si quantity viene como string, None, o número negativo →
+        default 1 (no romper el flow)."""
+        parsed = {
+            "pieces": [
+                {"description": "Mesada A", "largo": 2.0, "prof": 0.6, "quantity": "abc"},
+                {"description": "Mesada B", "largo": 2.0, "prof": 0.6, "quantity": None},
+                {"description": "Mesada C", "largo": 2.0, "prof": 0.6, "quantity": -5},
+                {"description": "Mesada D", "largo": 2.0, "prof": 0.6, "quantity": 0},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        for tramo in card["sectores"][0]["tramos"]:
+            assert tramo["quantity"] == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Total m² del sector — suma con quantities
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestSectorTotal:
+    def test_total_uses_multiplied_m2(self):
+        """Total m² = sum(m² × quantity) tanto para mesadas como zócalos."""
+        parsed = {
+            "pieces": [
+                {"description": "M1 mesada", "largo": 1.0, "prof": 0.6, "quantity": 2},  # 0.60 × 2 = 1.20
+                {"description": "M1 zócalo", "largo": 1.0, "alto": 0.10, "quantity": 2},  # 0.10 × 2 = 0.20
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        m2_total = card["sectores"][0]["m2_total"]["valor"]
+        # 1.20 (mesada) + 0.20 (zócalo) = 1.40
+        assert m2_total == 1.4
+
+    def test_dyscon_full_case(self):
+        """Caso real DYSCON — 14 piezas con quantities mixtas, total 42.39 m².
+        Si esto rompe, el bug original volvió."""
+        parsed = {
+            "pieces": [
+                {"description": "M1 mesada", "largo": 1.92, "prof": 0.60, "quantity": 24},
+                {"description": "M1 zócalo atrás", "largo": 1.92, "alto": 0.10, "quantity": 24},
+                {"description": "M2 mesada (Office 32)", "largo": 1.70, "prof": 0.60, "quantity": 1},
+                {"description": "M2 zócalo atrás", "largo": 1.70, "alto": 0.10, "quantity": 1},
+                {"description": "M3 mesada (Office 12)", "largo": 2.50, "prof": 0.60, "quantity": 1},
+                {"description": "M3 zócalo atrás", "largo": 2.50, "alto": 0.10, "quantity": 1},
+                {"description": "M4 mesada (Office 27)", "largo": 2.50, "prof": 0.60, "quantity": 1},
+                {"description": "M4 zócalo atrás", "largo": 2.50, "alto": 0.10, "quantity": 1},
+                {"description": "M5 mesada (Office 53)", "largo": 1.80, "prof": 0.60, "quantity": 1},
+                {"description": "M5 zócalo atrás", "largo": 1.80, "alto": 0.10, "quantity": 1},
+                {"description": "M6 mesada (Office 80/83)", "largo": 1.55, "prof": 0.60, "quantity": 2},
+                {"description": "M6 zócalo atrás", "largo": 1.55, "alto": 0.10, "quantity": 2},
+                {"description": "M7 mesada (Office 87/90)", "largo": 1.50, "prof": 0.60, "quantity": 2},
+                {"description": "M7 zócalo atrás", "largo": 1.50, "alto": 0.10, "quantity": 2},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        total = card["sectores"][0]["m2_total"]["valor"]
+        # Esperado: 42.39 m² ± 0.02 (rounding floor en parser).
+        # Cálculo del operador:
+        #   Mesadas: 27.60 + 1.02 + 1.50 + 1.50 + 1.08 + 1.86 + 1.80 = 36.36
+        #   Zócalos: 4.56 + 0.17 + 0.25 + 0.25 + 0.18 + 0.32 + 0.30 = 6.03
+        #   Total: 42.39
+        assert abs(total - 42.39) < 0.05, (
+            f"Caso DYSCON regresión: total {total} vs esperado 42.39 "
+            f"(delta {abs(total - 42.39):.2f})"
+        )
+
+    def test_total_without_quantity_unchanged(self):
+        """Brief sin quantities (cocina particular) → total idéntico
+        a pre-#405. Regression guard."""
+        parsed = {
+            "pieces": [
+                {"description": "Mesada", "largo": 2.0, "prof": 0.6},  # 1.20
+                {"description": "Zócalo", "largo": 2.0, "alto": 0.05},  # 0.10
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        # 1.20 + 0.10 = 1.30
+        assert card["sectores"][0]["m2_total"]["valor"] == 1.3
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# verified_context — render del quantity para que Claude lo lea
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestVerifiedContextRender:
+    def test_render_with_quantity_includes_multiplier(self):
+        """Cuando un tramo tiene quantity > 1, el verified_context debe
+        renderizar `× N = m²_total` para que Claude pase quantity al
+        calculate_quote.pieces[].quantity (NO un m²_override)."""
+        parsed = {
+            "pieces": [
+                {"description": "M1 mesada", "largo": 1.92, "prof": 0.6, "quantity": 24},
+                {"description": "M1 zócalo atrás", "largo": 1.92, "alto": 0.10, "quantity": 24},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        ctx = build_verified_context(card)
+        # Mesada: "× 24 = 27.6" debe aparecer.
+        assert "× 24" in ctx
+        assert "27.6" in ctx
+        # Zócalo: "× 24" también.
+        assert ctx.count("× 24") >= 2
+
+    def test_render_without_quantity_unchanged(self):
+        """Tramos con quantity=1 (default) → render idéntico a pre-#405:
+        `largo × ancho = m²` (sin × N)."""
+        parsed = {
+            "pieces": [
+                {"description": "Mesada", "largo": 2.0, "prof": 0.6},
+                {"description": "Zócalo", "largo": 2.0, "alto": 0.05},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        ctx = build_verified_context(card)
+        # Forma esperada: "Mesada: 2.0m × 0.6m = 1.2 m²" (sin × N).
+        assert "× 1 =" not in ctx
+        assert "1.2 m²" in ctx


### PR DESCRIPTION
## Summary

Fix crítico — **faltaba plata** en cualquier brief textual con tipologías repetidas (`× 24`, `×2`). Caso real DYSCON (quote `17052eac`): 14 piezas con qty mixtas → debía ser **42.39 m²**, sistema mostraba **9.43 m²**.

## Causa raíz (4 puntos en cadena)

| # | Archivo:línea | Falla |
|---|---|---|
| 1 | `text_parser.py:_parse_system` | Prompt LLM no pedía `quantity` |
| 2 | `text_parser.py:parse_measurements` | Pieces sin `quantity` (consecuencia de #1) |
| 3 | `text_parser.py:parsed_pieces_to_card` | Tramo sin `quantity`, `m2 = largo × prof` |
| 4 | `text_parser.py:183-187` | Total = sum(m²/u) sin multiplicar |

`calculator.py:calculate_m2` ya respetaba `quantity` desde antes — el bug estaba **enteramente** en el path texto.

## Fix (3 archivos, sin tocar calculator ni frontend)

### 1. `text_parser.py:_parse_system` — prompt LLM
Instrucción explícita para extraer `quantity` (default 1). Patrones reconocidos: `× 24`, `×2`, `(×N)`, `×24 unidades`, `= 27.60 m²` cuando dice `1.15 m²/u × 24`. **No multiplicar `largo`/`prof`** — quantity queda como número aparte para que el calculator no doble-multiplique.

### 2. `text_parser.py:parsed_pieces_to_card`
- Tramo gana campo `quantity`.
- `m2.valor = largo × prof × quantity` (m² total).
- Sufijo `(×N)` en `descripcion` cuando `quantity > 1` (parche visual sin tocar frontend).
- **Zócalo hereda `quantity` del tramo padre** cuando el LLM no la pasó (regla operador: 24 mesadas → 24 zócalos).
- `m2_total_valor` del sector suma con quantities aplicadas.

### 3. `dual_reader.py:build_verified_context`
Render `× quantity = m²_total` cuando `quantity > 1`. Esto le dice a Claude que pase `pieces[].quantity` al `calculate_quote` tool. Si `quantity == 1`, render idéntico a pre-#405.

## Garantías de no doble-multiplicación

- `largo` y `prof` quedan **por unidad** (no se multiplican).
- `m2.valor` sí queda multiplicado (display total).
- Calculator recibe `largo/prof/quantity` separados → multiplica una sola vez.
- **No se manda** `m2_override` (que skipearía el cálculo y rompería con `quantity`).

## Tests (10 casos en `tests/test_text_parser_quantity.py`)

✅ Default `qty=1` sin cambio (regression guard).
✅ `qty=24` → `m2 = largo × prof × 24`, descripción con `(×24)`.
✅ Zócalo hereda qty del tramo padre.
✅ Zócalo respeta qty propia si LLM la pasó.
✅ Inputs inválidos (string, None, negativo, 0) → fallback a 1.
✅ Total m² del sector con qty mixtas.
✅ **Caso DYSCON exacto** — 14 piezas → 42.39 m².
✅ Brief sin qty → total idéntico a pre-#405.
✅ `verified_context` renderiza `× N = m²` cuando qty > 1.
✅ `verified_context` idéntico cuando qty == 1.

Suite full: **1792 passing** (1 fail preexistente).

## Lo que NO toca

- Calculator.
- Frontend (la columna "Cant" se podría agregar en otro PR; el sufijo `(×N)` en descripción cubre la visibilidad mientras tanto).
- Path Dual Read del plano (no maneja quantity por diseño actual; tema separado).

## Test plan

- [x] `pytest tests/test_text_parser_quantity.py -v` → 10/10.
- [x] Suite full → 1792 passing.
- [ ] CI verde.
- [ ] Post-deploy: re-pegar brief DYSCON exacto → card muestra `(×24)` en M1, total 42.39 m². Confirmar despiece → calculator usa quantity correcta → Paso 2 con números reales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
