### PR TITLE
fix(calculator): pileta_qty desde mesadas cuando guardrail mo-list-authority inyectó

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -5468,6 +5468,13 @@ class AgentService:
                     )
                     inputs["pileta"] = "empotrada_cliente"
                     inputs.pop("pileta_sku", None)
+                    # PR #407 — flag de origen. El calculator usa esto para
+                    # decidir si activar el fallback de pileta_qty desde
+                    # mesadas (caso DYSCON: 32 mesadas → 32 piletas).
+                    # Si la pileta la pasó el operador explícita, este flag
+                    # NO se setea y el fallback no se activa — se respeta
+                    # el `pileta_qty` del operador, incluso si es 1.
+                    inputs["_pileta_inferred_by_guardrail"] = True
                 if not _mentions_anafe and inputs.get("anafe"):
                     logging.warning(
                         f"[mo-list-authority] Operator listed MO explicitly and "

--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -945,13 +945,56 @@ def calculate_quote(input_data: dict) -> dict:
 
         # Auto-count piletas from piece descriptions if not provided
         if pileta and pileta_qty <= 1:
+            # PR #407 fix A — sumar `quantity` (no contar 1 por línea).
+            # Antes: una pieza "Mesada con pileta × 24" contaba 1.
+            # Ahora: cuenta 24. Caso DYSCON no se beneficia de este path
+            # (sus descripciones no tienen keywords), pero edificios con
+            # etiquetado correcto ahora sí escalan.
+            _kw_pileta = ["pileta", "bacha", "lavatorio", "kitchenette",
+                          "c/pileta", "c/bacha"]
             auto_pileta_count = sum(
-                1 for p in (pp if isinstance(pp, dict) else pp.model_dump() for pp in pieces)
-                if any(kw in (p.get("description") or "").lower() for kw in ["pileta", "bacha", "lavatorio", "kitchenette", "c/pileta", "c/bacha"])
+                int(p.get("quantity", 1) or 1)
+                for p in (pp if isinstance(pp, dict) else pp.model_dump() for pp in pieces)
+                if any(kw in (p.get("description") or "").lower() for kw in _kw_pileta)
             )
             if auto_pileta_count > 1:
                 pileta_qty = auto_pileta_count
-                logging.info(f"Edificio guardrail: auto-detected {pileta_qty} piletas from piece descriptions")
+                logging.info(
+                    f"Edificio guardrail: auto-detected {pileta_qty} piletas "
+                    f"from piece descriptions (sum of quantities)"
+                )
+            elif input_data.get("_pileta_inferred_by_guardrail"):
+                # PR #407 fix B (acotado por origen) — fallback solo si
+                # la pileta fue **auto-inyectada** por el guardrail
+                # `mo-list-authority` (agent.py:5469). En ese caso el
+                # operador no declaró pileta y no etiquetó piezas; la
+                # convención del operador es que cada mesada del edificio
+                # lleva pileta. Caso DYSCON: 32 mesadas → 32 piletas.
+                #
+                # NO se activa cuando:
+                #   - El operador pasó `pileta_qty` explícito (ya filtra
+                #     el `pileta_qty <= 1` arriba).
+                #   - La pileta vino del operador (sin flag).
+                #   - Hay match por keyword (rama anterior toma precedencia).
+                #   - No hay mesadas con quantity > 1.
+                #
+                # Excluye: zócalos, frentín, regrueso, alzada, faldón —
+                # esas piezas no llevan pileta propia.
+                _kw_excluded = ("zócalo", "zocalo", "frentín", "frentin",
+                                "regrueso", "alzada", "faldón", "faldon")
+                _mesada_qty = sum(
+                    int(p.get("quantity", 1) or 1)
+                    for p in (pp if isinstance(pp, dict) else pp.model_dump() for pp in pieces)
+                    if "mesada" in (p.get("description") or "").lower()
+                    and not any(kw in (p.get("description") or "").lower()
+                                for kw in _kw_excluded)
+                )
+                if _mesada_qty > 1:
+                    pileta_qty = _mesada_qty
+                    logging.info(
+                        f"Edificio + pileta auto-inyectada por mo-list-authority: "
+                        f"pileta_qty={pileta_qty} (suma de quantities de mesadas)"
+                    )
 
         # Auto-calculate frentin_ml from piece descriptions if not provided
         if frentin and not input_data.get("frentin_ml"):

--- a/api/tests/test_pileta_qty_from_mesadas.py
+++ b/api/tests/test_pileta_qty_from_mesadas.py
@@ -1,0 +1,297 @@
+"""Tests para PR #407 — `pileta_qty` derivado de mesadas en edificios
+cuando la pileta fue auto-inyectada por el guardrail mo-list-authority.
+
+**Bug:** caso DYSCON (32 mesadas con quantities mixtas) cobraba
+"Agujero y pegado pileta" qty=1, debería ser qty=32. La causa: el
+auto-count del edificio guardrail (calculator.py:946) solo busca
+keywords ["pileta", "bacha", "lavatorio", "kitchenette", ...] en las
+descripciones; las descripciones DYSCON ("M1 mesada", "M2 mesada
+(Office 32)") no las tienen. Y aun si las tuviera, contaba 1 por
+línea ignorando `p.quantity`.
+
+Fix con dos cambios:
+
+1. **Bug A:** el sum del auto-count usa `quantity` en vez de 1. Si una
+   pieza con keyword tiene `quantity=10`, cuenta 10, no 1.
+
+2. **Bug B (acotado por origen):** si la pileta fue **auto-inyectada
+   por el guardrail mo-list-authority** (`agent.py:5469`, marcado con
+   `_pileta_inferred_by_guardrail=True`) y NO hay match por keyword,
+   asumir que cada mesada lleva pileta — `pileta_qty = sum(mesadas
+   .quantity)`. Excluye zócalos / frentín / regrueso / alzada / faldón.
+
+**Precedencia (de mayor a menor):**
+  1. `pileta_qty > 1` explícito del operador → respeta.
+  2. Auto-count por keywords → respeta.
+  3. Fallback "todas las mesadas" — solo si flag de origen está.
+  4. Default `pileta_qty=1`.
+
+**Lo que NO toca:**
+  - Cálculo del material o del regrueso (intactos).
+  - Path Dual Read del plano (sin quantity por diseño).
+  - Residencial simple (no es_edificio → no entra al guardrail).
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.modules.quote_engine.calculator import calculate_quote
+
+
+def _input(**overrides) -> dict:
+    base = {
+        "client_name": "Test Pileta",
+        "project": "Edificio",
+        "material": "Granito Gris Mara",
+        "pieces": [{"description": "Mesada", "largo": 2.0, "prof": 0.6}],
+        "localidad": "Rosario",
+        "plazo": "30 días",
+    }
+    base.update(overrides)
+    return base
+
+
+def _qty_of(item_desc: str, mo_items: list) -> int | float:
+    """Devuelve la quantity del primer mo_item cuya descripción matchea."""
+    for m in mo_items:
+        if item_desc.lower() in m["description"].lower():
+            return m["quantity"]
+    return 0
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Caso DYSCON — pileta auto-inyectada + 14 mesadas con quantities mixtas
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestDysconPiletaQtyFromMesadas:
+    def test_dyscon_pileta_qty_equals_32(self):
+        """Caso del bug: edificio con pileta auto-inyectada por
+        mo-list-authority + 14 piezas con quantities mixtas → debe
+        cobrar 32 piletas (suma de mesadas físicas)."""
+        result = calculate_quote(_input(
+            is_edificio=True,
+            pileta="empotrada_cliente",
+            _pileta_inferred_by_guardrail=True,  # flag del guardrail
+            colocacion=False,
+            pieces=[
+                {"description": "M1 mesada", "largo": 1.92, "prof": 0.6, "quantity": 24},
+                {"description": "M1 zócalo atrás", "largo": 1.92, "prof": 0.1, "quantity": 24},
+                {"description": "M2 mesada (Office 32)", "largo": 1.7, "prof": 0.6, "quantity": 1},
+                {"description": "M2 zócalo atrás", "largo": 1.7, "prof": 0.1, "quantity": 1},
+                {"description": "M3 mesada (Office 12)", "largo": 2.5, "prof": 0.6, "quantity": 1},
+                {"description": "M3 zócalo atrás", "largo": 2.5, "prof": 0.1, "quantity": 1},
+                {"description": "M4 mesada (Office 27)", "largo": 2.5, "prof": 0.6, "quantity": 1},
+                {"description": "M4 zócalo atrás", "largo": 2.5, "prof": 0.1, "quantity": 1},
+                {"description": "M5 mesada (Office 53)", "largo": 1.8, "prof": 0.6, "quantity": 1},
+                {"description": "M5 zócalo atrás", "largo": 1.8, "prof": 0.1, "quantity": 1},
+                {"description": "M6 mesada (Office 80/83)", "largo": 1.55, "prof": 0.6, "quantity": 2},
+                {"description": "M6 zócalo atrás", "largo": 1.55, "prof": 0.1, "quantity": 2},
+                {"description": "M7 mesada (Office 87/90)", "largo": 1.5, "prof": 0.6, "quantity": 2},
+                {"description": "M7 zócalo atrás", "largo": 1.5, "prof": 0.1, "quantity": 2},
+            ],
+        ))
+        assert result["ok"] is True
+        # Suma de mesadas: 24 + 1 + 1 + 1 + 1 + 2 + 2 = 32.
+        assert result["pileta_qty"] == 32, (
+            f"Caso DYSCON regresión: pileta_qty={result['pileta_qty']} "
+            f"esperaba 32 (suma de mesada quantities)"
+        )
+        assert _qty_of("agujero y pegado pileta", result["mo_items"]) == 32
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Precedencia — el override del operador siempre gana
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestPrecedence:
+    def test_operator_explicit_qty_1_respected(self):
+        """Si el operador pasa `pileta_qty=1` explícito en un edificio
+        grande con muchas mesadas (NO viene del guardrail), respetar
+        esa decisión — no aplicar el fallback. Caso real: edificio
+        con 1 sola pileta general en una sala común."""
+        result = calculate_quote(_input(
+            is_edificio=True,
+            pileta="empotrada_cliente",
+            pileta_qty=1,
+            # IMPORTANTE: sin _pileta_inferred_by_guardrail flag → operador
+            # declaró explícitamente.
+            colocacion=False,
+            pieces=[
+                {"description": "M1 mesada", "largo": 2.0, "prof": 0.6, "quantity": 30},
+            ],
+        ))
+        # NO debe escalar — operador dijo 1.
+        assert result["pileta_qty"] == 1
+        assert _qty_of("agujero y pegado pileta", result["mo_items"]) == 1
+
+    def test_operator_explicit_qty_5_respected(self):
+        """Override manual con qty>1 — respetar."""
+        result = calculate_quote(_input(
+            is_edificio=True,
+            pileta="empotrada_cliente",
+            pileta_qty=5,
+            _pileta_inferred_by_guardrail=True,  # incluso con flag, qty>1 manda.
+            colocacion=False,
+            pieces=[
+                {"description": "M1 mesada", "largo": 2.0, "prof": 0.6, "quantity": 30},
+            ],
+        ))
+        assert result["pileta_qty"] == 5
+
+    def test_keyword_match_takes_precedence_over_fallback(self):
+        """Si hay piezas con keyword (lavatorio, kitchenette, etc.)
+        + flag del guardrail, el auto-count keyword toma precedencia.
+        El fallback NO se activa (tiene un `elif`).
+
+        Nota sobre el filtro de keywords: el matcher es substring-based
+        — `"pileta"` matchea cualquier descripción que contenga esa
+        palabra, incluyendo casos como `"Mesada sin pileta"`. Ese es
+        un bug latente del filtro original (pre-#407), no scope de
+        este PR. Por eso el test usa descripciones sin la palabra
+        "pileta" para aislar el comportamiento del fallback."""
+        result = calculate_quote(_input(
+            is_edificio=True,
+            pileta="empotrada_cliente",
+            _pileta_inferred_by_guardrail=True,
+            colocacion=False,
+            pieces=[
+                {"description": "Lavatorio baño", "largo": 1.5, "prof": 0.6, "quantity": 10},
+                # Mesadas adicionales SIN keyword (ni "pileta" ni "bacha"
+                # ni "lavatorio" ni "kitchenette") — el filtro keyword
+                # no las cuenta.
+                {"description": "M1 mesada cocina", "largo": 2.0, "prof": 0.6, "quantity": 50},
+            ],
+        ))
+        # Auto-count keyword: 10 (de lavatorio × quantity).
+        # Fallback NO entra porque keyword devolvió >1.
+        assert result["pileta_qty"] == 10, (
+            f"Esperaba qty=10 (keyword match con quantity), got "
+            f"{result['pileta_qty']}. Fallback no debería activarse cuando "
+            f"keyword match resolvió."
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Regression — residencial / sin pileta / sin flag
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestNoRegression:
+    def test_residential_simple_qty_1(self):
+        """is_edificio=False → no entra al guardrail → respeta qty
+        default. Cocina particular con 1 pileta."""
+        result = calculate_quote(_input(
+            is_edificio=False,
+            pileta="empotrada_cliente",
+            # Sin flag, sin quantity multipliers.
+            pieces=[{"description": "Mesada cocina", "largo": 2.0, "prof": 0.6}],
+        ))
+        assert result["pileta_qty"] == 1
+        assert _qty_of("agujero y pegado pileta", result["mo_items"]) == 1
+
+    def test_no_pileta_no_item(self):
+        """Sin pileta seteada → no aparece el mo_item."""
+        result = calculate_quote(_input(
+            is_edificio=True,
+            # pileta=None
+            colocacion=False,
+            pieces=[{"description": "M1 mesada", "largo": 2.0, "prof": 0.6, "quantity": 10}],
+        ))
+        assert _qty_of("agujero y pegado pileta", result["mo_items"]) == 0
+
+    def test_edificio_without_guardrail_flag_stays_at_1(self):
+        """Edificio con pileta declarada por el operador (sin flag) +
+        descripciones sin keyword + mesadas con quantity → respeta
+        pileta_qty=1. El fallback solo se activa con el flag."""
+        result = calculate_quote(_input(
+            is_edificio=True,
+            pileta="empotrada_cliente",
+            # Sin _pileta_inferred_by_guardrail.
+            colocacion=False,
+            pieces=[
+                {"description": "M1 mesada", "largo": 2.0, "prof": 0.6, "quantity": 10},
+            ],
+        ))
+        # No keyword match + sin flag → no fallback → qty default 1.
+        assert result["pileta_qty"] == 1, (
+            f"Sin flag de guardrail, no debe activarse fallback. "
+            f"Got qty={result['pileta_qty']}"
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Bug A — el sum ahora respeta quantity (no cuenta 1 por línea)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestKeywordSumUsesQuantity:
+    def test_keyword_sum_uses_quantity_not_lines(self):
+        """1 línea con keyword 'lavatorio' y quantity=10 → pileta_qty=10
+        (no 1 como antes del fix)."""
+        result = calculate_quote(_input(
+            is_edificio=True,
+            pileta="empotrada_cliente",
+            colocacion=False,
+            pieces=[
+                {"description": "Lavatorio baño tipo A", "largo": 1.5, "prof": 0.6, "quantity": 10},
+            ],
+        ))
+        assert result["pileta_qty"] == 10
+
+    def test_keyword_sum_multiple_lines(self):
+        """Múltiples líneas con keywords y quantities mixtas → suma todas."""
+        result = calculate_quote(_input(
+            is_edificio=True,
+            pileta="empotrada_cliente",
+            colocacion=False,
+            pieces=[
+                {"description": "Lavatorio tipo A", "largo": 1.5, "prof": 0.6, "quantity": 10},
+                {"description": "Lavatorio tipo B", "largo": 1.7, "prof": 0.6, "quantity": 5},
+                {"description": "Kitchenette tipo C", "largo": 1.2, "prof": 0.6, "quantity": 3},
+            ],
+        ))
+        # 10 + 5 + 3 = 18.
+        assert result["pileta_qty"] == 18
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Bug B — el fallback excluye zócalos / frentín / regrueso / alzada
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestFallbackExcludesNonMesadaPieces:
+    def test_fallback_excludes_zocalos(self):
+        """El fallback solo cuenta mesadas; zócalos no llevan pileta."""
+        result = calculate_quote(_input(
+            is_edificio=True,
+            pileta="empotrada_cliente",
+            _pileta_inferred_by_guardrail=True,
+            colocacion=False,
+            pieces=[
+                {"description": "M1 mesada", "largo": 2.0, "prof": 0.6, "quantity": 10},
+                # Zócalos NO deben contarse aunque tengan "mesada" en la descripción.
+                {"description": "M1 zócalo atrás", "largo": 2.0, "prof": 0.1, "quantity": 10},
+            ],
+        ))
+        # Solo cuenta la mesada (10), no el zócalo.
+        assert result["pileta_qty"] == 10
+
+    def test_fallback_excludes_frentin_regrueso_alzada(self):
+        """Frentín, regrueso, alzada y faldón también se excluyen del
+        fallback aunque su descripción contenga 'mesada' por algún motivo."""
+        result = calculate_quote(_input(
+            is_edificio=True,
+            pileta="empotrada_cliente",
+            _pileta_inferred_by_guardrail=True,
+            colocacion=False,
+            pieces=[
+                {"description": "M1 mesada", "largo": 2.0, "prof": 0.6, "quantity": 5},
+                {"description": "M1 mesada frentín", "largo": 2.0, "alto": 0.05, "quantity": 5},
+                {"description": "M1 mesada regrueso", "largo": 2.0, "alto": 0.03, "quantity": 5},
+                {"description": "Alzada cocina mesada", "largo": 2.0, "alto": 0.1, "quantity": 5},
+            ],
+        ))
+        # Solo cuenta la mesada principal — 5.
+        assert result["pileta_qty"] == 5


### PR DESCRIPTION
## Summary

Fix ULTRA CRÍTICO del caso DYSCON: `Agujero y pegado pileta` qty=1 → qty=32.

**B + acotado por origen** (decidido en review). El fallback solo se activa si la pileta fue **auto-inyectada por el guardrail `mo-list-authority`** — respeta decisiones explícitas del operador.

## Causa raíz (3 puntos)

1. **`calculator.py:946`** — auto-count busca keywords (`pileta`, `bacha`, `lavatorio`, `kitchenette`, etc.). Las descripciones DYSCON (`M1 mesada`, `M2 mesada (Office 32)`) no las contienen. Match = 0.
2. **Mismo auto-count** usaba `sum(1 for p ...)`. Aunque hubiera matches, contaba 1 por línea ignorando `p.quantity`.
3. **`agent.py:5469`** (`mo-list-authority`) auto-inyectó `pileta=empotrada_cliente` porque el brief lista MO sin mencionar pileta. `pileta_qty` quedó en default 1.

## Fix (2 archivos)

### `agent.py:5471` — flag de origen
```python
inputs["pileta"] = "empotrada_cliente"
inputs.pop("pileta_sku", None)
inputs["_pileta_inferred_by_guardrail"] = True   # ← nuevo
```

### `calculator.py:946-1000` — fix sum + fallback acotado
```python
if pileta and pileta_qty <= 1:
    # Bug A — sum usa quantity, no 1 por línea.
    auto_pileta_count = sum(
        int(p.get("quantity", 1) or 1)
        for p in pieces if any(kw in desc.lower() for kw in _kw_pileta)
    )
    if auto_pileta_count > 1:
        pileta_qty = auto_pileta_count
    elif input_data.get("_pileta_inferred_by_guardrail"):
        # Bug B (acotado) — fallback solo si la pileta vino del guardrail.
        _mesada_qty = sum(
            int(p.get("quantity", 1) or 1)
            for p in pieces
            if "mesada" in desc.lower()
            and not any(kw in desc.lower() for kw in
                        ["zócalo", "zocalo", "frentín", "frentin",
                         "regrueso", "alzada", "faldón", "faldon"])
        )
        if _mesada_qty > 1:
            pileta_qty = _mesada_qty
```

## Precedencia (de mayor a menor)

1. `pileta_qty > 1` explícito del operador → **respeta**.
2. Auto-count por keywords (suma de quantity) → **respeta si > 1**.
3. Fallback "todas las mesadas" — **solo si flag de origen presente**.
4. Default `pileta_qty=1`.

## Por qué acotado por origen vs B simple

Si un operador declara `pileta_qty=1` explícito en un edificio con 30 mesadas (caso real: 1 pileta general en sala común), **B simple** lo sobreescribiría a 30. **B acotado respeta el 1** porque el flag NO está presente cuando el operador la declaró.

## Tests (11 casos)

| Test | Esperado |
|---|---|
| **Caso DYSCON exacto** (14 piezas, flag presente, sin keywords) | `pileta_qty=32` |
| Operador qty=1 sin flag | respeta 1 (no escala) |
| Operador qty=5 con flag | respeta 5 |
| Keyword match con flag | keyword path gana, fallback no entra |
| Residencial (`is_edificio=False`) | qty=1 |
| Sin pileta | no aparece mo_item |
| Edificio sin flag + mesadas con qty | qty=1 (no activa fallback) |
| Keyword sum: 1 línea qty=10 | `pileta_qty=10` (no 1) |
| Keyword sum múltiples líneas | suma todas |
| Fallback excluye zócalos | solo cuenta mesadas |
| Fallback excluye frentín/regrueso/alzada/faldón | solo cuenta mesadas |

Suite full: **1808 passing** (1 fail preexistente, no relacionado).

## Lo que NO toca

- Material quantity (#405 intacto).
- Calculator regrueso (#401/#403 intactos).
- Frontend / system_prompt / tool schema.
- Filtro keyword pre-existente que matchea `"Mesada sin pileta"` como pileta (bug latente del filtro original, fuera de scope).

## Test plan

- [x] `pytest tests/test_pileta_qty_from_mesadas.py -v` → 11/11.
- [x] Suite full → 1808 passing.
- [ ] CI verde.
- [ ] Post-deploy: re-cotizar DYSCON → log dice `pileta_qty=32 (suma de quantities de mesadas)`, output muestra `Agujero y pegado pileta | 32 | $53.840 | ✓ | $1.985.440`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
