### PR TITLE
fix(despiece): zócalos del despiece textual también multiplican por qty

### DIFF
--- a/api/app/modules/quote_engine/text_parser.py
+++ b/api/app/modules/quote_engine/text_parser.py
@@ -219,10 +219,28 @@ def parsed_pieces_to_card(parsed: dict) -> dict | None:
             # El zócalo hereda la quantity del tramo padre (24 mesadas →
             # 24 zócalos). Si el LLM ya pasó `quantity` para el zócalo,
             # respetarla; si no, heredar del tramo previo en el final.
+            #
+            # PR #408 — `m2` del zócalo ya multiplicado por quantity.
+            # `parsed_pieces_to_card` ya escribe `m2 = ml × alto × quantity`
+            # como m² total del zócalo (consistente con tramo.m2 que ya
+            # viene multiplicado por #405). Cualquier consumer (frontend
+            # render, build_verified_context, etc.) puede leer `m2`
+            # directamente sin recalcular ni re-multiplicar.
+            #
+            # `lado` lleva sufijo `(×N)` cuando quantity > 1 — espejo del
+            # tratamiento del tramo. Sin esto el operador veía
+            # "M1 mesada (×24)" pero el zócalo abajo decía solo "atrás"
+            # (mismo bug que motivó este PR).
+            base_lado = (p.get("description") or "trasero").replace("Zócalo ", "").replace("Zócalo", "").strip() or "trasero"
+            lado_display = f"{base_lado} (×{quantity})" if quantity > 1 else base_lado
+            ml_v = float(largo)
+            alto_v = float(alto)
             zocalo = {
-                "lado": (p.get("description") or "trasero").replace("Zócalo ", "").replace("Zócalo", "").strip() or "trasero",
-                "ml": float(largo),
-                "alto_m": float(alto),
+                "lado": lado_display,
+                "ml": ml_v,
+                "alto_m": alto_v,
+                # PR #408 — m² total del zócalo (ya multiplicado por quantity).
+                "m2": round(ml_v * alto_v * quantity, 2),
                 "status": "CONFIRMADO",
                 "opus_ml": None,
                 "sonnet_ml": None,
@@ -248,6 +266,10 @@ def parsed_pieces_to_card(parsed: dict) -> dict | None:
     # quantity=1 (el default del parser). Lo sobrescribimos con la
     # quantity del tramo padre — caso DYSCON: 24 mesadas → 24 zócalos.
     # Si el zócalo trae quantity > 1 explícita del LLM, respetarla.
+    #
+    # PR #408 — al heredar quantity, también recomputar `m2` y agregar
+    # sufijo `(×N)` al `lado` (porque ambos se calcularon arriba con
+    # quantity=1 default).
     for t in tramos:
         t_qty = t.get("quantity", 1)
         if t_qty <= 1:
@@ -255,17 +277,23 @@ def parsed_pieces_to_card(parsed: dict) -> dict | None:
         for z in t["zocalos"]:
             if z.get("quantity", 1) <= 1:
                 z["quantity"] = t_qty
+                # Recompute m² total con la quantity heredada.
+                z["m2"] = round(z.get("ml", 0) * z.get("alto_m", 0) * t_qty, 2)
+                # Sufijo (×N) al display del lado (idempotente: solo
+                # agrega si no estaba ya).
+                _lado = z.get("lado") or "trasero"
+                if f"(×{t_qty})" not in _lado:
+                    z["lado"] = f"{_lado} (×{t_qty})"
 
-    # PR #405 — total m² del sector, ya con cantidades aplicadas:
-    #   - tramo.m2.valor ya viene multiplicado por tramo.quantity.
-    #   - zocalo: ml × alto_m × quantity.
+    # PR #405 + #408 — total m² del sector, todo ya multiplicado.
+    #   - tramo.m2.valor ya viene con quantity aplicado (#405).
+    #   - zocalo.m2 ya viene con quantity aplicado (#408).
+    # Equivalente al cálculo viejo `ml * alto_m * quantity`, pero leyendo
+    # el campo persistido — fuente única de verdad para que el frontend
+    # pueda mostrar el mismo número sin recalcular.
     m2_total_valor = round(
         sum(t["m2"]["valor"] for t in tramos)
-        + sum(
-            z["ml"] * z["alto_m"] * z.get("quantity", 1)
-            for t in tramos
-            for z in t["zocalos"]
-        ),
+        + sum(z.get("m2", 0) for t in tramos for z in t["zocalos"]),
         2,
     )
 

--- a/api/tests/test_zocalo_m2_quantity.py
+++ b/api/tests/test_zocalo_m2_quantity.py
@@ -1,0 +1,154 @@
+"""Tests para PR #408 — `m2` propio del zócalo y sufijo `(×N)` en `lado`.
+
+**Bug:** PR #405 propagó `quantity` al zócalo como metadata pero:
+  - El backend no calculó un campo `m2` propio del zócalo (solo lo
+    hizo para el tramo).
+  - El display del `lado` del zócalo no llevaba sufijo `(×N)`
+    cuando quantity > 1 (a diferencia del tramo, que sí lo lleva).
+
+Resultado: la card editable del frontend renderizaba el m² del
+zócalo como `ml × alto_m` sin multiplicar por quantity → caso DYSCON
+mostraba 37.71 m² en vez de 42.39 (faltaban los 4.68 m² de los
+zócalos M1×24, M6×2 y M7×2).
+
+Fix:
+  1. Agregar `m2 = ml × alto × quantity` al zócalo (consistente con
+     `tramo.m2.valor` ya multiplicado).
+  2. Sufijo `(×N)` al `lado` cuando quantity > 1.
+  3. Cuando se hereda quantity del tramo padre (tramo qty>1, zócalo
+     qty=1 default), recomputar `m2` y agregar sufijo.
+  4. `m2_total_valor` del sector ahora suma `z.m2` (fuente única).
+
+Nota: el frontend (`DualReadResult.tsx`) también se modifica para
+multiplicar `ml × alto × quantity` al renderizar — sin esto el bug
+visual del despiece persiste aunque el backend tenga los números
+correctos.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.modules.quote_engine.text_parser import parsed_pieces_to_card
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Zócalo con quantity explícita del LLM
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestZocaloM2WithExplicitQuantity:
+    def test_zocalo_m2_field_multiplied(self):
+        """Zócalo con quantity=24 debe llevar `m2 = ml × alto × 24`."""
+        parsed = {
+            "pieces": [
+                {"description": "M1 mesada", "largo": 1.92, "prof": 0.6, "quantity": 24},
+                {"description": "M1 zócalo atrás", "largo": 1.92, "alto": 0.10, "quantity": 24},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        zocalo = card["sectores"][0]["tramos"][0]["zocalos"][0]
+        # 1.92 × 0.10 × 24 = 4.608 → round(2) = 4.61.
+        assert zocalo["m2"] == 4.61, (
+            f"Esperaba m² del zócalo = 4.61, got {zocalo['m2']}"
+        )
+        assert zocalo["quantity"] == 24
+        # Sufijo (×24) en el lado.
+        assert "(×24)" in zocalo["lado"], (
+            f"Falta sufijo (×24) en lado: {zocalo['lado']!r}"
+        )
+
+    def test_zocalo_quantity_1_no_suffix(self):
+        """Zócalo con quantity=1 (default) → m² sin multiplicar y sin
+        sufijo. Caso residencial simple."""
+        parsed = {
+            "pieces": [
+                {"description": "Mesada", "largo": 2.0, "prof": 0.6},
+                {"description": "Zócalo trasero", "largo": 2.0, "alto": 0.05},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        zocalo = card["sectores"][0]["tramos"][0]["zocalos"][0]
+        # 2.0 × 0.05 × 1 = 0.10.
+        assert zocalo["m2"] == 0.10
+        assert zocalo["quantity"] == 1
+        assert "(×" not in zocalo["lado"], (
+            f"No debe haber sufijo (×N) cuando quantity=1: {zocalo['lado']!r}"
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Zócalo que hereda quantity del tramo padre
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestZocaloInheritedQuantity:
+    def test_zocalo_inherits_and_recomputes_m2(self):
+        """Mesada con quantity=24 + zócalo SIN quantity explícita →
+        zócalo hereda 24, m² se recomputa con la quantity heredada."""
+        parsed = {
+            "pieces": [
+                {"description": "M1 mesada", "largo": 1.92, "prof": 0.6, "quantity": 24},
+                # Zócalo SIN quantity → debe heredar 24 del tramo.
+                {"description": "M1 zócalo atrás", "largo": 1.92, "alto": 0.10},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        zocalo = card["sectores"][0]["tramos"][0]["zocalos"][0]
+        assert zocalo["quantity"] == 24
+        # m² recomputed con la quantity heredada.
+        assert zocalo["m2"] == 4.61
+        # Sufijo agregado en herencia.
+        assert "(×24)" in zocalo["lado"]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Caso DYSCON exacto — total visible 42.39
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestDysconTotalMatchesBackend:
+    def test_dyscon_zocalos_contribute_full_m2(self):
+        """Caso real DYSCON. Si los zócalos M1×24, M6×2, M7×2 se
+        renderizaran con m²/u (bug pre-#408), el total del sector
+        sería 37.71. Con el fix, suma 42.39."""
+        parsed = {
+            "pieces": [
+                {"description": "M1 mesada", "largo": 1.92, "prof": 0.60, "quantity": 24},
+                {"description": "M1 zócalo atrás", "largo": 1.92, "alto": 0.10, "quantity": 24},
+                {"description": "M2 mesada (Office 32)", "largo": 1.70, "prof": 0.60, "quantity": 1},
+                {"description": "M2 zócalo atrás", "largo": 1.70, "alto": 0.10, "quantity": 1},
+                {"description": "M3 mesada (Office 12)", "largo": 2.50, "prof": 0.60, "quantity": 1},
+                {"description": "M3 zócalo atrás", "largo": 2.50, "alto": 0.10, "quantity": 1},
+                {"description": "M4 mesada (Office 27)", "largo": 2.50, "prof": 0.60, "quantity": 1},
+                {"description": "M4 zócalo atrás", "largo": 2.50, "alto": 0.10, "quantity": 1},
+                {"description": "M5 mesada (Office 53)", "largo": 1.80, "prof": 0.60, "quantity": 1},
+                {"description": "M5 zócalo atrás", "largo": 1.80, "alto": 0.10, "quantity": 1},
+                {"description": "M6 mesada (Office 80/83)", "largo": 1.55, "prof": 0.60, "quantity": 2},
+                {"description": "M6 zócalo atrás", "largo": 1.55, "alto": 0.10, "quantity": 2},
+                {"description": "M7 mesada (Office 87/90)", "largo": 1.50, "prof": 0.60, "quantity": 2},
+                {"description": "M7 zócalo atrás", "largo": 1.50, "alto": 0.10, "quantity": 2},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        sector = card["sectores"][0]
+        total = sector["m2_total"]["valor"]
+
+        # Sum esperado = mesadas (36.36) + zócalos multiplicados (6.04) ≈ 42.40.
+        # Tolerancia por rounding floor del parser (0.10).
+        assert 42.30 <= total <= 42.45, (
+            f"Total sector regresión: {total} fuera del rango esperado "
+            f"(42.30-42.45). Caso DYSCON debe sumar ~42.39."
+        )
+
+        # Verificar que los zócalos clave tienen m² correcto.
+        # Tramos = solo mesadas (zócalos van como child). 7 mesadas:
+        # M1[0], M2[1], M3[2], M4[3], M5[4], M6[5], M7[6].
+        # M1: 1.92 × 0.10 × 24 = 4.608 → 4.61.
+        # M6: 1.55 × 0.10 × 2 = 0.310 → 0.31.
+        # M7: 1.50 × 0.10 × 2 = 0.300 → 0.30.
+        m1_zocalo = sector["tramos"][0]["zocalos"][0]
+        m6_zocalo = sector["tramos"][5]["zocalos"][0]
+        m7_zocalo = sector["tramos"][6]["zocalos"][0]
+        assert m1_zocalo["m2"] == 4.61
+        assert m6_zocalo["m2"] == 0.31
+        assert m7_zocalo["m2"] == 0.30

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -102,6 +102,12 @@ interface Zocalo {
   ml: number | null;
   alto_m: number | null;
   status: string;
+  // PR #408 — quantity heredada del tramo padre cuando el brief textual
+  // declaró tipologías repetidas (ej: 24 mesadas con su zócalo cada una).
+  // Si está ausente o ≤1, se asume 1 unidad. El render del m² del
+  // zócalo multiplica por este valor para que el total coincida con el
+  // calculator downstream.
+  quantity?: number;
   _manual?: boolean;
 }
 
@@ -689,7 +695,14 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry, lock
       t.zocalos.forEach((z) => {
         const ml = safeNum(z.ml);
         if (ml > 0) {
-          zocalosM2 += ml * safeNum(z.alto_m);
+          // PR #408 — multiplicar por quantity heredada del tramo padre
+          // cuando el brief textual declaró tipologías repetidas (×N).
+          // Sin esto, el zócalo del Office tipo M1 ×24 contribuye solo
+          // su m²/u al total (0.19 en vez de 4.56) → display visible
+          // del despiece queda mintiendo. `quantity || 1` para retro-
+          // compatibilidad con duals viejos sin el field.
+          const qty = z.quantity || 1;
+          zocalosM2 += ml * safeNum(z.alto_m) * qty;
           zocalosCount += 1;
         }
       });
@@ -728,7 +741,12 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry, lock
           const ml = safeNum(z.ml);
           if (ml <= 0) return;
           const alto = safeNum(z.alto_m);
-          const zm2 = ml * alto;
+          // PR #408 — m² del zócalo multiplicado por quantity. Mismo
+          // tratamiento que el render de filas (más abajo, ~línea 950)
+          // y que el sumario del header (zocalosM2). Si el dual viene
+          // del plano (sin quantity), `quantity || 1` mantiene comportamiento.
+          const qty = z.quantity || 1;
+          const zm2 = ml * alto * qty;
           total += zm2;
           const altoDisplay = z.alto_m == null ? MISSING : alto.toFixed(2);
           lines.push(`| Zóc. ${z.lado} | ${ml.toFixed(2)} ml × ${altoDisplay} | ${zm2.toFixed(2)} |`);
@@ -947,7 +965,13 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry, lock
                           <span className="text-t4 ml-0.5">m</span>
                         </div>
                         <div className="text-t1 font-medium text-right flex items-center justify-end gap-2">
-                          <span>{(z.ml == null || z.alto_m == null) ? MISSING : (z.ml * z.alto_m).toFixed(2)}</span>
+                          {/* PR #408 — m² del zócalo en la fila editable
+                              también multiplica por quantity heredada. Si
+                              el zócalo es de un Office tipo M1 ×24, la
+                              fila muestra el m² total del lote (4.56),
+                              consistente con el resumen del header y con
+                              el cálculo del Paso 2 downstream. */}
+                          <span>{(z.ml == null || z.alto_m == null) ? MISSING : (z.ml * z.alto_m * (z.quantity || 1)).toFixed(2)}</span>
                           {/* PR #61 — botón remover siempre disponible, independiente
                               del status (el operador confirma con el cliente si lleva
                               zócalos o no; Dual Read solo sugiere). Hover aumenta


### PR DESCRIPTION
## Summary

Fix backend + frontend chico — zócalos del despiece textual ahora multiplican `m²` por `quantity` heredada.

## Bug observado

Caso DYSCON (post-#405): card editable mostraba `Total 37.71 m²` cuando debía ser `42.39 m²`. Las mesadas con `(×24)` / `(×2)` multiplicaban OK, los **zócalos NO**.

| Zócalo | Display actual | Debería |
|---|---|---|
| M1 zócalo atrás (×24) | `0.19` | `4.56` |
| M6 zócalo atrás (×2) | `0.16` | `0.32` |
| M7 zócalo atrás (×2) | `0.15` | `0.30` |

Diferencia visible: 4.68 m² faltantes. **El calculator del Paso 2 ya sumaba bien** (logs DYSCON dieron 42.39); el bug era solo el **render** de la card editable.

## Causa raíz

PR #405 propagó `quantity` al zócalo como metadata pero:
- Backend NO calculó un `m2` propio del zócalo.
- Display del `lado` no llevaba sufijo `(×N)`.
- Frontend computaba columna m² como `ml × alto_m` ignorando `quantity`.

## Fix

### Backend — `text_parser.py:parsed_pieces_to_card`
1. Zócalo gana campo `m2 = ml × alto × quantity` (consistente con `tramo.m2.valor` ya multiplicado).
2. Sufijo `(×N)` al `lado` cuando `quantity > 1`.
3. Cuando hereda quantity del tramo padre: recomputar `m2` + sufijo.
4. `m2_total_valor` del sector ahora suma `z.m2` (fuente única).

### Frontend — `DualReadResult.tsx`
1. Tipo `Zocalo` declara `quantity?: number`.
2. Tres lugares con `ml × alto_m` ahora multiplican por `(quantity || 1)`:
   - Sumario `zocalosM2` del header.
   - Markdown export (`despieceMarkdown`).
   - Render por fila de la columna m².

## Tests

**Nuevos** (`tests/test_zocalo_m2_quantity.py`, 4 casos):
- ✅ Zócalo con quantity explícita → `m2` multiplicado + sufijo.
- ✅ Zócalo con `quantity=1` → sin multiplicar, sin sufijo (regression).
- ✅ Zócalo hereda quantity → recomputa `m2` + sufijo.
- ✅ **Caso DYSCON exacto** — total sector ≈ 42.39, zócalos M1/M6/M7 con m² correcto.

**Existentes** (`tests/test_text_parser_quantity.py`, 10 casos): siguen verde.

Suite full: **1812 passing** (1 fail preexistente).
`tsc --noEmit`: verde.

## Lo que NO toca

- Calculator (downstream multiplica con `pieces[].quantity` — ya OK).
- Path Dual Read del plano (sin quantity por diseño actual).
- Schema del tool ni system prompt.

## Test plan

- [x] `pytest tests/test_zocalo_m2_quantity.py -v` → 4/4.
- [x] Suite full → 1812 passing.
- [x] `tsc --noEmit` verde.
- [ ] CI verde.
- [ ] Post-deploy: re-cotizar DYSCON → card editable muestra:
  - `Zóc. M1 zócalo atrás (×24)` con m² = `4.56`
  - `Zóc. M6 zócalo atrás (×2)` con m² = `0.32`
  - `Zóc. M7 zócalo atrás (×2)` con m² = `0.30`
  - Total visible = `42.39 m²`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
