### PR TITLE
fix(despiece): round-unit-then-multiply con _round_half_up (hotfix #408)

### DIFF
--- a/api/app/modules/quote_engine/text_parser.py
+++ b/api/app/modules/quote_engine/text_parser.py
@@ -9,6 +9,14 @@ import logging
 import anthropic
 
 from app.core.config import settings
+# PR #409 — política de redondeo unificada con calculator. Antes
+# usábamos `round()` (banker's: 0.155 → 0.15), ahora `_round_half_up`
+# (0.155 → 0.16) para alinear con `calculator._round_half_up`. Patrón
+# universal en el despiece textual:
+#   m²/u  = round_half_up(largo × prof, 2)
+#   m²    = round_half_up(m²/u × quantity, 2)
+# Garantiza que backend / frontend / Paso 2 coinciden al peso.
+from app.modules.quote_engine.calculator import _round_half_up
 
 logger = logging.getLogger(__name__)
 
@@ -191,8 +199,13 @@ def parsed_pieces_to_card(parsed: dict) -> dict | None:
             # Es una mesada. m2.valor = largo × prof × quantity (m² total
             # del tramo). Calculator downstream NO debe re-multiplicar:
             # se le pasa `quantity` separado y `largo/prof` por unidad.
-            m2_per_unit = round(largo * prof, 2)
-            m2 = round(m2_per_unit * quantity, 2)
+            #
+            # PR #409 — round_half_up sobre el unitario, después
+            # multiplicar. Esto alinea con calculator (calculate_m2:717):
+            # `m2_piece_2d = _round_half_up(raw_m2, 2); total += m2_piece_2d
+            # × qty`. Ej M1: round_half_up(1.92×0.60, 2)=1.15 × 24 = 27.60.
+            m2_per_unit = _round_half_up(largo * prof, 2)
+            m2 = _round_half_up(m2_per_unit * quantity, 2)
             base_desc = p.get("description") or f"Mesada {len(tramos) + 1}"
             descripcion = f"{base_desc} (×{quantity})" if quantity > 1 else base_desc
             tramo = {
@@ -235,12 +248,19 @@ def parsed_pieces_to_card(parsed: dict) -> dict | None:
             lado_display = f"{base_lado} (×{quantity})" if quantity > 1 else base_lado
             ml_v = float(largo)
             alto_v = float(alto)
+            # PR #408 — m² total del zócalo (ya multiplicado por quantity).
+            # PR #409 — round_half_up sobre m²/u, después multiplicar
+            # por quantity. Antes hacíamos `round(ml × alto × qty, 2)`
+            # (multiply-then-round) que daba 4.61 para M1 (1.92×0.10×24)
+            # cuando el operador esperaba 4.56. La regla unificada es:
+            #   m²/u  = round_half_up(ml × alto, 2)
+            #   m²    = round_half_up(m²/u × quantity, 2)
+            m2_unit_zocalo = _round_half_up(ml_v * alto_v, 2)
             zocalo = {
                 "lado": lado_display,
                 "ml": ml_v,
                 "alto_m": alto_v,
-                # PR #408 — m² total del zócalo (ya multiplicado por quantity).
-                "m2": round(ml_v * alto_v * quantity, 2),
+                "m2": _round_half_up(m2_unit_zocalo * quantity, 2),
                 "status": "CONFIRMADO",
                 "opus_ml": None,
                 "sonnet_ml": None,
@@ -277,8 +297,13 @@ def parsed_pieces_to_card(parsed: dict) -> dict | None:
         for z in t["zocalos"]:
             if z.get("quantity", 1) <= 1:
                 z["quantity"] = t_qty
-                # Recompute m² total con la quantity heredada.
-                z["m2"] = round(z.get("ml", 0) * z.get("alto_m", 0) * t_qty, 2)
+                # PR #409 — round-unit-then-multiply (mismo patrón que
+                # la creación). Antes: `round(ml × alto × qty, 2)` daba
+                # 4.61 para zócalos hereditarios M1×24; ahora 4.56.
+                _m2_unit = _round_half_up(
+                    z.get("ml", 0) * z.get("alto_m", 0), 2
+                )
+                z["m2"] = _round_half_up(_m2_unit * t_qty, 2)
                 # Sufijo (×N) al display del lado (idempotente: solo
                 # agrega si no estaba ya).
                 _lado = z.get("lado") or "trasero"

--- a/api/tests/test_zocalo_m2_quantity.py
+++ b/api/tests/test_zocalo_m2_quantity.py
@@ -1,28 +1,29 @@
-"""Tests para PR #408 — `m2` propio del zócalo y sufijo `(×N)` en `lado`.
+"""Tests para PR #408 + #409 — `m2` del zócalo con regla
+round-unit-then-multiply usando `_round_half_up`.
 
-**Bug:** PR #405 propagó `quantity` al zócalo como metadata pero:
-  - El backend no calculó un campo `m2` propio del zócalo (solo lo
-    hizo para el tramo).
-  - El display del `lado` del zócalo no llevaba sufijo `(×N)`
-    cuando quantity > 1 (a diferencia del tramo, que sí lo lleva).
+**Bug original (#408):** PR #405 propagó `quantity` al zócalo como
+metadata pero no calculó un campo `m2` propio. La card editable
+mostraba `ml × alto_m` sin multiplicar — caso DYSCON: total 37.71
+en vez de 42.39.
 
-Resultado: la card editable del frontend renderizaba el m² del
-zócalo como `ml × alto_m` sin multiplicar por quantity → caso DYSCON
-mostraba 37.71 m² en vez de 42.39 (faltaban los 4.68 m² de los
-zócalos M1×24, M6×2 y M7×2).
+**Bug de redondeo (#409):** PR #408 usó `round(ml × alto × qty, 2)`
+(multiply-then-round) → M1 ×24 daba 4.61 cuando el operador esperaba
+4.56. Política unificada del operador, alineada con calculator:
 
-Fix:
-  1. Agregar `m2 = ml × alto × quantity` al zócalo (consistente con
-     `tramo.m2.valor` ya multiplicado).
-  2. Sufijo `(×N)` al `lado` cuando quantity > 1.
-  3. Cuando se hereda quantity del tramo padre (tramo qty>1, zócalo
-     qty=1 default), recomputar `m2` y agregar sufijo.
-  4. `m2_total_valor` del sector ahora suma `z.m2` (fuente única).
+    m²/u  = round_half_up(base, 2)
+    m²    = round_half_up(m²/u × quantity, 2)
 
-Nota: el frontend (`DualReadResult.tsx`) también se modifica para
-multiplicar `ml × alto × quantity` al renderizar — sin esto el bug
-visual del despiece persiste aunque el backend tenga los números
-correctos.
+Casos esperados (DYSCON):
+  - M1: 1.92 × 0.10 = 0.192 → round_half_up=0.19 → × 24 = 4.56
+  - M6: 1.55 × 0.10 = 0.155 → round_half_up=0.16 → × 2  = 0.32
+  - M7: 1.50 × 0.10 = 0.150 → round_half_up=0.15 → × 2  = 0.30
+  - Total sector ≈ 42.39 m²
+
+Garantías post-#409:
+  - Backend (text_parser) usa `_round_half_up` (importado de
+    calculator).
+  - Frontend (DualReadResult.tsx) usa `roundHalfUp` JS espejo.
+  - Ambos producen los mismos números que `calculate_m2:717-719`.
 """
 from __future__ import annotations
 
@@ -37,8 +38,10 @@ from app.modules.quote_engine.text_parser import parsed_pieces_to_card
 
 
 class TestZocaloM2WithExplicitQuantity:
-    def test_zocalo_m2_field_multiplied(self):
-        """Zócalo con quantity=24 debe llevar `m2 = ml × alto × 24`."""
+    def test_zocalo_m2_field_multiplied_round_half_up(self):
+        """PR #409: M1 zócalo con quantity=24 debe usar
+        round-unit-then-multiply: 0.19/u × 24 = 4.56 (no 4.61
+        de multiply-then-round que tenía #408)."""
         parsed = {
             "pieces": [
                 {"description": "M1 mesada", "largo": 1.92, "prof": 0.6, "quantity": 24},
@@ -47,9 +50,10 @@ class TestZocaloM2WithExplicitQuantity:
         }
         card = parsed_pieces_to_card(parsed)
         zocalo = card["sectores"][0]["tramos"][0]["zocalos"][0]
-        # 1.92 × 0.10 × 24 = 4.608 → round(2) = 4.61.
-        assert zocalo["m2"] == 4.61, (
-            f"Esperaba m² del zócalo = 4.61, got {zocalo['m2']}"
+        # 1.92 × 0.10 = 0.192 → round_half_up=0.19 → × 24 = 4.56.
+        assert zocalo["m2"] == 4.56, (
+            f"PR #409 regresión: m² del zócalo M1 = {zocalo['m2']}, "
+            f"esperaba 4.56 (round-unit-then-multiply con _round_half_up)"
         )
         assert zocalo["quantity"] == 24
         # Sufijo (×24) en el lado.
@@ -95,8 +99,9 @@ class TestZocaloInheritedQuantity:
         card = parsed_pieces_to_card(parsed)
         zocalo = card["sectores"][0]["tramos"][0]["zocalos"][0]
         assert zocalo["quantity"] == 24
-        # m² recomputed con la quantity heredada.
-        assert zocalo["m2"] == 4.61
+        # PR #409: m² recomputed con round-unit-then-multiply.
+        # 0.19/u × 24 = 4.56 (no 4.61).
+        assert zocalo["m2"] == 4.56
         # Sufijo agregado en herencia.
         assert "(×24)" in zocalo["lado"]
 
@@ -133,22 +138,65 @@ class TestDysconTotalMatchesBackend:
         sector = card["sectores"][0]
         total = sector["m2_total"]["valor"]
 
-        # Sum esperado = mesadas (36.36) + zócalos multiplicados (6.04) ≈ 42.40.
-        # Tolerancia por rounding floor del parser (0.10).
-        assert 42.30 <= total <= 42.45, (
-            f"Total sector regresión: {total} fuera del rango esperado "
-            f"(42.30-42.45). Caso DYSCON debe sumar ~42.39."
+        # PR #409 — Total esperado exacto del operador: 42.39 m².
+        # Round-unit-then-multiply con _round_half_up es la regla.
+        assert total == 42.39, (
+            f"PR #409 regresión: total sector = {total}, esperaba 42.39 "
+            f"(suma exacta del operador con round_half_up unitario)"
         )
 
         # Verificar que los zócalos clave tienen m² correcto.
         # Tramos = solo mesadas (zócalos van como child). 7 mesadas:
         # M1[0], M2[1], M3[2], M4[3], M5[4], M6[5], M7[6].
-        # M1: 1.92 × 0.10 × 24 = 4.608 → 4.61.
-        # M6: 1.55 × 0.10 × 2 = 0.310 → 0.31.
-        # M7: 1.50 × 0.10 × 2 = 0.300 → 0.30.
+        # PR #409 — round-unit-then-multiply con _round_half_up:
+        # M1: round_half_up(1.92×0.10, 2)=0.19 × 24 = 4.56.
+        # M6: round_half_up(1.55×0.10, 2)=0.16 × 2  = 0.32.
+        # M7: round_half_up(1.50×0.10, 2)=0.15 × 2  = 0.30.
         m1_zocalo = sector["tramos"][0]["zocalos"][0]
         m6_zocalo = sector["tramos"][5]["zocalos"][0]
         m7_zocalo = sector["tramos"][6]["zocalos"][0]
-        assert m1_zocalo["m2"] == 4.61
-        assert m6_zocalo["m2"] == 0.31
-        assert m7_zocalo["m2"] == 0.30
+        assert m1_zocalo["m2"] == 4.56, f"M1 zócalo = {m1_zocalo['m2']}, esperaba 4.56"
+        assert m6_zocalo["m2"] == 0.32, f"M6 zócalo = {m6_zocalo['m2']}, esperaba 0.32 (half-up)"
+        assert m7_zocalo["m2"] == 0.30, f"M7 zócalo = {m7_zocalo['m2']}, esperaba 0.30"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PR #409 — política unificada round_half_up unitario primero
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestRoundHalfUpPolicy:
+    def test_half_up_breaks_python_banker_rounding(self):
+        """Caso clave: M6 zócalo. `round(0.155, 2)` con banker's de
+        Python da 0.15 (no 0.16). El operador requiere half-up = 0.16."""
+        parsed = {
+            "pieces": [
+                {"description": "M6 mesada", "largo": 1.55, "prof": 0.6, "quantity": 2},
+                {"description": "M6 zócalo atrás", "largo": 1.55, "alto": 0.10, "quantity": 2},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        zocalo = card["sectores"][0]["tramos"][0]["zocalos"][0]
+        # round_half_up(0.155, 2) = 0.16. × 2 = 0.32.
+        # Si esto rompe a 0.30, alguien volvió a `round()` (banker's).
+        assert zocalo["m2"] == 0.32, (
+            f"M6 zócalo m² = {zocalo['m2']}, esperaba 0.32. "
+            f"Si volvió a 0.30, regresión: alguien revertió `_round_half_up` "
+            f"a `round()` (banker's de Python). El operador requiere "
+            f"half-up: 0.155 → 0.16 (no 0.15)."
+        )
+
+    def test_mesada_uses_round_half_up_too(self):
+        """Mesada también usa round-unit-then-multiply para mantener
+        consistencia con zócalos y calculator."""
+        parsed = {
+            "pieces": [
+                {"description": "M1 mesada", "largo": 1.92, "prof": 0.6, "quantity": 24},
+            ],
+        }
+        card = parsed_pieces_to_card(parsed)
+        tramo = card["sectores"][0]["tramos"][0]
+        # 1.92 × 0.60 = 1.152 → round_half_up=1.15 → × 24 = 27.60.
+        assert tramo["m2"]["valor"] == 27.60, (
+            f"M1 mesada m² = {tramo['m2']['valor']}, esperaba 27.60"
+        )

--- a/web/src/components/chat/DualReadResult.tsx
+++ b/web/src/components/chat/DualReadResult.tsx
@@ -25,6 +25,26 @@ const safeNum = (n: unknown): number =>
 const displayNum = (n: unknown): string =>
   typeof n === "number" && Number.isFinite(n) ? n.toFixed(2) : MISSING;
 
+// PR #409 — roundHalfUp en JS, espejo de `calculator._round_half_up`.
+// Math.round() en JS hace banker's-like rounding por float imprecision
+// (0.155 → 0.15 en algunos casos), igual que Python `round`. Para
+// alinear con backend usamos string-based rounding via `toFixed` con
+// epsilon: si el dígito siguiente al decimal target es >= 5, incrementa.
+// Patrón requerido por el operador para el despiece textual:
+//   m²/u  = roundHalfUp(base, 2)
+//   m²    = roundHalfUp(m²/u × quantity, 2)
+// Garantiza que frontend display = backend persistido = Paso 2 calculator.
+function roundHalfUp(value: number, decimals = 2): number {
+  if (!Number.isFinite(value)) return 0;
+  const factor = Math.pow(10, decimals);
+  // El epsilon (1e-9) compensa imprecisión binaria del float JS:
+  // 0.155 internamente es 0.15499999... — sin epsilon, Math.round
+  // devuelve 0.15. Con epsilon (que se suma con el signo del valor),
+  // 0.155 + 1.55e-10 redondea a 0.16 como espera el operador.
+  const sign = value < 0 ? -1 : 1;
+  return Math.round(value * factor + sign * 1e-9) / factor;
+}
+
 // Normaliza el shape del payload dual_read: garantiza que sectores/tramos/
 // zocalos sean arrays y que FieldValue no sea null/undefined. Preserva los
 // valores null internos (valor, ml, alto_m) — son señal de "no medí esto"
@@ -695,14 +715,13 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry, lock
       t.zocalos.forEach((z) => {
         const ml = safeNum(z.ml);
         if (ml > 0) {
-          // PR #408 — multiplicar por quantity heredada del tramo padre
-          // cuando el brief textual declaró tipologías repetidas (×N).
-          // Sin esto, el zócalo del Office tipo M1 ×24 contribuye solo
-          // su m²/u al total (0.19 en vez de 4.56) → display visible
-          // del despiece queda mintiendo. `quantity || 1` para retro-
-          // compatibilidad con duals viejos sin el field.
+          // PR #408 — multiplicar por quantity heredada del tramo padre.
+          // PR #409 — round-unit-then-multiply con `roundHalfUp` para
+          // alinear con backend / calculator (caso DYSCON M1 zócalo:
+          // 1.92 × 0.10 = 0.192 → 0.19/u → × 24 = 4.56).
           const qty = z.quantity || 1;
-          zocalosM2 += ml * safeNum(z.alto_m) * qty;
+          const m2Unit = roundHalfUp(ml * safeNum(z.alto_m), 2);
+          zocalosM2 += roundHalfUp(m2Unit * qty, 2);
           zocalosCount += 1;
         }
       });
@@ -741,12 +760,11 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry, lock
           const ml = safeNum(z.ml);
           if (ml <= 0) return;
           const alto = safeNum(z.alto_m);
-          // PR #408 — m² del zócalo multiplicado por quantity. Mismo
-          // tratamiento que el render de filas (más abajo, ~línea 950)
-          // y que el sumario del header (zocalosM2). Si el dual viene
-          // del plano (sin quantity), `quantity || 1` mantiene comportamiento.
+          // PR #408 — m² del zócalo multiplicado por quantity.
+          // PR #409 — round-unit-then-multiply con `roundHalfUp`.
           const qty = z.quantity || 1;
-          const zm2 = ml * alto * qty;
+          const m2Unit = roundHalfUp(ml * alto, 2);
+          const zm2 = roundHalfUp(m2Unit * qty, 2);
           total += zm2;
           const altoDisplay = z.alto_m == null ? MISSING : alto.toFixed(2);
           lines.push(`| Zóc. ${z.lado} | ${ml.toFixed(2)} ml × ${altoDisplay} | ${zm2.toFixed(2)} |`);
@@ -965,13 +983,17 @@ export default function DualReadResult({ data, quoteId, onConfirm, onRetry, lock
                           <span className="text-t4 ml-0.5">m</span>
                         </div>
                         <div className="text-t1 font-medium text-right flex items-center justify-end gap-2">
-                          {/* PR #408 — m² del zócalo en la fila editable
-                              también multiplica por quantity heredada. Si
-                              el zócalo es de un Office tipo M1 ×24, la
-                              fila muestra el m² total del lote (4.56),
-                              consistente con el resumen del header y con
-                              el cálculo del Paso 2 downstream. */}
-                          <span>{(z.ml == null || z.alto_m == null) ? MISSING : (z.ml * z.alto_m * (z.quantity || 1)).toFixed(2)}</span>
+                          {/* PR #408 + #409 — m² del zócalo en la fila
+                              editable: round-unit-then-multiply con
+                              `roundHalfUp`. M1 ×24: 0.19/u × 24 = 4.56. */}
+                          <span>{
+                            (z.ml == null || z.alto_m == null)
+                              ? MISSING
+                              : roundHalfUp(
+                                  roundHalfUp(z.ml * z.alto_m, 2) * (z.quantity || 1),
+                                  2,
+                                ).toFixed(2)
+                          }</span>
                           {/* PR #61 — botón remover siempre disponible, independiente
                               del status (el operador confirma con el cliente si lleva
                               zócalos o no; Dual Read solo sugiere). Hover aumenta


### PR DESCRIPTION
## Summary

Hotfix de #408. Política unificada de redondeo en el despiece textual: `round_half_up` unitario primero, después multiplicar por quantity.

## Bug

El operador detectó que la card editable seguía mintiendo:
- **M1 zócalo (×24)** mostraba `4.61`, esperado `4.56`.

Causa: PR #408 usó `round(ml × alto × quantity, 2)` (multiply-then-round). El cálculo da `1.92 × 0.10 × 24 = 4.608 → 4.61`. La regla correcta del operador, **igual que el calculator** (`calculate_m2:717-719`):

```
m²/u = round_half_up(base, 2)
m²   = round_half_up(m²/u × quantity, 2)
```

## Sub-detalle: `round()` Python no sirve

`round()` de Python hace banker's-like rounding por imprecisión float (`0.155 → 0.15`, no `0.16`). Si usábamos `round()` simple, M6 quedaba en `0.31` (× 2 = `0.30`) y el operador seguía sin ver `0.32`.

Por eso usamos `_round_half_up` (que ya existe en `calculator.py` con Decimal/string-based rounding).

## Casos esperados (DYSCON)

| Pieza | Cálculo | m² esperado |
|---|---|---|
| M1 zócalo (×24) | 0.192 → 0.19 → × 24 | **4.56** |
| M6 zócalo (×2) | 0.155 → **0.16** (half-up) → × 2 | **0.32** |
| M7 zócalo (×2) | 0.150 → 0.15 → × 2 | **0.30** |
| **Total sector** | | **42.39 m²** |

## Cambios

### Backend (`text_parser.py`)
1. Importa `_round_half_up` de `calculator` (fuente única).
2. Mesada y zócalo (creación + herencia) usan `_round_half_up` siempre.

### Frontend (`DualReadResult.tsx`)
1. Implementa `roundHalfUp` JS (espejo del Python). Usa epsilon `1e-9` para compensar imprecisión binaria.
2. Tres lugares aplican `round-unit-then-multiply`:
   - Sumario header (`zocalosM2`).
   - Markdown export.
   - Render por fila.

## Tests (16 casos)

- ✅ M1 = 4.56, M6 = 0.32, M7 = 0.30, total = 42.39 (caso DYSCON exacto).
- ✅ Test que rompe si alguien revierte a `round()` Python (banker's).
- ✅ Mesada también usa `_round_half_up` (consistencia).
- ✅ Tests existentes de #405/#408 con assertions actualizadas.
- ✅ Sin regresión en residencial simple, herencia de quantity, etc.

Suite full: **1814 passing** (1 fail preexistente).
`tsc --noEmit`: verde.

## Lo que NO toca

- Calculator (regla ya correcta, intacta — fuimos hacia ella).
- Path Dual Read del plano.
- Material total / Paso 2.
- Schema del tool ni system prompt.

## Test plan

- [x] `pytest tests/test_zocalo_m2_quantity.py tests/test_text_parser_quantity.py -v` → 16/16.
- [x] Suite full → 1814 passing.
- [x] `tsc --noEmit` verde.
- [ ] CI verde.
- [ ] **Criterio de salida (vos)**: validar en producción
  - M1 zócalo = `4.56`
  - M6 zócalo = `0.32`
  - M7 zócalo = `0.30`
  - Total visual = `42.39 m²`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
