### PR TITLE
feat(paso1): render determinístico desde backend (build_deterministic_paso1)

### DIFF
--- a/api/CONTEXT.md
+++ b/api/CONTEXT.md
@@ -11,6 +11,7 @@
 
 **⛔ PROHIBIDO en PASO 1:** llamar catalog_lookup, catalog_batch_lookup, calculate_quote.
 **✅ OBLIGATORIO en PASO 1 (presupuestos normales):** llamar `list_pieces` para obtener labels + total m². Usar sus valores exactos.
+**⛔ REGLA ABSOLUTA DE PASO 1:** Cuando `list_pieces()` devuelve `_paso1_rendered`, usá ese texto EXACTO como tu Paso 1. NO recalcules m² (ya viene multiplicado por `qty`), NO sumes manualmente las filas (usá `total_m2` literal), NO armes una tabla propia "para acompañar". El render es determinístico y es la fuente de verdad. Si `qty > 1` la columna Cant muestra `×N`; si es 1 muestra `—`. Caso real: brief con tipologías repetidas (×24, ×2) — multiplicar mal acá implica miles de m² de error y warnings falsos de "discrepancia".
 **⛔ EXCEPCIÓN EDIFICIO:** si recibiste JSON pre-calculado del sistema de edificio, ese JSON ES la fuente de verdad. NO llamar list_pieces. NO aplanar piezas. Presentar separado por material tal como viene.
 **⛔ PROHIBIDO en PASO 2:** llamar generate_documents.
 

--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -4836,6 +4836,27 @@ class AgentService:
                     await db.execute(update(Quote).where(Quote.id == quote_id).values(quote_breakdown=_bd))
                     await db.commit()
                     logging.info(f"[paso1] Persisted {len(inputs['pieces'])} pieces, total_m2={result.get('total_m2')}")
+
+                    # PR #412 — render determinístico del Paso 1 (gemelo
+                    # de `_paso2_rendered`). Inyectamos un string markdown
+                    # listo para que el LLM lo emita verbatim, evitando
+                    # que recalcule m² o sume mal las filas (caso DYSCON
+                    # 9,43 vs 42,39). Ver system prompt para la regla
+                    # "usar `_paso1_rendered` literal".
+                    try:
+                        from app.modules.quote_engine.calculator import (
+                            build_deterministic_paso1,
+                        )
+                        result["_paso1_rendered"] = build_deterministic_paso1(
+                            result,
+                            client_name=_q.client_name,
+                            project=_q.project,
+                            material=_q.material,
+                        )
+                    except Exception as _e_p1:
+                        logging.warning(
+                            f"[paso1] build_deterministic_paso1 failed: {_e_p1}"
+                        )
             except Exception as e:
                 logging.warning(f"[paso1] Failed to persist pieces: {e}")
             return result

--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -831,6 +831,84 @@ def list_pieces(pieces: list, is_edificio: bool = False) -> dict:
     }
 
 
+def build_deterministic_paso1(
+    list_pieces_result: dict,
+    *,
+    client_name: str | None = None,
+    project: str | None = None,
+    material: str | None = None,
+) -> str:
+    """Build Paso 1 markdown from `list_pieces` output — 100% deterministic.
+
+    PR #412 — Paso 1 venía siendo armado libremente por el LLM como
+    respuesta de chat. El LLM ignoraba `piece.m2` y `total_m2` del
+    response y rehacía la cuenta como `largo × prof` (m²/u, sin
+    multiplicar por `qty`). Caso DYSCON: tabla decía 9.43 m² cuando
+    `total_m2` era 42.39, y el propio modelo emitía un warning de
+    "DISCREPANCIA DETECTADA" como efecto secundario del bug.
+
+    Patrón: gemelo a `build_deterministic_paso2` (línea ~1607). El
+    handler de `list_pieces` en agent.py inyecta este string como
+    `result["_paso1_rendered"]`. El system prompt instruye al LLM a
+    usarlo verbatim — sin recalcular ni acompañar con tabla propia.
+
+    Reglas del render:
+    - Una fila por `piece` del response.
+    - Columna `Cant`: `×N` cuando `qty > 1`, `—` cuando `qty == 1`.
+    - Columna `m²`: usar **`piece.m2` literal** (ya viene multiplicado
+      por qty desde `list_pieces:821`).
+    - TOTAL: usar **`total_m2` literal** del response (suma del
+      backend, fuente de verdad — nunca recalcular sumando filas).
+    - Header con cliente/obra/material si se pasaron.
+    """
+    pieces = list_pieces_result.get("pieces") or []
+    total_m2 = list_pieces_result.get("total_m2", 0)
+
+    lines: list[str] = []
+
+    # Header — cliente / obra / material (si vienen).
+    if client_name or project:
+        header_parts = []
+        if client_name:
+            header_parts.append(f"**{client_name}**")
+        if project:
+            header_parts.append(f"**Obra:** {project}")
+        lines.append(" | ".join(header_parts))
+        lines.append("")
+
+    # Material + total m² del sector.
+    if material:
+        # `_round_half_up` para alinear display con el cálculo (ARS rules).
+        _total_disp = _round_half_up(total_m2, 2)
+        # Display ARS-style: 42.39 → "42,39" (coma decimal). El render
+        # del Paso 2 hace lo mismo en otras partes del breakdown.
+        _total_str = f"{_total_disp:.2f}".replace(".", ",")
+        lines.append(f"### {material} — {_total_str} m²")
+        lines.append("")
+
+    # Tabla de piezas.
+    lines.append("| Pieza | Cant | m² |")
+    lines.append("|---|---|---|")
+    for p in pieces:
+        label = p.get("label") or ""
+        qty = p.get("qty", 1) or 1
+        try:
+            qty_int = int(qty)
+        except (TypeError, ValueError):
+            qty_int = 1
+        cant_disp = f"×{qty_int}" if qty_int > 1 else "—"
+        m2 = p.get("m2", 0)
+        m2_disp = f"{m2:.2f}".replace(".", ",")
+        lines.append(f"| {label} | {cant_disp} | {m2_disp} |")
+
+    # TOTAL — fuente única de verdad: `total_m2` del response.
+    _total_disp = _round_half_up(total_m2, 2)
+    _total_str = f"{_total_disp:.2f}".replace(".", ",")
+    lines.append(f"| **TOTAL** | | **{_total_str} m²** |")
+
+    return "\n".join(lines)
+
+
 def calculate_merma(m2_needed: float, material_type: str, is_edificio: bool = False) -> dict:
     """Calculate merma for synthetic materials.
 

--- a/api/tests/test_build_deterministic_paso1.py
+++ b/api/tests/test_build_deterministic_paso1.py
@@ -1,0 +1,147 @@
+"""Tests para PR #412 — `build_deterministic_paso1`.
+
+**Bug observado:** el Paso 1 markdown lo armaba el LLM Sonnet libremente
+desde el response de `list_pieces`. El LLM ignoraba `piece.m2` y
+`total_m2` (ya correctos en el response) y rehacía la cuenta como
+`largo × prof` (m²/u, sin multiplicar por `qty`).
+
+Caso real DYSCON (quote `bb4196f1` post-#411):
+- `list_pieces` devolvió `total_m2=42.39` correcto.
+- LLM mostró tabla con m²/u (1.15, 0.19, 0.93, 0.16) y total 9.43.
+- LLM emitió un warning falso de "DISCREPANCIA DETECTADA" como
+  efecto secundario.
+
+**Fix (gemelo del Paso 2 determinístico):**
+- `build_deterministic_paso1` en calculator construye el markdown
+  desde el response de `list_pieces`. Una sola fuente de verdad.
+- agent.py inyecta el resultado como `result["_paso1_rendered"]`.
+- CONTEXT.md instruye al LLM a usarlo verbatim (regla absoluta,
+  análoga a `_paso2_rendered`).
+
+Cobertura:
+- DYSCON exacto: 14 piezas con quantities mixtas, total = 42.39.
+- Caso simple sin quantity: sin `(×N)`, total m² correcto.
+- Header con cliente/proyecto/material.
+- Render usa los valores literales del response (no recalcula).
+- Total = `total_m2` del response (no suma de filas).
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.modules.quote_engine.calculator import (
+    build_deterministic_paso1,
+    list_pieces,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Caso DYSCON — 14 piezas con quantities mixtas, total 42.39
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestDysconRender:
+    def test_dyscon_full_render(self):
+        """Brief DYSCON exacto: total esperado 42.39 m². Las filas
+        muestran m² total (con qty aplicada), nunca m²/u."""
+        pieces = [
+            {"description": "M1 mesada", "largo": 1.92, "prof": 0.60, "quantity": 24},
+            {"description": "M1 zócalo atrás", "largo": 1.92, "alto": 0.10, "quantity": 24},
+            {"description": "M2 mesada (Office 32)", "largo": 1.70, "prof": 0.60, "quantity": 1},
+            {"description": "M2 zócalo atrás", "largo": 1.70, "alto": 0.10, "quantity": 1},
+            {"description": "M3 mesada (Office 12)", "largo": 2.50, "prof": 0.60, "quantity": 1},
+            {"description": "M3 zócalo atrás", "largo": 2.50, "alto": 0.10, "quantity": 1},
+            {"description": "M4 mesada (Office 27)", "largo": 2.50, "prof": 0.60, "quantity": 1},
+            {"description": "M4 zócalo atrás", "largo": 2.50, "alto": 0.10, "quantity": 1},
+            {"description": "M5 mesada (Office 53)", "largo": 1.80, "prof": 0.60, "quantity": 1},
+            {"description": "M5 zócalo atrás", "largo": 1.80, "alto": 0.10, "quantity": 1},
+            {"description": "M6 mesada (Office 80/83)", "largo": 1.55, "prof": 0.60, "quantity": 2},
+            {"description": "M6 zócalo atrás", "largo": 1.55, "alto": 0.10, "quantity": 2},
+            {"description": "M7 mesada (Office 87/90)", "largo": 1.50, "prof": 0.60, "quantity": 2},
+            {"description": "M7 zócalo atrás", "largo": 1.50, "alto": 0.10, "quantity": 2},
+        ]
+        lp = list_pieces(pieces, is_edificio=True)
+        assert lp["ok"] is True
+        # Sanity: el response del list_pieces ya tiene 42.39.
+        assert abs(lp["total_m2"] - 42.39) < 0.05
+
+        md = build_deterministic_paso1(
+            lp,
+            client_name="DYSCON S.A.",
+            project="Unidad Penal N°8 — Piñero",
+            material="GRANITO GRIS MARA EXTRA 2 ESP",
+        )
+        # Header con cliente/obra/material.
+        assert "DYSCON S.A." in md
+        assert "Unidad Penal N°8 — Piñero" in md
+        assert "GRANITO GRIS MARA EXTRA 2 ESP" in md
+        # Total visible = 42,39 m² (coma decimal ARS-style).
+        assert "42,39 m²" in md, (
+            f"Total render regresión: '42,39 m²' no está en el markdown.\n{md}"
+        )
+        # NO debe aparecer "9,43" ni "9.43" (el bug viejo).
+        assert "9,43" not in md and "9.43" not in md, (
+            f"Regresión PR #412: el render contiene 9,43 (suma de m²/u). "
+            f"Backend está re-introduciendo el bug del LLM.\n{md}"
+        )
+        # M1 mesada con qty=24 → fila con (×24) y m² = 27.60.
+        assert "×24" in md
+        # M6 mesada con qty=2 → fila con (×2) y m² = 1.86.
+        assert "×2" in md
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Caso simple — 1 pieza sin quantity (residencial)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestSimpleRender:
+    def test_simple_no_quantity(self):
+        """Cocina particular: 1 mesada + 1 zócalo. Sin sufijo (×N),
+        cant = '—'. Render compacto."""
+        pieces = [
+            {"description": "Mesada", "largo": 2.0, "prof": 0.6},
+            {"description": "Zócalo trasero", "largo": 2.0, "alto": 0.05},
+        ]
+        lp = list_pieces(pieces, is_edificio=False)
+        md = build_deterministic_paso1(
+            lp,
+            client_name="Pérez",
+            project="Cocina Casa",
+            material="Silestone Blanco Norte",
+        )
+        # Header básico.
+        assert "Pérez" in md
+        assert "Silestone Blanco Norte" in md
+        # No debe haber sufijos (×N) — todas las piezas son qty=1.
+        assert "×" not in md or md.count("×") == md.count("× 0"), (
+            f"Caso simple no debe tener sufijos (×N). Render:\n{md}"
+        )
+        # La columna Cant debe mostrar `—` (em-dash) para qty=1.
+        # (Verificamos que aparezca al menos 2 veces — una por cada pieza.)
+        assert md.count("—") >= 2
+
+    def test_total_uses_response_value_not_sum(self):
+        """El TOTAL del render = `total_m2` del response, NO una suma
+        manual de las filas. Prueba que si `total_m2` del response
+        difiere de la suma visual (caso edge: rounding), respetamos
+        el response."""
+        # Inyectamos un response artificial con total que NO coincide
+        # con la suma de las filas — el helper debe respetar `total_m2`.
+        fake_response = {
+            "ok": True,
+            "pieces": [
+                {"label": "Pieza A", "m2": 1.00, "qty": 1},
+                {"label": "Pieza B", "m2": 2.00, "qty": 1},
+            ],
+            "total_m2": 99.99,  # ← intencionalmente raro
+        }
+        md = build_deterministic_paso1(
+            fake_response, client_name="Test", project="Test", material="Test"
+        )
+        # El TOTAL debe reflejar 99.99, no 3.00.
+        assert "99,99 m²" in md, (
+            f"El render NO debe sumar filas — debe usar `total_m2` "
+            f"literal del response. Got:\n{md}"
+        )
+        assert "3,00 m²" not in md


### PR DESCRIPTION
## Summary

Render determinístico del Paso 1 desde backend — gemelo de `build_deterministic_paso2`. Saca la matemática visual del LLM.

## Bug

Caso DYSCON (post-#411): `list_pieces` devolvió `total_m2=42.39` correcto, pero el LLM Sonnet armó el markdown del Paso 1 ignorando `piece.m2` y `total_m2`, recalculando filas como `largo × prof` sin multiplicar por `qty`. Tabla mostró 9.43 m². El propio modelo emitió warning falso de "DISCREPANCIA DETECTADA".

Backend siempre estuvo correcto (PR #401-#411). El bug es de **render libre del LLM** — capa frágil ya identificada por el patrón Paso 2.

## Fix (3 cambios chicos)

### 1. `calculator.py:build_deterministic_paso1`
Construye markdown desde el response de `list_pieces`:
- Header: cliente / obra / material.
- Material + total m² del sector.
- Tabla `| Pieza | Cant | m² |`:
  - **`Cant`**: `×N` cuando `qty > 1`, `—` cuando `qty == 1`.
  - **`m²`**: usa `piece.m2` **literal** (ya viene multiplicado).
- **TOTAL**: usa `total_m2` **literal** del response (nunca recalcular).
- Format ARS-style (coma decimal).

### 2. `agent.py:list_pieces` handler
Después de ejecutar `list_pieces` + persistir, inyecta:
```python
result["_paso1_rendered"] = build_deterministic_paso1(result, client_name=..., project=..., material=...)
```
Análogo a `_paso2_rendered`.

### 3. `CONTEXT.md` — instrucción dura
> "Cuando `list_pieces()` devuelve `_paso1_rendered`, usá ese texto EXACTO. NO recalcules m² ni sumes filas. Es la fuente de verdad — el render es determinístico."

## Tests (3 casos)

- ✅ **DYSCON exacto** (14 piezas, qty mixtas) → total `42,39 m²`, filas `(×24)` / `(×2)`, **NO aparece 9,43**.
- ✅ **Caso simple sin qty** → sin sufijos, `Cant = —`, render compacto.
- ✅ **TOTAL del render = `total_m2` literal** (drift guard: si alguien re-introduce suma manual de filas, este test rompe).

Suite full: **1839 passing** (1 fail preexistente).

## Lo que NO toca

- Calculator (matemática intacta — ya correcta desde #401-#411).
- `list_pieces` input/output (mismos campos).
- Paso 2 (independiente).
- Frontend, tool schema.

## Test plan

- [x] `pytest tests/test_build_deterministic_paso1.py -v` → 3/3.
- [x] Suite full → 1839 passing.
- [ ] CI verde.
- [ ] **Criterio de salida**: re-cotizar DYSCON →
  - Paso 1 muestra **Total = 42,39 m²** (no 9,43).
  - Filas con `×24` / `×2`.
  - **NO aparece** "DISCREPANCIA DETECTADA" (el efecto secundario del bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
