### PR TITLE
fix(validator): respetar price_includes_vat:true en chequeo MO IVA (hotfix #414)

### DIFF
--- a/api/app/modules/agent/tools/catalog_tool.py
+++ b/api/app/modules/agent/tools/catalog_tool.py
@@ -182,6 +182,15 @@ def catalog_lookup(catalog: str, sku: str) -> dict:
                 result["sink_type"] = item["sink_type"]
             if "thickness_mm" in item:
                 result["thickness_mm"] = item["thickness_mm"]
+            # PR #415 — propagar `price_includes_vat: true` al output.
+            # Necesario para que downstream (calculator → mo_item →
+            # validation_tool._check_mo_iva) sepa que `unit_price ==
+            # base_price` es la regla correcta para este item, en vez
+            # de exigir `unit_price == round(base × 1.21)`.
+            # PR #414 hizo que el price salga ya con IVA pero el flag
+            # se quedaba en el item sin propagar.
+            if _price_already_has_vat:
+                result["price_includes_vat"] = True
 
             return result
 

--- a/api/app/modules/agent/tools/validation_tool.py
+++ b/api/app/modules/agent/tools/validation_tool.py
@@ -98,11 +98,30 @@ def _check_iva_mo(qdata: dict) -> tuple[list[str], list[str]]:
         up = mo.get("unit_price")
         desc = mo.get("description", "?")
         has_edif_disc = bool(mo.get("edificio_discount"))
+        # PR #415 — items con `price_includes_vat: true` (caso flete
+        # Piñero/Cañada/Alvear): el JSON ya tiene el precio final con
+        # IVA, así que `unit_price == base_price`. La fórmula
+        # `unit == round(base × 1.21)` NO aplica para estos. Sin este
+        # skip el validador bloqueaba generate_documents y Sonnet
+        # caía a recalcular cambiando localidad → flete viejo + render
+        # incorrecto (caso DYSCON post-#414).
+        price_includes_vat = bool(mo.get("price_includes_vat"))
 
         if bp is None:
             continue  # Old data without base_price — skip silently
         if up is None:
             warnings.append(f"MO '{desc}' sin unit_price")
+            continue
+
+        if price_includes_vat:
+            # Cuando el catálogo ya trae el precio con IVA, el "base"
+            # es igual al "with_iva". Validar igualdad estricta —
+            # cualquier divergencia es bug del calculator/catalog_lookup.
+            if abs(up - bp) > 1:
+                errors.append(
+                    f"MO '{desc}' con price_includes_vat=true esperaba "
+                    f"unit==base ({bp}), actual={up}"
+                )
             continue
 
         if has_edif_disc:

--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -1386,7 +1386,23 @@ def calculate_quote(input_data: dict) -> dict:
                 logging.info(f"Edificio flete: {num_pieces} piezas físicas ÷ {_per_trip} = {flete_qty} fletes")
             else:
                 flete_qty = 1
-            mo_items.append({"description": f"Flete + toma medidas {localidad}", "quantity": flete_qty, "unit_price": flete_price, "base_price": flete_base, "total": round(flete_price * flete_qty)})
+            # PR #415 — propagar el flag price_includes_vat del catálogo
+            # al mo_item para que el validador (`_check_mo_iva`) sepa
+            # que la fórmula `unit == round(base × 1.21)` NO aplica
+            # cuando el item ya viene con IVA incluido en el JSON
+            # (caso Piñero/Cañada/Alvear). Sin esto el validador
+            # falla y bloquea generate_documents (caso DYSCON post-#414).
+            _flete_includes_vat = bool(flete_result.get("price_includes_vat"))
+            _flete_item = {
+                "description": f"Flete + toma medidas {localidad}",
+                "quantity": flete_qty,
+                "unit_price": flete_price,
+                "base_price": flete_base,
+                "total": round(flete_price * flete_qty),
+            }
+            if _flete_includes_vat:
+                _flete_item["price_includes_vat"] = True
+            mo_items.append(_flete_item)
 
             # Pulido de cantos extra: if zone has pulido_extra=true AND colocación is on
             if colocacion and flete_result.get("pulido_extra", False):

--- a/api/tests/test_validator_includes_vat_flag.py
+++ b/api/tests/test_validator_includes_vat_flag.py
@@ -1,0 +1,185 @@
+"""Tests para PR #415 — validator skipea check IVA cuando mo_item
+tiene `price_includes_vat: true`.
+
+**Bug observado:** PR #414 hizo que `catalog_lookup` respete el flag
+y devuelva `price_ars = price_ars_base` (mismo valor) cuando el JSON
+dice `price_includes_vat: true`. Eso es correcto.
+
+Pero el validador (`validation_tool._check_iva_mo`) seguía exigiendo
+`unit_price == round(base × 1.21)`. Para el flete de Piñero
+(base=100000, unit=100000) el validador fallaba con:
+
+    IVA MO inconsistente en 'Flete + toma medidas Piñero':
+    base=100000.0 × 1.21 → esperado=121000, actual=100000.0
+
+Eso bloqueaba `generate_documents` y Sonnet caía a recalcular
+cambiando "Piñero" por "Rosario" como "solución" (alucinación).
+
+**Fix (3 cambios en cadena):**
+  1. `catalog_lookup` propaga `price_includes_vat: true` al output.
+  2. `calculator` copia el flag al `mo_item` cuando arma el flete.
+  3. `validator` reconoce el flag: si está, exige `unit == base`
+     (no `unit == base × 1.21`).
+
+Tests cubren los 3 niveles:
+  - catalog_lookup output incluye el flag.
+  - calculator agrega flag al mo_item del flete.
+  - validator pasa cuando flag está, sigue chequeando cuando no.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.modules.agent.tools.catalog_tool import catalog_lookup
+from app.modules.agent.tools.validation_tool import _check_iva_mo
+from app.modules.quote_engine.calculator import calculate_quote
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# catalog_lookup propaga el flag
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestCatalogLookupPropagatesFlag:
+    def test_pinero_includes_flag_in_output(self):
+        result = catalog_lookup("delivery-zones", "ENVPIÑERO")
+        assert result.get("found") is True
+        assert result.get("price_includes_vat") is True
+
+    def test_canada_includes_flag(self):
+        result = catalog_lookup("delivery-zones", "FLETE CAÑADA")
+        assert result.get("found") is True
+        assert result.get("price_includes_vat") is True
+
+    def test_rosario_does_not_include_flag(self):
+        """Items SIN el flag en JSON no deben tener `price_includes_vat`
+        en el output (o tener False)."""
+        result = catalog_lookup("delivery-zones", "ENVIOROS")
+        assert result.get("found") is True
+        # El field puede no estar (preferido) o estar como False.
+        assert not result.get("price_includes_vat", False)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Validador respeta el flag
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestValidatorRespectsFlag:
+    def test_pinero_flete_passes_validation(self):
+        """Item de flete Piñero (base=100000, unit=100000, flag=true)
+        debe pasar validación. Pre-#415 fallaba con 'IVA MO inconsistente'."""
+        qdata = {
+            "mo_items": [
+                {
+                    "description": "Flete + toma medidas Piñero",
+                    "quantity": 3,
+                    "unit_price": 100000,
+                    "base_price": 100000,
+                    "total": 300000,
+                    "price_includes_vat": True,
+                },
+            ],
+        }
+        errors, warnings = _check_iva_mo(qdata)
+        assert errors == [], (
+            f"Esperaba sin errores cuando price_includes_vat=true. "
+            f"Got errors={errors}"
+        )
+
+    def test_normal_flete_still_validated(self):
+        """Item sin flag (Rosario, etc): validador sigue exigiendo
+        unit == round(base × 1.21). Regression guard."""
+        qdata = {
+            "mo_items": [
+                {
+                    "description": "Flete + toma medidas Rosario",
+                    "quantity": 1,
+                    "unit_price": 52000,    # final con IVA
+                    "base_price": 42975,    # sin IVA → × 1.21 ≈ 51999.75
+                    "total": 52000,
+                    # NO flag — debe validar.
+                },
+            ],
+        }
+        errors, warnings = _check_iva_mo(qdata)
+        # 52000 ≈ round(42975 × 1.21) = round(51999.75) = 52000 ✓
+        assert errors == []
+
+    def test_normal_flete_with_wrong_unit_fails(self):
+        """Si un item normal tiene unit_price mal calculado, sigue
+        fallando (drift guard)."""
+        qdata = {
+            "mo_items": [
+                {
+                    "description": "MO Test",
+                    "quantity": 1,
+                    "unit_price": 1000,     # mal: debería ser ~1210
+                    "base_price": 1000,
+                    "total": 1000,
+                    # NO flag.
+                },
+            ],
+        }
+        errors, warnings = _check_iva_mo(qdata)
+        assert any("IVA MO inconsistente" in e for e in errors)
+
+    def test_flag_true_with_unit_diff_from_base_fails(self):
+        """Drift guard: si flag=true pero unit ≠ base, eso es bug del
+        calculator/catalog_lookup → debe fallar."""
+        qdata = {
+            "mo_items": [
+                {
+                    "description": "Flete bug",
+                    "quantity": 1,
+                    "unit_price": 121000,   # mal: con flag=true debería ser igual al base
+                    "base_price": 100000,
+                    "total": 121000,
+                    "price_includes_vat": True,
+                },
+            ],
+        }
+        errors, warnings = _check_iva_mo(qdata)
+        assert any("price_includes_vat=true esperaba unit==base" in e for e in errors)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# End-to-end — calculator inyecta flag y validador lo respeta
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestEndToEndPineroPasses:
+    def test_pinero_quote_validates_clean(self):
+        """Quote real con flete Piñero: el flujo completo (calculator
+        agrega flete con flag → validador lo respeta) no debe generar
+        `_validation_errors`. Regression del caso DYSCON post-#414."""
+        result = calculate_quote({
+            "client_name": "DYSCON Test",
+            "project": "Test",
+            "material": "Granito Negro Brasil",
+            "pieces": [{"description": "Mesada", "largo": 2.0, "prof": 0.6}],
+            "localidad": "Piñero",
+            "plazo": "30 días",
+            "is_edificio": True,
+            "colocacion": False,
+            "pileta": "empotrada_cliente",
+            "flete_qty": 3,
+        })
+        assert result["ok"] is True
+        # El item del flete Piñero debe estar y tener el flag.
+        flete_items = [
+            m for m in result["mo_items"] if "piñero" in m["description"].lower()
+        ]
+        assert len(flete_items) == 1
+        flete = flete_items[0]
+        assert flete.get("price_includes_vat") is True
+        assert flete["unit_price"] == 100000
+        assert flete["total"] == 300000
+
+        # Y NO debe haber errores de validación de IVA en el flete.
+        validation_errors = result.get("_validation_errors") or []
+        flete_errors = [e for e in validation_errors if "Piñero" in e or "piñero" in e]
+        assert flete_errors == [], (
+            f"Regresión PR #415: validador sigue fallando con flete Piñero. "
+            f"Errors: {flete_errors}"
+        )


### PR DESCRIPTION
## Summary

**Bug colateral de PR #414** detectado en log de DYSCON quote `76054bf2-...`. PR #414 hizo que `catalog_lookup` respete el flag `price_includes_vat: true`, pero el **validador no se enteró** y bloqueaba `generate_documents`. Sonnet alucinaba "cambiar Piñero por Rosario" como solución.

## Cadena del bug observada

```
1. calculate_quote → flete Piñero unit=100000 (correcto post-#414)
2. validator._check_iva_mo → "IVA MO inconsistente: 100000 × 1.21 ≠ 100000" ❌
3. generate_documents → bloqueado por _validation_errors
4. Sonnet ve error → recalcula con localidad="Rosario" 🤡
5. Render final: "Flete + toma medidas Rosario × 3 = $156.000" + "Armado frentín" inventado
```

## Fix (3 cambios en cadena)

### 1. `catalog_lookup` propaga el flag
```python
if _price_already_has_vat:
    result["price_includes_vat"] = True
```

### 2. Calculator copia el flag al `mo_item` del flete
```python
_flete_item = {..., "price_includes_vat": True}  # cuando aplica
mo_items.append(_flete_item)
```

### 3. Validador `_check_iva_mo` reconoce el flag
| Caso | Antes | Después |
|---|---|---|
| flag=true, unit==base | ❌ "esperado=base×1.21" | ✓ pasa |
| flag=true, unit≠base | ✓ pasa (mal) | ❌ "esperaba unit==base" |
| flag ausente | sigue igual | sigue igual |

## Tests (8 casos)

- ✅ catalog_lookup propaga flag para Piñero/Cañada, no para Rosario.
- ✅ Validator pasa con flete Piñero (base=100k, unit=100k, flag=true).
- ✅ Validator sigue chequeando flete Rosario normal (regression).
- ✅ Validator falla con item sin flag y unit_price mal.
- ✅ **Drift guard**: flag=true + unit≠base → falla.
- ✅ **End-to-end**: `calculate_quote` localidad=Piñero produce `mo_item` con flag y NO genera `_validation_errors` del flete.

Suite full: **1867 passing + 1 xfail** (1 fail preexistente).

## Lo que NO toca

- Calculator math (solo agrega un campo metadata).
- Otros validadores (`_check_iva_material`, `_check_material_total`, etc) — solo MO IVA.
- Frontend, system prompt.

## Test plan

- [x] `pytest tests/test_validator_includes_vat_flag.py -v` → 8/8.
- [x] Suite full → 1867 passing.
- [ ] CI verde.
- [ ] **Criterio de salida**: re-cotizar DYSCON →
  - Paso 2: `Flete + toma medidas Piñero | 3 | $100.000 | $300.000`
  - "Confirmar" → `generate_documents` SUCCESS, NO recalcula.
  - PDF generado con localidad correcta = Piñero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
