### PR TITLE
fix(guardrail): bloquear generate_documents sin confirmación explícita

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1378,6 +1378,139 @@ def _extract_quote_info(user_message: str) -> dict:
     return info
 
 
+# ─────────────────────────────────────────────────────────────────────
+# PR #416 — Intent classifier para guardrail post-Paso 2.
+#
+# Objetivo: bloquear `generate_documents` cuando el último mensaje del
+# operador NO es una confirmación explícita. Caso real (DYSCON post-#415):
+#
+#   1. Paso 2 renderizado correcto.
+#   2. Operador: "flete + toma medidas Piñero $100.000 poner 3 fletes"
+#      → Sonnet recalcula OK (mensaje largo + numérico).
+#   3. Operador: "Armado frentín en mano de obra no va."
+#      → Sonnet va directo a generate_documents (mensaje corto + heurística
+#         `len < 200` lo marca como confirm) → PDF con datos viejos.
+#
+# Filosofía (review feedback):
+#   - Confirmación = whitelist POSITIVA. Sin señal explícita, no es
+#     confirmación — independiente del length. "Length < 200" es proxy
+#     basura ya quemado dos veces.
+#   - Modificación = (imperativo + noun) OR (negación + concepto).
+#     Dos detectores semánticos distintos, no uno solo con AND.
+#   - Bloquear generate_documents = ausencia de confirm Y presencia de
+#     mod (o ambiguo). Esto reduce blast radius — no bloquea por
+#     keyword de negación suelta ("no va a haber problema, generá").
+#
+# Deuda anotada: si aparece un 4° caso whack-a-mole (ya van pileta /
+# regrueso+material / confirm-mod), refactor a clasificador Haiku con
+# 1 call: "CONFIRM | MODIFY | OTHER". Por ahora keywords basta.
+# ─────────────────────────────────────────────────────────────────────
+
+# Whitelist: si el mensaje contiene EXACTAMENTE alguna de estas frases
+# (o sustring claro), es confirmación. La regla es positiva-explícita.
+_CONFIRM_PHRASES = (
+    "confirmo",
+    "confirmar",
+    "confirmá",
+    "dale",
+    # "generá"/"genera"/"generar" como invocación directa post-Paso 2.
+    # Padded con espacios para evitar match en "regenerá" / "considera".
+    " genera ",
+    " generá ",
+    " generar ",
+    "imprimí",
+    "imprimir",
+    "listo",
+    "perfecto",
+    "todo ok",
+    "todo bien",
+    "está bien",
+    "esta bien",
+    "está perfecto",
+    "esta perfecto",
+    "aprobado",
+    "apruebo",
+    " sí ",      # con espacios para evitar matches en "siglo", "asíduo", etc.
+    " si ",
+    "yes",
+    "ok ",       # "ok" suelto; el espacio post evita "okay" parcial
+)
+
+# Imperativos que indican modificación cuando van con un sustantivo.
+_MOD_IMPERATIVES = (
+    "agreg", "sumá", "sumar", "añad", "poné", "poner",
+    "sac", "quit", "remov", "borr", "elimin",
+    "cambi", "modific", "correg", "edit", "ajust", "rectific",
+    "actualiz", "reemplaz",
+)
+
+# Sustantivos / conceptos que pueden ser objeto de modificación.
+# Cubre material (zócalo/mesada/tramo/sector — del card-editor) y
+# MO/comercial (frentín, regrueso, flete, anafe, colocación, descuento,
+# pileta, bacha). Lista deliberadamente amplia para detectar mod intent
+# — el AND con imperativo o la negación-cerca evita falsos positivos.
+_MOD_NOUNS = (
+    "zócal", "zocal", "mesada", "tramo", "pieza", "sector",
+    "bacha", "pileta", "frentín", "frentin", "regrueso",
+    "flete", "anafe", "colocación", "colocacion", "armado",
+    "mano de obra", "descuento", "merma", "iva", "material",
+    "precio", "total",
+)
+
+# Negaciones que indican modificación cuando aparecen cerca de un
+# concepto (`_MOD_NOUNS`). Distintas semánticamente de los imperativos
+# — ej: "el frentín no va", "el descuento no aplica".
+_NEG_PATTERNS = (
+    "no va", "no debe", "no incluir", "no aplicar", "no aplica",
+    "no corresponde", "no usar", "no quiero",
+    "fuera de", "sacar", "quitar",  # imperativos también, pero también pueden venir solos
+)
+
+
+def _user_intent(msg: str) -> str:
+    """Clasifica el intent del último mensaje del operador.
+
+    Returns:
+        "confirm"  — operador confirmó explícitamente (whitelist positiva).
+        "modify"   — operador pidió un cambio (imperativo+noun o
+                     negación+concepto).
+        "other"    — ambiguo / otro / vacío. **Default conservador**:
+                     trata como NO-confirmación.
+
+    El guardrail de `generate_documents` solo permite ejecutar si
+    intent=="confirm". "modify" y "other" lo bloquean — la diferencia
+    es solo el mensaje de error que ve el LLM (mod = "recalculá",
+    other = "pedí confirmación explícita").
+    """
+    if not msg or not msg.strip():
+        return "other"
+    m = msg.lower().strip()
+
+    # 1. Confirmación: whitelist explícita.
+    # Padding con espacios para que substrings precisos matcheen
+    # (ej: " sí " no matchea "siglo" pero sí "tengo sí en el medio").
+    _padded = f" {m} "
+    for phrase in _CONFIRM_PHRASES:
+        if phrase in _padded:
+            return "confirm"
+
+    # 2. Modificación — DOS detectores OR'ed.
+    # 2a. Imperativo + sustantivo en el mismo mensaje.
+    has_imp = any(kw in m for kw in _MOD_IMPERATIVES)
+    has_noun = any(kw in m for kw in _MOD_NOUNS)
+    if has_imp and has_noun:
+        return "modify"
+
+    # 2b. Negación + sustantivo (sin requerir imperativo).
+    # Ej: "el frentín no va", "el descuento no aplica".
+    if has_noun:
+        for neg in _NEG_PATTERNS:
+            if neg in m:
+                return "modify"
+
+    return "other"
+
+
 # PR #413 — Brief guards: extract structured data from operator brief
 # to override LLM (Sonnet) hallucinations or omissions in calc_input.
 # Used in the `mo-list-authority` block to compare brief vs Sonnet
@@ -4978,6 +5111,65 @@ class AgentService:
             return await read_plan(inputs["filename"], inputs.get("crop_instructions", []))
         elif name == "generate_documents":
             import uuid as uuid_mod
+
+            # PR #416 — Guardrail post-Paso 2: bloquear generate_documents
+            # cuando el último mensaje del operador NO es una confirmación
+            # explícita. Caso DYSCON: "Armado frentín en mano de obra no
+            # va." (51 chars, sin keyword de confirm) → Sonnet decidía
+            # generar PDF directo en vez de recalcular. Resultado: PDF
+            # con datos viejos.
+            #
+            # Filosofía: confirmación = whitelist positiva. Sin "confirmo"
+            # / "dale" / "ok generá" / etc., NO se generan documentos —
+            # se devuelve un error que fuerza al LLM a recalcular y
+            # mostrar Paso 2 antes de re-intentar.
+            #
+            # Solo aplica si Paso 2 ya está hecho (`total_ars` poblado).
+            # En el primer generate (post-confirmación inicial) `total_ars`
+            # no existe todavía y el guardrail no entra.
+            try:
+                _gd_qr = await db.execute(select(Quote).where(Quote.id == quote_id))
+                _gd_q = _gd_qr.scalar_one_or_none()
+                _has_paso2 = bool(_gd_q and _gd_q.total_ars)
+                if _has_paso2 and current_user_message:
+                    _intent = _user_intent(current_user_message)
+                    if _intent != "confirm":
+                        logging.warning(
+                            f"[guardrail-generate] BLOCKED generate_documents "
+                            f"for {quote_id}: last user_message intent='{_intent}' "
+                            f"(no explicit confirm). msg_preview="
+                            f"{current_user_message[:120]!r}"
+                        )
+                        if _intent == "modify":
+                            _err = (
+                                "⛔ El operador pidió una modificación, NO una "
+                                "confirmación. ANTES de generar documentos:\n"
+                                "1. Llamá a `calculate_quote` con los valores "
+                                "actualizados según el último mensaje.\n"
+                                "2. Mostrá el Paso 2 nuevo completo (tabla + "
+                                "MO + GRAND TOTAL).\n"
+                                "3. Esperá una confirmación EXPLÍCITA del "
+                                "operador (ej: 'Confirmo', 'Dale', 'OK generá') "
+                                "antes de re-intentar generate_documents."
+                            )
+                        else:
+                            _err = (
+                                "⛔ El último mensaje del operador no es una "
+                                "confirmación explícita. Pedí una confirmación "
+                                "clara ('Confirmo', 'Dale', 'OK generá') antes "
+                                "de llamar a generate_documents. Si el operador "
+                                "pidió un cambio, recalculá primero."
+                            )
+                        return {"ok": False, "error": _err}
+            except Exception as _e_guard:
+                # Guard nunca debe romper el flow. Si falla la lectura,
+                # logueamos y dejamos pasar — fallback al comportamiento
+                # antiguo (Sonnet decide solo).
+                logging.warning(
+                    f"[guardrail-generate] check failed for {quote_id}: "
+                    f"{_e_guard} (allowing through as fallback)"
+                )
+
             quotes_data = inputs.get("quotes", [])
             # Backward compat: if old format with quote_data, wrap it
             if not quotes_data and "quote_data" in inputs:

--- a/api/tests/test_user_intent_classifier.py
+++ b/api/tests/test_user_intent_classifier.py
@@ -1,0 +1,171 @@
+"""Tests para PR #416 — `_user_intent` classifier (whitelist confirm).
+
+**Bug observado (DYSCON post-#415):** dos cambios encadenados post-Paso 2.
+Primer cambio (flete, msg largo) recalculó OK. Segundo cambio
+("Armado frentín en mano de obra no va.", 51 chars) → Sonnet decidió
+generate_documents directo, PDF con datos viejos.
+
+Causa raíz: `_is_confirmation = len(msg) < 200` es heurística basura.
+Cualquier mensaje corto se trataba como confirmación.
+
+Fix: clasificador con whitelist positiva — confirmación requiere señal
+explícita ("confirmo", "dale", "ok generá", etc.). Sin whitelist match,
+no es confirm. Plus detector de modificación (imperativo+noun OR
+negación+concepto). Bloquea generate_documents si intent != "confirm".
+
+Tests cubren los casos del review feedback:
+  - Whitelist gana sobre keyword de negación ("OK dale, sin cambios").
+  - Negación+concepto detecta sin requerir imperativo.
+  - "no va a haber problema, generá" → confirm (whitelist gana).
+  - Mensajes vacíos → other (default conservador).
+  - Mensajes ambiguos sin señal → other.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.modules.agent.agent import _user_intent
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Confirm intent — whitelist positiva
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestConfirmWhitelist:
+    @pytest.mark.parametrize("msg", [
+        "Confirmo",
+        "confirmo",
+        "Confirmar",
+        "Confirmá",
+        "dale",
+        "Dale",
+        "ok genera",
+        "OK generá",
+        "Ok generar PDF",
+        "imprimí",
+        "Listo",
+        "perfecto",
+        "todo ok",
+        "Todo bien",
+        "está bien",
+        "está perfecto",
+        "Aprobado",
+        "Sí",
+        "yes",
+        "ok dale",
+    ])
+    def test_explicit_confirm(self, msg):
+        assert _user_intent(msg) == "confirm", (
+            f"Esperaba confirm para {msg!r}"
+        )
+
+    def test_confirm_wins_over_negation_keyword(self):
+        """'OK dale, sin cambios' — palabra 'sin' aparece pero whitelist
+        de 'dale'/'ok' debe ganar (review feedback)."""
+        assert _user_intent("OK dale, sin cambios") == "confirm"
+
+    def test_confirm_with_extra_text(self):
+        """'Confirmo, fuera de eso todo bien' — 'fuera' es keyword de
+        negación pero whitelist de 'confirmo' gana."""
+        assert _user_intent("Confirmo, fuera de eso todo bien") == "confirm"
+
+    def test_confirm_phrase_with_neg_intent(self):
+        """'no va a haber cambios, generá' — el operador dice 'generá'
+        explícito → confirm. Sin whitelist de 'generá' caería como
+        modify por 'no va'."""
+        assert _user_intent("no va a haber cambios, generá") == "confirm"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Modify intent — imperativo+noun OR negación+concepto
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestModifyDetector:
+    def test_dyscon_frentin_no_va(self):
+        """Caso real DYSCON: 'Armado frentín en mano de obra no va.'
+        → modify. Tiene 'no va' + 'frentín' + 'mano de obra'."""
+        assert _user_intent("Armado frentín en mano de obra no va.") == "modify"
+
+    def test_imperative_plus_noun(self):
+        """'sacá el flete' → imperativo 'sac' + noun 'flete'."""
+        assert _user_intent("sacá el flete") == "modify"
+
+    def test_remove_pegadopileta(self):
+        assert _user_intent("quitá el agujero de pileta") == "modify"
+
+    def test_negation_with_concept(self):
+        """'El descuento del 18% no va' — review feedback: detector
+        de negación funciona aunque 'descuento' no esté como imperativo
+        clásico de despiece."""
+        assert _user_intent("El descuento del 18% no va") == "modify"
+
+    def test_no_aplica(self):
+        assert _user_intent("el flete no aplica") == "modify"
+
+    def test_modify_zocalo(self):
+        """Caso clásico del card-editor: agregar zócalo."""
+        assert _user_intent("agregá un zócalo lateral") == "modify"
+
+    def test_change_material(self):
+        assert _user_intent("cambiar material a Negro Brasil") == "modify"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Other / default conservador
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestOtherDefault:
+    def test_empty_string(self):
+        assert _user_intent("") == "other"
+
+    def test_whitespace_only(self):
+        assert _user_intent("   \n\t  ") == "other"
+
+    def test_none_input(self):
+        assert _user_intent(None) == "other"
+
+    def test_neutral_question(self):
+        """'¿cuánto sale?' — pregunta, no confirma ni modifica."""
+        assert _user_intent("¿cuánto sale?") == "other"
+
+    def test_random_text(self):
+        """Texto sin señales claras → other."""
+        assert _user_intent("hola buenas tardes") == "other"
+
+    def test_negation_without_concept(self):
+        """'no va a haber problema' — tiene 'no va' pero ningún
+        concepto (frentín/flete/etc) → other, NO modify. Esto evita
+        bloquear confirmaciones legítimas que mencionan negación
+        sin sustantivo (review feedback)."""
+        # Nota: 'problema' no está en _MOD_NOUNS — correcto.
+        assert _user_intent("no va a haber problema") == "other"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Drift guards — combinaciones que importan al guardrail
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestGuardrailIntegration:
+    def test_only_confirm_unblocks_generate(self):
+        """Solo intent='confirm' debe permitir generate_documents.
+        Cualquier otro valor lo bloquea. Este test es contrato del
+        guardrail — si rompe, el guardrail se rompió."""
+        # Simulación de la condición que usa el guardrail:
+        for msg, expected_unblock in [
+            ("Confirmo", True),
+            ("OK genera", True),
+            ("Armado frentín no va", False),
+            ("agregá zócalo", False),
+            ("", False),
+            ("hola", False),
+        ]:
+            intent = _user_intent(msg)
+            unblocks = intent == "confirm"
+            assert unblocks is expected_unblock, (
+                f"msg={msg!r} → intent={intent} → unblocks={unblocks} "
+                f"(esperaba {expected_unblock})"
+            )


### PR DESCRIPTION
## Summary

**Load-bearing fix** del bug crítico de workflow post-Paso 2 (DYSCON cambio 2 → PDF con datos viejos). Guardrail backend que bloquea `generate_documents` cuando el último mensaje del operador NO es confirmación explícita.

**C primero solo** según review feedback. A+B (keywords del card-editor + reemplazo de `_is_confirmation` heurístico) van en PR posterior, después de 24-48h de C en prod sin regresión.

## Bug

Caso DYSCON post-#415:
1. Paso 2 renderizado correcto.
2. **Cambio 1**: "flete + toma de medidas Piñero $100.000 poner 3 fletes" → recalcula OK. ✓
3. **Cambio 2**: "Armado frentín en mano de obra no va." (51 chars) → Sonnet decide `generate_documents` directo. PDF con datos viejos. ❌

Causa raíz: `_is_confirmation = len(msg) < 200` trataba mensaje corto como confirmación. Sonnet lo lee como "OK generá" y dispara docs.

## Fix

### Helper `_user_intent(msg) -> "confirm" | "modify" | "other"`

| Intent | Detección |
|---|---|
| `confirm` | Whitelist positiva: `confirmo`, `dale`, `generá`, `imprimí`, `perfecto`, `ok`, ` sí `, `yes`, `todo bien`, `aprobado`... |
| `modify` | (Imperativo + noun) OR (negación + concepto). Ej: "agregá zócalo" / "frentín no va". |
| `other` | Default conservador. Empty / ambiguo / pregunta. |

Las dos detecciones de modify son **semánticas distintas** (review feedback): una para imperativos, otra para negaciones contextuales. No mezcla.

### Guardrail en `generate_documents`

Si Paso 2 ya hecho (`total_ars` poblado) Y intent != "confirm" → bloquea con error contextual:

- **modify** → "El operador pidió una modificación. Llamá `calculate_quote`, mostrá Paso 2 nuevo, esperá confirmación EXPLÍCITA."
- **other** → "Pedí una confirmación clara antes de generar."

Try/except defensivo: si el guard falla por algún motivo, deja pasar (fallback al comportamiento antiguo).

## Casos críticos del review feedback (todos verde)

| Mensaje | Intent | Por qué |
|---|---|---|
| `Confirmo` | confirm | Whitelist |
| `OK dale, sin cambios` | **confirm** | Whitelist gana sobre "sin" |
| `Confirmo, fuera de eso todo bien` | **confirm** | Whitelist gana sobre "fuera" |
| `no va a haber cambios, generá` | **confirm** | "generá" en whitelist |
| `Armado frentín en mano de obra no va.` | **modify** | Caso DYSCON exacto |
| `El descuento del 18% no va` | **modify** | Negación + "descuento" (concepto) |
| `no va a haber problema` | **other** | Negación SIN noun → no es modify |
| `""` / whitespace / None | other | Default conservador |

## Tests (37 casos)

- 17 cases de confirm whitelist + 4 cases del review (whitelist > negación).
- 7 cases de modify (imperativo+noun, negación+concepto).
- 6 cases de other (vacío, pregunta, negación sin noun).
- 1 drift guard del contrato del guardrail.

Suite full: **1904 passing + 1 xfail** (1 fail preexistente).

## Split intencional (review feedback)

| Item | PR | Por qué |
|---|---|---|
| Guardrail generate_documents (C) | #416 (este) | Load-bearing — evita PDFs falsos |
| Card-editor keywords (A) | Después | UX — no crítico |
| `_is_confirmation` rewrite (B) | Después | Cubierto por C transitivamente |

Si A o B rompen un flow legítimo, no se llevan puesto C.

## Deuda anotada

3er caso de whack-a-mole de keywords (pileta + regrueso/material + confirm/mod). **4° caso → refactor a clasificador Haiku** ("CONFIRM | MODIFY | OTHER" con 1 call).

## Test plan

- [x] `pytest tests/test_user_intent_classifier.py -v` → 37/37.
- [x] Suite full → 1904 passing.
- [ ] CI verde.
- [ ] **Criterio de salida**: re-cotizar DYSCON →
  - Cambio 1 (flete) → recalcula como antes. ✓
  - Cambio 2 ("frentín no va") → guardrail dispara, Sonnet recalcula y muestra Paso 2 nuevo SIN frentín. NO genera PDF.
  - "Confirmo" después → genera PDF correcto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
