### PR TITLE
fix(calculator): sumar m² del regrueso al material total

### DIFF
--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -1160,8 +1160,25 @@ def calculate_quote(input_data: dict) -> dict:
         price_unit = mat_result["price_ars"]
         price_base = mat_result["price_ars_base"]
 
+    # Resolver regrueso_ml ANTES del m² total: el regrueso consume material
+    # análogo al zócalo (canto visible de 5cm de alto). PR #401 sumó la MO,
+    # pero los m² nunca se acumulaban → material subfacturado.
+    # Ver rules/calculation-formulas.md:83-88 ("SI suma m²: ml_total × alto").
+    regrueso = input_data.get("regrueso", False)
+    regrueso_ml = input_data.get("regrueso_ml", 0)
+    if regrueso and regrueso_ml <= 0:
+        for p in (pp if isinstance(pp, dict) else pp.model_dump() for pp in pieces):
+            desc = (p.get("description") or "").lower()
+            if "regrueso" in desc:
+                regrueso_ml += p.get("largo", 0)
+        if regrueso_ml <= 0:
+            regrueso_ml = 1
+
     # 2. Calculate m2
     total_m2, piece_details = calculate_m2([p if isinstance(p, dict) else p.model_dump() for p in pieces])
+    if regrueso and regrueso_ml > 0:
+        regrueso_m2 = round(regrueso_ml * 0.05, 4)
+        total_m2 = round(total_m2 + regrueso_m2, 4)
 
     # 3. Merma
     merma = calculate_merma(total_m2, mat_result.get("name", material_name), is_edificio=is_edificio)
@@ -1299,33 +1316,8 @@ def calculate_quote(input_data: dict) -> dict:
             ml_45 = round(frentin_ml * 2, 2)
             mo_items.append({"description": "Corte 45", "quantity": ml_45, "unit_price": price_45, "base_price": base_45, "total": round(price_45 * ml_45)})
 
-    # PR #401 — Regrueso (refuerzo de espesor en frentes). Análogo al
-    # frentín pero más simple:
-    #   - Único SKU "REGRUESO" en labor.json (sin variante sintético).
-    #   - No tiene CORTE45 asociado — el regrueso se pega plano al frente.
-    #   - Cobrado por metro lineal igual que el frentín.
-    #
-    # Causa raíz histórica: PR #392 introdujo el detector + apply de
-    # respuesta de regrueso en pending_questions, pero asumió que el
-    # calculator lo procesaría automáticamente. No había bloque para
-    # convertir `regrueso_ml` → mo_item, por lo que el texto fuente
-    # ("M.O. REGRUESO frente 1x60,68ml") nunca se reflejaba en el costo
-    # final. Este bloque lo cierra.
-    regrueso = input_data.get("regrueso", False)
-    regrueso_ml = input_data.get("regrueso_ml", 0)
-    if regrueso and regrueso_ml <= 0:
-        # Auto-calculate from pieces with "regrueso" en la descripción.
-        # Mismo patrón que el auto-detect del frentín (línea 1130-1136):
-        # si el operador declaró el regrueso pero no pasó ml, sumamos el
-        # largo de las piezas marcadas como tal. Fallback de 1 ml si no
-        # se encuentra ninguna — pero al menos genera la línea para que
-        # el operador la vea (vs silenciosamente perderla).
-        for p in (pp if isinstance(pp, dict) else pp.model_dump() for pp in pieces):
-            desc = (p.get("description") or "").lower()
-            if "regrueso" in desc:
-                regrueso_ml += p.get("largo", 0)
-        if regrueso_ml <= 0:
-            regrueso_ml = 1  # Fallback: at least 1 ml
+    # PR #401 — Regrueso MO. La resolución de `regrueso_ml` se hace arriba
+    # (antes del cálculo de total_m2) porque también consume material.
     if regrueso and regrueso_ml > 0:
         price, base = _get_mo_price("REGRUESO")
         ml = round(regrueso_ml, 2)

--- a/api/tests/test_regrueso_mo.py
+++ b/api/tests/test_regrueso_mo.py
@@ -165,3 +165,25 @@ class TestRegruesoRegressionGuards:
         descriptions = [m["description"].lower() for m in result["mo_items"]]
         assert any("regrueso" in d for d in descriptions)
         assert not any("armado frentín" in d or "armado frentin" in d for d in descriptions)
+
+    def test_regrueso_suma_m2_al_material(self):
+        """El regrueso consume material como un canto de 5cm de alto
+        (análogo al zócalo). `material_m2` debe incluir `regrueso_ml × 0.05`
+        — antes solo se cobraba la MO, el material quedaba subfacturado.
+
+        Caso del bug: 42.39 m² de mesadas + 60.68 ml de regrueso →
+        material_m2 esperado = 42.39 + 3.034 = 45.424."""
+        base_pieces = [{"description": "Mesada", "largo": 7.065, "prof": 6.0, "quantity": 1}]
+
+        sin = calculate_quote(_input(pieces=base_pieces))
+        con = calculate_quote(_input(pieces=base_pieces, regrueso=True, regrueso_ml=60.68))
+
+        assert sin["material_m2"] == 42.39
+        assert con["material_m2"] == 45.424, (
+            f"material_m2 debería sumar 60.68 × 0.05 = 3.034 al base. "
+            f"Obtuve {con['material_m2']}, esperaba 45.424."
+        )
+        assert con["material_total"] > sin["material_total"], (
+            "El total de material con regrueso debe ser mayor — el regrueso "
+            "consume m² adicional que se multiplica por price_unit."
+        )


### PR DESCRIPTION
## Bug

El regrueso consume material igual que el zócalo (canto visible de 5cm de alto), pero el cálculo de `total_m2` solo consideraba las piezas. PR #401 sumó la **MO** del regrueso pero los **m²** nunca se acumulaban → presupuestos subfacturados por `regrueso_ml × 0.05 × price_unit`.

**Caso reportado:** 42.39 m² (mesadas) + 60.68 ml de regrueso → cobraba 42.39 m² cuando debería cobrar **45.42 m²** (delta exacto: 60.68 × 0.05 = 3.034 m²).

## Fix

- Resuelvo `regrueso` y `regrueso_ml` (incluyendo auto-detect desde piezas) **antes** del cálculo de `total_m2` en [calculator.py:1163-1175](api/app/modules/quote_engine/calculator.py:1163).
- Sumo `regrueso_ml × 0.05` al `total_m2` justo después de `calculate_m2`, para que el aumento se propague a:
  - `merma` (sintéticos)
  - auto-discount edificio (umbral por m²)
  - `material_total = total_m2 × price_unit`
  - `colocacion` (mínimo por m²)
  - el output `material_m2` (snapshot de quote)
- El bloque MO del regrueso queda igual; solo se elimina la resolución duplicada de `regrueso_ml` que ahora vive arriba.

Constante `0.05` = 5cm de alto del canto, alineado con `rules/calculation-formulas.md:83-88` ("**SI suma m²: ml_total × alto**").

## Test plan

- [x] Suite completa: `246 passed, 3 skipped, 1 xfailed` (filtros calculator/material/regrueso/merma)
- [x] Tests existentes de `test_regrueso_mo.py`: 7/7 verdes (sin tocarlos)
- [x] Nuevo test de regresión `test_regrueso_suma_m2_al_material` en [test_regrueso_mo.py](api/tests/test_regrueso_mo.py): verifica que `material_m2` sin regrueso = 42.39 y con regrueso 60.68 ml = 45.424
- [x] Verificación end-to-end con calculator real: delta de 3.034 m² exacto

🤖 Generated with [Claude Code](https://claude.com/claude-code)