### PR TITLE
chore(observability): logs estructurados de m2-audit

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -6312,6 +6312,25 @@ class AgentService:
 
             calc_result = calculate_quote(inputs)
 
+            # PR #418 — observabilidad: log estructurado del par
+            # (material_m2, piece_details) tal como queda al salir del
+            # calculator. No toca lógica. Sirve para diagnosticar drift
+            # contra `_check_piece_m2` (validador) sin pedirle al
+            # operador un dump del breakdown desde Railway.
+            try:
+                from app.modules.quote_engine.audit import log_m2_audit
+                if calc_result.get("ok"):
+                    log_m2_audit(
+                        quote_id=save_to_qid,
+                        source="calculator",
+                        material_m2=calc_result.get("material_m2"),
+                        piece_details=calc_result.get("piece_details"),
+                    )
+            except Exception as _audit_err:
+                # La observabilidad NUNCA rompe el flow. Si el helper
+                # falla por shape inesperado, seguimos.
+                logging.debug(f"[m2-audit] post-calculate log skipped: {_audit_err}")
+
             # ── Surface variant negations from the brief (PR #10) ──────────
             # El LLM normaliza el material name antes de pasarlo a
             # calculate_quote, por lo que `_find_material` no ve frases como

--- a/api/app/modules/agent/tools/validation_tool.py
+++ b/api/app/modules/agent/tools/validation_tool.py
@@ -245,6 +245,25 @@ def _check_piece_m2(qdata: dict) -> tuple[list[str], list[str]]:
     declared_m2 = qdata.get("material_m2")
     if declared_m2 is not None:
         expected_total = round(total_m2, 2)
+
+        # PR #418 — observabilidad: log estructurado SIEMPRE, no solo
+        # cuando hay error. Así tenemos traza del happy path también
+        # (sirve para diagnosticar regresiones por comparación).
+        # MISMATCH se loguea adentro del helper si delta > 0.01.
+        try:
+            from app.modules.quote_engine.audit import log_m2_audit
+            log_m2_audit(
+                quote_id=qdata.get("quote_id"),
+                source="validator",
+                material_m2=declared_m2,
+                piece_details=pieces,
+                recomputed_total=expected_total,
+            )
+        except Exception:
+            # Observabilidad nunca rompe la validación. El error de
+            # mismatch igual se sigue acumulando abajo si corresponde.
+            pass
+
         if abs(declared_m2 - expected_total) > 0.01:
             errors.append(
                 f"material_m2={declared_m2} no coincide con suma de piezas={expected_total}"

--- a/api/app/modules/quote_engine/audit.py
+++ b/api/app/modules/quote_engine/audit.py
@@ -1,0 +1,205 @@
+"""Observabilidad de m² — logs estructurados sin tocar lógica de negocio.
+
+**Por qué existe este módulo (PR #418):**
+
+Caso DYSCON post-#416/#417: el validador rechazó `generate_documents` con
+`material_m2=48.584 no coincide con suma de piezas=45.55`. Para diagnosticar
+el RC el camino tradicional era pedirle al operador un dump del
+`quote_breakdown` desde Railway DB. Mal — la observabilidad es nuestra,
+no del operador.
+
+Este helper escribe el shape exacto que necesitamos para diagnosticar
+divergencias entre `material_m2` (lo que persiste el calculator) y
+`sum(piece.m2 × piece.quantity)` (lo que recomputa el validator).
+
+**Diseño:**
+
+- Cero side-effects fuera del logger.
+- Try/except interno: si algo falla acá, NO rompe el flow del cálculo
+  ni de la validación. La observabilidad nunca tira producción.
+- Tag estable `[m2-audit:<quote_id>]` para que `grep m2-audit` filtre
+  el ruido de Railway en un instante.
+
+**Cuándo se llama:**
+
+1. Desde `agent.py` post-`calculate_quote` (source="calculator") — captura
+   lo que el calculator persiste a la DB. Una línea por pieza con todo el
+   contexto que pediría un humano.
+2. Desde `validation_tool._check_piece_m2` (source="validator") — captura
+   lo que el validador ve y recomputa, ANTES de emitir el error. Si hay
+   delta, dispara una línea fuerte `MISMATCH`.
+
+**No reemplaza el fix.** Es la red para el próximo caso.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+
+# Campos por pieza que sí o sí queremos ver. El orden importa porque el
+# operador (o yo) lee la línea del log de izquierda a derecha buscando el
+# valor sospechoso. description primero — el shape del bug suele estar
+# correlacionado con el tipo de pieza (regrueso, frentín, override, etc.).
+_PIECE_FIELDS_PRIMARY = (
+    "description", "largo", "dim2", "quantity", "m2",
+    "override", "_is_frentin",
+)
+# Campos opcionales — solo se loguean si están presentes en la pieza.
+# Evita ruido en quotes que no usan esas marcas.
+_PIECE_FIELDS_OPTIONAL = (
+    "_derived_kind", "_pileta_inferred_by_guardrail", "prof", "alto",
+)
+
+
+def _format_piece(idx: int, piece: dict) -> str:
+    """Una línea por pieza. m2_unit y m2_total explícitos para no obligar
+    al lector a multiplicar mentalmente.
+
+    Si `piece` no es un dict (defensivo), devolvemos un placeholder en
+    vez de tirar — el log es best-effort.
+    """
+    if not isinstance(piece, dict):
+        return f"  piece[{idx}] <not-a-dict: {type(piece).__name__}>"
+
+    parts = [f"  piece[{idx}]"]
+    # Primary: siempre se loguean (con None si faltan). Sirve para detectar
+    # piezas que vienen mal-formadas — un None acá ya es señal.
+    for field in _PIECE_FIELDS_PRIMARY:
+        val = piece.get(field)
+        # description con repr para captar espacios/emojis pegados.
+        if field == "description":
+            parts.append(f"description={val!r}")
+        else:
+            parts.append(f"{field}={val}")
+
+    # Optional: solo si están en el dict. No usamos default — la presencia
+    # del campo es información en sí misma.
+    for field in _PIECE_FIELDS_OPTIONAL:
+        if field in piece:
+            parts.append(f"{field}={piece[field]!r}")
+
+    # m2_unit y m2_total derivados — para no obligar al lector a multiplicar.
+    try:
+        m2_unit = float(piece.get("m2") or 0)
+        qty = int(piece.get("quantity") or 1)
+        m2_total = round(m2_unit * qty, 4)
+        parts.append(f"m2_unit={m2_unit}")
+        parts.append(f"m2_total={m2_total}")
+    except (TypeError, ValueError):
+        parts.append("m2_unit=<unparseable>")
+        parts.append("m2_total=<unparseable>")
+
+    return " ".join(parts)
+
+
+def _sum_piece_details(pieces: Iterable[dict]) -> float:
+    """Suma `m2 × quantity` de cada pieza. Mismo cálculo que hace el
+    validador en `_check_piece_m2`, replicado acá para que el log del
+    calculator pueda mostrar la suma esperada SIN tener que correr el
+    validador. Así un log solo del calculator ya delata el mismatch.
+
+    Tolera piezas mal formadas (skip silencioso por pieza).
+    """
+    total = 0.0
+    for p in pieces or []:
+        if not isinstance(p, dict):
+            continue
+        try:
+            m2 = float(p.get("m2") or 0)
+            qty = int(p.get("quantity") or 1)
+            total += m2 * qty
+        except (TypeError, ValueError):
+            continue
+    return round(total, 2)
+
+
+def log_m2_audit(
+    quote_id: str | None,
+    source: str,
+    material_m2: float | None,
+    piece_details: list[dict] | None,
+    recomputed_total: float | None = None,
+) -> None:
+    """Emite log estructurado para auditoría de `material_m2` vs piezas.
+
+    Args:
+        quote_id: identificador de la quote. Si None, se loguea como "?"
+            (no rompemos por falta de tag).
+        source: "calculator" cuando lo llama el caller del calc result,
+            "validator" cuando lo llama `_check_piece_m2`. Determina el
+            shape del header.
+        material_m2: el valor persistido / declarado.
+        piece_details: la lista de piezas tal como quedó en el breakdown.
+        recomputed_total: solo para source="validator" — el total que
+            recomputó el validador. Si delta > 0.01, se emite también
+            la línea `MISMATCH`.
+
+    Nunca tira excepción al caller. Errores internos se loguean en debug.
+    """
+    try:
+        qid = quote_id or "?"
+        pieces = list(piece_details or [])
+
+        if source == "calculator":
+            sum_pd = _sum_piece_details(pieces)
+            header = (
+                f"[m2-audit:{qid}] calculator material_m2={material_m2} "
+                f"sum_piece_details={sum_pd} pieces={len(pieces)}"
+            )
+        elif source == "validator":
+            delta = None
+            if material_m2 is not None and recomputed_total is not None:
+                delta = round(material_m2 - recomputed_total, 4)
+            header = (
+                f"[m2-audit:{qid}] validator material_m2={material_m2} "
+                f"recomputed_total={recomputed_total} delta={delta} "
+                f"pieces={len(pieces)}"
+            )
+        else:
+            # Source desconocido — logueamos igual con shape genérico
+            # para no perder la info. No esperamos llegar acá.
+            header = (
+                f"[m2-audit:{qid}] {source} material_m2={material_m2} "
+                f"pieces={len(pieces)}"
+            )
+
+        # Construimos el bloque completo (header + piezas) y lo emitimos
+        # como UNA línea de logger.info — Railway colapsa multi-línea en
+        # el panel; mejor que sea un solo evento para que se lea junto.
+        body_lines = [header]
+        for i, p in enumerate(pieces):
+            body_lines.append(_format_piece(i, p))
+        logger.info("\n".join(body_lines))
+
+        # MISMATCH alert — línea separada para que `grep MISMATCH` la encuentre.
+        # Threshold 0.01 alineado con el tolerance del validator
+        # (`abs(declared_m2 - expected_total) > 0.01`).
+        if source == "calculator":
+            sum_pd = _sum_piece_details(pieces)
+            if material_m2 is not None and abs(material_m2 - sum_pd) > 0.01:
+                logger.warning(
+                    f"[m2-audit:{qid}] MISMATCH delta="
+                    f"{round(material_m2 - sum_pd, 4)} "
+                    f"source=calculator_vs_piece_details "
+                    f"material_m2={material_m2} sum_piece_details={sum_pd}"
+                )
+        elif source == "validator":
+            if (
+                material_m2 is not None
+                and recomputed_total is not None
+                and abs(material_m2 - recomputed_total) > 0.01
+            ):
+                logger.warning(
+                    f"[m2-audit:{qid}] MISMATCH delta="
+                    f"{round(material_m2 - recomputed_total, 4)} "
+                    f"source=stored_material_m2_vs_recomputed "
+                    f"material_m2={material_m2} recomputed={recomputed_total}"
+                )
+    except Exception as e:
+        # La observabilidad nunca rompe el flow. Si por algún motivo el
+        # piece_details viene en un shape no-iterable o algo raro, solo
+        # logueamos un debug y seguimos.
+        logger.debug(f"[m2-audit] log helper failed: {e}")

--- a/api/tests/test_m2_audit.py
+++ b/api/tests/test_m2_audit.py
@@ -1,0 +1,239 @@
+"""Tests para PR #418 — `log_m2_audit` helper.
+
+**Por qué este PR (load-bearing observability):** caso DYSCON
+post-#416/#417 mostró un mismatch entre `material_m2` (calculator) y
+suma de `piece_details` (validador). Para diagnosticar el RC había que
+pedirle al operador un dump de DB. Mal — la observabilidad es del
+sistema, no del operador.
+
+Este helper:
+- Loguea estado calculator y validator con shape uniforme.
+- Tag `[m2-audit:<quote_id>]` para `grep` rápido en Railway.
+- Línea fuerte `MISMATCH` cuando delta > 0.01.
+- NUNCA tira excepciones al caller.
+
+Tests cubren:
+- Shape del log calculator y validator.
+- MISMATCH se dispara solo cuando delta supera el threshold.
+- Tolerancia a piezas mal-formadas (None, no-dict, m2 unparseable).
+- quote_id None se renderiza como "?" sin romper.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from app.modules.quote_engine.audit import (
+    _format_piece,
+    _sum_piece_details,
+    log_m2_audit,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# _sum_piece_details — usado por el log de calculator
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestSumPieceDetails:
+    def test_basic_sum(self):
+        pieces = [
+            {"m2": 1.5, "quantity": 2},
+            {"m2": 0.6, "quantity": 1},
+        ]
+        assert _sum_piece_details(pieces) == 3.6
+
+    def test_empty(self):
+        assert _sum_piece_details([]) == 0.0
+
+    def test_none(self):
+        assert _sum_piece_details(None) == 0.0
+
+    def test_skips_non_dict(self):
+        """Pieza mal formada NO debe romper la suma."""
+        pieces = [
+            {"m2": 2.0, "quantity": 1},
+            "not-a-dict",
+            {"m2": 1.5, "quantity": 1},
+        ]
+        assert _sum_piece_details(pieces) == 3.5
+
+    def test_skips_unparseable_m2(self):
+        pieces = [
+            {"m2": "abc", "quantity": 1},  # unparseable
+            {"m2": 2.0, "quantity": 1},
+        ]
+        assert _sum_piece_details(pieces) == 2.0
+
+    def test_default_quantity_1(self):
+        """Pieza sin quantity → asume 1."""
+        pieces = [{"m2": 1.5}]
+        assert _sum_piece_details(pieces) == 1.5
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# _format_piece — shape de la línea por pieza
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestFormatPiece:
+    def test_primary_fields_present(self):
+        line = _format_piece(0, {
+            "description": "Mesada",
+            "largo": 1.5,
+            "dim2": 0.6,
+            "quantity": 2,
+            "m2": 0.9,
+            "override": False,
+            "_is_frentin": False,
+        })
+        # Todos los campos primary visibles.
+        assert "piece[0]" in line
+        assert "description='Mesada'" in line
+        assert "largo=1.5" in line
+        assert "dim2=0.6" in line
+        assert "quantity=2" in line
+        assert "m2=0.9" in line
+        assert "override=False" in line
+        assert "_is_frentin=False" in line
+        # Derivados.
+        assert "m2_unit=0.9" in line
+        assert "m2_total=1.8" in line
+
+    def test_optional_field_only_when_present(self):
+        """`_derived_kind` se loguea solo si está en la pieza."""
+        with_field = _format_piece(0, {
+            "description": "x", "largo": 1, "dim2": 1, "quantity": 1,
+            "m2": 1, "override": False, "_is_frentin": False,
+            "_derived_kind": "regrueso",
+        })
+        without_field = _format_piece(0, {
+            "description": "x", "largo": 1, "dim2": 1, "quantity": 1,
+            "m2": 1, "override": False, "_is_frentin": False,
+        })
+        assert "_derived_kind='regrueso'" in with_field
+        assert "_derived_kind" not in without_field
+
+    def test_not_a_dict_does_not_raise(self):
+        line = _format_piece(0, "not-a-dict")
+        assert "not-a-dict" in line.lower()
+        assert "piece[0]" in line
+
+    def test_unparseable_m2_does_not_raise(self):
+        line = _format_piece(0, {
+            "description": "x", "largo": 1, "dim2": 1, "quantity": 1,
+            "m2": "garbage", "override": False, "_is_frentin": False,
+        })
+        # No tira — emite placeholder.
+        assert "m2_unit=<unparseable>" in line
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# log_m2_audit — shape del header + MISMATCH
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestLogM2Audit:
+    def test_calculator_header_shape(self, caplog):
+        with caplog.at_level(logging.INFO, logger="app.modules.quote_engine.audit"):
+            log_m2_audit(
+                quote_id="abc-123",
+                source="calculator",
+                material_m2=10.5,
+                piece_details=[
+                    {"description": "M1", "largo": 1, "dim2": 1, "quantity": 1, "m2": 10.5, "override": False, "_is_frentin": False},
+                ],
+            )
+        msgs = [r.message for r in caplog.records]
+        full = "\n".join(msgs)
+        assert "[m2-audit:abc-123]" in full
+        assert "calculator" in full
+        assert "material_m2=10.5" in full
+        assert "sum_piece_details=10.5" in full
+        assert "pieces=1" in full
+
+    def test_validator_header_shape(self, caplog):
+        with caplog.at_level(logging.INFO, logger="app.modules.quote_engine.audit"):
+            log_m2_audit(
+                quote_id="abc-123",
+                source="validator",
+                material_m2=10.5,
+                piece_details=[
+                    {"description": "M1", "largo": 1, "dim2": 1, "quantity": 1, "m2": 10.5, "override": False, "_is_frentin": False},
+                ],
+                recomputed_total=10.5,
+            )
+        full = "\n".join(r.message for r in caplog.records)
+        assert "[m2-audit:abc-123]" in full
+        assert "validator" in full
+        assert "recomputed_total=10.5" in full
+        assert "delta=0.0" in full
+
+    def test_mismatch_calculator_emits_warning(self, caplog):
+        """material_m2 != sum(piece_details) → línea MISMATCH warning."""
+        with caplog.at_level(logging.INFO, logger="app.modules.quote_engine.audit"):
+            log_m2_audit(
+                quote_id="dyscon",
+                source="calculator",
+                material_m2=48.58,  # como en el caso real
+                piece_details=[
+                    {"description": "x", "largo": 1, "dim2": 1, "quantity": 1, "m2": 45.55, "override": False, "_is_frentin": False},
+                ],
+            )
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("MISMATCH" in w.message for w in warnings), \
+            f"esperaba MISMATCH warning, vi: {[w.message for w in warnings]}"
+        msg = next(w.message for w in warnings if "MISMATCH" in w.message)
+        assert "delta=" in msg
+        assert "calculator_vs_piece_details" in msg
+
+    def test_mismatch_validator_emits_warning(self, caplog):
+        with caplog.at_level(logging.INFO, logger="app.modules.quote_engine.audit"):
+            log_m2_audit(
+                quote_id="dyscon",
+                source="validator",
+                material_m2=48.584,
+                piece_details=[
+                    {"description": "x", "largo": 1, "dim2": 1, "quantity": 1, "m2": 45.55, "override": False, "_is_frentin": False},
+                ],
+                recomputed_total=45.55,
+            )
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("MISMATCH" in w.message for w in warnings)
+        msg = next(w.message for w in warnings if "MISMATCH" in w.message)
+        assert "stored_material_m2_vs_recomputed" in msg
+        assert "delta=" in msg
+
+    def test_no_mismatch_within_tolerance(self, caplog):
+        """delta <= 0.01 → NO emite MISMATCH (alineado con validator)."""
+        with caplog.at_level(logging.INFO, logger="app.modules.quote_engine.audit"):
+            log_m2_audit(
+                quote_id="x",
+                source="calculator",
+                material_m2=10.005,
+                piece_details=[
+                    {"description": "p", "largo": 1, "dim2": 1, "quantity": 1, "m2": 10.0, "override": False, "_is_frentin": False},
+                ],
+            )
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert not any("MISMATCH" in w.message for w in warnings)
+
+    def test_quote_id_none_renders_as_question_mark(self, caplog):
+        with caplog.at_level(logging.INFO, logger="app.modules.quote_engine.audit"):
+            log_m2_audit(
+                quote_id=None,
+                source="calculator",
+                material_m2=1.0,
+                piece_details=[],
+            )
+        full = "\n".join(r.message for r in caplog.records)
+        assert "[m2-audit:?]" in full
+
+    def test_helper_never_raises(self):
+        """Garbage input no debe romper. Es observabilidad, no negocio."""
+        # Llamadas con shapes inesperados — todas deben retornar None.
+        log_m2_audit(quote_id=None, source="calculator", material_m2=None, piece_details=None)
+        log_m2_audit(quote_id="x", source="unknown", material_m2="not-a-number", piece_details="not-a-list")
+        log_m2_audit(quote_id="x", source="calculator", material_m2=1, piece_details=[None, "garbage", 42])
+        # Si llegamos acá sin excepción, OK.


### PR DESCRIPTION
## Summary

**Observabilidad antes que fix.** Caso DYSCON post-#416/#417: validador rechazó `generate_documents` con `material_m2=48.584 no coincide con suma de piezas=45.55`. Para diagnosticar el RC había que pedirle al operador un dump de DB — mal.

Este PR agrega logs estructurados en los dos puntos clave (calculator output y validator check). Cuando vuelva a pasar, los logs lo dicen sin SQL.

**Cero cambios de lógica.** Solo logs.

## Cambios

### 1. `audit.py` nuevo módulo
- `log_m2_audit(quote_id, source, material_m2, piece_details, recomputed_total)`.
- Tag estable `[m2-audit:<quote_id>]` para `grep` rápido en Railway.
- Por pieza loguea: `description, largo, dim2, quantity, m2, override, _is_frentin` (+ `_derived_kind` opcional), más `m2_unit` y `m2_total` derivados.
- MISMATCH `WARNING` cuando `delta > 0.01` (mismo threshold que el validator).
- Try/except total: observabilidad nunca rompe el flow.

### 2. `agent.py:6315` — post-`calculate_quote`
- Llama log con `source="calculator"`. Captura el estado que el calculator persiste a la DB.

### 3. `validation_tool._check_piece_m2`
- Llama log con `source="validator"`. **Loguea siempre** (no solo en error) para tener baseline del happy path.
- El check de error sigue igual — el log es additivo antes.

## Cómo se lee un mismatch

```
$ railway logs | grep "m2-audit"
[m2-audit:60f8d5de-...] calculator material_m2=48.584 sum_piece_details=45.55 pieces=27
  piece[0] description='Mesada' largo=2.34 dim2=0.62 quantity=4 m2=1.45 override=False _is_frentin=False m2_unit=1.45 m2_total=5.8
  piece[1] ...
[m2-audit:60f8d5de-...] MISMATCH delta=3.034 source=calculator_vs_piece_details ...
[m2-audit:60f8d5de-...] validator material_m2=48.584 recomputed_total=45.55 delta=3.034 pieces=27
  piece[0] ...
[m2-audit:60f8d5de-...] MISMATCH delta=3.034 source=stored_material_m2_vs_recomputed ...
```

Con esto se identifica en segundos si el drift es:
- **override/grouping** — alguna pieza con `m2` inflado / agrupación rara.
- **piece mutation** — validator ve distinto que calculator (mismo `quote_id` pero piece_details diferentes).
- **source divergence** — `material_m2` no viene de `calculate_m2` (ej. edificio_parser u otro path).

## Tests (17 casos en `test_m2_audit.py`)

- Shape de header calculator y validator.
- MISMATCH dispara solo cuando `delta > 0.01`.
- Tolera piezas mal-formadas (None, no-dict, m2 unparseable).
- `quote_id=None` se renderiza como `?` sin romper.
- Helper nunca tira excepción (test exhaustivo de garbage input).

Suite full: **2257 passing** (+17 nuevos). 16 fallos preexistentes en `tests/evaluation/` y `test_edificio_render.py` (mismos en main sin este PR — verificado con `git stash`).

## Lo que NO toca

- Calculator: ningún cambio. Solo lectura desde el caller.
- Validator: el log es additivo antes del check, el check sigue igual.
- Frontend, prompts, schemas de tools, catálogos: intactos.

## Test plan

- [x] `pytest tests/test_m2_audit.py -v` → 17/17.
- [x] Suite full → 2257 passing (+17 vs main, 0 regresiones).
- [ ] CI verde.
- [ ] **Criterio de salida**: cualquier `calculate_quote` real en prod debería emitir UNA línea `[m2-audit:<qid>] calculator ...` en Railway. Cualquier `generate_documents` debería emitir UNA línea `[m2-audit:<qid>] validator ...`. El próximo caso de mismatch dispara `MISMATCH` y resuelve el RC sin pedir DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)