### PR TITLE
fix(calculator): double-count del regrueso (regression #417, caso DYSCON)

### DIFF
--- a/api/app/modules/agent/tools/validation_tool.py
+++ b/api/app/modules/agent/tools/validation_tool.py
@@ -40,6 +40,7 @@ def validate_despiece(qdata: dict) -> ValidationResult:
         _check_piece_m2,
         _check_mo_item_totals,
         _check_colocacion_qty,
+        _check_regrueso_consistency,  # PR #419 — detecta double-count
     ):
         try:
             errors, warnings = check(qdata)
@@ -328,4 +329,96 @@ def _check_colocacion_qty(qdata: dict) -> tuple[list[str], list[str]]:
             return errors, warnings
 
     warnings.append("Colocación=True pero no se encontró ítem MO de colocación")
+    return errors, warnings
+
+
+# Tolerancia para el check de consistencia regrueso. 5 cm² = 0.05 m².
+# Calibrada para regrueso_ml >= 30 (típico DYSCON-scale: ~60 ml → ~3 m²
+# expected → 1.7% slack relativo, $$ ruido <$15K).
+#
+# TOLERANCIA: 0.05 m² absoluto. Calibrado para regrueso_ml >= 30.
+# Proyectos chicos (regrueso_ml=10 → expected 0.5 m²) tienen 10% slack
+# relativo, pero riesgo monetario absoluto bajo (~$9K máx).
+# Si aparece caso de undercount en proyecto chico, migrar a
+# `max(0.05, 0.02 * expected)` (relativo o absoluto, lo que sea mayor).
+# YAGNI hasta que aparezca el caso.
+_REGRUESO_CONSISTENCY_TOLERANCE_M2 = 0.05
+
+
+def _check_regrueso_consistency(qdata: dict) -> tuple[list[str], list[str]]:
+    """Verifica consistencia entre `regrueso_ml` y suma de m² de las
+    piezas regrueso en `piece_details`.
+
+    **Por qué es ruidoso (errors, no warnings):** caso espejo del
+    DYSCON post-#417 — operador declara `regrueso_ml=60.68` pero
+    incluye solo 5 de 7 piezas regrueso en el despiece (suman 2.17 m²
+    vs expected 3.034 m²). Si fuera silencioso (skip cuantitativo),
+    el cliente termina subfacturado ~$193K sin que nadie se entere
+    en 3 semanas. Errores ruidosos > undercount silencioso.
+
+    Lógica:
+
+    1. Si no hay `regrueso=True` o `regrueso_ml<=0` → no aplica.
+    2. Si `pieces_regrueso_m2 < 0.001` → caso #417 original (regrueso
+       declarado SIN piezas) → calculator ya sumó `regrueso_ml × 0.05`
+       al total. NO chequeamos consistencia (no hay nada que comparar).
+    3. Si hay piezas regrueso en piece_details:
+       - Comparar `sum(piece.m2 × qty for piece regrueso)` vs
+         `regrueso_ml × 0.05`.
+       - Si delta supera la tolerancia (0.05 m²) → error ruidoso.
+       - Si dentro de tolerancia → ok, calculator no double-counteó.
+
+    Tolerancia documentada arriba (`_REGRUESO_CONSISTENCY_TOLERANCE_M2`).
+    """
+    errors, warnings = [], []
+    if not qdata.get("regrueso"):
+        return errors, warnings
+    regrueso_ml = qdata.get("regrueso_ml") or 0
+    try:
+        regrueso_ml = float(regrueso_ml)
+    except (TypeError, ValueError):
+        return errors, warnings
+    if regrueso_ml <= 0:
+        return errors, warnings
+
+    # Import local para no acoplar el módulo a quote_engine en import
+    # time. El validator ya importa otras cosas de quote_engine si fuera
+    # necesario; esta es la única vez que toca regrueso_detect.
+    try:
+        from app.modules.quote_engine.regrueso_detect import sum_regrueso_pieces_m2
+    except Exception as exc:
+        warnings.append(
+            f"_check_regrueso_consistency: no se pudo cargar regrueso_detect: {exc}"
+        )
+        return errors, warnings
+
+    pieces = qdata.get("piece_details") or []
+    pieces_regrueso_m2 = sum_regrueso_pieces_m2(pieces)
+
+    if pieces_regrueso_m2 < 0.001:
+        # Caso #417 baseline: regrueso declarado sin piezas en despiece.
+        # Calculator ya sumó `regrueso_ml × 0.05` al total. No tenemos
+        # contra qué comparar — confiamos en el declarado.
+        return errors, warnings
+
+    expected_m2 = round(regrueso_ml * 0.05, 4)
+    # Redondeo a 4 decimales del delta antes de comparar — sin esto el
+    # boundary `delta == 0.05` es indeterminado por float imprecision
+    # (`abs(0.25 - 0.2)` da 0.04999999999999998 en Python). Con round
+    # el comparador `>` es estable y un cambio futuro a `>=` se
+    # detecta en los tests de boundary.
+    delta = round(abs(pieces_regrueso_m2 - expected_m2), 4)
+    if delta > _REGRUESO_CONSISTENCY_TOLERANCE_M2:
+        # Error ruidoso — bloquea generate_documents. El operador
+        # tiene que decidir: o declaró mal el despiece (faltan piezas
+        # regrueso) o regrueso_ml está mal. NO elegimos por él.
+        errors.append(
+            f"Inconsistencia regrueso: piezas con 'regrueso' en "
+            f"description suman {pieces_regrueso_m2:.4f} m² pero "
+            f"regrueso_ml={regrueso_ml} × 0.05 = {expected_m2:.4f} m². "
+            f"Delta {delta:.4f} m² supera tolerancia "
+            f"{_REGRUESO_CONSISTENCY_TOLERANCE_M2}. "
+            f"O faltan piezas regrueso en el despiece, o regrueso_ml "
+            f"está mal. Confirmar con operador."
+        )
     return errors, warnings

--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -1177,8 +1177,31 @@ def calculate_quote(input_data: dict) -> dict:
     # 2. Calculate m2
     total_m2, piece_details = calculate_m2([p if isinstance(p, dict) else p.model_dump() for p in pieces])
     if regrueso and regrueso_ml > 0:
-        regrueso_m2 = round(regrueso_ml * 0.05, 4)
-        total_m2 = round(total_m2 + regrueso_m2, 4)
+        # PR #419 — fix double-count del regrueso (regression del #417).
+        # Si el operador declaró las piezas "frente regrueso" en el
+        # despiece (caso DYSCON), `calculate_m2` YA las incluyó en
+        # `total_m2`. Sumar `regrueso_ml × 0.05` encima generaba
+        # double-count → cobraba ~3 m² × $224.825 = $675K de más.
+        #
+        # Estrategia: si HAY piezas regrueso en piece_details, no
+        # sumar extra (ya están). El validator
+        # `_check_regrueso_consistency` chequea ruidosamente que la
+        # suma de pieces regrueso ≈ regrueso_ml × 0.05 (tolerancia
+        # 0.05 m²) — si difieren, error y bloquea generate_documents.
+        # NO elegimos silenciosamente — la subfacturación silenciosa
+        # (5 de 7 piezas declaradas, suman 2.17 m² vs expected 3.034)
+        # es peor que el sobrecount ruidoso.
+        from app.modules.quote_engine.regrueso_detect import sum_regrueso_pieces_m2
+        _pieces_regrueso_m2 = sum_regrueso_pieces_m2(piece_details)
+        if _pieces_regrueso_m2 < 0.001:
+            # Caso #417 original: regrueso declarado SIN piezas en el
+            # despiece → sumar el extra para que afecte material total,
+            # merma y discount edificio.
+            regrueso_m2 = round(regrueso_ml * 0.05, 4)
+            total_m2 = round(total_m2 + regrueso_m2, 4)
+        # else: piezas regrueso ya en piece_details → total_m2 las
+        # incluye. La validación de consistencia es responsabilidad
+        # del validator (ruidoso, no acá).
 
     # 3. Merma
     merma = calculate_merma(total_m2, mat_result.get("name", material_name), is_edificio=is_edificio)

--- a/api/app/modules/quote_engine/regrueso_detect.py
+++ b/api/app/modules/quote_engine/regrueso_detect.py
@@ -1,0 +1,128 @@
+"""Detección de piezas regrueso en piece_details.
+
+**Por qué este módulo existe (PR #419):**
+
+El #417 introdujo un double-count del m² del regrueso cuando el operador
+declaraba las piezas "frente regrueso" en el despiece (caso DYSCON):
+`calculate_m2(pieces)` ya las incluía, y el #417 sumaba además
+`regrueso_ml × 0.05` encima → cobraba ~3 m² × $224.825 = $675K de más.
+
+El primer instinto fue `"regrueso" in description.lower()` — substring
+match. Frágil de los dos lados:
+
+- **False positive**: "Frente sin regrueso" → matchearía como pieza
+  regrueso → calculator skipearía la suma del extra → undercount
+  silencioso (peor que el sobrecount, que al menos lo agarra el
+  validator de m²).
+- **False negative**: "FR" abreviado → no matchea — fail loud vía
+  validator (delta > 0.05) cuando aparezca el caso.
+
+Por eso vive en su propio módulo — la lógica es lo bastante delicada
+como para no inlineearla en calculator + validator. Y deja un único
+lugar donde refactorizar cuando se migre a un campo estructurado
+`is_regrueso: bool` en piece_details (deuda anotada como Issue A
+en el PR #419).
+
+**Convenciones de matching:**
+
+- Word boundary (`\bregrueso\b`) — "regruesoadicional" no matchea por
+  accidente, "regrueso" como palabra suelta sí.
+- Negación previa: "sin regrueso", "no incluye regrueso",
+  "no lleva regrueso", "no tiene regrueso", "no va regrueso" → NO match.
+
+**Edge cases conocidos** (NO se manejan acá, fallan loud vía validator
+o se documentan como deuda):
+
+- "regrueso: no" / "regrueso=no" → matchea positivo (negación posterior,
+  no antes). Probabilidad bajísima en lenguaje real de operador
+  marmolería; si aparece, validator lo agarra como mismatch ruidoso.
+- "sin frente regrueso" → matchea positivo (la negación califica al
+  frente, no al regrueso). Ambiguo semánticamente — el operador
+  tendría que aclarar.
+- "FR", "Frente regr." y abreviaturas → NO matchean. Validator
+  detectará el mismatch entre `regrueso_ml × 0.05` y la suma de
+  pieces y emitirá error ruidoso.
+
+Ninguno justifica complicar el regex. Si aparece un caso real, abrimos
+issue específico — por ahora YAGNI.
+"""
+from __future__ import annotations
+
+import re
+
+# Word boundary para evitar matches accidentales como "regruesoX".
+# IGNORECASE para que "REGRUESO" mayúscula también matchee.
+_REGRUESO_RE = re.compile(r'\bregrueso\b', re.IGNORECASE)
+
+# Negación previa: la palabra "regrueso" precedida por "sin" o "no
+# (incluye|lleva|tiene|va)" cuenta como NEGATIVA. Solo aplica cuando
+# la negación está INMEDIATAMENTE antes — construcciones invertidas
+# tipo "regrueso: no" no se detectan acá (ver edge cases en docstring
+# del módulo). Mantener simple — el validator atrapa lo que pase.
+_NEG_REGRUESO_RE = re.compile(
+    r'\b(sin|no(?:\s+(?:incluye|lleva|tiene|va))?)\s+regrueso\b',
+    re.IGNORECASE,
+)
+
+
+def is_regrueso_piece(piece: dict) -> bool:
+    """¿Esta pieza es un "frente regrueso" o equivalente?
+
+    True si la description contiene "regrueso" como palabra entera
+    SIN una negación inmediatamente antes.
+
+    Args:
+        piece: dict de piece_details con clave "description".
+
+    Returns:
+        True si es pieza regrueso, False si no o si la pieza no tiene
+        description.
+
+    Examples:
+        >>> is_regrueso_piece({"description": "M1 frente regrueso"})
+        True
+        >>> is_regrueso_piece({"description": "Frente sin regrueso"})
+        False
+        >>> is_regrueso_piece({"description": "Mesada"})
+        False
+        >>> is_regrueso_piece({})
+        False
+    """
+    if not isinstance(piece, dict):
+        return False
+    desc = piece.get("description") or ""
+    if not isinstance(desc, str) or not desc:
+        return False
+    # Negación previa gana — chequear primero.
+    if _NEG_REGRUESO_RE.search(desc):
+        return False
+    return bool(_REGRUESO_RE.search(desc))
+
+
+def sum_regrueso_pieces_m2(piece_details: list[dict] | None) -> float:
+    """Suma `m2 × quantity` de las piezas que matchean is_regrueso_piece.
+
+    Helper único compartido entre calculator (decisión de double-count)
+    y validator (check de consistencia ruidoso). Si la lógica de
+    matching cambia, ambas partes la heredan en sincro.
+
+    Tolera piece_details None / lista vacía / piezas mal-formadas
+    (skip silencioso por pieza — la observabilidad es del audit log,
+    no de este helper).
+
+    Returns:
+        Suma redondeada a 4 decimales. 0.0 si no hay piezas regrueso.
+    """
+    if not piece_details:
+        return 0.0
+    total = 0.0
+    for p in piece_details:
+        if not is_regrueso_piece(p):
+            continue
+        try:
+            m2 = float(p.get("m2") or 0)
+            qty = int(p.get("quantity") or 1)
+            total += m2 * qty
+        except (TypeError, ValueError):
+            continue
+    return round(total, 4)

--- a/api/tests/test_regrueso_double_count.py
+++ b/api/tests/test_regrueso_double_count.py
@@ -1,0 +1,422 @@
+"""Tests para PR #419 — fix double-count del regrueso (regression #417).
+
+**Contexto del bug** (caso DYSCON observado en logs `9da51080-...`):
+
+El #417 sumaba `regrueso_ml × 0.05` al `total_m2` siempre que `regrueso=True`.
+Pero cuando el operador declaraba las piezas "frente regrueso" en el
+despiece (con `prof=0.05`), `calculate_m2` ya las contabilizaba.
+Resultado: double-count de 3.034 m² × $224.825 = **$675K cobrados de
+más al cliente**.
+
+**El caso espejo (peor)**: si fixeáramos con `any(regrueso in piece) →
+skip` (binario), un operador que declara 5 de 7 piezas regrueso
+generaría undercount silencioso (~0.86 m² faltantes = ~$193K menos
+cobrados) que nadie detecta hasta que el cliente compara ml vs m²
+facturados.
+
+**Estrategia (review feedback):**
+
+1. Calculator (`regrueso_detect.is_regrueso_piece` + branch en
+   `calculate_quote`): si HAY piezas regrueso → no sumar extra (ya
+   están). Si NO hay → sumar `regrueso_ml × 0.05` (caso #417 original).
+2. Validator (`_check_regrueso_consistency`): chequea cuantitativamente
+   que `sum(regrueso pieces m²) ≈ regrueso_ml × 0.05` con tolerancia
+   0.05 m². Si difiere → error RUIDOSO que bloquea generate_documents.
+
+**Tests cubren:**
+
+1. DYSCON exact (caso real del log) → no double-count, validator verde.
+2. Subfacturación silenciosa (5 de 7 pieces) → ERROR ruidoso.
+3. False positive "Frente sin regrueso" → no matchea, calc suma extra.
+4. Boundary delta=0.05 exacto → pasa (no error).
+5. Boundary delta=0.0501 → error.
+6. Caso #417 baseline (regrueso_ml SIN pieces regrueso) → suma extra.
+7. regrueso_ml=0 + pieces regrueso → no aplica check, pieces normal.
+8. regrueso=False + regrueso_ml positivo → no aplica nada.
+9. Drift guard de la API pública (importable + signature estable).
+
+**Nota crítica para futuros refactores:**
+
+Si tocás este archivo y removés cualquier test, **leé primero el bug
+DYSCON original**. El test #2 (subfacturación silenciosa) NO ES
+OPCIONAL — sin él, una implementación binaria del fix se cuela y
+abre el caso espejo del bug original.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.modules.quote_engine.calculator import calculate_quote
+from app.modules.quote_engine.regrueso_detect import (
+    is_regrueso_piece,
+    sum_regrueso_pieces_m2,
+)
+from app.modules.agent.tools.validation_tool import (
+    _check_regrueso_consistency,
+    validate_despiece,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Helpers — armar el qdata mínimo para el validator sin pasar por
+# calculate_quote (más rápido y aísla la lógica del check).
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _qdata(regrueso=True, regrueso_ml=60.68, pieces=None) -> dict:
+    """qdata mínimo para invocar `_check_regrueso_consistency` directo."""
+    return {
+        "regrueso": regrueso,
+        "regrueso_ml": regrueso_ml,
+        "piece_details": pieces or [],
+    }
+
+
+def _piece(desc: str, m2: float, qty: int = 1, **extra) -> dict:
+    """Pieza mínima de piece_details."""
+    return {
+        "description": desc,
+        "m2": m2,
+        "quantity": qty,
+        "largo": 1.0,
+        "dim2": m2,  # placeholder, no validamos largo×dim2 acá
+        **extra,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# is_regrueso_piece — word boundary + negación
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestIsRegruesoPiece:
+    @pytest.mark.parametrize("desc", [
+        "Frente regrueso",
+        "M1 frente regrueso",
+        "REGRUESO",
+        "regrueso del frente h:5cm",
+        "M3 frente regrueso (Office 12)",
+    ])
+    def test_positive(self, desc):
+        assert is_regrueso_piece({"description": desc}) is True
+
+    @pytest.mark.parametrize("desc", [
+        "Frente sin regrueso",
+        "Mesada sin regrueso",
+        "no incluye regrueso",
+        "no lleva regrueso",
+        "no tiene regrueso",
+        "no va regrueso",
+    ])
+    def test_negation_wins(self, desc):
+        """'sin regrueso', 'no incluye regrueso' etc. → NO matchea como pieza."""
+        assert is_regrueso_piece({"description": desc}) is False
+
+    @pytest.mark.parametrize("desc", [
+        "Mesada",
+        "Zócalo lateral",
+        "Pileta empotrada",
+        "regruesoadicional",  # word boundary: NO matchea sin espacio
+        "",
+    ])
+    def test_negative(self, desc):
+        assert is_regrueso_piece({"description": desc}) is False
+
+    def test_no_description(self):
+        assert is_regrueso_piece({}) is False
+        assert is_regrueso_piece({"description": None}) is False
+
+    def test_not_a_dict(self):
+        """Defensive — no rompe con shape inesperado."""
+        assert is_regrueso_piece(None) is False
+        assert is_regrueso_piece("not-a-dict") is False
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# sum_regrueso_pieces_m2 — helper compartido calc + validator
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestSumRegruesoPiecesM2:
+    def test_dyscon_exact(self):
+        """Caso real DYSCON: 7 piezas regrueso, sum_total ≈ 3.034 m²."""
+        pieces = [
+            _piece("M1 frente regrueso", m2=0.10, qty=24),  # 2.40
+            _piece("M2 frente regrueso", m2=0.085, qty=1),  # 0.085
+            _piece("M3 frente regrueso", m2=0.125, qty=1),  # 0.125
+            _piece("M4 frente regrueso", m2=0.125, qty=1),  # 0.125
+            _piece("M5 frente regrueso", m2=0.09, qty=1),   # 0.09
+            _piece("M6 frente regrueso", m2=0.08, qty=2),   # 0.16
+            _piece("M7 frente regrueso", m2=0.08, qty=2),   # 0.16
+        ]
+        # 2.40 + 0.085 + 0.125 + 0.125 + 0.09 + 0.16 + 0.16 = 3.145
+        # (los m2 redondeados a 2 decimales del log real dan ~3.145).
+        result = sum_regrueso_pieces_m2(pieces)
+        assert 3.0 <= result <= 3.2, f"esperaba ~3.1, vi {result}"
+
+    def test_skips_non_regrueso(self):
+        pieces = [
+            _piece("Mesada", m2=2.0, qty=1),
+            _piece("Frente regrueso", m2=0.5, qty=2),
+            _piece("Zócalo", m2=0.3, qty=1),
+        ]
+        assert sum_regrueso_pieces_m2(pieces) == 1.0  # solo 0.5 × 2
+
+    def test_skips_negation(self):
+        """'Frente sin regrueso' NO se cuenta."""
+        pieces = [
+            _piece("Frente sin regrueso", m2=0.5, qty=1),
+            _piece("Frente regrueso", m2=0.3, qty=1),
+        ]
+        assert sum_regrueso_pieces_m2(pieces) == 0.3
+
+    def test_empty(self):
+        assert sum_regrueso_pieces_m2([]) == 0.0
+        assert sum_regrueso_pieces_m2(None) == 0.0
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# _check_regrueso_consistency — validator ruidoso
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestRegruesoConsistencyCheck:
+    # ── 1. DYSCON exact ──────────────────────────────────────────────
+    def test_dyscon_exact_passes(self):
+        """Caso real: regrueso_ml=60.68, pieces ~3.034 m². Dentro de
+        tolerancia → no error."""
+        # Construyo pieces que sumen exacto regrueso_ml × 0.05 = 3.034.
+        # 7 pieces con largos del DYSCON real.
+        pieces = [
+            _piece("M1 frente regrueso", m2=1.92 * 0.05, qty=24),  # 2.304
+            _piece("M2 frente regrueso", m2=1.7 * 0.05, qty=1),    # 0.085
+            _piece("M3 frente regrueso", m2=2.5 * 0.05, qty=1),    # 0.125
+            _piece("M4 frente regrueso", m2=2.5 * 0.05, qty=1),    # 0.125
+            _piece("M5 frente regrueso", m2=1.8 * 0.05, qty=1),    # 0.09
+            _piece("M6 frente regrueso", m2=1.55 * 0.05, qty=2),   # 0.155
+            _piece("M7 frente regrueso", m2=1.5 * 0.05, qty=2),    # 0.15
+        ]
+        # Suma = 2.304 + 0.085 + 0.125 + 0.125 + 0.09 + 0.155 + 0.15 = 3.034
+        errors, _ = _check_regrueso_consistency(_qdata(
+            regrueso=True, regrueso_ml=60.68, pieces=pieces,
+        ))
+        assert errors == [], f"esperaba sin errores, vi {errors}"
+
+    # ── 2. Subfacturación silenciosa (CRÍTICO — no borrar este test) ──
+    def test_undercount_emits_loud_error(self):
+        """Operador declara 5 de 7 piezas regrueso + regrueso_ml=60.68.
+        Pieces suman ~2.17 m² vs expected 3.034 m². Delta 0.86 supera
+        tolerancia 0.05 → ERROR RUIDOSO. Si este test pasa con un fix
+        que silencia la inconsistencia, el bug del caso espejo está
+        abierto y un cliente pagaría ~$193K menos."""
+        pieces = [
+            _piece("M1 frente regrueso", m2=1.92 * 0.05, qty=24),  # 2.304
+            _piece("M2 frente regrueso", m2=1.7 * 0.05, qty=1),    # 0.085
+            # M3, M4, M5 OMITIDOS — operador se olvidó.
+            _piece("M6 frente regrueso", m2=1.55 * 0.05, qty=2),   # 0.155
+            _piece("M7 frente regrueso", m2=1.5 * 0.05, qty=2),    # 0.15
+        ]
+        # Suma ~2.694, expected 3.034, delta ~0.34 → error.
+        errors, _ = _check_regrueso_consistency(_qdata(
+            regrueso=True, regrueso_ml=60.68, pieces=pieces,
+        ))
+        assert len(errors) == 1, f"esperaba 1 error, vi {errors}"
+        assert "Inconsistencia regrueso" in errors[0]
+        assert "Confirmar con operador" in errors[0]
+
+    # ── 3. False positive "sin regrueso" ─────────────────────────────
+    def test_false_positive_sin_regrueso(self):
+        """Pieza con 'sin regrueso' en description NO debe contar como
+        pieza regrueso. Si el operador declara `regrueso_ml=60.68` y
+        las piezas son "Frente sin regrueso", el calculator debe sumar
+        el extra normal — no skipearlo por false positive."""
+        pieces = [
+            _piece("Mesada principal", m2=1.0, qty=1),
+            _piece("Frente sin regrueso", m2=0.5, qty=1),
+        ]
+        # pieces_regrueso_m2 = 0 → caso baseline #417. No error.
+        errors, _ = _check_regrueso_consistency(_qdata(
+            regrueso=True, regrueso_ml=60.68, pieces=pieces,
+        ))
+        assert errors == []
+
+    # ── 4. Boundary delta = 0.05 exacto → pasa ──────────────────────
+    def test_boundary_delta_exact_005_passes(self):
+        """`delta == 0.05` con check `> 0.05` debe pasar (no error).
+        Si alguien cambia `>` por `>=` en 6 meses, este test lo agarra."""
+        # regrueso_ml=20 → expected = 1.0
+        # pieces suman 1.05 → delta = 0.05 exacto.
+        pieces = [_piece("Frente regrueso", m2=1.05, qty=1)]
+        errors, _ = _check_regrueso_consistency(_qdata(
+            regrueso=True, regrueso_ml=20.0, pieces=pieces,
+        ))
+        assert errors == [], f"delta=0.05 exacto debería pasar, vi {errors}"
+
+    # ── 5. Boundary delta = 0.0501 → error ─────────────────────────
+    def test_boundary_delta_above_005_fails(self):
+        """`delta > 0.05` (apenas) debe disparar error."""
+        # regrueso_ml=20 → expected = 1.0
+        # pieces suman 1.0501 → delta = 0.0501 > tolerancia 0.05.
+        pieces = [_piece("Frente regrueso", m2=1.0501, qty=1)]
+        errors, _ = _check_regrueso_consistency(_qdata(
+            regrueso=True, regrueso_ml=20.0, pieces=pieces,
+        ))
+        assert len(errors) == 1, \
+            f"delta=0.0501 debería fallar, vi {errors}"
+
+    # ── 6. Caso #417 baseline ──────────────────────────────────────
+    def test_417_baseline_no_pieces_regrueso(self):
+        """regrueso_ml declarado SIN piezas regrueso en despiece →
+        no error (no hay nada que comparar). El calculator suma el
+        extra al total. Comportamiento original del #417."""
+        pieces = [
+            _piece("Mesada", m2=2.5, qty=1),
+            _piece("Zócalo", m2=0.5, qty=1),
+        ]
+        errors, _ = _check_regrueso_consistency(_qdata(
+            regrueso=True, regrueso_ml=60.68, pieces=pieces,
+        ))
+        assert errors == []
+
+    # ── 7. regrueso_ml=0 con pieces regrueso ────────────────────────
+    def test_regrueso_ml_zero_skips_check(self):
+        """`regrueso_ml=0` → check no aplica aunque haya pieces regrueso.
+        El operador no declaró el ml total — no hay contra qué comparar."""
+        pieces = [_piece("Frente regrueso", m2=2.0, qty=1)]
+        errors, _ = _check_regrueso_consistency(_qdata(
+            regrueso=True, regrueso_ml=0, pieces=pieces,
+        ))
+        assert errors == []
+
+    # ── 8. regrueso=False + regrueso_ml positivo ───────────────────
+    def test_regrueso_flag_false_skips_check(self):
+        """`regrueso=False` → check no aplica, sin importar regrueso_ml
+        o pieces."""
+        pieces = [_piece("Frente regrueso", m2=2.0, qty=1)]
+        errors, _ = _check_regrueso_consistency(_qdata(
+            regrueso=False, regrueso_ml=60.68, pieces=pieces,
+        ))
+        assert errors == []
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Calculator — no double-count cuando hay pieces regrueso
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestCalculatorDoubleCountFix:
+    def test_dyscon_real_input_no_double_count(self):
+        """Reproduce el input real del log DYSCON post-#417. El bug
+        original mostraba `material_m2=48.584 vs sum_pieces=45.55`
+        (delta 3.034). Post-fix: deben coincidir dentro de 0.01."""
+        result = calculate_quote({
+            "material": "GRANITO GRIS MARA EXTRA 2 ESP",
+            "client_name": "DYSCON S.A.",
+            "project": "Unidad Penal N°8 — Piñero",
+            "plazo": "30 días",
+            "localidad": "Piñero",
+            "is_edificio": True,
+            "colocacion": False,
+            "pileta": "empotrada_cliente",
+            "pileta_qty": 32,
+            "regrueso": True,
+            "regrueso_ml": 60.68,
+            "pieces": [
+                {"description": "M1 mesada", "largo": 1.92, "prof": 0.6, "quantity": 24},
+                {"description": "M1 zócalo atrás", "largo": 1.92, "prof": 0.1, "quantity": 24},
+                {"description": "M1 frente regrueso", "largo": 1.92, "prof": 0.05, "quantity": 24},
+                {"description": "M2 mesada", "largo": 1.7, "prof": 0.6, "quantity": 1},
+                {"description": "M2 zócalo atrás", "largo": 1.7, "prof": 0.1, "quantity": 1},
+                {"description": "M2 frente regrueso", "largo": 1.7, "prof": 0.05, "quantity": 1},
+                {"description": "M3 mesada", "largo": 2.5, "prof": 0.6, "quantity": 1},
+                {"description": "M3 zócalo atrás", "largo": 2.5, "prof": 0.1, "quantity": 1},
+                {"description": "M3 frente regrueso", "largo": 2.5, "prof": 0.05, "quantity": 1},
+                {"description": "M4 mesada", "largo": 2.5, "prof": 0.6, "quantity": 1},
+                {"description": "M4 zócalo atrás", "largo": 2.5, "prof": 0.1, "quantity": 1},
+                {"description": "M4 frente regrueso", "largo": 2.5, "prof": 0.05, "quantity": 1},
+                {"description": "M5 mesada", "largo": 1.8, "prof": 0.6, "quantity": 1},
+                {"description": "M5 zócalo atrás", "largo": 1.8, "prof": 0.1, "quantity": 1},
+                {"description": "M5 frente regrueso", "largo": 1.8, "prof": 0.05, "quantity": 1},
+                {"description": "M6 mesada", "largo": 1.55, "prof": 0.6, "quantity": 2},
+                {"description": "M6 zócalo atrás", "largo": 1.55, "prof": 0.1, "quantity": 2},
+                {"description": "M6 frente regrueso", "largo": 1.55, "prof": 0.05, "quantity": 2},
+                {"description": "M7 mesada", "largo": 1.5, "prof": 0.6, "quantity": 2},
+                {"description": "M7 zócalo atrás", "largo": 1.5, "prof": 0.1, "quantity": 2},
+                {"description": "M7 frente regrueso", "largo": 1.5, "prof": 0.05, "quantity": 2},
+            ],
+        })
+        assert result.get("ok") is True, f"calc falló: {result.get('error')}"
+        material_m2 = result["material_m2"]
+        # Suma manual de pieces (m2 × qty para cada uno).
+        sum_pieces = sum(
+            (p["m2"] or 0) * (p["quantity"] or 1)
+            for p in result["piece_details"]
+        )
+        delta = abs(material_m2 - sum_pieces)
+        # Pre-fix: delta ≈ 3.034 (double-count del regrueso).
+        # Post-fix: delta ≤ 0.01 (solo rounding cosmético).
+        assert delta < 0.01, (
+            f"material_m2={material_m2} vs sum_pieces={sum_pieces:.4f} "
+            f"delta={delta:.4f} > 0.01 — double-count regression"
+        )
+
+    def test_417_baseline_still_works(self):
+        """regrueso_ml declarado SIN pieces regrueso → calculator debe
+        seguir sumando `regrueso_ml × 0.05` al total (comportamiento
+        del #417 original que arregló el subfacturado)."""
+        result = calculate_quote({
+            "client_name": "Test Cliente",
+            "project": "Test Proyecto",
+            "plazo": "30 días",
+            "material": "GRANITO GRIS MARA EXTRA 2 ESP",
+            "regrueso": True,
+            "regrueso_ml": 10.0,  # 10 ml × 0.05 = 0.5 m² extra
+            "pieces": [
+                # Sin piezas "regrueso" — solo mesada.
+                {"description": "Mesada", "largo": 2.0, "prof": 0.6, "quantity": 1},
+            ],
+        })
+        assert result.get("ok") is True, f"calc falló: {result.get('error')}"
+        # mesada = 2.0 × 0.6 = 1.20 m². + regrueso 0.5 = 1.70 m² total.
+        assert abs(result["material_m2"] - 1.70) < 0.01, (
+            f"material_m2={result['material_m2']}, esperaba ~1.70 "
+            f"(1.20 mesada + 0.50 regrueso extra)"
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Drift guard — API pública estable
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestPublicAPIDriftGuard:
+    def test_is_regrueso_piece_importable(self):
+        """Si alguien renombra `is_regrueso_piece`, este test rompe y
+        avisa que hay que actualizar callsites en calculator + validator."""
+        from app.modules.quote_engine.regrueso_detect import is_regrueso_piece
+        assert callable(is_regrueso_piece)
+
+    def test_check_regrueso_in_validate_despiece_pipeline(self):
+        """`_check_regrueso_consistency` debe estar registrado en el
+        pipeline de `validate_despiece`. Si alguien lo saca, los errors
+        de inconsistencia desaparecen silenciosamente — exactamente el
+        anti-patrón que este PR resuelve."""
+        # Construyo un qdata que SÍ debería emitir error de regrueso.
+        # Si validate_despiece no incluye el check, no veríamos el error.
+        qdata = {
+            "regrueso": True,
+            "regrueso_ml": 20.0,  # expected 1.0 m²
+            "piece_details": [
+                _piece("Frente regrueso", m2=2.0, qty=1),  # delta 1.0
+            ],
+            # Otros campos requeridos (mínimos para no romper otros checks).
+            "material_currency": "ARS",
+            "material_price_unit": None,
+            "material_price_base": None,
+        }
+        result = validate_despiece(qdata)
+        # Esperamos al menos un error con "Inconsistencia regrueso".
+        regrueso_errors = [e for e in result.errors if "Inconsistencia regrueso" in e]
+        assert len(regrueso_errors) == 1, (
+            f"Esperaba 1 error de regrueso en pipeline, vi: {result.errors}"
+        )


### PR DESCRIPTION
## Summary

**Bug observado** en logs de DYSCON post-#418 (m2-audit funcionó, captó el caso):

```
[m2-audit:9da51080] calculator material_m2=48.584 sum_piece_details=45.55
[m2-audit:9da51080] MISMATCH delta=3.034 source=calculator_vs_piece_details
```

`delta=3.034 = regrueso_ml × 0.05 = 60.68 × 0.05`. Exacto. **Cliente cobrado $675K de más.**

**Causa raíz**: el #417 sumaba `regrueso_ml × 0.05` al `total_m2` siempre que `regrueso=True`. Cuando el operador declara las piezas "frente regrueso" en el despiece (caso DYSCON), `calculate_m2(pieces)` ya las contabilizaba → double-count.

## Estrategia: cuantitativo + ruidoso, NO binario

Review feedback rechazó el primer impulso (`if any(regrueso in piece) → skip`) por abrir el **caso espejo**: operador declara 5 de 7 piezas regrueso → undercount silencioso ~$193K.

**El undercount silencioso es peor que el sobrecount ruidoso.** Por eso:

| Capa | Responsabilidad |
|---|---|
| **Calculator** | Solo decide double-count. NO valida. |
| **Validator** | Chequea cuantitativamente con tolerancia. ERROR ruidoso si difiere. |

## Cambios

### 1. `regrueso_detect.py` (módulo nuevo)

- `is_regrueso_piece(piece)`: word boundary `\bregrueso\b` + negación previa.
  - ✓ "Frente regrueso", "M1 frente regrueso", "REGRUESO"
  - ✗ "Frente sin regrueso", "no incluye regrueso", "regruesoadicional"
- `sum_regrueso_pieces_m2(piece_details)`: helper compartido calc + validator.
- Edge cases conocidos documentados ("regrueso: no", "FR" abreviado) — fallan loud vía validator si aparecen, no se complica el regex.

### 2. `calculator.py:1178` — branch en `calculate_quote`

```python
if regrueso and regrueso_ml > 0:
    pieces_regrueso_m2 = sum_regrueso_pieces_m2(piece_details)
    if pieces_regrueso_m2 < 0.001:
        # Caso #417 baseline: regrueso sin pieces → sumar extra.
        total_m2 = round(total_m2 + round(regrueso_ml * 0.05, 4), 4)
    # else: pieces ya en total_m2 → no double-count.
```

### 3. `validation_tool._check_regrueso_consistency` — check ruidoso

```python
delta = round(abs(pieces_regrueso_m2 - expected_m2), 4)
if delta > 0.05:  # 5 cm²
    errors.append("Inconsistencia regrueso: ... Confirmar con operador.")
```

`errors` (no warnings) → bloquea `generate_documents` vía `_validation_errors`.

`round(..., 4)` del delta antes de comparar — sin esto el boundary `delta == 0.05` es indeterminado por float imprecision.

Tolerancia 0.05 absoluta documentada en código:

```python
# TOLERANCIA: 0.05 m² absoluto. Calibrado para regrueso_ml >= 30.
# Proyectos chicos (regrueso_ml=10 → expected 0.5 m²) tienen 10% slack
# relativo, pero riesgo monetario absoluto bajo (~$9K máx).
# Si aparece caso de undercount en proyecto chico, migrar a
# `max(0.05, 0.02 * expected)`. YAGNI hasta que aparezca el caso.
```

## Tests (34 casos)

- **`is_regrueso_piece`**: 5 positivos + 6 negation_wins + 5 negativos + defensive.
- **`sum_regrueso_pieces_m2`**: DYSCON exact, skip non-regrueso, skip negation.
- **`test_dyscon_exact_passes`**: caso real → validator verde.
- **`test_undercount_emits_loud_error`** ⚠️ **CRÍTICO** (review feedback, marcado "no borrar"): 5 de 7 piezas regrueso → ERROR ruidoso. Si pasa con un fix que silencia, el bug del caso espejo queda abierto.
- **`test_false_positive_sin_regrueso`**: "Frente sin regrueso" no matchea, calc suma extra normal.
- **`test_boundary_delta_exact_005_passes`** + `_above_005_fails`: boundary `>` vs `>=`. Si alguien cambia el operador en 6 meses, estos tests lo agarran.
- Baselines: #417 sin pieces, regrueso_ml=0, regrueso=False.
- Drift guards: API pública importable + check registrado en `validate_despiece`.
- **Calculator end-to-end DYSCON real**: `material_m2 ≈ sum_pieces` (delta < 0.01). Pre-fix delta=3.034.

Suite full: **2291 passing** (+34 nuevos). 16 fallos preexistentes en `tests/evaluation/` y `test_edificio_render.py` (mismos en main, no introducidos por este PR).

## Lo que NO toca

- m2-audit logs del #418 — siguen funcionando, ahora capturan happy path post-fix.
- Calculator math en otras partes.
- Frontend, prompts, schemas.

## Deuda anotada (issues a abrir post-merge)

- **Issue A (tech-debt)** — refactor semántica `regrueso_ml`. Significa dos cosas (input labor + input m² extra). Cada PR que lo toca pisa el bug. Solución: `regrueso_ml` solo para labor, m² siempre de pieces; si operador declara `regrueso_ml` sin pieces → generar pieces sintéticas o abortar pidiendo despiece.
- **Issue B (agent-behavior, alta)** — Sonnet retry behavior ante validator error. Pattern observado en logs DYSCON: Sonnet duplicó valores (1755% diff, agarrado por guardrail-B). El próximo validator que falle va a disparar el mismo patrón.

## Test plan

- [x] `pytest tests/test_regrueso_double_count.py -v` → 34/34.
- [x] Suite full → 2291 passing (+34 vs main, 0 regresiones).
- [ ] CI verde.
- [ ] **Validación post-merge** (review feedback explícito):
  - Re-cotizar DYSCON real → `material_m2 == sum_pieces_m2` en logs m2-audit, NO MISMATCH.
  - Caso espejo (5 de 7 piezas regrueso, ml=60.68) en staging → validator emite error ruidoso, generate_documents bloqueado, operador ve mensaje claro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)