### PR TITLE
fix(pdf): eliminar TOTAL ARS subtotal del bloque material

### DIFF
--- a/api/app/modules/agent/tools/document_tool.py
+++ b/api/app/modules/agent/tools/document_tool.py
@@ -1425,11 +1425,25 @@ def _generate_pdf(pdf_path: Path, data: dict) -> None:
     # Build right-side overlay rows (Descuento + TOTAL)
     # Applies to both USD and ARS — originally gated to USD only which
     # hid the discount line for ARS edificios (bug DINALE 14/04/2026).
+    #
+    # PR #420 — `TOTAL ARS` se elimina del bloque material por pedido
+    # del operador: era un subtotal intermedio ruidoso que confundía
+    # al cliente. El único total visible en cotizaciones ARS es el
+    # PRESUPUESTO TOTAL al final del documento. La línea `Descuento N%`
+    # con monto en negativo se MANTIENE — junto con el grand total
+    # final permite reconstruir mentalmente la cuenta (material bruto −
+    # descuento + MO = grand total).
+    #
+    # USD se mantiene porque la convención del operador es distinta:
+    # cotizaciones USD muestran el subtotal en USD en el bloque material
+    # para que el cliente vea el monto en dólares antes del grand total
+    # mixto (USD material + ARS MO).
     right_rows = []
     if discount_pct:
         desc_amount = round(total_mat_bruto * discount_pct / 100)
         right_rows.append(("I", f"Descuento {discount_pct}%", f"- {fmt_price(desc_amount)}"))
-        right_rows.append(("B", f"TOTAL {currency}", fmt_price(total_mat)))
+        if currency == "USD":
+            right_rows.append(("B", f"TOTAL {currency}", fmt_price(total_mat)))
     elif currency == "USD":
         # Keep legacy behavior for USD without discount — always show TOTAL USD
         # row so the user sees the net material total in the material block.
@@ -1753,13 +1767,19 @@ def _generate_excel(output_path: Path, data: dict) -> None:
     # Build right-side overlay (Descuento + TOTAL)
     # Applies to both USD and ARS — originally gated to USD only which hid
     # the discount line for ARS edificios (bug DINALE 14/04/2026).
+    #
+    # PR #420 — `TOTAL ARS` se elimina del bloque material por pedido
+    # del operador (mismo cambio que el PDF). USD se mantiene porque
+    # aclara al cliente el monto en dólares antes del grand total mixto.
+    # Ver document_tool.py:1428 (PDF) para el racional completo.
     italic_sm = Font(name="Arial", italic=True, size=9)
     _xl_fmt = _fmt_usd if currency == "USD" else _fmt_ars
     right_rows_xl = []
     if discount_pct:
         desc_amount = round(total_mat * discount_pct / 100)
         right_rows_xl.append(("I", f"Descuento {discount_pct}%", f"- {_xl_fmt(desc_amount)}"))
-        right_rows_xl.append(("B", f"TOTAL {currency}", _xl_fmt(total_mat_net)))
+        if currency == "USD":
+            right_rows_xl.append(("B", f"TOTAL {currency}", _xl_fmt(total_mat_net)))
     elif currency == "USD":
         right_rows_xl.append(("B", f"TOTAL {currency}", _xl_fmt(total_mat_net)))
 

--- a/api/tests/test_excel_regression.py
+++ b/api/tests/test_excel_regression.py
@@ -505,8 +505,15 @@ class TestDiscountVisibleForARS:
             "is_edificio": True,
         }
 
-    def test_pdf_ars_shows_discount_line(self, tmp_path):
-        """PDF for ARS quote with discount_pct must render 'Descuento N%' + 'TOTAL ARS'."""
+    def test_pdf_ars_shows_discount_without_total_ars(self, tmp_path):
+        """PR #420 — PDF para quote ARS con descuento debe mostrar
+        'Descuento N%' pero NO 'TOTAL ARS' (subtotal intermedio
+        ruidoso que confundía al cliente). El único total visible
+        en cotizaciones ARS es el `PRESUPUESTO TOTAL` del final.
+
+        Test invertido respecto a versión anterior — antes assertaba
+        que `TOTAL ARS` apareciera. Si alguien lo restaura, este
+        test lo agarra."""
         from app.modules.agent.tools.document_tool import _generate_pdf
         out = tmp_path / "ars_disc.pdf"
         _generate_pdf(out, self._ars_data_with_discount())
@@ -520,12 +527,29 @@ class TestDiscountVisibleForARS:
             ).stdout
         except FileNotFoundError:
             pytest.skip("pdftotext not installed")
-        assert "Descuento 15%" in txt, f"Expected 'Descuento 15%' in PDF text:\n{txt[:1500]}"
-        assert "TOTAL ARS" in txt, f"Expected 'TOTAL ARS' in PDF text:\n{txt[:1500]}"
-        assert "5.994.846" in txt, f"Expected material net (5.994.846) in PDF:\n{txt[:1500]}"
+        assert "Descuento 15%" in txt, (
+            f"Expected 'Descuento 15%' in PDF text:\n{txt[:1500]}"
+        )
+        # PR #420 — TOTAL ARS NO debe aparecer como subtotal del bloque
+        # material. PRESUPUESTO TOTAL al final sigue mostrando el grand
+        # total — eso es OTRO label, no se chequea acá.
+        assert "TOTAL ARS" not in txt, (
+            f"'TOTAL ARS' subtotal removed in PR #420 — should not appear "
+            f"in material block. Found in:\n{txt[:1500]}"
+        )
+        # Monto del descuento sigue visible con formato negativo
+        # (operador: "se mantiene en negativo, así el total de abajo
+        # suma menos desc más MO da el total"). Chequeamos el "- $"
+        # como marca del monto en negativo, sin pinear un número
+        # exacto que depende del rounding interno.
+        import re as _re_neg
+        assert _re_neg.search(r"-\s*\$\s*[\d.]+", txt), (
+            f"Discount amount with negative sign missing from ARS PDF:\n{txt[:1500]}"
+        )
 
-    def test_excel_ars_shows_discount_line(self, tmp_path):
-        """Excel for ARS quote with discount_pct must include 'Descuento N%' cell."""
+    def test_excel_ars_shows_discount_without_total_ars(self, tmp_path):
+        """PR #420 — Excel para quote ARS con descuento debe incluir
+        'Descuento N%' pero NO 'TOTAL ARS' (mismo criterio que el PDF)."""
         from app.modules.agent.tools.document_tool import _generate_excel
         out = tmp_path / "ars_disc.xlsx"
         _generate_excel(out, self._ars_data_with_discount())
@@ -536,10 +560,18 @@ class TestDiscountVisibleForARS:
             sheet = z.read("xl/worksheets/sheet1.xml").decode("utf-8")
         all_text = shared + sheet
         assert "Descuento 15%" in all_text, "'Descuento 15%' label missing from ARS Excel"
-        assert "TOTAL ARS" in all_text, "'TOTAL ARS' row missing from ARS Excel"
+        assert "TOTAL ARS" not in all_text, (
+            "'TOTAL ARS' row removed in PR #420 — should not appear in "
+            "material block of ARS Excel."
+        )
 
-    def test_pdf_usd_still_shows_discount(self, tmp_path):
-        """Regression guard: USD discount path must still work unchanged."""
+    def test_pdf_usd_still_shows_total_with_discount(self, tmp_path):
+        """Regression guard: USD discount path must still work unchanged.
+
+        PR #420 mantiene `TOTAL USD` porque la convención del operador
+        es distinta: cotizaciones USD muestran el subtotal en USD para
+        que el cliente vea el monto en dólares antes del grand total
+        mixto (USD material + ARS MO)."""
         from app.modules.agent.tools.document_tool import _generate_pdf
         data = self._ars_data_with_discount()
         data["material_currency"] = "USD"
@@ -557,4 +589,68 @@ class TestDiscountVisibleForARS:
         except FileNotFoundError:
             pytest.skip("pdftotext not installed")
         assert "Descuento 15%" in txt
-        assert "TOTAL USD" in txt
+        assert "TOTAL USD" in txt, (
+            f"USD path should keep TOTAL USD subtotal (PR #420 only "
+            f"removed TOTAL ARS). Text:\n{txt[:1500]}"
+        )
+
+    def test_pdf_ars_no_discount_no_total_ars(self, tmp_path):
+        """PR #420 drift guard — quote ARS SIN descuento tampoco debe
+        mostrar `TOTAL ARS` (antes del PR ya era así para ARS sin
+        descuento, pero el cambio podría romperlo si alguien
+        reorganiza el bloque). El bloque material queda con solo
+        las piezas listadas, sin subtotal del lado derecho."""
+        from app.modules.agent.tools.document_tool import _generate_pdf
+        data = self._ars_data_with_discount()
+        data["discount_pct"] = 0
+        data["discount_amount"] = 0
+        out = tmp_path / "ars_no_disc.pdf"
+        _generate_pdf(out, data)
+        import subprocess
+        try:
+            txt = subprocess.run(
+                ["pdftotext", "-layout", str(out), "-"],
+                capture_output=True, text=True, timeout=15,
+            ).stdout
+        except FileNotFoundError:
+            pytest.skip("pdftotext not installed")
+        assert "TOTAL ARS" not in txt, (
+            f"ARS quote without discount should also NOT have TOTAL ARS "
+            f"subtotal in material block (PR #420). Text:\n{txt[:1500]}"
+        )
+        # PRESUPUESTO TOTAL sí debe aparecer al final — es el único total
+        # visible. El test no asserta el label literal porque el formato
+        # del grand total puede tener distintos wordings; mínimo, esperamos
+        # que el monto neto del material aparezca en algún lado.
+        assert "PRESUPUESTO TOTAL" in txt or "TOTAL" in txt, (
+            f"Grand total missing entirely from PDF:\n{txt[:1500]}"
+        )
+
+    def test_pdf_usd_no_discount_keeps_total_usd(self, tmp_path):
+        """PR #420 — quote USD SIN descuento sigue mostrando `TOTAL USD`
+        (legacy behavior). Test explícito porque es la única ruta del
+        `right_rows` que NO pasa por el `if discount_pct` — un refactor
+        que la borrara accidentalmente quitaría info importante al
+        cliente."""
+        from app.modules.agent.tools.document_tool import _generate_pdf
+        data = self._ars_data_with_discount()
+        data["material_currency"] = "USD"
+        data["material_price_unit"] = 519
+        data["total_usd"] = 2507
+        data["total_ars"] = 0
+        data["discount_pct"] = 0
+        data["discount_amount"] = 0
+        out = tmp_path / "usd_no_disc.pdf"
+        _generate_pdf(out, data)
+        import subprocess
+        try:
+            txt = subprocess.run(
+                ["pdftotext", "-layout", str(out), "-"],
+                capture_output=True, text=True, timeout=15,
+            ).stdout
+        except FileNotFoundError:
+            pytest.skip("pdftotext not installed")
+        assert "TOTAL USD" in txt, (
+            f"USD without discount should still show TOTAL USD (legacy "
+            f"behavior preserved by PR #420). Text:\n{txt[:1500]}"
+        )


### PR DESCRIPTION
## Summary

**Pedido del operador** (screenshot adjunto):

```
Descuento 12%    - $1.228.893,00
TOTAL ARS        $9.011.886,00   ← ELIMINAR
```

> En el template PDF, en el bloque de material eliminar únicamente la línea TOTAL ARS. Mantener Descuento 12%. Esa línea de TOTAL ARS es un subtotal intermedio que no debe aparecer. El único total visible debe ser el PRESUPUESTO TOTAL al final del documento.

## Asimetría intencional ARS vs USD

Aclaración del operador:

> el de USD es correcto, el que no debe aparecer es el de pesos

USD se mantiene porque el cliente necesita ver el subtotal en dólares antes del grand total mixto (USD material + ARS MO). En cotizaciones puramente ARS, el `TOTAL ARS` intermedio confunde porque hay otro `PRESUPUESTO TOTAL` al final.

## Por qué se mantiene el descuento con monto en negativo

> se mantiene el descuento en negativo, así el total de abajo suma menos desc más m.o da el total

Con el monto negativo visible, el cliente reconstruye mentalmente: `material bruto − descuento + MO = grand total`.

## Cambios (cero lógica de negocio)

| Archivo | Cambio |
|---|---|
| `document_tool.py:_generate_pdf` | `right_rows.append(\"TOTAL\")` ahora condicionado a `currency == \"USD\"` dentro del bloque `if discount_pct`. ARS con descuento renderiza solo `Descuento N%`. |
| `document_tool.py:_generate_excel` | Mismo cambio en `right_rows_xl`. Excel y PDF visualmente coherentes. |

## Lo que NO toca

- **Sobrante / merma**: intacto. Es monto que SUMA al grand total (no subtotal). Confirmado con operador: `merma sobrante dejalo, porque es un monto más, lo que no va es total (ese intermedio confunde)`.
- **`PRESUPUESTO TOTAL` final**: único total visible — sin cambios.
- **Paso 2 markdown del chat**: no se toca (instrucción fue para el PDF).
- **Tabla comparativa de variantes** (`document_tool.py:2216`): el `(\"TOTAL ARS\", \"total_ars\", ...)` ahí es el grand total de cada columna en la página de comparación, no el subtotal del bloque material.

## Tests (5 casos)

| Test | Cubre |
|---|---|
| `test_pdf_ars_shows_discount_without_total_ars` | ARS + desc → `Descuento 15%` ✓, `TOTAL ARS` ✗ |
| `test_excel_ars_shows_discount_without_total_ars` | Idem para Excel |
| `test_pdf_usd_still_shows_total_with_discount` | USD + desc → `TOTAL USD` SE MANTIENE (regression guard contra generalizar fix a USD) |
| `test_pdf_ars_no_discount_no_total_ars` | ARS sin desc → tampoco TOTAL ARS (drift guard) |
| `test_pdf_usd_no_discount_keeps_total_usd` | USD sin desc → mantiene TOTAL USD (legacy guard — única ruta que no pasa por `if discount_pct`) |

Tests 3 y 5 **explícitamente protegen el comportamiento USD** — si alguien hace un refactor que borra el `right_rows.append` de USD por accidente, los tests lo agarran.

Suite full: **2293 passing** (+2 vs main). 16 fallos preexistentes en `tests/evaluation/` y `test_edificio_render.py` — no introducidos por este PR.

## Test plan

- [x] `pytest tests/test_excel_regression.py::TestDiscountVisibleForARS -v` → 5/5.
- [x] Suite full → 2293 passing (+2, 0 regresiones).
- [ ] CI verde.
- [ ] **Validación post-merge** (con datos reales): re-cotizar DYSCON ARS → PDF muestra `Descuento 12% - \$1.228.893,00` y `PRESUPUESTO TOTAL: \$X` final, **sin** `TOTAL ARS` intermedio. Re-cotizar quote USD cualquiera → sigue mostrando `TOTAL USD` en el bloque material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)