### PR TITLE
feat(agent): retry counter por tool — bloquea auto-fix de Sonnet

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -4002,6 +4002,23 @@ class AgentService:
         MAX_READ_PLAN_CALLS = 3       # Hard limit: max 3 read_plan calls per conversation
         _visual_builder_done = False  # Track if visual builder already processed
 
+        # PR #423 — retry counter (Issue #422). Caso DYSCON observado en
+        # producción: cuando una tool retorna error, Sonnet a veces intenta
+        # auto-fixear inventando valores (en el caso real, infló m² 1755%).
+        # Guardrail-B atrapó ESE caso específico, pero el patrón vuelve con
+        # cualquier validator nuevo que metamos. Lógica aislada en
+        # `retry_guard` para que sea unit-testable sin mockear Anthropic.
+        # Reset implícito: cada llamada nueva a `stream_chat` (turno del
+        # operador) crea un dict nuevo.
+        from app.modules.agent.retry_guard import (
+            build_retry_block_result,
+            increment_failure,
+            is_tool_failure,
+            should_block_retry,
+            DEFAULT_RETRY_THRESHOLD,
+        )
+        _tool_failure_count: dict[str, int] = {}
+
         while True:
             if _loop_iterations >= MAX_ITERATIONS:
                 logging.error(f"Agent exceeded MAX_ITERATIONS ({MAX_ITERATIONS}) for quote {quote_id}")
@@ -4730,18 +4747,47 @@ class AgentService:
                 # el prefix + formato.
                 log_tool_call(quote_id, tool_use.name, tool_use.input)
 
-                try:
-                    result = await self._execute_tool(
-                        tool_use.name,
-                        tool_use.input,
-                        quote_id=quote_id,
-                        db=db,
-                        conversation_history=messages,
-                        current_user_message=user_message,
+                # PR #423 — retry counter (Issue #422). Si esta tool ya
+                # falló threshold veces en este turno del operador, NO la
+                # ejecutamos: devolvemos un error sintético que fuerza a
+                # Sonnet a parar y consultar al operador. Lógica aislada
+                # en `retry_guard` (unit-tests + reuso futuro).
+                if should_block_retry(tool_use.name, _tool_failure_count):
+                    _prior = _tool_failure_count.get(tool_use.name, 0)
+                    result = build_retry_block_result(tool_use.name, _prior)
+                    logging.warning(
+                        f"[retry-block:{quote_id}] tool={tool_use.name} "
+                        f"count={_prior} BLOCKED — forcing operator "
+                        f"consultation"
                     )
-                except Exception as e:
-                    logging.error(f"Tool execution error ({tool_use.name}): {e}", exc_info=True)
-                    result = {"ok": False, "error": f"Error ejecutando {tool_use.name}: {str(e)}"}
+                else:
+                    try:
+                        result = await self._execute_tool(
+                            tool_use.name,
+                            tool_use.input,
+                            quote_id=quote_id,
+                            db=db,
+                            conversation_history=messages,
+                            current_user_message=user_message,
+                        )
+                    except Exception as e:
+                        logging.error(f"Tool execution error ({tool_use.name}): {e}", exc_info=True)
+                        result = {"ok": False, "error": f"Error ejecutando {tool_use.name}: {str(e)}"}
+
+                # PR #423 — contar el fallo (si lo hubo) DESPUÉS de la
+                # ejecución. La pre-block check de arriba ya incluye los
+                # bloqueos sintéticos como "fallo" (tienen ok=False), por
+                # lo que el contador queda monotónicamente creciente
+                # mientras la tool no se recupere. NO reseteamos con
+                # éxitos intermedios — el contador acumula errores totales
+                # por tool en el turno del operador.
+                if is_tool_failure(result):
+                    _new_count = increment_failure(tool_use.name, _tool_failure_count)
+                    _err_preview = str(result.get("error", "?"))[:120]
+                    logging.info(
+                        f"[retry-counter:{quote_id}] tool={tool_use.name} "
+                        f"count={_new_count} error={_err_preview}"
+                    )
 
                 # Log result summary
                 # PR #385 — tool result REAL. El log anterior filtraba a

--- a/api/app/modules/agent/retry_guard.py
+++ b/api/app/modules/agent/retry_guard.py
@@ -1,0 +1,120 @@
+"""Retry counter para tool calls fallidas en el loop agéntico.
+
+**Por qué este módulo existe (PR #423, Issue #422):**
+
+Caso DYSCON observado en producción (28/04/2026, logs `9da51080-...`):
+
+```
+1. validator rebota: "material_m2=48.584 no coincide con suma=45.55"
+2. Sonnet decide "lo arreglo yo" → llama calculate_quote DE NUEVO
+   con m2_override en cada pieza inventando valores.
+3. pasa 845.03 m² (1755% del valor real). guardrail-B aborta. ✓
+```
+
+Sonnet NO le preguntó al operador. Intentó auto-fixear inventando
+valores. El guardrail-B (específico al m² total) lo agarró ESE caso.
+Cualquier validator nuevo que metamos reabre el riesgo: si Sonnet
+inventa valores que NO triggerean guardrail-B, el PDF se genera con
+números fabricados por la IA, no por el operador.
+
+**Estrategia (review feedback):** retry counter en `agent.py`.
+
+> El system prompt es demasiado frágil en conversaciones largas, ya
+> lo vimos en esta sesión donde Valentina ignoró varias instrucciones
+> del brief. Un contador en agent.py es un cambio de 10 líneas que da
+> garantía real.
+
+Las 2 micro-funciones de este módulo están aisladas para que sean
+unit-testable sin tener que mockear la API de Anthropic. La integración
+en `agent.py` es trivial — 3 líneas — y el test integration vive en
+el módulo del bucle agéntico.
+
+**Convenciones:**
+
+- Threshold por defecto = 2: 1 ejecución original + 1 retry permitido +
+  3er intento bloqueado. `count >= 2 → block` antes de ejecutar la 3ra.
+- Por nombre de tool. Tool A fallando 2x no bloquea tool B.
+- NO hay reset por éxito intermedio. `count` acumula errores totales
+  por tool en el turno del operador (un turno = una llamada a
+  `stream_chat`). Reset implícito al siguiente turno.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# Threshold default. Importable y override-able por tests.
+DEFAULT_RETRY_THRESHOLD = 2
+
+
+def is_tool_failure(result: Any) -> bool:
+    """¿Este tool result cuenta como fallo para el retry counter?
+
+    Reglas:
+    - `dict` con `ok: False` → fallo.
+    - `dict` con `error` truthy (string no vacío, etc.) → fallo.
+    - Cualquier otro `dict` (sin esos campos) → éxito.
+    - Lista (read_plan con content blocks de imagen+texto) → éxito.
+    - None / no-dict → éxito (defensivo, no lo penalizamos al agente).
+
+    NO clasifica el error por severidad — un warning con campo `error`
+    cuenta igual que un crash. El threshold (2 fallos) absorbe el ruido
+    de errores transitorios sin penalizar al primer error.
+    """
+    if not isinstance(result, dict):
+        return False
+    if result.get("ok") is False:
+        return True
+    err = result.get("error")
+    # Truthy check: string vacío o None → no es fallo. String con
+    # contenido o cualquier otro truthy → fallo.
+    if err:
+        return True
+    return False
+
+
+def build_retry_block_result(tool_name: str, prior_failures: int) -> dict:
+    """Construye el `tool_result` sintético cuando se bloquea un retry.
+
+    El mensaje fuerza a Sonnet a parar y consultar al operador. NO le
+    da pistas para "fixearlo" — explícitamente le dice que NO reintente
+    con valores distintos sin confirmación. El flag `_retry_blocked`
+    es para que callers downstream (logs, telemetría) sepan que este
+    result fue sintético, no del tool real.
+    """
+    return {
+        "ok": False,
+        "error": (
+            f"⛔ Bloqueé este tool ({tool_name}) después de "
+            f"{prior_failures} intentos fallidos. NO puedo resolver "
+            f"esto automáticamente. Pedile al operador que revise los "
+            f"datos antes de continuar — NO reintentes con valores "
+            f"distintos sin su confirmación explícita."
+        ),
+        "_retry_blocked": True,
+    }
+
+
+def should_block_retry(
+    tool_name: str,
+    counter: dict[str, int],
+    threshold: int = DEFAULT_RETRY_THRESHOLD,
+) -> bool:
+    """¿Hay que bloquear esta tool antes de ejecutarla?
+
+    True si la tool ya falló `threshold` veces o más en este turno.
+    Pure función — no muta `counter` ni `threshold`.
+    """
+    return counter.get(tool_name, 0) >= threshold
+
+
+def increment_failure(
+    tool_name: str,
+    counter: dict[str, int],
+) -> int:
+    """Incrementa el contador para la tool y devuelve el nuevo valor.
+
+    Muta `counter` in-place. Helper único para que el caller no tenga
+    que recordar la fórmula `counter.get(name, 0) + 1`.
+    """
+    counter[tool_name] = counter.get(tool_name, 0) + 1
+    return counter[tool_name]

--- a/api/tests/test_agent_retry_guard.py
+++ b/api/tests/test_agent_retry_guard.py
@@ -1,0 +1,306 @@
+"""Tests para PR #423 — retry counter (Issue #422).
+
+**Caso DYSCON observado en producción:**
+
+Cuando una tool retorna error, Sonnet a veces intenta auto-fixear
+inventando valores (logs `9da51080-...` infló m² a 1755%). El
+guardrail-B atrapó ESE caso pero el patrón vuelve con cualquier
+validator nuevo. Este PR mete un retry counter en el loop agéntico
+que bloquea la tool después de 2 fallos en el mismo turno y fuerza
+a Sonnet a consultar al operador.
+
+**Tests cubren los 5 escenarios del Issue #422:**
+
+1. Tool falla 1 vez → retry permitido (count=1, threshold no alcanzado).
+2. Tool falla 2 veces → 3er intento bloqueado con mensaje al operador.
+3. Tool exitoso entre fallos → contador NO se resetea (sigue contando
+   solo errores).
+4. Tool distinto NO contribuye al contador del primero (counter por tool).
+5. Drift guard: el bloque sintético tiene `_retry_blocked=True` y un
+   mensaje claro que NO da pistas de auto-fix.
+
+**Por qué unit-tests directos sobre `retry_guard` y no integration:**
+
+La integración (loop agéntico en `stream_chat`) requiere mockear la
+API de Anthropic — overkill. Las funciones de `retry_guard` son
+puras y deterministicas; testearlas directamente cubre la lógica.
+La integración la valida el caso real en staging (logs `[retry-block:<qid>]`).
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.modules.agent.retry_guard import (
+    DEFAULT_RETRY_THRESHOLD,
+    build_retry_block_result,
+    increment_failure,
+    is_tool_failure,
+    should_block_retry,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# is_tool_failure — definición de "fallo"
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestIsToolFailure:
+    def test_ok_false_is_failure(self):
+        assert is_tool_failure({"ok": False, "error": "x"}) is True
+
+    def test_error_field_is_failure(self):
+        """Algunos tools no tienen `ok`, solo `error`."""
+        assert is_tool_failure({"error": "validation failed"}) is True
+
+    def test_ok_true_is_success(self):
+        assert is_tool_failure({"ok": True, "data": "..."}) is False
+
+    def test_no_ok_no_error_is_success(self):
+        """`catalog_lookup` retorna `{"found": True, "price_ars": ...}` —
+        no tiene `ok` ni `error` y es éxito."""
+        assert is_tool_failure({"found": True, "price_ars": 100000}) is False
+
+    def test_empty_dict_is_success(self):
+        """Defensivo — un dict vacío no tiene info de fallo."""
+        assert is_tool_failure({}) is False
+
+    def test_list_is_success(self):
+        """`read_plan` retorna list de content blocks (image+text),
+        no un dict. NO es fallo."""
+        assert is_tool_failure([{"type": "image"}, {"type": "text"}]) is False
+
+    def test_none_is_success(self):
+        """Defensivo — None no penaliza al agente."""
+        assert is_tool_failure(None) is False
+
+    def test_empty_error_string_is_success(self):
+        """`error: ""` no debe contar como fallo (truthy check)."""
+        assert is_tool_failure({"error": ""}) is False
+
+    def test_ok_true_with_error_field_still_success(self):
+        """Edge case: `{ok: True, error: ""}`. Si ok=True, no es fallo
+        sin importar el campo error vacío. Pero si error es truthy, es
+        ambiguo — la convención de la app es que ok manda."""
+        # Tomamos la decisión MÁS conservadora: si hay error truthy,
+        # contamos como fallo aunque ok=True. Mejor falso positivo
+        # (un retry de más) que falso negativo (Sonnet sigue inventando).
+        assert is_tool_failure({"ok": True, "error": "warning real"}) is True
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# should_block_retry — pre-execution check
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestShouldBlockRetry:
+    def test_zero_failures_no_block(self):
+        assert should_block_retry("calculate_quote", {}) is False
+
+    def test_one_failure_no_block(self):
+        """1 fallo → 2do intento permitido."""
+        counter = {"calculate_quote": 1}
+        assert should_block_retry("calculate_quote", counter) is False
+
+    def test_two_failures_blocks(self):
+        """2 fallos → 3er intento bloqueado (threshold alcanzado)."""
+        counter = {"calculate_quote": 2}
+        assert should_block_retry("calculate_quote", counter) is True
+
+    def test_three_failures_blocks(self):
+        """Más allá del threshold sigue bloqueado."""
+        counter = {"calculate_quote": 5}
+        assert should_block_retry("calculate_quote", counter) is True
+
+    def test_block_per_tool_name(self):
+        """Tool A failando 2x NO bloquea tool B (counter por tool)."""
+        counter = {"calculate_quote": 2}
+        assert should_block_retry("calculate_quote", counter) is True
+        assert should_block_retry("generate_documents", counter) is False
+
+    def test_custom_threshold(self):
+        """`threshold` override-able por callers (tests, futuras tunes)."""
+        counter = {"calculate_quote": 1}
+        assert should_block_retry("calculate_quote", counter, threshold=1) is True
+        assert should_block_retry("calculate_quote", counter, threshold=5) is False
+
+    def test_default_threshold_is_2(self):
+        """Drift guard del default. Si alguien lo cambia, este test
+        falla y obliga a actualizar el Issue + docs."""
+        assert DEFAULT_RETRY_THRESHOLD == 2
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# build_retry_block_result — mensaje sintético al agente
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestBuildRetryBlockResult:
+    def test_has_retry_blocked_flag(self):
+        """Caller downstream (logs, telemetría) debe poder identificar
+        que este result fue sintético, no del tool real."""
+        result = build_retry_block_result("calculate_quote", 2)
+        assert result.get("_retry_blocked") is True
+
+    def test_has_ok_false(self):
+        """`is_tool_failure` reconoce este result como fallo (sigue
+        contando para el threshold si el agent persiste)."""
+        result = build_retry_block_result("calculate_quote", 2)
+        assert result.get("ok") is False
+        assert is_tool_failure(result) is True
+
+    def test_error_mentions_tool_name(self):
+        result = build_retry_block_result("calculate_quote", 2)
+        assert "calculate_quote" in result["error"]
+
+    def test_error_mentions_failure_count(self):
+        result = build_retry_block_result("calculate_quote", 5)
+        assert "5" in result["error"]
+
+    def test_error_forces_operator_consultation(self):
+        """El mensaje DEBE mencionar al operador y NO dar pistas de
+        cómo auto-fixear. Sin esto, Sonnet puede ignorar el block."""
+        result = build_retry_block_result("calculate_quote", 2)
+        msg = result["error"].lower()
+        assert "operador" in msg
+        assert "no reintentes" in msg or "no reintentar" in msg
+        # NO debe sugerir fixes ni dar opciones — solo "consultá al operador".
+        assert "intentá" not in msg or "no" in msg
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# increment_failure — mutación del counter
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestIncrementFailure:
+    def test_first_increment(self):
+        counter: dict[str, int] = {}
+        new = increment_failure("calculate_quote", counter)
+        assert new == 1
+        assert counter == {"calculate_quote": 1}
+
+    def test_subsequent_increments(self):
+        counter = {"calculate_quote": 1}
+        new = increment_failure("calculate_quote", counter)
+        assert new == 2
+        assert counter["calculate_quote"] == 2
+
+    def test_independent_per_tool(self):
+        counter = {"calculate_quote": 2}
+        increment_failure("generate_documents", counter)
+        assert counter == {"calculate_quote": 2, "generate_documents": 1}
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Escenarios completos del Issue #422
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestRetryCounterScenarios:
+    """Tests end-to-end de la lógica del loop, sin la API.
+
+    Simulamos el bucle:
+        for tool_use in [...]:
+            if should_block_retry(name, counter):
+                result = build_retry_block_result(name, count)
+            else:
+                result = mock_execute_tool(...)
+            if is_tool_failure(result):
+                increment_failure(name, counter)
+    """
+
+    def _simulate_call(
+        self,
+        tool_name: str,
+        counter: dict[str, int],
+        mock_result: dict,
+    ) -> dict:
+        """Una iteración del loop agéntico, con un result mockeado."""
+        if should_block_retry(tool_name, counter):
+            prior = counter.get(tool_name, 0)
+            result = build_retry_block_result(tool_name, prior)
+        else:
+            result = mock_result
+        if is_tool_failure(result):
+            increment_failure(tool_name, counter)
+        return result
+
+    # ── 1. Tool falla 1 vez → retry permitido ─────────────────────────
+    def test_one_failure_allows_retry(self):
+        counter: dict[str, int] = {}
+        result1 = self._simulate_call(
+            "calculate_quote", counter, {"ok": False, "error": "fail 1"},
+        )
+        # 1ra ejecutó normal (no bloqueada).
+        assert result1.get("_retry_blocked") is None
+        assert counter["calculate_quote"] == 1
+
+    # ── 2. Tool falla 2 veces → 3er intento bloqueado ────────────────
+    def test_two_failures_then_block(self):
+        counter: dict[str, int] = {}
+        # 1ra
+        r1 = self._simulate_call("calculate_quote", counter, {"ok": False, "error": "fail 1"})
+        assert r1.get("_retry_blocked") is None
+        assert counter["calculate_quote"] == 1
+        # 2da
+        r2 = self._simulate_call("calculate_quote", counter, {"ok": False, "error": "fail 2"})
+        assert r2.get("_retry_blocked") is None
+        assert counter["calculate_quote"] == 2
+        # 3ra → BLOCKED. El mock_result pasado se descarta porque el
+        # block dispara antes de llegar a "ejecutar".
+        r3 = self._simulate_call("calculate_quote", counter, {"ok": False, "error": "fail 3"})
+        assert r3.get("_retry_blocked") is True
+        assert "operador" in r3["error"].lower()
+        # El bloque sintético TAMBIÉN cuenta como fallo (ok=False) →
+        # counter sigue subiendo. Si Sonnet ignora el block y vuelve a
+        # llamar, sigue en estado bloqueado, no entra en bucle infinito.
+        assert counter["calculate_quote"] == 3
+
+    # ── 3. Éxito intermedio NO resetea el contador ───────────────────
+    def test_success_between_failures_does_not_reset(self):
+        """Anti-patrón a evitar: si Sonnet alterna fail-success-fail,
+        el contador debe seguir contando los errores totales. Si
+        reseteáramos con éxitos, Sonnet podría caminar el sistema
+        haciendo un succ artificial entre cada retry."""
+        counter: dict[str, int] = {}
+        self._simulate_call("calculate_quote", counter, {"ok": False, "error": "fail 1"})
+        assert counter["calculate_quote"] == 1
+        # Éxito intermedio
+        r_success = self._simulate_call("calculate_quote", counter, {"ok": True, "data": "..."})
+        assert r_success.get("ok") is True
+        assert counter["calculate_quote"] == 1, "Éxito NO debe resetear"
+        # Otro fail
+        self._simulate_call("calculate_quote", counter, {"ok": False, "error": "fail 2"})
+        assert counter["calculate_quote"] == 2
+        # 3ra debería bloquear (a pesar del éxito intermedio).
+        r_blocked = self._simulate_call("calculate_quote", counter, {"ok": True, "data": "..."})
+        assert r_blocked.get("_retry_blocked") is True
+
+    # ── 4. Tool distinto NO contribuye al primer counter ─────────────
+    def test_independent_tool_counters(self):
+        counter: dict[str, int] = {}
+        # calculate_quote falla 2 veces → próxima bloqueada.
+        self._simulate_call("calculate_quote", counter, {"ok": False, "error": "fail"})
+        self._simulate_call("calculate_quote", counter, {"ok": False, "error": "fail"})
+        assert counter["calculate_quote"] == 2
+        # generate_documents en su 1ra → debe pasar normal.
+        r = self._simulate_call("generate_documents", counter, {"ok": False, "error": "validation fail"})
+        assert r.get("_retry_blocked") is None
+        assert counter["generate_documents"] == 1
+        # calculate_quote 3ra sigue bloqueada.
+        r2 = self._simulate_call("calculate_quote", counter, {"ok": True, "data": "..."})
+        assert r2.get("_retry_blocked") is True
+
+    # ── 5. Drift guard del block — NO debe sugerir fixes ─────────────
+    def test_block_message_does_not_suggest_autofix(self):
+        """El mensaje del bloque debe forzar consulta al operador, no
+        sugerir 'intentá con otros valores'. Sin esto Sonnet puede
+        ignorar el block y meter más valores inventados."""
+        counter = {"calculate_quote": 2}
+        r = self._simulate_call("calculate_quote", counter, {})
+        msg = r["error"].lower()
+        assert "operador" in msg
+        # Frases que NO deben aparecer (incentivan auto-fix):
+        forbidden = ["probá con", "intentá con valores", "ajustá los"]
+        for phrase in forbidden:
+            assert phrase not in msg, f"Found auto-fix hint: {phrase!r} in {msg!r}"


### PR DESCRIPTION
Closes #422

## Summary

**Bug observado en producción** (logs DYSCON `9da51080-...`):

```
1. validator rebota: "material_m2=48.584 no coincide con suma=45.55"
2. Sonnet decide "lo arreglo yo" → llama calculate_quote DE NUEVO
   con m2_override en cada pieza inventando valores.
3. pasa 845.03 m² (1755% del valor real). guardrail-B aborta. ✓
```

Sonnet **NO le preguntó al operador**. El guardrail-B atrapó ESE caso pero el patrón vuelve con cualquier validator nuevo.

**Estrategia (review feedback en Issue #422):** retry counter en `agent.py`. Camino #2 sobre #1 (system prompt):

> El system prompt es demasiado frágil en conversaciones largas, ya lo vimos en esta sesión donde Valentina ignoró varias instrucciones del brief. Un contador en agent.py es un cambio de 10 líneas que da garantía real.

## Cambios

### 1. `retry_guard.py` (módulo nuevo, aislado para tests)

```python
DEFAULT_RETRY_THRESHOLD = 2  # 1 original + 1 retry + 3er bloqueado

def is_tool_failure(result) -> bool: ...
def should_block_retry(name, counter, threshold=2) -> bool: ...
def build_retry_block_result(name, prior) -> dict: ...
def increment_failure(name, counter) -> int: ...
```

### 2. `agent.py:stream_chat` (~10 LOC)

```python
_tool_failure_count: dict[str, int] = {}

# ... loop:
if should_block_retry(tool_use.name, _tool_failure_count):
    result = build_retry_block_result(tool_use.name, _prior)
    logging.warning(f"[retry-block:{quote_id}] ...")
else:
    result = await self._execute_tool(...)

if is_tool_failure(result):
    increment_failure(tool_use.name, _tool_failure_count)
    logging.info(f"[retry-counter:{quote_id}] ...")
```

Reset implícito por turno del operador (cada `stream_chat` crea dict nuevo).

## Tests (29 casos)

- `is_tool_failure` (9): dict/list/None/empty/edge.
- `should_block_retry` (7): boundary + per-tool + custom threshold + drift guard `DEFAULT == 2`.
- `build_retry_block_result` (5): shape + drift guard del mensaje (debe forzar operador y NO sugerir auto-fix).
- `increment_failure` (3): mutación, independencia por tool.
- **Escenarios E2E del Issue #422 (5 críticos)**:
  1. Tool falla 1 vez → retry permitido ✓
  2. Tool falla 2 veces → 3er intento BLOCKED ✓
  3. **Éxito intermedio NO resetea** — anti-patrón evitado ✓
  4. Tool distinto NO contribuye al counter del primero ✓
  5. Drift guard: mensaje no sugiere `intentá con valores...` ✓

Suite full: **2322 passing** (+29 nuevos). 16 fallos preexistentes (no introducidos por este PR).

## Lo que NO toca

- Tools individuales: comportamiento idéntico.
- System prompt: intacto (camino #1 descartado por review).
- Calculator, validator, frontend, schemas.

## Test plan

- [x] `pytest tests/test_agent_retry_guard.py -v` → 29/29.
- [x] Suite full → 2322 passing (+29, 0 regresiones).
- [ ] CI verde.
- [ ] **Validación post-merge** (con datos reales en staging):
  - Forzar un quote que dispare validator error → confirmar logs Railway:
    ```
    [retry-counter:<qid>] tool=calculate_quote count=1 error=...
    [retry-counter:<qid>] tool=calculate_quote count=2 error=...
    [retry-block:<qid>] tool=calculate_quote count=2 BLOCKED — forcing operator consultation
    ```
  - Confirmar que Sonnet ya NO sigue inventando valores después del block — emite mensaje al operador en su próxima respuesta.

## Deuda pendiente (no en este PR)

Issue #422 menciona el camino **#3 (hard guard por valores 30%+ distintos entre llamadas)** como segunda capa. Este PR solo implementa el #2. Cuando se justifique con un caso real, otro PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)