### PR TITLE
fix(brief-analyzer): override LLM hallucination cuando "frente regrueso" → frentin

### DIFF
--- a/api/app/modules/quote_engine/brief_analyzer.py
+++ b/api/app/modules/quote_engine/brief_analyzer.py
@@ -227,6 +227,59 @@ _REGRUESO = re.compile(r"\bregrueso\b", re.IGNORECASE)
 _PULIDO = re.compile(r"\bpulido\b", re.IGNORECASE)
 
 
+# Map de flags que el LLM puede marcar como `true` y que validamos
+# contra el brief literal con word-boundary. PR #425 — fix
+# alucinación del LLM Haiku que confundía "frente regrueso" con
+# "frentín". Ver `_validate_llm_word_mentions` abajo.
+_LLM_WORD_VALIDATIONS = (
+    ("frentin_mentioned", _FRENTIN, "frent[ií]n"),
+    ("regrueso_mentioned", _REGRUESO, "regrueso"),
+    ("pulido_mentioned", _PULIDO, "pulido"),
+)
+
+
+def _validate_llm_word_mentions(brief: str, result: dict) -> None:
+    """Override flags ruidosos del LLM cuando la palabra literal NO
+    aparece word-boundary en el brief.
+
+    **Por qué existe (PR #425, caso DYSCON 29/04/2026):**
+
+    El LLM Haiku marcaba `frentin_mentioned: true` para briefs que
+    contenían "frente regrueso" (interpretaba "frente" como frentín,
+    aunque son dos conceptos distintos en marmolería: frentín =
+    pieza vertical pegada al borde frontal, MO con SKU FALDON;
+    frente regrueso = pieza horizontal que aumenta espesor visual
+    del frente, MO con SKU REGRUESO).
+
+    Endurecer el system prompt es frágil (review feedback: "el
+    system prompt es demasiado frágil en conversaciones largas").
+    Garantía dura: post-process con los mismos regex word-boundary
+    que ya usa el fallback. Si el LLM dice `true` pero la palabra
+    literal NO está en el brief, override a `False` con log.
+
+    **Edge case conocido**: "sin frentín" → `frentin_mentioned: true`
+    porque la palabra literal aparece. Es técnicamente correcto a
+    nivel del analyzer (la mención está). Sonnet maneja la negación
+    contextualmente. No es responsabilidad de este filtro detectar
+    negación — anotado en Issue follow-up.
+
+    Muta `result` in-place. NO tira excepciones — la observabilidad
+    nunca rompe el flow (warning log + continúa).
+    """
+    for flag_key, regex, word_label in _LLM_WORD_VALIDATIONS:
+        if not result.get(flag_key):
+            continue
+        if regex.search(brief):
+            continue  # LLM y regex coinciden — OK
+        # LLM dijo true pero la palabra literal no está → alucinación.
+        logger.warning(
+            f"[brief-analyzer] LLM hallucination override: "
+            f"{flag_key}=true sin literal '{word_label}' en brief. "
+            f"Override → False. Brief snippet: {brief[:150]!r}"
+        )
+        result[flag_key] = False
+
+
 def _extract_material_regex(brief: str) -> str | None:
     low = brief.lower()
     start_idx = -1
@@ -417,4 +470,11 @@ async def analyze_brief(brief: str) -> dict:
         f"{result['pileta_simple_doble']}, anafe_count={result['anafe_count']}, "
         f"isla={result['isla_mentioned']}, es_edificio={result['es_edificio']}"
     )
+
+    # PR #425 — post-process anti-alucinación. Mismas regex word-boundary
+    # que el fallback regex; se ejecuta SOLO en la rama LLM porque el
+    # fallback ya usa los regex como única fuente y no produce false
+    # positives por construcción.
+    _validate_llm_word_mentions(brief, result)
+
     return result

--- a/api/tests/test_brief_analyzer_llm_hallucination.py
+++ b/api/tests/test_brief_analyzer_llm_hallucination.py
@@ -1,0 +1,254 @@
+"""Tests para PR #425 — fix alucinación del LLM Haiku que confunde
+"frente regrueso" con "frentín".
+
+**Caso DYSCON 29/04/2026:**
+
+El "Análisis de contexto" del operador mostraba:
+- "Frentín: Mencionado _(brief)_"
+
+PERO el brief NO contenía la palabra "frentín". Sí contenía "M1 frente
+regrueso × 24" (las piezas frente regrueso del despiece).
+
+**Causa raíz:** `brief_analyzer.py` usa Haiku como fuente primaria con
+regex como fallback. El LLM interpretaba "frente regrueso" como
+"frentín" — son términos distintos:
+- frentín / faldón = pieza vertical pegada al borde frontal de la
+  mesada (5–10 cm de alto), MO con SKU FALDON.
+- frente regrueso = pieza horizontal que aumenta el espesor visual
+  del frente (5 cm), MO con SKU REGRUESO.
+
+El regex fallback `\\bfrent[ií]n\\b` con word boundary NO matchearía
+"frente regrueso" — pero el regex es solo fallback, no se ejecuta
+cuando el LLM responde.
+
+**Fix (review feedback "no toques el system prompt"):** post-process
+con regex word-boundary después del LLM. Si LLM dice
+`frentin_mentioned: true` pero la palabra literal NO aparece →
+override a False con log.
+
+**Tests cubren:**
+
+1. **Caso DYSCON real**: "frente regrueso" en el brief → frentin
+   override a False, regrueso queda en True.
+2. **Caso positivo legítimo**: "con frentín h:5cm" → no se override.
+3. **Edge case "sin frentín"**: la palabra aparece → flag queda True
+   aunque sea negación contextual. Documentado en docstring del
+   helper — Sonnet maneja la negación, no el analyzer.
+4. **Drift guard**: el helper se ejecuta en la rama LLM (no en regex
+   fallback, donde no hay false positives por construcción).
+5. **Análogos para regrueso/pulido**: el LLM puede alucinar
+   cualquiera de los 3 — el helper los cubre simétricamente.
+6. **No-op cuando LLM responde correctamente**: si LLM dice false,
+   el helper no toca nada.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.modules.quote_engine.brief_analyzer import (
+    _validate_llm_word_mentions,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Caso DYSCON real — caso del bug reportado
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestDysconHallucination:
+    def test_frente_regrueso_does_not_imply_frentin(self):
+        """Caso real DYSCON: brief con "M1 frente regrueso × 24" y
+        análogos. LLM marca frentin_mentioned=true (alucinación).
+        Override a False post-process."""
+        brief = (
+            "CLIENTE: DYSCON S.A.\n"
+            "OBRA: Unidad Penal N°8 — Piñero\n"
+            "M1 mesada × 24, M1 zócalo atrás × 24, M1 frente regrueso × 24\n"
+            "M2 mesada (Office 32), M2 zócalo atrás, M2 frente regrueso\n"
+        )
+        result = {
+            "frentin_mentioned": True,   # ← alucinación del LLM
+            "regrueso_mentioned": True,  # ← legítimo (sí dice "regrueso")
+            "pulido_mentioned": False,
+        }
+        _validate_llm_word_mentions(brief, result)
+        assert result["frentin_mentioned"] is False, (
+            "Override fallido: 'frente regrueso' no debe disparar frentin"
+        )
+        assert result["regrueso_mentioned"] is True, (
+            "Regrueso es legítimo — la palabra 'regrueso' aparece word-boundary"
+        )
+        assert result["pulido_mentioned"] is False  # invariante
+
+    def test_only_frente_no_regrueso_overrides_both(self):
+        """Brief que dice 'frente' pero no 'regrueso' explícito (raro
+        pero posible). LLM podría marcar ambos por confusión."""
+        brief = "Mesada con frente plano de 5cm"
+        result = {
+            "frentin_mentioned": True,
+            "regrueso_mentioned": True,  # también alucinación si no dice "regrueso"
+            "pulido_mentioned": False,
+        }
+        _validate_llm_word_mentions(brief, result)
+        assert result["frentin_mentioned"] is False
+        assert result["regrueso_mentioned"] is False
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Casos legítimos — no se override
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestLegitimateMentions:
+    def test_frentin_literal_keeps_true(self):
+        """'con frentín h:5cm' → la palabra está, flag queda True."""
+        brief = "Mesada con frentín h:5cm"
+        result = {"frentin_mentioned": True, "regrueso_mentioned": False, "pulido_mentioned": False}
+        _validate_llm_word_mentions(brief, result)
+        assert result["frentin_mentioned"] is True
+
+    def test_frentin_no_tilde_keeps_true(self):
+        """'frentin' (sin tilde) también es literal — el regex matchea
+        ambos `\\bfrent[ií]n\\b`."""
+        brief = "Mesada con frentin de 5cm"
+        result = {"frentin_mentioned": True, "regrueso_mentioned": False, "pulido_mentioned": False}
+        _validate_llm_word_mentions(brief, result)
+        assert result["frentin_mentioned"] is True
+
+    def test_frentin_uppercase_keeps_true(self):
+        """Case-insensitive — 'FRENTÍN' debería match."""
+        brief = "Mesada CON FRENTÍN H:5CM"
+        result = {"frentin_mentioned": True, "regrueso_mentioned": False, "pulido_mentioned": False}
+        _validate_llm_word_mentions(brief, result)
+        assert result["frentin_mentioned"] is True
+
+    def test_regrueso_literal_keeps_true(self):
+        brief = "Regrueso de 5cm en frente"
+        result = {"frentin_mentioned": False, "regrueso_mentioned": True, "pulido_mentioned": False}
+        _validate_llm_word_mentions(brief, result)
+        assert result["regrueso_mentioned"] is True
+
+    def test_pulido_literal_keeps_true(self):
+        brief = "Pulido especial en cantos visibles"
+        result = {"frentin_mentioned": False, "regrueso_mentioned": False, "pulido_mentioned": True}
+        _validate_llm_word_mentions(brief, result)
+        assert result["pulido_mentioned"] is True
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Edge case documentado: "sin frentín"
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestNegationEdgeCase:
+    def test_sin_frentin_keeps_flag_true(self):
+        """**Edge case (review feedback)**: 'sin frentín' contiene la
+        palabra literal → flag queda True. Es responsabilidad de
+        Sonnet manejar la negación contextualmente, NO del analyzer
+        filtrar negaciones. Anotado en Issue follow-up.
+
+        Si el día de mañana se decide filtrar negaciones a este
+        nivel, este test SE ROMPERÁ y obligará a actualizar la
+        documentación + el flow."""
+        brief = "Mesada sin frentín, solo zócalo atrás"
+        result = {"frentin_mentioned": True, "regrueso_mentioned": False, "pulido_mentioned": False}
+        _validate_llm_word_mentions(brief, result)
+        assert result["frentin_mentioned"] is True, (
+            "Negación NO se filtra acá — Sonnet maneja contexto. "
+            "Si esto cambia, ver Issue follow-up del PR #425."
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# No-op cuando el LLM responde correctamente
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestNoOpWhenLLMCorrect:
+    def test_llm_says_false_no_change(self):
+        """Si LLM dice False, el helper NO toca nada (incluso si la
+        palabra aparece — confiamos en el LLM cuando dice False)."""
+        brief = "Mesada con frentín h:5cm"
+        result = {"frentin_mentioned": False, "regrueso_mentioned": False, "pulido_mentioned": False}
+        _validate_llm_word_mentions(brief, result)
+        assert result["frentin_mentioned"] is False  # sin cambios
+
+    def test_all_flags_false_no_op(self):
+        brief = "Brief sin trabajos extra"
+        result = {"frentin_mentioned": False, "regrueso_mentioned": False, "pulido_mentioned": False}
+        _validate_llm_word_mentions(brief, result)
+        assert result == {"frentin_mentioned": False, "regrueso_mentioned": False, "pulido_mentioned": False}
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Logging
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestObservability:
+    def test_override_emits_warning(self, caplog):
+        """Cuando se hace override, debe quedar log warning con el
+        snippet del brief para diagnosticar. Si en producción aparece
+        muchas veces, sabemos que el LLM aluciona seguido."""
+        import logging
+        brief = "M1 frente regrueso × 24"
+        result = {"frentin_mentioned": True, "regrueso_mentioned": True, "pulido_mentioned": False}
+        with caplog.at_level(logging.WARNING, logger="app.modules.quote_engine.brief_analyzer"):
+            _validate_llm_word_mentions(brief, result)
+        warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("hallucination" in m.lower() for m in warnings), (
+            f"Esperaba warning de hallucination, vi {warnings}"
+        )
+        assert any("frentin_mentioned" in m for m in warnings)
+
+    def test_no_override_no_warning(self, caplog):
+        """Sin override → ningún warning del helper."""
+        import logging
+        brief = "Mesada con frentín h:5cm"
+        result = {"frentin_mentioned": True, "regrueso_mentioned": False, "pulido_mentioned": False}
+        with caplog.at_level(logging.WARNING, logger="app.modules.quote_engine.brief_analyzer"):
+            _validate_llm_word_mentions(brief, result)
+        warnings = [
+            r.message for r in caplog.records
+            if r.levelno >= logging.WARNING and "hallucination" in r.message.lower()
+        ]
+        assert warnings == []
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Drift guards
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestDriftGuards:
+    def test_helper_does_not_raise_on_missing_keys(self):
+        """Defensivo: result puede no tener todos los flags si llegó
+        un shape incompleto. No tirar excepción."""
+        brief = "frente regrueso"
+        result = {}  # ← shape incompleta
+        _validate_llm_word_mentions(brief, result)  # no debe romper
+        # No agrega keys que no estaban
+        assert "frentin_mentioned" not in result
+
+    def test_empty_brief_no_op(self):
+        """Brief vacío → nada que validar. Helper no tira."""
+        result = {"frentin_mentioned": True, "regrueso_mentioned": True, "pulido_mentioned": True}
+        _validate_llm_word_mentions("", result)
+        # Brief vacío → todas las palabras "no aparecen" → todos override.
+        assert result["frentin_mentioned"] is False
+        assert result["regrueso_mentioned"] is False
+        assert result["pulido_mentioned"] is False
+
+    def test_validation_map_has_three_entries(self):
+        """Drift guard: si alguien agrega un nuevo flag al schema
+        (ej. `inglete_mentioned`), tiene que agregarlo también al
+        mapa de validation. Test recuerda."""
+        from app.modules.quote_engine.brief_analyzer import _LLM_WORD_VALIDATIONS
+        flag_keys = {entry[0] for entry in _LLM_WORD_VALIDATIONS}
+        assert flag_keys == {
+            "frentin_mentioned", "regrueso_mentioned", "pulido_mentioned",
+        }, (
+            f"Validation map cambió: {flag_keys}. Si agregaste un nuevo "
+            "flag de tipo `*_mentioned`, agregalo a _LLM_WORD_VALIDATIONS "
+            "para protegerlo de alucinaciones del LLM."
+        )


### PR DESCRIPTION
## Summary

**Bug observado** (Análisis de contexto, 29/04/2026):

```
- Frentín: Mencionado _(brief)_
```

Pero el brief NO contenía la palabra "frentín". Sí contenía `M1 frente regrueso × 24` (despiece DYSCON).

**Causa raíz:** `brief_analyzer.py` usa Haiku como fuente primaria con regex como fallback. El LLM interpretaba "frente regrueso" como "frentín" — son conceptos distintos:

| Término | Qué es | SKU MO |
|---|---|---|
| frentín / faldón | Pieza vertical pegada al borde frontal (5–10 cm) | FALDON |
| frente regrueso | Pieza horizontal que aumenta espesor visual del frente (5 cm) | REGRUESO |

El regex fallback `\bfrent[ií]n\b` con word boundary NO matchea "frente regrueso", pero el regex es solo fallback — no se ejecuta cuando el LLM responde.

## Fix

**No tocar el system prompt** (review feedback explícito: prompt frágil en conversaciones largas, garantía dura > heurística verbal).

Post-process con regex word-boundary después del LLM:

```python
def _validate_llm_word_mentions(brief, result):
    for flag_key, regex, word_label in _LLM_WORD_VALIDATIONS:
        if not result.get(flag_key):
            continue
        if regex.search(brief):
            continue  # LLM y regex coinciden — OK
        # LLM dijo true pero la palabra literal no está → alucinación.
        logger.warning(...)
        result[flag_key] = False
```

`_LLM_WORD_VALIDATIONS` cubre los 3 flags conocidos: `frentin_mentioned`, `regrueso_mentioned`, `pulido_mentioned`. Drift guard en tests obliga a agregar al map cualquier flag nuevo del schema.

## Tests (15 casos)

| Categoría | Tests | Foco |
|---|---|---|
| DYSCON real | 2 | "frente regrueso" override frentin pero conserva regrueso |
| Legítimos | 5 | frentín con/sin tilde/uppercase, regrueso, pulido — flags quedan True |
| **Edge case `sin frentín`** | 1 | Flag queda True (palabra literal aparece). Sonnet maneja negación, NO el analyzer. Documentado en docstring + Issue follow-up. |
| No-op | 2 | LLM dice False → no toca; todo False → no-op |
| Observability | 2 | Warning log cuando override / sin warning cuando no |
| Drift guards | 3 | No rompe con shape incompleta; brief vacío override todo; map tiene exactamente los 3 flags |

Suite full: **2365 passing** (+15). 16 fallos preexistentes (no introducidos por este PR).

## Lo que NO toca

- System prompt del LLM Haiku.
- `_analyze_regex_fallback` (usa los mismos regex como única fuente).
- `context_analyzer.py` (solo cambia el `analysis` que recibe).

## Issue follow-up (anotado en docstring + se abre post-merge)

Edge case "sin frentín" / "no incluye frentín": el analyzer marca `frentin_mentioned: true` porque la palabra literal aparece. Es correcto a nivel del analyzer (la mención está). Sonnet maneja la negación contextualmente. Si se decide filtrar negaciones a este nivel, el test `test_sin_frentin_keeps_flag_true` se rompe y obliga a actualizar.

## Test plan

- [x] `pytest tests/test_brief_analyzer_llm_hallucination.py -v` → 15/15.
- [x] Suite full → 2365 passing (+15, 0 regresiones).
- [ ] **Validación post-merge**: re-procesar brief DYSCON real → "Análisis de contexto" YA NO debe mostrar `Frentín: Mencionado`. Logs Railway: buscar `[brief-analyzer] LLM hallucination override` para medir frecuencia del bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)