### PR TITLE
fix(agent): bypass contexto/despiece para briefs solo-producto + fix validator rebote

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -2370,6 +2370,156 @@ class AgentService:
             logging.warning(f"[card-editor] handler exception (non-fatal): {e}", exc_info=True)
             # Fall through al flujo normal de Claude.
 
+        _is_system_trigger = user_message and user_message.strip().startswith("[")
+
+        # ── PR #427 — Products-only short-circuit ──
+        # Caso DYSCON 29/04/2026: brief "Pileta Johnson E50 × 32, sin MO,
+        # sin flete, descuento 5%". El flujo normal (text-parser →
+        # context_analysis → despiece) es ruidoso e inútil para
+        # cotizaciones de producto suelto:
+        # - Genera "Análisis de contexto" con frentin/regrueso/mesadas
+        #   inventadas (alucinación del LLM Haiku).
+        # - Emite card de despiece editable con piezas que no
+        #   corresponden.
+        # - Ridireccionando todo al modo products_only del calculator
+        #   solo después de un Paso 2 confuso.
+        #
+        # Detector + parser determinísticos (3 señales: "solo producto"
+        # + "sin MO" + producto pileta/bacha). Cuando dispara, llamamos
+        # `calculate_quote` directo, emitimos `_paso2_rendered` al
+        # stream y cerramos el turno. Mismo patrón que el PASO 2
+        # short-circuit del while loop más abajo.
+        #
+        # Skipea si: hay plano adjunto, hay system trigger, ya existe
+        # card previa, o el detector NO dispara → fallback al flujo
+        # normal sin tocar nada.
+        if (
+            not _just_confirmed_dual_read
+            and not plan_bytes
+            and not (extra_files or [])
+            and user_message
+            and not _is_system_trigger
+        ):
+            try:
+                from app.modules.quote_engine.products_only_detector import (
+                    is_products_only_brief,
+                    parse_products_brief,
+                )
+                if is_products_only_brief(user_message):
+                    parsed_po = parse_products_brief(user_message)
+                    if parsed_po:
+                        # Quote check — no re-disparar si ya hay breakdown
+                        # products_only persistido (operador re-envía el
+                        # mismo brief o reload del chat).
+                        _po_q = await db.execute(
+                            select(Quote).where(Quote.id == quote_id)
+                        )
+                        _po_quote = _po_q.scalar_one_or_none()
+                        _po_bd = (
+                            (_po_quote.quote_breakdown or {})
+                            if _po_quote else {}
+                        )
+                        _po_already = bool(
+                            _po_bd.get("_quote_mode") == "products_only"
+                        )
+                        if not _po_already and _po_quote is not None:
+                            yield {
+                                "type": "action",
+                                "content": "🛒 Cotización solo producto detectada — calculando...",
+                            }
+                            # Heredar client_name/project del quote si el
+                            # parser no los encontró en el brief.
+                            if not parsed_po.get("client_name"):
+                                parsed_po["client_name"] = (
+                                    _po_quote.client_name or "DYSCON S.A."
+                                )
+                            if not parsed_po.get("project"):
+                                parsed_po["project"] = (
+                                    _po_quote.project or "Cotización productos"
+                                )
+                            try:
+                                from app.modules.quote_engine.calculator import (
+                                    build_deterministic_paso2,
+                                    calculate_quote as _calc_po,
+                                )
+                                _po_result = _calc_po(parsed_po)
+                            except Exception as _e_po_calc:
+                                logging.warning(
+                                    f"[products-only] calculate_quote crashed: "
+                                    f"{_e_po_calc}. Falling back to normal flow."
+                                )
+                                _po_result = {"ok": False, "error": str(_e_po_calc)}
+
+                            if _po_result.get("ok"):
+                                # Build deterministic Paso 2 + persistir
+                                _po_result["_paso2_rendered"] = (
+                                    build_deterministic_paso2(_po_result)
+                                )
+                                _po_result["quote_id"] = quote_id
+
+                                # Persistir breakdown + columnas dedicadas
+                                # (cliente/proyecto) para que aparezca en
+                                # dashboard listado desde el turno 1.
+                                _po_persist = {
+                                    "quote_breakdown": dict(_po_result),
+                                    "total_ars": _po_result.get("total_ars", 0),
+                                    "total_usd": 0,
+                                    "material": "",  # explicit empty
+                                }
+                                if parsed_po.get("client_name"):
+                                    _po_persist["client_name"] = parsed_po["client_name"]
+                                if parsed_po.get("project"):
+                                    _po_persist["project"] = parsed_po["project"]
+                                try:
+                                    await db.execute(
+                                        update(Quote).where(
+                                            Quote.id == quote_id
+                                        ).values(**_po_persist)
+                                    )
+                                    # Emit + persist assistant turn
+                                    _po_paso2 = _po_result.get("_paso2_rendered", "")
+                                    if _po_paso2:
+                                        yield {
+                                            "type": "text",
+                                            "content": _po_paso2,
+                                        }
+                                        await db.execute(
+                                            update(Quote).where(
+                                                Quote.id == quote_id
+                                            ).values(
+                                                messages=list(_po_quote.messages or []) + [
+                                                    {"role": "user", "content": user_message},
+                                                    {"role": "assistant", "content": _po_paso2},
+                                                ]
+                                            )
+                                        )
+                                    await db.commit()
+                                    logging.info(
+                                        f"[products-only] short-circuit OK "
+                                        f"for {quote_id}: qty={parsed_po['pileta_qty']}, "
+                                        f"sku={parsed_po['pileta_sku']}, "
+                                        f"total={_po_result.get('total_ars')}"
+                                    )
+                                    return  # ← end turn, NO contexto/despiece
+                                except Exception as _e_po_persist:
+                                    logging.warning(
+                                        f"[products-only] persist failed: "
+                                        f"{_e_po_persist}. Continuing to normal flow."
+                                    )
+                            else:
+                                # calc rebotó (ej: SKU no encontrado).
+                                # NO short-circuit — caemos al flujo normal
+                                # para que Sonnet maneje el error.
+                                logging.warning(
+                                    f"[products-only] calc rejected: "
+                                    f"{_po_result.get('error')}. Fallback normal."
+                                )
+            except Exception as _e_po_outer:
+                logging.warning(
+                    f"[products-only] detector/parser crashed: "
+                    f"{_e_po_outer}. Fallback normal flow."
+                )
+
         # ── Text-only brief → emit card editable ──
         # Si no hay archivos adjuntos pero el operador mandó texto con medidas,
         # parseamos el texto y emitimos la MISMA card que dual_read. Así el
@@ -2381,7 +2531,6 @@ class AgentService:
         # - No es un trigger de sistema ([DUAL_READ_CONFIRMED], [SYSTEM_TRIGGER])
         # - No hay card previa ya emitida ni medidas confirmadas (dedup)
         # - El parser devuelve ≥1 mesada válida
-        _is_system_trigger = user_message and user_message.strip().startswith("[")
         if (
             not _just_confirmed_dual_read
             and not plan_bytes

--- a/api/app/modules/agent/tools/validation_tool.py
+++ b/api/app/modules/agent/tools/validation_tool.py
@@ -142,6 +142,15 @@ def _check_iva_mo(qdata: dict) -> tuple[list[str], list[str]]:
 def _check_material_total(qdata: dict) -> tuple[list[str], list[str]]:
     """Verify material_total = round(m2 * price_unit) - discount_amount."""
     errors, warnings = [], []
+
+    # PR #427 — modo products_only: el `discount_amount` aplica sobre
+    # el subtotal de SINKS, no sobre el material (que es 0). Sin este
+    # skip, el check ve `m2=0, price=0, gross=0, discount=N` →
+    # expected=-N, actual=0 → rebota generate_documents. La consistencia
+    # del descuento con sinks ya se valida en `_check_products_only_consistency`.
+    if qdata.get("_quote_mode") == "products_only":
+        return errors, warnings
+
     m2 = qdata.get("material_m2")
     price_unit = qdata.get("material_price_unit")
     total = qdata.get("material_total")
@@ -192,6 +201,16 @@ def _check_merma_rules(qdata: dict) -> tuple[list[str], list[str]]:
 def _check_pegadopileta(qdata: dict) -> tuple[list[str], list[str]]:
     """If pileta is empotrada, exactly 1 pileta MO item should exist."""
     errors, warnings = [], []
+
+    # PR #427 — modo products_only: el operador pidió "sin MO"
+    # explícito. El calculator NO inyecta MO de pileta en ese modo,
+    # pero `pileta` puede quedar seteado en el calc_result si Sonnet
+    # lo pasó como input (costumbre del flujo normal). Sin este skip,
+    # el validator rebota generate_documents → operador no llega al
+    # PDF (caso DYSCON solo-piletas, 29/04/2026).
+    if qdata.get("_quote_mode") == "products_only":
+        return errors, warnings
+
     pileta = qdata.get("pileta") or ""
 
     if pileta not in ("empotrada_johnson", "empotrada_cliente"):

--- a/api/app/modules/quote_engine/products_only_detector.py
+++ b/api/app/modules/quote_engine/products_only_detector.py
@@ -1,0 +1,254 @@
+"""Detector + parser determinístico para briefs de "solo producto".
+
+**Por qué este módulo existe (PR #427, caso DYSCON 29/04/2026):**
+
+PR #424 implementó el modo `products_only` en el calculator + validator
++ renderers. Pero el flujo upstream del agente (text-parser, dual-read,
+context_analysis) sigue corriendo igual para briefs de "solo piletas":
+muestra un "Análisis de contexto" con "Frentín: Mencionado" y un
+despiece inventado, antes de llegar al cálculo correcto.
+
+Para evitar ese ruido, este módulo provee:
+
+1. **Detector binario** `is_products_only_brief(brief)` — devuelve
+   True solo si el brief tiene 3 señales fuertes simultáneas:
+   - "solo producto" / "solo piletas" / "solo bachas" (variantes).
+   - "sin MO" / "sin mano de obra".
+   - Mención de pileta/bacha.
+
+   3 señales requeridas para minimizar falsos positivos. Un brief
+   normal de cocina/edificio no las tiene todas a la vez.
+
+2. **Parser determinístico** `parse_products_brief(brief)` — extrae
+   `{pileta_sku, pileta_qty, discount_pct, client_name, project}`
+   con regex. Devuelve None si no encuentra producto/cantidad.
+
+**Decisiones de diseño:**
+
+- **Determinístico, no LLM.** El review feedback de PR #423 fue
+  explícito: "el system prompt es demasiado frágil en conversaciones
+  largas". Mismo principio acá — regex que cualquier humano puede
+  auditar.
+- **3 señales requeridas, no OR.** Si solo aparece "sin MO" en un
+  brief de mesadas que pide "sin MO de colocación específica", NO
+  queremos disparar. Las 3 juntas son señal de cotización pura de
+  producto.
+- **Match case-insensitive con word-boundaries** donde aplica, para
+  evitar false positives ("frentín" no debería matchear "frente").
+
+**Edge cases conocidos** (NO se manejan, fallan loud o se documentan):
+
+- "solo producto pileta apoyo" → matchea (correcto, es solo producto).
+- "solo producto pero con MO de instalación" → NO matchea (falta
+  "sin MO" → flujo normal).
+- "Pileta Johnson sin MO" sin la frase "solo producto" → NO matchea
+  (falta señal "solo *"). Decisión conservadora.
+"""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# ─────────────────────────────────────────────────────────────────────
+# Detector
+# ─────────────────────────────────────────────────────────────────────
+
+# Variantes de "solo producto" que el operador puede escribir.
+# Lista deliberadamente cerrada — ampliarla solo si aparece un caso
+# real con frases distintas.
+_SOLO_PRODUCTO_PHRASES = (
+    "solo producto",
+    "solo piletas",
+    "solo pileta",
+    "solo bachas",
+    "solo bacha",
+    "sólo producto",
+    "sólo piletas",
+)
+
+# "Sin MO" en sus variantes habituales. Word-boundary en `\bmo\b` para
+# no matchear "minimo", "modelo", etc.
+_SIN_MO_RE = re.compile(
+    r"\bsin\s+(?:m\.?o\.?|mano\s+de\s+obra)\b",
+    re.IGNORECASE,
+)
+
+# Mención de producto pileta/bacha como palabra suelta.
+_HAS_PILETA_RE = re.compile(r"\b(pileta|bacha)\b", re.IGNORECASE)
+
+
+def is_products_only_brief(brief: str) -> bool:
+    """¿El brief indica cotización solo de producto sin MO/instalación?
+
+    Requiere LAS TRES señales simultáneamente:
+    1. Frase del tipo "solo producto"/"solo piletas".
+    2. "sin MO" / "sin mano de obra".
+    3. Mención de "pileta" o "bacha".
+
+    Cualquier 2-de-3 NO dispara — minimiza falsos positivos.
+
+    Returns:
+        True si las 3 señales están presentes. False en cualquier otro
+        caso, incluido `brief` vacío o None.
+    """
+    if not brief:
+        return False
+    b_lower = brief.lower()
+    has_solo = any(s in b_lower for s in _SOLO_PRODUCTO_PHRASES)
+    if not has_solo:
+        return False
+    has_no_mo = bool(_SIN_MO_RE.search(brief))
+    if not has_no_mo:
+        return False
+    has_product = bool(_HAS_PILETA_RE.search(brief))
+    return has_product
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Parser — extracción de campos del brief
+# ─────────────────────────────────────────────────────────────────────
+
+# "Pileta Johnson E50 × 32" / "× 32 unidades" / "x 32u" / "32 unidades"
+# Capturamos la cantidad. El × puede ser "×" Unicode o "x" ASCII.
+# Para 'Pileta ... × N' o 'N unidades/u' al final.
+_QTY_RE_AFTER_PRODUCT = re.compile(
+    r"(?:[×x]\s*)(\d+)(?:\s*(?:unidades?|u\b))?",
+    re.IGNORECASE,
+)
+_QTY_RE_BEFORE_PRODUCT = re.compile(
+    r"\b(\d+)\s*(?:unidades?|u\b)",
+    re.IGNORECASE,
+)
+
+# SKU Johnson: matchea letra(s) seguidas de números, opcionalmente
+# con "/" y más números (ej: E50, E50/18, LUXOR S171, Q71A).
+_JOHNSON_SKU_RE = re.compile(
+    r"\b(?:johnson\s+)?([A-Z]{1,5}\d{1,4}[A-Z]?(?:/\d{1,4})?)\b",
+    re.IGNORECASE,
+)
+
+# Descuento: "descuento 5%", "dto 5%", "5% descuento".
+_DISCOUNT_RE = re.compile(
+    r"(?:descuento|dto\.?|desc\.?)\s*(\d+(?:[.,]\d+)?)\s*%"
+    r"|(\d+(?:[.,]\d+)?)\s*%\s*(?:de\s+)?descuento",
+    re.IGNORECASE,
+)
+
+# Cliente: "CLIENTE: NAME" / "Cliente: Name".
+_CLIENT_RE = re.compile(
+    r"cliente\s*:\s*([^\n]+?)(?:\n|$|\|)",
+    re.IGNORECASE,
+)
+
+# Proyecto/obra: "OBRA: ..." / "Proyecto: ...".
+_PROJECT_RE = re.compile(
+    r"(?:obra|proyecto)\s*:\s*([^\n]+?)(?:\n|$|\|)",
+    re.IGNORECASE,
+)
+
+
+def _extract_qty(brief: str) -> Optional[int]:
+    """Extrae la cantidad de productos. Prefiere "× N" / "x N" después
+    del producto; cae en "N unidades" si no encuentra el primero.
+
+    Returns: int positivo o None si no encuentra cantidad confiable.
+    """
+    m = _QTY_RE_AFTER_PRODUCT.search(brief)
+    if m:
+        try:
+            n = int(m.group(1))
+            if n > 0:
+                return n
+        except (TypeError, ValueError):
+            pass
+    m = _QTY_RE_BEFORE_PRODUCT.search(brief)
+    if m:
+        try:
+            n = int(m.group(1))
+            if n > 0:
+                return n
+        except (TypeError, ValueError):
+            pass
+    return None
+
+
+def _extract_sku(brief: str) -> Optional[str]:
+    """Extrae el SKU de la pileta Johnson del brief.
+
+    Busca un patrón tipo `E50`, `E50/18`, `Q71A`, etc. opcionalmente
+    precedido por "Johnson ". Devuelve el SKU canonicalizado (uppercase,
+    sin "johnson " prefix).
+
+    NO valida contra el catálogo — eso lo hace `_calculate_quote_products_only`
+    via `catalog_lookup`. Acá solo extraemos el string candidato.
+    """
+    m = _JOHNSON_SKU_RE.search(brief)
+    if not m:
+        return None
+    return m.group(1).upper()
+
+
+def _extract_discount(brief: str) -> Optional[float]:
+    """Extrae el porcentaje de descuento como float (5%, 12.5%, etc.).
+
+    Returns: float positivo o None.
+    """
+    m = _DISCOUNT_RE.search(brief)
+    if not m:
+        return None
+    raw = m.group(1) or m.group(2)
+    if not raw:
+        return None
+    try:
+        return float(raw.replace(",", "."))
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_client_project(brief: str) -> tuple[Optional[str], Optional[str]]:
+    """Extrae cliente y proyecto del brief, si están en formato
+    `CLIENTE: ...` / `OBRA: ...`. Devuelve (client, project) — cualquiera
+    puede ser None si no aparece."""
+    client = None
+    project = None
+    m = _CLIENT_RE.search(brief)
+    if m:
+        client = m.group(1).strip()
+    m = _PROJECT_RE.search(brief)
+    if m:
+        project = m.group(1).strip()
+    return client, project
+
+
+def parse_products_brief(brief: str) -> Optional[dict]:
+    """Parsea un brief de "solo producto" a un dict listo para
+    `calculate_quote`.
+
+    Returns:
+        dict con `client_name`, `project`, `pileta_sku`, `pileta_qty`,
+        `discount_pct`, `pieces=[]`, `plazo`. None si falta SKU o qty
+        (sin esos dos no podemos cotizar).
+
+    NO chequea `is_products_only_brief` adentro — el caller decide
+    cuándo invocarlo. Acá solo extraemos campos.
+    """
+    if not brief:
+        return None
+
+    qty = _extract_qty(brief)
+    sku = _extract_sku(brief)
+    if not qty or not sku:
+        return None
+
+    discount = _extract_discount(brief)
+    client, project = _extract_client_project(brief)
+
+    return {
+        "client_name": client or "",
+        "project": project or "",
+        "pieces": [],
+        "pileta_sku": sku,
+        "pileta_qty": qty,
+        "discount_pct": discount or 0.0,
+        "plazo": "A confirmar",
+    }

--- a/api/tests/test_products_only_detector.py
+++ b/api/tests/test_products_only_detector.py
@@ -1,0 +1,356 @@
+"""Tests para PR #427 — detector + parser determinísticos del modo
+products_only + fix del rebote en `_check_pegadopileta`.
+
+**Caso DYSCON 29/04/2026** (continuación del bug):
+
+PR #424 implementó el modo `products_only` en calculator + validator
++ renderers. PERO el flujo upstream del agente (text-parser,
+context_analysis, dual_read) seguía corriendo IGUAL para briefs de
+"solo piletas" → mostraba "Análisis de contexto" con frentín
+inventado y un despiece falso ANTES de llegar al cálculo correcto.
+
+Y al confirmar el Paso 2 products_only, el `generate_documents`
+rebotaba en `_check_pegadopileta` porque el calculator NO inyecta
+MO de pileta en este modo, pero el validator lo exigía.
+
+Este PR:
+1. Detector + parser determinísticos para skipear contexto+despiece.
+2. Short-circuit en `agent.py:stream_chat` antes del text-parser.
+3. Validator `_check_pegadopileta`: skip si `_quote_mode==products_only`.
+
+**Regresión crítica que el test inverso protege:**
+products_only=False + pileta="empotrada_johnson" + mo_items=[]
+DEBE seguir fallando (validator catches). Sin esto, el fix
+enmascara bugs futuros del flujo normal.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.modules.quote_engine.products_only_detector import (
+    is_products_only_brief,
+    parse_products_brief,
+    _extract_qty,
+    _extract_sku,
+    _extract_discount,
+    _extract_client_project,
+)
+from app.modules.agent.tools.validation_tool import _check_pegadopileta
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Detector — 3 señales obligatorias
+# ═══════════════════════════════════════════════════════════════════════
+
+
+_DYSCON_BRIEF = """2 — PILETAS (solo producto)
+CLIENTE: DYSCON S.A.
+OBRA: Unidad Penal N°8 — Piñero
+PAGO: Contado | ENTREGA: A confirmar
+ARCHIVO: 'DYSCON SA - Piletas - 29.04.2026'
+
+PRODUCTO — solo piletas, sin MO, sin flete:
+Pileta Johnson E50 × 32 unidades
+Descuento 5% sobre total → línea separada visible
+
+REGLAS
+* Solo producto de pileta
+* Sin MO
+* Sin flete
+* Descuento 5% sobre piletas únicamente"""
+
+
+class TestDetector:
+    # ── Caso real DYSCON ──────────────────────────────────────────────
+    def test_dyscon_brief_triggers(self):
+        """El brief real del operador debe disparar el detector."""
+        assert is_products_only_brief(_DYSCON_BRIEF) is True
+
+    # ── Las 3 señales son requeridas (no 2 de 3) ─────────────────────
+    def test_only_solo_producto_does_not_trigger(self):
+        """Falta sin MO + producto."""
+        assert is_products_only_brief("Solo producto") is False
+
+    def test_only_sin_mo_does_not_trigger(self):
+        """Falta solo producto + producto pileta."""
+        assert is_products_only_brief("Cocina sin MO") is False
+
+    def test_only_pileta_does_not_trigger(self):
+        """Falta solo producto + sin MO."""
+        assert is_products_only_brief("Pileta Johnson") is False
+
+    def test_solo_producto_plus_sin_mo_no_pileta_does_not_trigger(self):
+        """2 de 3 señales — falta producto pileta/bacha."""
+        assert is_products_only_brief("solo producto, sin MO") is False
+
+    def test_solo_producto_plus_pileta_no_sin_mo_does_not_trigger(self):
+        """2 de 3 — falta 'sin MO'."""
+        assert is_products_only_brief("solo producto, pileta Johnson E50") is False
+
+    # ── Variantes de "solo producto" ─────────────────────────────────
+    @pytest.mark.parametrize("phrase", [
+        "solo producto",
+        "solo piletas",
+        "solo pileta",
+        "solo bachas",
+        "solo bacha",
+        "sólo producto",
+    ])
+    def test_solo_phrase_variants(self, phrase):
+        brief = f"{phrase}, sin MO, pileta Johnson"
+        assert is_products_only_brief(brief) is True
+
+    # ── Variantes de "sin MO" ────────────────────────────────────────
+    @pytest.mark.parametrize("phrase", [
+        "sin MO",
+        "sin mo",
+        "sin M.O.",
+        "sin M.O",
+        "sin mano de obra",
+        "Sin Mano De Obra",
+    ])
+    def test_sin_mo_variants(self, phrase):
+        brief = f"solo producto, {phrase}, pileta Johnson"
+        assert is_products_only_brief(brief) is True
+
+    # ── False positives a evitar ─────────────────────────────────────
+    def test_normal_kitchen_brief_does_not_trigger(self):
+        """Brief típico de cocina/edificio NO debe disparar."""
+        brief = (
+            "Cocina con mesada 2.5×0.6, zócalo atrás, pileta empotrada "
+            "Johnson E50, anafe gas. Granito Gris Mara. Cliente Pérez."
+        )
+        assert is_products_only_brief(brief) is False
+
+    def test_minimo_word_does_not_trigger_sin_mo(self):
+        """'Mínimo 2m²' no debe matchear 'sin MO' por substring.
+        Word boundary previene false positive de \\bmo\\b."""
+        brief = "solo producto pileta, mínimo 2 unidades, fenólico"
+        # NO tiene "sin MO" — solo "minimo" que contiene "mo".
+        assert is_products_only_brief(brief) is False
+
+    # ── Empty/None ───────────────────────────────────────────────────
+    def test_empty_brief(self):
+        assert is_products_only_brief("") is False
+
+    def test_none_brief(self):
+        assert is_products_only_brief(None) is False
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Parser — extracción de campos
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestParserQty:
+    @pytest.mark.parametrize("brief,expected", [
+        ("Pileta E50 × 32", 32),
+        ("Pileta E50 x 32", 32),
+        ("Pileta E50 × 32 unidades", 32),
+        ("Pileta E50 × 32 u", 32),
+        ("32 unidades de pileta E50", 32),
+        ("32u Johnson E50", 32),
+    ])
+    def test_qty_extraction(self, brief, expected):
+        assert _extract_qty(brief) == expected
+
+    def test_qty_none_when_no_number(self):
+        assert _extract_qty("Pileta Johnson sin cantidad") is None
+
+
+class TestParserSKU:
+    @pytest.mark.parametrize("brief,expected", [
+        ("Pileta Johnson E50 × 32", "E50"),
+        ("Pileta Johnson E50/18", "E50/18"),
+        ("Pileta Q71A", "Q71A"),
+        # "Johnson LUXOR S171" — el regex requiere letra+dígito ej "S171".
+        # "LUXOR" sin números NO matchea (es texto, no SKU). Aceptamos
+        # "S171" como SKU canónico — Sonnet/operador puede pasar el
+        # SKU completo si lo necesita.
+        ("Johnson LUXOR S171", "S171"),
+    ])
+    def test_sku_extraction(self, brief, expected):
+        assert _extract_sku(brief) == expected
+
+    def test_sku_none_when_no_pattern(self):
+        assert _extract_sku("Una pileta cualquiera") is None
+
+
+class TestParserDiscount:
+    @pytest.mark.parametrize("brief,expected", [
+        ("descuento 5%", 5.0),
+        ("Descuento 5%", 5.0),
+        ("dto 5%", 5.0),
+        ("dto. 5%", 5.0),
+        ("5% descuento", 5.0),
+        ("5% de descuento", 5.0),
+        ("descuento 12.5%", 12.5),
+        ("descuento 12,5%", 12.5),
+    ])
+    def test_discount_extraction(self, brief, expected):
+        assert _extract_discount(brief) == expected
+
+    def test_no_discount_returns_none(self):
+        assert _extract_discount("Pileta sin descuento") is None
+
+
+class TestParserClientProject:
+    def test_dyscon_extracts_both(self):
+        client, project = _extract_client_project(_DYSCON_BRIEF)
+        assert client == "DYSCON S.A."
+        assert "Unidad Penal N°8" in project
+
+    def test_only_client(self):
+        c, p = _extract_client_project("CLIENTE: Juan Pérez\nMaterial: granito")
+        assert c == "Juan Pérez"
+        assert p is None
+
+
+class TestParserFull:
+    def test_dyscon_full_parse(self):
+        """End-to-end del parser sobre el brief real DYSCON."""
+        result = parse_products_brief(_DYSCON_BRIEF)
+        assert result is not None
+        assert result["client_name"] == "DYSCON S.A."
+        assert "Unidad Penal" in result["project"]
+        assert result["pileta_sku"] == "E50"  # primer match
+        assert result["pileta_qty"] == 32
+        assert result["discount_pct"] == 5.0
+        assert result["pieces"] == []
+
+    def test_returns_none_without_qty(self):
+        """Sin cantidad → no podemos cotizar → None."""
+        result = parse_products_brief("Pileta Johnson E50 sin cantidad")
+        assert result is None
+
+    def test_returns_none_without_sku(self):
+        """Sin SKU del producto → None."""
+        result = parse_products_brief("32 unidades sin pileta")
+        assert result is None
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Validator fix: _check_pegadopileta skip en products_only
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestValidatorPegadopiletaSkip:
+    def test_products_only_with_pileta_set_does_not_fail(self):
+        """**Bug original**: products_only + pileta='empotrada_johnson' +
+        mo_items=[] → validator rebotaba con error de pileta sin MO,
+        bloqueando generate_documents. Fix: skip si products_only."""
+        qdata = {
+            "_quote_mode": "products_only",
+            "pileta": "empotrada_johnson",  # ← Sonnet a veces lo pasa
+            "mo_items": [],                  # ← sin MO (correcto en este modo)
+            "sinks": [{"name": "PILETA E50", "quantity": 32, "unit_price": 100000}],
+        }
+        errors, warnings = _check_pegadopileta(qdata)
+        assert errors == [], (
+            f"products_only debe skipear el check, vi errors={errors}"
+        )
+
+    def test_products_only_without_pileta_field_does_not_fail(self):
+        """Caso happy path: products_only sin `pileta` field tampoco
+        debe rebotar (skip aplica antes de leer pileta)."""
+        qdata = {
+            "_quote_mode": "products_only",
+            "mo_items": [],
+            "sinks": [{"name": "x", "quantity": 1, "unit_price": 100}],
+        }
+        errors, _ = _check_pegadopileta(qdata)
+        assert errors == []
+
+    # ── Test inverso (review feedback explícito): asegurar que el fix
+    # NO enmascara bugs futuros del flujo normal ─────────────────────
+    def test_normal_mode_pileta_without_mo_still_fails(self):
+        """**Caso inverso CRÍTICO** (review feedback): si NO estamos
+        en products_only y hay pileta='empotrada_johnson' sin
+        mo_items de pileta, el validator DEBE seguir rebotando.
+
+        Sin este test, el fix podría enmascarar bugs futuros del
+        flujo normal donde Sonnet olvide inyectar la MO de pileta
+        — el cliente terminaría sin la línea de MO en el PDF y se
+        cobraría de menos."""
+        qdata = {
+            # NO _quote_mode → flujo normal
+            "pileta": "empotrada_johnson",
+            "mo_items": [],  # ← BUG: falta MO de pileta
+            "sinks": [{"name": "PILETA", "quantity": 1, "unit_price": 50000}],
+        }
+        errors, _ = _check_pegadopileta(qdata)
+        assert len(errors) == 1, (
+            f"Flujo normal debe seguir rebotando, vi errors={errors}"
+        )
+        # `errors[0].lower()` convierte "MO" → "mo".
+        assert "no hay ítem mo" in errors[0].lower()
+
+    def test_normal_mode_with_pileta_mo_passes(self):
+        """Regression del happy path normal: pileta + MO presente → OK."""
+        qdata = {
+            "pileta": "empotrada_johnson",
+            "mo_items": [
+                {"description": "Agujero y pegado pileta", "quantity": 1, "unit_price": 53840, "total": 53840},
+            ],
+        }
+        errors, _ = _check_pegadopileta(qdata)
+        assert errors == []
+
+    def test_other_quote_mode_not_skipped(self):
+        """Drift guard: solo `_quote_mode==products_only` skipea.
+        Cualquier otro valor (ej. inventado/futuro) NO debe skipear
+        — debe ir al check normal."""
+        qdata = {
+            "_quote_mode": "some_future_mode",  # ← NO products_only
+            "pileta": "empotrada_johnson",
+            "mo_items": [],
+        }
+        errors, _ = _check_pegadopileta(qdata)
+        # NO se skipea → check normal corre → falla por falta de MO.
+        assert len(errors) == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# End-to-end DYSCON: brief → calculate_quote → render OK
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestEndToEndDyscon:
+    def test_full_flow_calc_quote_from_dyscon_brief(self):
+        """Brief DYSCON real → detector → parser → calculate_quote →
+        calc_result válido products_only. Sin pasar por
+        text_parser/context_analysis."""
+        from app.modules.quote_engine.calculator import calculate_quote
+
+        assert is_products_only_brief(_DYSCON_BRIEF)
+        parsed = parse_products_brief(_DYSCON_BRIEF)
+        assert parsed is not None
+
+        result = calculate_quote(parsed)
+        assert result.get("ok") is True, f"calc rebotó: {result.get('error')}"
+        assert result.get("_quote_mode") == "products_only"
+        assert result["material_m2"] == 0
+        assert result["mo_items"] == []
+        assert len(result["sinks"]) == 1
+        assert result["sinks"][0]["quantity"] == 32
+
+        # Total = sinks_subtotal - 5%
+        sinks_subtotal = sum(
+            s["unit_price"] * s["quantity"] for s in result["sinks"]
+        )
+        expected_total = sinks_subtotal - round(sinks_subtotal * 0.05)
+        assert result["total_ars"] == expected_total
+
+    def test_full_flow_passes_validator(self):
+        """Drift guard E2E: el calc_result armado por el flow
+        completo NO rebota en NINGÚN validator (ni el de pegadopileta
+        que arreglamos, ni los demás)."""
+        from app.modules.quote_engine.calculator import calculate_quote
+        from app.modules.agent.tools.validation_tool import validate_despiece
+
+        parsed = parse_products_brief(_DYSCON_BRIEF)
+        result = calculate_quote(parsed)
+        validation = validate_despiece(result)
+        assert validation.ok is True, (
+            f"validate_despiece rebotó products_only: {validation.errors}"
+        )


### PR DESCRIPTION
## Summary

**Caso DYSCON 29/04/2026 — continuación de PR #424.**

PR #424 implementó `products_only` en calculator + validator + renderers. PERO el flujo upstream del agente seguía corriendo igual:

1. `text_parser` inventaba "7 mesadas" del despiece DYSCON viejo.
2. `context_analyzer` emitía card con "Frentín: Mencionado" y campos irrelevantes.
3. Operador veía toda esa UI ruidosa antes del cálculo correcto.
4. **Y al confirmar el Paso 2, `generate_documents` REBOTABA** por dos validators que no respetaban el modo.

## Cambios

### 1. `products_only_detector.py` (módulo nuevo)

- `is_products_only_brief()`: requiere LAS 3 señales simultáneamente.
- `parse_products_brief()`: regex determinísticos para SKU/qty/descuento/cliente/proyecto.
- Cero LLM — review feedback "prompt frágil, garantía dura > heurística".

### 2. `agent.py:stream_chat` short-circuit

Antes del bloque text-parser y dual_read:
- Detector dispara → parser → `calculate_quote` directo → emit `_paso2_rendered` → `return`.
- Sonnet NO se invoca en ese turno. NO contexto. NO despiece.
- Cualquier error → fallback al flujo normal sin tocar nada.

### 3. Validator fixes (descubiertos en E2E)

| Validator | Bug | Fix |
|---|---|---|
| `_check_pegadopileta` | Sonnet pasa `pileta="empotrada_johnson"`, calc no inyecta MO en products_only, validator rebota | Skip si `_quote_mode==products_only` |
| `_check_material_total` | `discount_amount` aplica sobre sinks pero el check lo cruza con `material_total=0` → rebota | Skip si `_quote_mode==products_only` |

## Tests (55 casos)

| Sección | Casos | Foco |
|---|---|---|
| Detector | 12 | 3 señales requeridas, variantes, false positives evitados |
| Parser | 18 | qty/SKU/discount/client/project en variantes |
| **Validator skip** | 5 | products_only skipea + **CASO INVERSO CRÍTICO** (review feedback): NO products_only + pileta sin MO → SIGUE FALLANDO. Drift guard: `_quote_mode` futuro distinto NO skipea. |
| **E2E DYSCON** | 2 | brief → detector → parser → calc → validator → todos los checks pasan |

Suite full: **2420 passing** (+55), 16 fallos preexistentes (no introducidos).

## Caso inverso explícito (review feedback)

> el test extra que agregás para `_check_pegadopileta` es crítico — asegurate de que cubra también el caso inverso: products_only=false + pileta="empotrada_johnson" + mo_items=[] → debe seguir fallando.

`test_normal_mode_pileta_without_mo_still_fails` lo cubre. Sin este test, el fix enmascararía bugs futuros del flujo normal donde Sonnet olvide inyectar MO de pileta — el cliente terminaría sin la línea de MO en el PDF y se cobraría de menos.

## Lo que NO toca

- Calculator products_only (#424): intacto.
- Renderers PDF/Excel (#424): intactos.
- Flujo normal de mesadas: intacto. Short-circuit es return early solo cuando dispara, fallback total en error.
- System prompt: intacto.

## Test plan

- [x] `pytest tests/test_products_only_detector.py -v` → 55/55.
- [x] Suite full → 2420 passing (+55, 0 regresiones).
- [ ] **Validación post-merge en staging**:
  - Reproducir brief DYSCON pileta-only → ver `[products-only] short-circuit OK` en Railway logs. Operador ve Paso 2 directo, NO contexto, NO despiece. Al confirmar → PDF generado.
  - Re-cotizar caso normal mesada+pileta → flujo intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)