### PR TITLE
fix(dashboard): material descriptivo en listado para quotes products_only

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -2460,11 +2460,24 @@ class AgentService:
                                 # Persistir breakdown + columnas dedicadas
                                 # (cliente/proyecto) para que aparezca en
                                 # dashboard listado desde el turno 1.
+                                # PR #428 — material descriptivo en el
+                                # listado del dashboard. Antes era "" →
+                                # se mostraba como "—" en la columna
+                                # material y el operador no podía
+                                # identificar qué cotización era. Helper
+                                # vive en `products_only_detector` para
+                                # ser unit-testable sin DB ni Anthropic.
+                                from app.modules.quote_engine.products_only_detector import (
+                                    build_products_only_material_label,
+                                )
+                                _po_label = build_products_only_material_label(
+                                    _po_result.get("sinks")
+                                )
                                 _po_persist = {
                                     "quote_breakdown": dict(_po_result),
                                     "total_ars": _po_result.get("total_ars", 0),
                                     "total_usd": 0,
-                                    "material": "",  # explicit empty
+                                    "material": _po_label,
                                 }
                                 if parsed_po.get("client_name"):
                                     _po_persist["client_name"] = parsed_po["client_name"]

--- a/api/app/modules/quote_engine/products_only_detector.py
+++ b/api/app/modules/quote_engine/products_only_detector.py
@@ -220,6 +220,39 @@ def _extract_client_project(brief: str) -> tuple[Optional[str], Optional[str]]:
     return client, project
 
 
+def build_products_only_material_label(sinks: list[dict] | None) -> str:
+    """Construye el label que aparece en la columna 'material' del listado
+    del dashboard para una quote en modo `products_only`.
+
+    **Por qué existe (PR #428):** el `_po_persist` del short-circuit
+    (PR #427) seteaba `material=""` → en el listado se mostraba "—"
+    (em-dash) y el operador no podía identificar qué cotización era
+    al escanear la lista.
+
+    Formato:
+    - 1 sink: ``"<name> × <qty>"`` (ej: "PILETA JOHNSON E50/18 × 32").
+    - N sinks: ``"<first.name> × <first.qty> (+<N-1> más)"`` para
+      indicar que hay más productos. El operador entra al detalle
+      si quiere ver el resto.
+    - 0 sinks: string vacío (defensivo — no debería ocurrir si el
+      flujo de products_only se activó correctamente).
+
+    NO valida el shape de los sinks — confía en lo que produjo
+    `_calculate_quote_products_only` (que ya filtra entradas mal
+    formadas).
+    """
+    if not sinks:
+        return ""
+    first = sinks[0] if isinstance(sinks[0], dict) else {}
+    name = (first.get("name") or "PRODUCTO").strip()
+    qty = first.get("quantity") or 1
+    label = f"{name} × {qty}"
+    extras = len(sinks) - 1
+    if extras > 0:
+        label += f" (+{extras} más)"
+    return label
+
+
 def parse_products_brief(brief: str) -> Optional[dict]:
     """Parsea un brief de "solo producto" a un dict listo para
     `calculate_quote`.

--- a/api/tests/test_products_only_detector.py
+++ b/api/tests/test_products_only_detector.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import pytest
 
 from app.modules.quote_engine.products_only_detector import (
+    build_products_only_material_label,
     is_products_only_brief,
     parse_products_brief,
     _extract_qty,
@@ -342,6 +343,104 @@ class TestEndToEndDyscon:
         assert result["total_ars"] == expected_total
 
     def test_full_flow_passes_validator(self):
+        """Drift guard E2E: el calc_result armado por el flow
+        completo NO rebota en NINGÚN validator (ni el de pegadopileta
+        que arreglamos, ni los demás)."""
+        from app.modules.quote_engine.calculator import calculate_quote
+        from app.modules.agent.tools.validation_tool import validate_despiece
+
+        parsed = parse_products_brief(_DYSCON_BRIEF)
+        result = calculate_quote(parsed)
+        validation = validate_despiece(result)
+        assert validation.ok is True, (
+            f"validate_despiece rebotó products_only: {validation.errors}"
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Material label para listado del dashboard (PR #428)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestMaterialLabel:
+    """**Caso del operador (29/04/2026)**: el listado del dashboard
+    mostraba "—" (em-dash) en la columna material para quotes
+    products_only, porque PR #427 persistía `material=""`. El
+    operador no podía identificar qué cotización era al escanear
+    la lista. Este helper construye un label descriptivo desde
+    los sinks del calc_result."""
+
+    def test_single_sink_format(self):
+        """1 sink → 'NAME × QTY' sin sufijo de "más"."""
+        sinks = [
+            {"name": "PILETA JOHNSON E50/18", "quantity": 32, "unit_price": 100000},
+        ]
+        label = build_products_only_material_label(sinks)
+        assert label == "PILETA JOHNSON E50/18 × 32"
+
+    def test_multiple_sinks_first_plus_extra_count(self):
+        """N sinks → primero + sufijo '(+N-1 más)' para indicar al
+        operador que hay más productos sin ocupar todo el ancho del
+        listado."""
+        sinks = [
+            {"name": "PILETA JOHNSON E50/18", "quantity": 32, "unit_price": 100000},
+            {"name": "PILETA JOHNSON Q71A", "quantity": 5, "unit_price": 80000},
+            {"name": "BACHA AUXILIAR", "quantity": 1, "unit_price": 50000},
+        ]
+        label = build_products_only_material_label(sinks)
+        assert label == "PILETA JOHNSON E50/18 × 32 (+2 más)"
+
+    def test_two_sinks_one_extra(self):
+        """Boundary: exactly 2 sinks → '(+1 más)'."""
+        sinks = [
+            {"name": "PILETA A", "quantity": 1, "unit_price": 100},
+            {"name": "PILETA B", "quantity": 2, "unit_price": 200},
+        ]
+        label = build_products_only_material_label(sinks)
+        assert label == "PILETA A × 1 (+1 más)"
+
+    def test_empty_sinks_returns_empty(self):
+        """Defensivo: products_only no debería llegar acá sin sinks
+        (el calculator rebota antes), pero si pasa, no romper —
+        devolver string vacío para que el listado muestre '—' como
+        antes y no algo confuso."""
+        assert build_products_only_material_label([]) == ""
+
+    def test_none_sinks_returns_empty(self):
+        assert build_products_only_material_label(None) == ""
+
+    def test_sink_without_name_uses_placeholder(self):
+        """Defensivo: sink mal-formado sin name → 'PRODUCTO' como
+        fallback. Mejor un label genérico que un crash o '—'."""
+        sinks = [{"quantity": 5, "unit_price": 1000}]
+        label = build_products_only_material_label(sinks)
+        assert label == "PRODUCTO × 5"
+
+    def test_sink_without_quantity_defaults_to_1(self):
+        sinks = [{"name": "PILETA X", "unit_price": 1000}]
+        label = build_products_only_material_label(sinks)
+        assert label == "PILETA X × 1"
+
+    def test_sink_with_whitespace_in_name_stripped(self):
+        """Edge: nombre con espacios al borde NO debe meterlos en el
+        label. Si los catálogos tienen names con padding, lo limpiamos."""
+        sinks = [{"name": "  PILETA JOHNSON E50  ", "quantity": 32}]
+        label = build_products_only_material_label(sinks)
+        assert label == "PILETA JOHNSON E50 × 32"
+
+    # ── End-to-end con el calc_result real ──────────────────────────
+    def test_dyscon_full_label(self):
+        """Caso DYSCON real: el calc_result que produce
+        `_calculate_quote_products_only` debe generar un label
+        identificable. Reproducimos el flujo completo."""
+        from app.modules.quote_engine.calculator import calculate_quote
+        parsed = parse_products_brief(_DYSCON_BRIEF)
+        result = calculate_quote(parsed)
+        assert result.get("ok") is True
+        label = build_products_only_material_label(result["sinks"])
+        # El nombre exacto del catálogo. Verificamos que contenga "JOHNSON" + qty.
+        assert "JOHNSON" in label.upper()
+        assert "× 32" in label
         """Drift guard E2E: el calc_result armado por el flow
         completo NO rebota en NINGÚN validator (ni el de pegadopileta
         que arreglamos, ni los demás)."""


### PR DESCRIPTION
## Summary

PR #427 persistía `material=""` para quotes products_only → en el listado se mostraba "—" (em-dash) y el operador no podía identificar qué cotización era al escanear la lista.

## Cambios

### `products_only_detector.build_products_only_material_label(sinks)` (nuevo helper)

| Caso | Output |
|---|---|
| 1 sink | `"PILETA JOHNSON E50/18 × 32"` |
| N sinks | `"PILETA JOHNSON E50/18 × 32 (+2 más)"` |
| Empty/None | `""` (defensivo) |
| Sin name | `"PRODUCTO × N"` (fallback) |

Vive en `products_only_detector` para no acoplar `agent.py` a lógica de presentación. Unit-testable.

### `agent.py:_po_persist`

```python
# Antes
"material": "",

# Después
"material": build_products_only_material_label(_po_result.get("sinks")),
```

## Listado del dashboard

**Antes (PR #427):**
```
DYSCON S.A.                   —              $4.146.864     • Validado
```

**Después (PR #428):**
```
DYSCON S.A.                   PILETA JOHNSON E50/18 × 32     $4.146.864     • Validado
```

## Tests (9 casos)

- Single sink, multiple sinks, boundary 2-sinks.
- Defensivo: empty/None/sin name/sin quantity/whitespace.
- E2E DYSCON real: label contiene "JOHNSON" + "× 32".

Suite full: **2429 passing** (+9, 0 regresiones).

## Lo que NO toca

- Frontend (`web/`): `q.material` se sigue leyendo igual, solo cambia el contenido.
- Endpoint `/quotes`: idem.
- Calculator/renderers/flujo normal: intactos.

## Test plan

- [x] `pytest tests/test_products_only_detector.py::TestMaterialLabel -v` → 9/9.
- [x] Suite full → 2429 passing (+9, 0 regresiones).
- [ ] **Validación post-merge**: re-cotizar DYSCON pileta-only en staging → en el listado del dashboard, la columna material debe mostrar `PILETA JOHNSON E50/18 × 32` en lugar de `—`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)