### PR TITLE
fix(agent): short-circuit products_only debe emitir 'done' antes del return

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -2513,6 +2513,20 @@ class AgentService:
                                         f"sku={parsed_po['pileta_sku']}, "
                                         f"total={_po_result.get('total_ars')}"
                                     )
+                                    # PR #430 — bug crítico observado en
+                                    # prod (caso DYSCON 29/04/2026): el
+                                    # frontend espera un evento `done`
+                                    # para cerrar el stream SSE limpio,
+                                    # des-bloquear el composer y permitir
+                                    # al operador escribir "Confirmo".
+                                    # Sin esto, el frontend timeoutea
+                                    # ("⚠️ servicio saturado"), interpreta
+                                    # el cierre como falla y vuelve al
+                                    # listado. Operador no puede confirmar.
+                                    # Todos los otros short-circuits del
+                                    # archivo emiten `done` — este se
+                                    # olvidó en PR #427.
+                                    yield {"type": "done", "content": ""}
                                     return  # ← end turn, NO contexto/despiece
                                 except Exception as _e_po_persist:
                                     logging.warning(

--- a/api/tests/test_products_only_detector.py
+++ b/api/tests/test_products_only_detector.py
@@ -636,3 +636,54 @@ class TestBuildPaso2ProductsOnly:
         # El nombre exacto del catálogo. Verificamos que contenga "JOHNSON" + qty.
         assert "JOHNSON" in label.upper()
         assert "× 32" in label
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Drift guard — short-circuit emite `done` antes del return (PR #430)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestShortCircuitEmitsDone:
+    """**Bug crítico observado en prod (29/04/2026):**
+
+    Logs Railway mostraban `[products-only] short-circuit OK` pero
+    después: nada. El operador confirmaba y "se cerraba todo, volvía
+    al listado".
+
+    Causa: el short-circuit del PR #427 hacía `return` SIN emitir
+    `yield {"type": "done", "content": ""}`. El frontend espera ese
+    evento para cerrar el stream SSE limpio, des-bloquear el composer
+    y permitir al operador escribir "Confirmo". Sin él, el frontend
+    timeoutea ("⚠️ servicio saturado"), interpreta el cierre como
+    falla y redirige al listado.
+
+    Todos los otros short-circuits del archivo emiten `done` (ver
+    grep `\\"type\\":\\s*\\"done\\"` en agent.py — 10+ matches).
+
+    Este test inspecciona el source de `stream_chat` y verifica que
+    el bloque `[products-only]` SÍ tiene `yield {"type": "done"`
+    antes del `return  # ← end turn` final. Si alguien refactoreriza
+    y se olvida del done de nuevo, este test rompe.
+    """
+
+    def test_short_circuit_yields_done_before_return(self):
+        import inspect
+        from app.modules.agent import agent as agent_mod
+        src = inspect.getsource(agent_mod.AgentService.stream_chat)
+        # Buscar el bloque `[products-only] short-circuit OK` y verificar
+        # que entre ese log y el `return  # ← end turn` haya un yield done.
+        idx_log = src.find("[products-only] short-circuit OK")
+        assert idx_log > 0, "No se encontró el log del short-circuit"
+        # El return del short-circuit es el primero "return  # ← end turn"
+        # después del log.
+        idx_return = src.find("return  # ← end turn", idx_log)
+        assert idx_return > idx_log, (
+            "No se encontró el `return` final del short-circuit"
+        )
+        between = src[idx_log:idx_return]
+        assert '"type": "done"' in between, (
+            "Falta `yield {\"type\": \"done\"}` antes del `return` del "
+            "short-circuit products_only. Sin ese evento, el frontend "
+            "no cierra el stream y el operador no puede confirmar. "
+            "Ver caso DYSCON 29/04/2026 / PR #430."
+        )


### PR DESCRIPTION
## Bug crítico en producción

Logs Railway (caso DYSCON 29/04/2026):
```
[products-only] short-circuit OK for b83d2440-...: qty=32, sku=E50, total=4146864.0
```

Después del log: NADA. El operador confirmaba el Paso 2 limpio (post #429) y **"se cerraba todo, volvía al listado"** — overlay "⚠️ servicio momentáneamente saturado" en el chat.

## Causa raíz

El short-circuit del PR #427 hacía `return` SIN emitir `yield {"type": "done", "content": ""}`. Todos los otros short-circuits del archivo (10+ matches en `grep`) sí emiten ese evento. Sin él:

1. Frontend espera el `done` para cerrar el stream SSE.
2. Como no llega, timeoutea → muestra "saturado".
3. Interpreta el cierre del stream como falla → redirige al listado.
4. Operador no llega a escribir "Confirmo" → no genera PDF.

## Fix: 1 línea

```python
# Antes
return  # ← end turn

# Después
yield {"type": "done", "content": ""}
return  # ← end turn
```

## Test (drift guard)

`TestShortCircuitEmitsDone` usa `inspect.getsource(stream_chat)` y verifica que entre el log `[products-only] short-circuit OK` y el `return  # ← end turn` haya un `"type": "done"`. Si alguien refactoriza y se olvida del done otra vez, el test rompe con mensaje claro citando este PR.

**Por qué no integration test del stream completo:** mockear Anthropic + DB es overkill para una línea. El drift guard via inspect cubre el caso real (alguien borra/mueve el yield) sin fragilidad de mocks.

Suite: **2445 passing** (+1, 0 regresiones).

## Validación post-merge

Reproducir brief DYSCON pileta-only:
- Operador ve Paso 2 limpio + **composer habilitado** para escribir "Confirmo".
- Confirmar → genera PDF/Excel sin redirect al listado.
- Logs Railway: el stream se cierra con `done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)