### PR TITLE
fix(agent): products_only confirm short-circuit → genera PDF directo

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -2372,6 +2372,133 @@ class AgentService:
 
         _is_system_trigger = user_message and user_message.strip().startswith("[")
 
+        # ── PR #431 — Products-only CONFIRM short-circuit ──
+        # Caso DYSCON 29/04/2026 (turno 2 del operador):
+        # 1. Turno 1: brief solo-piletas → PR #427 short-circuit emite
+        #    Paso 2 + done. ✓
+        # 2. Turno 2: operador escribe "Confirmo" para generar PDF.
+        # 3. **BUG**: caía al flujo normal → Sonnet se invocaba sin
+        #    tener el calc_result en su contexto (solo el markdown del
+        #    Paso 2). Sonnet decidía conservadoramente re-llamar
+        #    `calculate_quote` en lugar de `generate_documents` →
+        #    el operador veía el Paso 2 emitido OTRA VEZ. Loop.
+        #
+        # Fix determinístico: si hay breakdown products_only persistido
+        # Y el mensaje del operador es confirmación explícita
+        # (whitelist `_user_intent`), llamamos `_execute_tool(
+        # "generate_documents", ...)` directo desde código, sin pasar
+        # por Sonnet. El `_canonicalize_quotes_data_from_db` reemplaza
+        # los campos visuales con el calc_result canónico (incluido
+        # `_quote_mode` agregado al `_VISUAL_FIELDS` en PR #424).
+        #
+        # **Importante**: solo dispara con `_user_intent == "confirm"`.
+        # "no, cambiá la cantidad" / "agregá otra pileta" / cualquier
+        # mod intent → caen al flujo normal donde Sonnet maneja la
+        # modificación. La whitelist del PR #416 es estricta —
+        # requiere señal explícita ("confirmo", "dale", "OK generá",
+        # etc.). Esto es exactamente lo que el review feedback pidió.
+        if (
+            not _just_confirmed_dual_read
+            and not plan_bytes
+            and not (extra_files or [])
+            and user_message
+            and not _is_system_trigger
+        ):
+            try:
+                _po_cf_q = await db.execute(
+                    select(Quote).where(Quote.id == quote_id)
+                )
+                _po_cf_quote = _po_cf_q.scalar_one_or_none()
+                _po_cf_bd = (
+                    (_po_cf_quote.quote_breakdown or {})
+                    if _po_cf_quote else {}
+                )
+                _po_cf_is_products = (
+                    _po_cf_bd.get("_quote_mode") == "products_only"
+                )
+                _po_cf_intent = _user_intent(user_message)
+                if _po_cf_is_products and _po_cf_intent == "confirm":
+                    yield {
+                        "type": "action",
+                        "content": "📄 Generando PDF y Excel...",
+                    }
+                    # Armamos el input de generate_documents con el
+                    # calc_result canónico persistido. canonicalize lo
+                    # reemplaza igual, pero pasamos el shape correcto
+                    # por las dudas.
+                    _po_cf_quotes_input = {"quotes": [dict(_po_cf_bd)]}
+                    try:
+                        _po_cf_result = await self._execute_tool(
+                            "generate_documents",
+                            _po_cf_quotes_input,
+                            quote_id=quote_id,
+                            db=db,
+                            conversation_history=messages,
+                            current_user_message=user_message,
+                        )
+                    except Exception as _e_po_gen:
+                        logging.warning(
+                            f"[products-only-confirm] generate_documents "
+                            f"crashed: {_e_po_gen}. Falling back to normal flow."
+                        )
+                        _po_cf_result = None
+
+                    if isinstance(_po_cf_result, dict) and _po_cf_result.get("ok"):
+                        # Persist assistant turn con el resumen + links.
+                        _po_cf_msg_lines = ["✅ PDF y Excel generados."]
+                        for _doc_key, _doc_label in (
+                            ("pdf_url", "PDF"),
+                            ("excel_url", "Excel"),
+                            ("drive_url", "Drive"),
+                        ):
+                            _doc_val = _po_cf_result.get(_doc_key)
+                            if _doc_val:
+                                _po_cf_msg_lines.append(
+                                    f"- {_doc_label}: {_doc_val}"
+                                )
+                        _po_cf_msg = "\n".join(_po_cf_msg_lines)
+                        yield {"type": "text", "content": _po_cf_msg}
+                        try:
+                            await db.execute(
+                                update(Quote).where(
+                                    Quote.id == quote_id
+                                ).values(
+                                    messages=list(_po_cf_quote.messages or []) + [
+                                        {"role": "user", "content": user_message},
+                                        {"role": "assistant", "content": _po_cf_msg},
+                                    ]
+                                )
+                            )
+                            await db.commit()
+                        except Exception as _e_po_persist_cf:
+                            logging.warning(
+                                f"[products-only-confirm] persist failed: "
+                                f"{_e_po_persist_cf}"
+                            )
+                        logging.info(
+                            f"[products-only-confirm] short-circuit OK "
+                            f"for {quote_id}"
+                        )
+                        # Yield done — sin esto, frontend timeoutea
+                        # (mismo bug del PR #430 — siempre emit done
+                        # antes del return).
+                        yield {"type": "done", "content": ""}
+                        return
+                    elif isinstance(_po_cf_result, dict):
+                        # generate_documents rebotó (validator, error, etc).
+                        # NO short-circuit — caemos al flujo normal donde
+                        # Sonnet maneja el error como en cualquier quote.
+                        logging.warning(
+                            f"[products-only-confirm] generate_documents "
+                            f"rejected: {_po_cf_result.get('error', '?')}. "
+                            f"Fallback normal flow."
+                        )
+            except Exception as _e_po_cf_outer:
+                logging.warning(
+                    f"[products-only-confirm] outer crashed: "
+                    f"{_e_po_cf_outer}. Fallback normal flow."
+                )
+
         # ── PR #427 — Products-only short-circuit ──
         # Caso DYSCON 29/04/2026: brief "Pileta Johnson E50 × 32, sin MO,
         # sin flete, descuento 5%". El flujo normal (text-parser →

--- a/api/tests/test_products_only_detector.py
+++ b/api/tests/test_products_only_detector.py
@@ -687,3 +687,181 @@ class TestShortCircuitEmitsDone:
             "no cierra el stream y el operador no puede confirmar. "
             "Ver caso DYSCON 29/04/2026 / PR #430."
         )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Confirm short-circuit (PR #431) — al confirmar genera PDF directo
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestConfirmShortCircuit:
+    """**Bug crítico observado en prod (caso DYSCON 29/04/2026, turno 2):**
+
+    Después de PR #427 (brief solo-piletas → Paso 2 limpio) y PR #430
+    (yield done para que el composer quede habilitado), el operador
+    podía escribir "Confirmo" — pero el agent **no generaba el PDF**.
+
+    Sonnet recibía el "Confirmo" sin tener el calc_result como
+    tool_use en su contexto (solo el markdown del Paso 2). Decidía
+    conservadoramente re-llamar `calculate_quote` → calculator
+    detectaba products_only otra vez → emitía Paso 2 nuevo. Loop.
+
+    **Fix (PR #431):** confirm short-circuit determinístico.
+    Si hay breakdown products_only persistido Y `_user_intent` ==
+    "confirm", llamamos `_execute_tool("generate_documents", ...)`
+    directo desde código, bypaso Sonnet.
+
+    Tests vía `inspect.getsource` (no mockeamos el stream agéntico
+    completo — la lógica crítica es el guard `_user_intent == confirm`
+    y el llamado directo a generate_documents)."""
+
+    def test_user_intent_confirm_passes_strict_whitelist(self):
+        """Recordatorio del whitelist (PR #416): solo confirmaciones
+        explícitas disparan. El review feedback fue claro: la
+        whitelist debe ser estricta para no auto-generar PDF cuando
+        el operador escribe modificaciones."""
+        from app.modules.agent.agent import _user_intent
+        # Confirm explícito → pasa.
+        for msg in ["Confirmo", "confirmo", "Dale", "OK generá",
+                    "Sí", "yes", "perfecto"]:
+            assert _user_intent(msg) == "confirm", (
+                f"{msg!r} debería ser confirm"
+            )
+
+    def test_user_intent_modify_does_NOT_pass(self):
+        """**Caso crítico**: 'no, cambiá la cantidad' / 'agregá otra
+        pileta' / etc. NO deben disparar confirm. El short-circuit
+        chequea exactamente `_user_intent == 'confirm'` — cualquier
+        otro intent (modify, other) cae al flujo normal donde Sonnet
+        maneja la modificación.
+
+        Sin esta estrictez, el operador escribe 'cambiá la cantidad
+        a 33' y el sistema le genera el PDF con la cantidad vieja —
+        bug grave de cobro incorrecto."""
+        from app.modules.agent.agent import _user_intent
+        for msg in [
+            "no, cambiá la cantidad",
+            "agregá otra pileta",
+            "sacá una pileta",
+            "cambiar a 33 unidades",
+            "no, está mal",
+            "modificar el descuento al 10%",
+            "el descuento es del 8%",
+        ]:
+            intent = _user_intent(msg)
+            assert intent != "confirm", (
+                f"{msg!r} NO debería ser confirm, vi intent={intent!r}. "
+                f"Si pasa como confirm, el operador modifica y le "
+                f"generamos PDF viejo → cobro incorrecto."
+            )
+
+    def test_short_circuit_block_exists_in_source(self):
+        """Drift guard: el bloque `[products-only-confirm]` debe
+        existir en `stream_chat`. Si alguien lo borra, este test
+        rompe."""
+        import inspect
+        from app.modules.agent import agent as agent_mod
+        src = inspect.getsource(agent_mod.AgentService.stream_chat)
+        assert "[products-only-confirm] short-circuit OK" in src, (
+            "Falta el log del confirm short-circuit. Sin él, el "
+            "operador escribe 'Confirmo' y Sonnet re-emite el Paso 2 "
+            "(bug DYSCON 29/04/2026 turno 2 / PR #431)."
+        )
+
+    def test_short_circuit_uses_user_intent_confirm_check(self):
+        """Drift guard: el bloque debe chequear `_user_intent` ==
+        "confirm" estrictamente. Si alguien lo cambia a un substring
+        match de "confirm" o algo más laxo, mensajes como
+        'cambiá la cantidad' podrían disparar el PDF y cobrar mal."""
+        import inspect
+        from app.modules.agent import agent as agent_mod
+        src = inspect.getsource(agent_mod.AgentService.stream_chat)
+        idx = src.find("[products-only-confirm] short-circuit OK")
+        assert idx > 0
+        # Buscamos hacia atrás el bloque del confirm short-circuit.
+        # Empieza con el comentario `── PR #431`.
+        idx_block_start = src.rfind("PR #431", 0, idx)
+        assert idx_block_start > 0
+        block = src[idx_block_start:idx]
+        # Debe tener el guard estricto.
+        assert "_user_intent(" in block, (
+            "El confirm short-circuit no usa _user_intent — riesgo de "
+            "matching laxo de 'confirm'."
+        )
+        assert '== "confirm"' in block, (
+            "El check debe ser `_user_intent(...) == 'confirm'` "
+            "estricto (no `in` ni substring). Sin esto el flujo "
+            "podría disparar con 'cambiá' / 'corregí' / etc."
+        )
+
+    def test_short_circuit_calls_generate_documents_directly(self):
+        """Drift guard: el bloque debe llamar `_execute_tool(
+        "generate_documents", ...)`. Si en un refactor alguien lo
+        cambia a `calculate_quote` (el bug original), el operador
+        vuelve a ver Paso 2 en lugar del PDF."""
+        import inspect
+        from app.modules.agent import agent as agent_mod
+        src = inspect.getsource(agent_mod.AgentService.stream_chat)
+        idx_block_start = src.find("PR #431")
+        assert idx_block_start > 0
+        # Rango: desde "PR #431" (encabezado) hasta el header del
+        # bloque siguiente "── PR #427 — Products-only short-circuit"
+        # (el comentario header del otro bloque). NO usamos "PR #427"
+        # solo porque el comentario del #431 menciona ese número.
+        idx_block_end = src.find(
+            "── PR #427 — Products-only short-circuit",
+            idx_block_start,
+        )
+        assert idx_block_end > idx_block_start
+        block = src[idx_block_start:idx_block_end]
+        assert '"generate_documents"' in block, (
+            "El confirm short-circuit no llama generate_documents. "
+            "Sin esto, vuelve el bug DYSCON: Sonnet re-emite Paso 2."
+        )
+
+    def test_short_circuit_yields_done_before_return(self):
+        """Drift guard: yield done antes del return (mismo patrón
+        del PR #430). Buscamos el `yield {"type": "done"` literal
+        después del log del short-circuit. Si está, OK; si no,
+        bug de timeout en frontend."""
+        import inspect
+        from app.modules.agent import agent as agent_mod
+        src = inspect.getsource(agent_mod.AgentService.stream_chat)
+        idx_log = src.find("[products-only-confirm] short-circuit OK")
+        assert idx_log > 0
+        # Marcador de fin del bloque: el header del PR #427 siguiente.
+        idx_block_end = src.find(
+            "── PR #427 — Products-only short-circuit",
+            idx_log,
+        )
+        assert idx_block_end > idx_log
+        between = src[idx_log:idx_block_end]
+        # Buscamos el yield done específico (no `# yield` en comentario).
+        assert 'yield {"type": "done"' in between, (
+            "Falta yield done en el confirm short-circuit. Sin esto "
+            "el frontend timeoutea (bug PR #430 replicado)."
+        )
+
+    def test_short_circuit_only_when_quote_mode_products_only(self):
+        """Drift guard: el bloque debe chequear `_quote_mode ==
+        "products_only"`. Si en un refactor sacan ese guard, el
+        confirm short-circuit dispararía para CUALQUIER quote (con
+        pileta o no), bypaseando el flujo normal."""
+        import inspect
+        from app.modules.agent import agent as agent_mod
+        src = inspect.getsource(agent_mod.AgentService.stream_chat)
+        idx_block_start = src.find("PR #431")
+        # Rango: desde "PR #431" (encabezado) hasta el header del
+        # bloque siguiente "── PR #427 — Products-only short-circuit"
+        # (el comentario header del otro bloque). NO usamos "PR #427"
+        # solo porque el comentario del #431 menciona ese número.
+        idx_block_end = src.find(
+            "── PR #427 — Products-only short-circuit",
+            idx_block_start,
+        )
+        block = src[idx_block_start:idx_block_end]
+        assert '"products_only"' in block, (
+            "El confirm short-circuit no chequea _quote_mode. "
+            "Sin ese guard, dispararía para cualquier quote y "
+            "rompería el flujo normal de mesadas."
+        )


### PR DESCRIPTION
## Bug observado en prod (caso DYSCON 29/04/2026, turno 2)

Tras los PRs #427/#429/#430, el operador llega al Paso 2 limpio + composer habilitado para "Confirmo". PERO al confirmar, **el sistema NO genera el PDF — re-emite el Paso 2 otra vez**.

## Causa

Sonnet recibía el "Confirmo" sin tener el calc_result como tool_use en su contexto (solo el markdown del Paso 2 emitido por short-circuit). Decidía conservadoramente re-llamar `calculate_quote` → calculator detectaba products_only otra vez → emitía Paso 2 nuevo. Loop.

Pista en el screenshot del operador: el 2do Paso 2 dice `"Demora: A confirmar | Rosario"` (con localidad), el 1ro solo `"A confirmar"`. Confirma que Sonnet re-llamó calculate_quote con `localidad="Rosario"` por default.

## Fix

Mismo patrón que PR #427: short-circuit determinístico, sin Sonnet.

```python
if (products_only persistido) and (_user_intent(msg) == "confirm"):
    result = await self._execute_tool("generate_documents", ...)
    yield text con links del PDF/Excel
    yield {"type": "done"}
    return
```

Inserción ANTES del short-circuit del brief (PR #427). Turno 1 dispara el del brief, turno 2 dispara el del confirm.

## Estrictez del check (review feedback explícito)

> El test #3 es el más importante — asegurate que "no, cambiá la cantidad" no dispare el generate_documents. La whitelist de `_user_intent` debe ser estricta.

Check exacto: `_user_intent(...) == "confirm"`. Sin esta estrictez, "cambiá la cantidad a 33" generaría PDF con cantidad vieja → cobro incorrecto.

## Tests (7 nuevos)

| Test | Foco |
|---|---|
| `test_user_intent_confirm_passes_strict_whitelist` | "Confirmo", "Dale", "OK generá", "Sí" → confirm |
| **`test_user_intent_modify_does_NOT_pass`** | **CRÍTICO** (review feedback): "no cambiá la cantidad", "agregá otra pileta", "modificar el descuento", etc. → NO confirm |
| `test_short_circuit_block_exists_in_source` | Drift guard: el bloque `[products-only-confirm]` existe |
| `test_short_circuit_uses_user_intent_confirm_check` | Check estricto `== "confirm"` (no `in`, no substring) |
| `test_short_circuit_calls_generate_documents_directly` | Llama `generate_documents` (no `calculate_quote` — el bug original) |
| `test_short_circuit_yields_done_before_return` | Yield done antes del return (patrón #430) |
| `test_short_circuit_only_when_quote_mode_products_only` | Guard `_quote_mode == "products_only"` (sin ese check, dispararía para cualquier quote) |

Suite full: **2452 passing** (+7, 0 regresiones).

## Validación post-merge

1. Brief DYSCON pileta-only → Paso 2 emitido (PR #427 + #429 + #430).
2. **"Confirmo"** → genera PDF/Excel + emite links + queda en chat con `done`. **NO** redirect, **NO** re-emite Paso 2.
3. "no, cambiá a 33 unidades" → cae al flujo normal donde Sonnet re-cota.

🤖 Generated with [Claude Code](https://claude.com/claude-code)