### PR TITLE
fix(agent): _validate_quote_data preflight skipea products_only

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -31,6 +31,34 @@ def _validate_quote_data(qdata: dict) -> tuple[list[str], list[str]]:
     errors: list[str] = []
     warnings: list[str] = []
 
+    # PR #432 — modo products_only: el operador pidió cotización
+    # solo de pileta/bacha sin material/MO/instalación. Sin este
+    # skip, los 3 checks de abajo (material, sectors, mo_items)
+    # rebotan generate_documents → operador escribe "Confirmo" y
+    # nunca llega al PDF. Ya pasó tres veces hoy (PRs #427/#431):
+    # `validate_despiece` del validation_tool.py también requirió
+    # skips simétricos. Este es el preflight independiente del
+    # `validate_despiece`. Bug DYSCON 29/04/2026 turno 2.
+    if qdata.get("_quote_mode") == "products_only":
+        # Mínimo set de checks que SÍ aplican en products_only:
+        # cliente presente, total no zero, sinks no vacío.
+        if not qdata.get("client_name"):
+            errors.append("Falta nombre del cliente")
+        if not qdata.get("total_ars") and not qdata.get("total_usd"):
+            errors.append("Totales en $0 — verificar cálculo")
+        if not qdata.get("sinks"):
+            errors.append("products_only sin sinks/productos definidos")
+        # Delivery vague replacement (legítimo en este modo también).
+        _VAGUE_DELIVERY_PO = {"", "a confirmar", "a convenir", "n/a", "n/d", "-", "—", "."}
+        _current_delivery_po = (qdata.get("delivery_days") or "").strip()
+        if _current_delivery_po.lower() in _VAGUE_DELIVERY_PO:
+            try:
+                _cfg_raw = json.loads((BASE_DIR / "catalog" / "config.json").read_text(encoding="utf-8"))
+                qdata["delivery_days"] = _cfg_raw.get("delivery_days", {}).get("display", "30 dias desde la toma de medidas")
+            except Exception:
+                qdata["delivery_days"] = "30 dias desde la toma de medidas"
+        return errors, warnings
+
     # ── Errors (block generation) ──
     if not qdata.get("client_name"):
         errors.append("Falta nombre del cliente")

--- a/api/tests/test_products_only_detector.py
+++ b/api/tests/test_products_only_detector.py
@@ -842,6 +842,90 @@ class TestConfirmShortCircuit:
             "el frontend timeoutea (bug PR #430 replicado)."
         )
 
+    def test_preflight_validate_quote_data_skips_products_only(self):
+        """**Bug del operador (29/04/2026, turno 2):** logs Railway
+        mostraban:
+
+            [products-only-confirm] generate_documents rejected:
+            Pre-flight fallido para :
+            ❌ Falta material
+            ❌ Sin piezas definidas
+            ❌ Sin ítems de mano de obra
+
+        El validator `_validate_quote_data` (preflight de agent.py,
+        distinto al `validate_despiece`) no respetaba el modo
+        products_only y rebotaba con 3 errores.
+
+        Fix: skip en products_only. Solo aplica los checks que sí
+        tienen sentido (cliente, total, sinks)."""
+        from app.modules.agent.agent import _validate_quote_data
+        # Calc result válido products_only (lo que persistió el
+        # short-circuit del PR #427).
+        qdata = {
+            "_quote_mode": "products_only",
+            "client_name": "DYSCON S.A.",
+            "project": "Unidad Penal N°8 — Piñero",
+            "delivery_days": "A confirmar",
+            "material_name": "",  # ← antes rebotaba "Falta material"
+            "material_m2": 0,
+            "sectors": [],         # ← antes rebotaba "Sin piezas"
+            "mo_items": [],        # ← antes rebotaba "Sin ítems MO"
+            "sinks": [
+                {"name": "PILETA JOHNSON E50/18", "quantity": 32, "unit_price": 136410},
+            ],
+            "total_ars": 4146864,
+        }
+        errors, warnings = _validate_quote_data(qdata)
+        assert errors == [], f"Preflight rebotó products_only: {errors}"
+
+    def test_preflight_products_only_without_sinks_fails(self):
+        """En products_only, la lista de sinks es obligatoria — sin
+        eso no hay nada que cotizar. Validator debe fallar."""
+        from app.modules.agent.agent import _validate_quote_data
+        qdata = {
+            "_quote_mode": "products_only",
+            "client_name": "X",
+            "delivery_days": "30 días",
+            "sinks": [],  # ← vacío
+            "total_ars": 0,
+        }
+        errors, _ = _validate_quote_data(qdata)
+        assert any("sinks" in e.lower() or "productos" in e.lower() for e in errors)
+
+    def test_preflight_products_only_without_client_fails(self):
+        """Cliente sigue siendo obligatorio aún en products_only."""
+        from app.modules.agent.agent import _validate_quote_data
+        qdata = {
+            "_quote_mode": "products_only",
+            "client_name": "",
+            "delivery_days": "30 días",
+            "sinks": [{"name": "x", "quantity": 1, "unit_price": 100}],
+            "total_ars": 100,
+        }
+        errors, _ = _validate_quote_data(qdata)
+        assert any("cliente" in e.lower() for e in errors)
+
+    def test_preflight_normal_mode_still_requires_material(self):
+        """**Caso inverso CRÍTICO** (mismo patrón que PR #427): el
+        flujo NORMAL debe seguir requiriendo material/sectors/mo_items.
+        Sin este test, alguien borra el guard de products_only y el
+        flujo normal se rompe sin darse cuenta."""
+        from app.modules.agent.agent import _validate_quote_data
+        qdata = {
+            # Sin _quote_mode → flujo normal
+            "client_name": "X",
+            "delivery_days": "30 días",
+            "material_name": "",  # ← falta
+            "sectors": [],
+            "mo_items": [],
+            "total_ars": 100,
+        }
+        errors, _ = _validate_quote_data(qdata)
+        # Debe rebotar por los 3 checks normales.
+        assert any("material" in e.lower() for e in errors)
+        assert any("piezas" in e.lower() for e in errors)
+        assert any("mano de obra" in e.lower() for e in errors)
+
     def test_short_circuit_only_when_quote_mode_products_only(self):
         """Drift guard: el bloque debe chequear `_quote_mode ==
         "products_only"`. Si en un refactor sacan ese guard, el


### PR DESCRIPTION
## Bug en producción (logs reales)

Caso DYSCON 29/04/2026, turno 2 — después de mergear #427/#429/#430/#431, el operador escribe "Confirmo" y los logs Railway muestran:

```
[products-only-confirm] short-circuit OK ... ← mi guard SÍ disparó
[products-only-confirm] generate_documents rejected: Pre-flight fallido para :
  ❌ Falta material
  ❌ Sin piezas definidas
  ❌ Sin ítems de mano de obra
```

Mi confirm short-circuit del PR #431 funcionó. **Pero el preflight `_validate_quote_data`** (en `agent.py:29`, distinto al `validate_despiece` del `validation_tool.py`) rebotó.

Tras el rebote, fallback al flujo normal → Sonnet → re-llama `calculate_quote` → re-emite Paso 2 (con `localidad="Rosario"` por default — que es exactamente lo que el screenshot del operador mostró).

## Causa

Tercera vez en este ciclo que aparece un validator escondido que no respeta `_quote_mode == "products_only"`. Ya arreglé:
- `validate_despiece` + `_check_pegadopileta` (PR #427)
- `_check_material_total` (PR #427)
- `_check_regrueso_consistency` (PR #427)

Y **no me di cuenta** de este preflight independiente con sus propios 3 checks: material, sectors, mo_items.

## Fix

Mismo patrón. Skip si `_quote_mode == "products_only"`. En ese modo aplica solo el subset que tiene sentido:
- `client_name` requerido.
- `total_ars > 0` requerido.
- `sinks` no vacío requerido.
- Material/sectors/mo_items omitidos (por diseño son vacíos).

## Tests (4 nuevos)

| Test | Foco |
|---|---|
| `test_preflight_validate_quote_data_skips_products_only` | qdata products_only sin material/sectors/mo → preflight pasa |
| `test_preflight_products_only_without_sinks_fails` | sinks=[] → error (correcto) |
| `test_preflight_products_only_without_client_fails` | cliente sigue siendo obligatorio |
| **`test_preflight_normal_mode_still_requires_material`** | **CASO INVERSO CRÍTICO** — flujo normal sin `_quote_mode` SIGUE rebotando los 3 checks. Sin este test, alguien borra el guard y el flujo normal se rompe silenciosamente. |

Suite full: **2456 passing** (+4, 0 regresiones).

## Deuda anotada (Issue follow-up post-merge)

Refactor de validators a un solo pipeline. Hoy hay 2-3 capas distintas (`_validate_quote_data`, `validate_despiece`, sub-validators individuales). Cada vez que aparece un modo nuevo (products_only, regrueso, etc.) hay que agregar el guard simétrico en TODAS las capas — y descubrirlo en producción.

## Validación post-merge

Reproducir DYSCON pileta-only:
1. Brief → Paso 2 limpio.
2. **"Confirmo" → genera PDF/Excel directo, NO redirect, NO re-emite Paso 2.**

Logs esperados: `[products-only-confirm] short-circuit OK` SIN el "rejected".

🤖 Generated with [Claude Code](https://claude.com/claude-code)