### PR TITLE
fix(format): "Descuento 5.0%" → "Descuento 5%" en PDF/Excel/Paso2

### DIFF
--- a/api/app/modules/agent/tools/document_tool.py
+++ b/api/app/modules/agent/tools/document_tool.py
@@ -183,6 +183,25 @@ def _fmt_qty(value: float) -> str:
     return f"{value:.2f}".replace(".", ",")
 
 
+def _fmt_pct(pct) -> str:
+    """Formato de porcentaje sin decimales superfluos para PDF/Excel.
+
+    PR #433 — operador reportó "molesta mucho" ver `Descuento 5.0%`
+    en el PDF. El parser extrae `discount_pct` como float; cuando es
+    entero, mostramos sin punto decimal.
+
+    `_fmt_pct(5.0)` → "5", `_fmt_pct(12.5)` → "12,5", `_fmt_pct(None)` → "".
+    """
+    if pct is None:
+        return ""
+    try:
+        if float(pct) == int(pct):
+            return f"{int(pct)}"
+        return str(pct).replace(".", ",")
+    except (TypeError, ValueError):
+        return ""
+
+
 def _normalize_delivery(raw: str) -> str:
     """Ensure delivery text is complete, not just a number or short phrase.
 
@@ -1461,7 +1480,7 @@ def _generate_pdf(pdf_path: Path, data: dict) -> None:
     if _has_material_block:
         if discount_pct:
             desc_amount = round(total_mat_bruto * discount_pct / 100)
-            right_rows.append(("I", f"Descuento {discount_pct}%", f"- {fmt_price(desc_amount)}"))
+            right_rows.append(("I", f"Descuento {_fmt_pct(discount_pct)}%", f"- {fmt_price(desc_amount)}"))
             if currency == "USD":
                 right_rows.append(("B", f"TOTAL {currency}", fmt_price(total_mat)))
         elif currency == "USD":
@@ -1538,7 +1557,7 @@ def _generate_pdf(pdf_path: Path, data: dict) -> None:
         _disc_sinks = round(sinks_subtotal * discount_pct / 100)
         f = row_fill()
         pdf.set_font("Helvetica", "I", 9)
-        pdf.cell(w[0] + w[1], rh, f"Descuento {discount_pct}%", fill=f)
+        pdf.cell(w[0] + w[1], rh, f"Descuento {_fmt_pct(discount_pct)}%", fill=f)
         pdf.cell(w[2], rh, "", fill=f)
         pdf.cell(w[3], rh, f"- {_fmt_ars(_disc_sinks)}", align="R", fill=f, new_x="LMARGIN", new_y="NEXT")
         row_done()
@@ -1595,7 +1614,7 @@ def _generate_pdf(pdf_path: Path, data: dict) -> None:
     if _mo_disc_pct and _mo_disc_amt:
         f = row_fill()
         pdf.set_font("Helvetica", "I", 9)
-        pdf.cell(w[0] + w[1], rh, f"Descuento {_mo_disc_pct}% sobre MO (excluye flete)", fill=f)
+        pdf.cell(w[0] + w[1], rh, f"Descuento {_fmt_pct(_mo_disc_pct)}% sobre MO (excluye flete)", fill=f)
         pdf.cell(w[2], rh, "", fill=f)
         pdf.cell(w[3], rh, f"- {_fmt_ars(_mo_disc_amt)}", align="R", fill=f, new_x="LMARGIN", new_y="NEXT")
         row_done()
@@ -1841,7 +1860,7 @@ def _generate_excel(output_path: Path, data: dict) -> None:
     if _has_material_block:
         if discount_pct:
             desc_amount = round(total_mat * discount_pct / 100)
-            right_rows_xl.append(("I", f"Descuento {discount_pct}%", f"- {_xl_fmt(desc_amount)}"))
+            right_rows_xl.append(("I", f"Descuento {_fmt_pct(discount_pct)}%", f"- {_xl_fmt(desc_amount)}"))
             if currency == "USD":
                 right_rows_xl.append(("B", f"TOTAL {currency}", _xl_fmt(total_mat_net)))
         elif currency == "USD":
@@ -1911,7 +1930,7 @@ def _generate_excel(output_path: Path, data: dict) -> None:
             )
             _disc_sinks = round(sinks_subtotal * discount_pct / 100)
             disc_row = sinks_header_row + 1 + len(sinks)
-            ws.cell(disc_row, 1).value = f"Descuento {discount_pct}%"
+            ws.cell(disc_row, 1).value = f"Descuento {_fmt_pct(discount_pct)}%"
             ws.cell(disc_row, 1).font = italic_sm
             ws.cell(disc_row, 6).value = -_disc_sinks
             ws.cell(disc_row, 6).number_format = ars_fmt
@@ -1987,7 +2006,7 @@ def _generate_excel(output_path: Path, data: dict) -> None:
     if _mo_disc_pct and _mo_disc_amt:
         disc_row = mo_end_row + 1
         ws.insert_rows(disc_row)
-        ws.cell(disc_row, 1).value = f"Descuento {_mo_disc_pct}% sobre MO (excluye flete)"
+        ws.cell(disc_row, 1).value = f"Descuento {_fmt_pct(_mo_disc_pct)}% sobre MO (excluye flete)"
         ws.cell(disc_row, 1).font = italic_sm
         ws.cell(disc_row, 6).value = -_mo_disc_amt
         ws.cell(disc_row, 6).number_format = ars_fmt

--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -22,6 +22,36 @@ def _round_half_up(value: float, decimals: int = 2) -> float:
     return float(Decimal(str(value)).quantize(quant, rounding=ROUND_HALF_UP))
 
 
+def _fmt_pct(pct) -> str:
+    """Formato de porcentaje sin decimales superfluos para display.
+
+    PR #433 — el operador reportó "molesta mucho" ver `Descuento 5.0%`
+    en el PDF en lugar de `Descuento 5%`. El parser de descuento del
+    brief (PR #427) extrae `discount_pct` como float ("5%" → 5.0).
+    Cuando el float es entero, lo mostramos sin punto decimal.
+    Cuando tiene decimales reales (12.5%, 8.25%), conserva los
+    dígitos pero con coma decimal (convención AR).
+
+    Examples:
+        >>> _fmt_pct(5.0)
+        '5'
+        >>> _fmt_pct(5)
+        '5'
+        >>> _fmt_pct(12.5)
+        '12,5'
+        >>> _fmt_pct(None)
+        ''
+    """
+    if pct is None:
+        return ""
+    try:
+        if float(pct) == int(pct):
+            return f"{int(pct)}"
+        return str(pct).replace(".", ",")
+    except (TypeError, ValueError):
+        return ""
+
+
 _AMBIENTE_KEYWORDS = {
     "cocina": "Cocina",
     "lavadero": "Lavadero",
@@ -1975,7 +2005,7 @@ def _build_paso2_products_only(calc: dict) -> str:
 
     # Descuento (si aplica) — siempre con monto en negativo, "sobre productos".
     if discount_pct and discount_amount:
-        lines.append(f"**DESCUENTO — {discount_pct}%**")
+        lines.append(f"**DESCUENTO — {_fmt_pct(discount_pct)}%**")
         lines.append(f"- -{fmt_ars(discount_amount)} sobre productos")
         lines.append("")
 
@@ -2120,7 +2150,7 @@ def build_deterministic_paso2(calc: dict) -> str:
 
     # Descuento
     if discount_pct:
-        lines.append(f"**DESCUENTO — {discount_pct}%**")
+        lines.append(f"**DESCUENTO — {_fmt_pct(discount_pct)}%**")
         lines.append(f"- {fmt_usd(discount_amount) if currency == 'USD' else fmt_ars(discount_amount)} sobre material")
         lines.append(f"- Total material neto: {fmt_usd(mat_total_net) if currency == 'USD' else fmt_ars(mat_total_net)}")
     else:
@@ -2181,7 +2211,7 @@ def build_deterministic_paso2(calc: dict) -> str:
             )
         if mo_discount_pct:
             lines.append(
-                f"| **Descuento {mo_discount_pct}% sobre MO (excluye flete)** | | | | **-{fmt_ars(mo_discount_amount)}** |"
+                f"| **Descuento {_fmt_pct(mo_discount_pct)}% sobre MO (excluye flete)** | | | | **-{fmt_ars(mo_discount_amount)}** |"
             )
         lines.append(f"| **TOTAL MO** | | | | **{fmt_ars(_total_mo_subtotal)}** |")
     else:

--- a/api/app/modules/quote_engine/edificio_parser.py
+++ b/api/app/modules/quote_engine/edificio_parser.py
@@ -923,7 +923,9 @@ def render_edificio_paso2(summary: dict, localidad: str = "Rosario") -> dict:
         lines.append(f"| Superficie | {_fmt_num(m2)} m² |")
         lines.append(f"| Subtotal | {cur_sym}{_fmt_num(mr['material_total'], 0)} |")
         if mr["discount_pct"]:
-            lines.append(f"| Descuento {mr['discount_pct']}% | -{cur_sym}{_fmt_num(mr['discount_amount'], 0)} |")
+            # PR #433 — `_fmt_pct` evita "5.0%" en favor de "5%".
+            from app.modules.quote_engine.calculator import _fmt_pct as _pct
+            lines.append(f"| Descuento {_pct(mr['discount_pct'])}% | -{cur_sym}{_fmt_num(mr['discount_amount'], 0)} |")
             lines.append(f"| **Total material** | **{cur_sym}{_fmt_num(mr['material_net'], 0)}** |")
         else:
             lines.append(f"| **Total material** | **{cur_sym}{_fmt_num(mr['material_total'], 0)}** |")

--- a/api/tests/test_products_only_detector.py
+++ b/api/tests/test_products_only_detector.py
@@ -949,3 +949,71 @@ class TestConfirmShortCircuit:
             "Sin ese guard, dispararía para cualquier quote y "
             "rompería el flujo normal de mesadas."
         )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# _fmt_pct — formato de porcentaje sin decimales superfluos (PR #433)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestFmtPct:
+    """**Caso operador (29/04/2026):** "podríamos ponerle 5% y no
+    5.0% molesta mucho en el pdf". El parser extrae `discount_pct`
+    como float, los renderers lo imprimían como "5.0%".
+
+    Helper `_fmt_pct` (en calculator.py + document_tool.py):
+    - Entero (5.0, 8) → "5", "8".
+    - Decimales reales (12.5) → "12,5" (coma AR).
+    - None / unparseable → "" (defensivo).
+    """
+
+    def test_integer_float_no_decimal(self):
+        from app.modules.quote_engine.calculator import _fmt_pct
+        assert _fmt_pct(5.0) == "5"
+        assert _fmt_pct(8.0) == "8"
+        assert _fmt_pct(12.0) == "12"
+
+    def test_int_no_decimal(self):
+        from app.modules.quote_engine.calculator import _fmt_pct
+        assert _fmt_pct(5) == "5"
+        assert _fmt_pct(0) == "0"
+
+    def test_real_decimal_argentine_comma(self):
+        from app.modules.quote_engine.calculator import _fmt_pct
+        assert _fmt_pct(12.5) == "12,5"
+        assert _fmt_pct(8.25) == "8,25"
+
+    def test_none_returns_empty(self):
+        from app.modules.quote_engine.calculator import _fmt_pct
+        assert _fmt_pct(None) == ""
+
+    def test_unparseable_returns_empty(self):
+        from app.modules.quote_engine.calculator import _fmt_pct
+        assert _fmt_pct("not a number") == ""
+
+    def test_document_tool_helper_matches(self):
+        """document_tool.py tiene su propio `_fmt_pct` (sin import
+        cruzado). Drift guard: ambos deben dar el mismo resultado."""
+        from app.modules.quote_engine.calculator import _fmt_pct as _calc_pct
+        from app.modules.agent.tools.document_tool import _fmt_pct as _doc_pct
+        for v in [5.0, 5, 12.5, 0, None, "garbage"]:
+            assert _calc_pct(v) == _doc_pct(v), (
+                f"_fmt_pct divergente para {v!r}: "
+                f"calc={_calc_pct(v)!r} doc={_doc_pct(v)!r}"
+            )
+
+    def test_paso2_products_only_uses_fmt_pct(self):
+        """End-to-end: el Paso 2 markdown products_only NO debe
+        contener '5.0%' — debe ser '5%'."""
+        from app.modules.quote_engine.calculator import (
+            calculate_quote, build_deterministic_paso2,
+        )
+        parsed = parse_products_brief(_DYSCON_BRIEF)
+        result = calculate_quote(parsed)
+        md = build_deterministic_paso2(result)
+        assert "5.0%" not in md, (
+            f"Paso 2 contiene '5.0%' (decimal superfluo):\n{md[:1500]}"
+        )
+        assert "DESCUENTO — 5%" in md, (
+            f"Paso 2 debería tener 'DESCUENTO — 5%':\n{md[:1500]}"
+        )


### PR DESCRIPTION
## Pedido del operador

> podríamos ponerle 5% y no 5.0% molesta mucho en el pdf

El parser del PR #427 extrae `discount_pct` como float ("5%" → 5.0). Renderers imprimían "5.0%" sin formato.

## Fix

Helper `_fmt_pct(pct)`:
- Entero (5.0, 8) → "5", "8".
- Decimales reales (12.5) → "12,5" (coma AR).
- None / unparseable → "" (defensivo).

Definido en 2 lugares (sin imports cruzados): `calculator.py` y `document_tool.py`. Drift guard test verifica que ambos den el mismo resultado.

## 10 call sites actualizados

| Archivo | Función | Tipo |
|---|---|---|
| calculator.py | `_build_paso2_products_only` | Paso 2 markdown products_only |
| calculator.py | `build_deterministic_paso2` × 2 | DESCUENTO + MO commercial |
| document_tool.py | `_generate_pdf` × 3 | overlay material, sinks (products_only), MO commercial |
| document_tool.py | `_generate_excel` × 3 | idem PDF |
| edificio_parser.py | `_render_material_table` | Paso 2 edificio |

## Tests (7)

- Float entero / int / decimales reales / None / unparseable.
- Drift guard: helpers de los 2 archivos dan mismo resultado.
- E2E DYSCON: Paso 2 markdown SIN "5.0%", CON "DESCUENTO — 5%".

Suite full: **2463 passing** (+7, 0 regresiones).

## Resultado

| Antes | Después |
|---|---|
| `Descuento 5.0%` | `Descuento 5%` |
| `**DESCUENTO — 5.0%**` | `**DESCUENTO — 5%**` |
| `Descuento 12.5%` | `Descuento 12,5%` (con coma AR) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)