### PR TITLE
fix(dashboard): material label persiste post-confirm en quotes products_only

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -2619,15 +2619,16 @@ class AgentService:
                                 # listado del dashboard. Antes era "" →
                                 # se mostraba como "—" en la columna
                                 # material y el operador no podía
-                                # identificar qué cotización era. Helper
-                                # vive en `products_only_detector` para
-                                # ser unit-testable sin DB ni Anthropic.
+                                # identificar qué cotización era. PR #434:
+                                # usamos `resolve_material_label_for_db`
+                                # — mismo helper que los handlers de
+                                # calculate_quote y generate_documents,
+                                # garantía de que el label sea consistente
+                                # en cualquier ruta de persistencia.
                                 from app.modules.quote_engine.products_only_detector import (
-                                    build_products_only_material_label,
+                                    resolve_material_label_for_db,
                                 )
-                                _po_label = build_products_only_material_label(
-                                    _po_result.get("sinks")
-                                )
+                                _po_label = resolve_material_label_for_db(_po_result)
                                 _po_persist = {
                                     "quote_breakdown": dict(_po_result),
                                     "total_ars": _po_result.get("total_ars", 0),
@@ -5657,8 +5658,15 @@ class AgentService:
                 # placeholder/junk ("O Proyecto", "Proyecto", "Cliente",
                 # "Sin nombre", etc.), lo sobreescribimos con el nuevo.
                 # Eso rescata quotes viejos contaminados por drift previo.
+                # PR #434 — products_only: usar el helper que devuelve
+                # el label desde sinks cuando _quote_mode==products_only.
+                # Sin esto, generate_documents sobrescribía
+                # `quote.material = ""` y el listado mostraba "—".
+                from app.modules.quote_engine.products_only_detector import (
+                    resolve_material_label_for_db,
+                )
                 save_vals = {
-                    "material": qdata.get("material_name"),
+                    "material": resolve_material_label_for_db(qdata),
                     "total_ars": qdata.get("total_ars"),
                     "total_usd": qdata.get("total_usd"),
                     "quote_breakdown": qdata,
@@ -6876,11 +6884,20 @@ class AgentService:
                             if _keep_key in old_quote.quote_breakdown and _keep_key not in _merged_bd:
                                 _merged_bd[_keep_key] = old_quote.quote_breakdown[_keep_key]
 
+                    # PR #434 — modo products_only: `material_name = ""`
+                    # en el calc_result, pero el listado del dashboard
+                    # debe mostrar el label descriptivo (PR #428). Sin
+                    # este helper, este handler de calculate_quote
+                    # sobrescribía con "" cada vez que Sonnet recotaba
+                    # un products_only (turno 2+ del operador).
+                    from app.modules.quote_engine.products_only_detector import (
+                        resolve_material_label_for_db,
+                    )
                     _values = {
                         "quote_breakdown": _merged_bd,
                         "total_ars": calc_result.get("total_ars"),
                         "total_usd": calc_result.get("total_usd"),
-                        "material": calc_result.get("material_name"),
+                        "material": resolve_material_label_for_db(calc_result),
                         "change_history": history,
                     }
                     if calc_result.get("is_edificio"):

--- a/api/app/modules/quote_engine/products_only_detector.py
+++ b/api/app/modules/quote_engine/products_only_detector.py
@@ -266,6 +266,31 @@ def build_products_only_material_label(sinks: list[dict] | None) -> str:
     return label
 
 
+def resolve_material_label_for_db(calc_result: dict) -> str:
+    """Devuelve el string que va en `Quote.material` (columna DB usada
+    por el listado del dashboard).
+
+    **Por qué existe (PR #434):** sin este helper, los handlers de
+    `calculate_quote` y `generate_documents` hacían
+    `quote.material = calc_result.get("material_name")`. Para
+    products_only `material_name = ""` → sobrescribía el label
+    descriptivo del PR #428 → en el listado se veía "—".
+
+    Reglas:
+    - Si `_quote_mode == "products_only"` → label desde sinks
+      (mismo helper que usa el short-circuit del PR #427).
+    - Si no → `material_name` directo (flujo normal intacto).
+
+    Si el calc_result no tiene `_quote_mode` explícito pero TIENE
+    sinks Y NO tiene material_name (caso defensivo: products_only
+    persistido viejo sin flag), también usa el label de sinks.
+    """
+    if calc_result.get("_quote_mode") == "products_only":
+        return build_products_only_material_label(calc_result.get("sinks"))
+    # Flujo normal: usar material_name directo.
+    return calc_result.get("material_name") or ""
+
+
 def parse_products_brief(brief: str) -> Optional[dict]:
     """Parsea un brief de "solo producto" a un dict listo para
     `calculate_quote`.

--- a/api/tests/test_products_only_detector.py
+++ b/api/tests/test_products_only_detector.py
@@ -31,6 +31,7 @@ from app.modules.quote_engine.products_only_detector import (
     build_products_only_material_label,
     is_products_only_brief,
     parse_products_brief,
+    resolve_material_label_for_db,
     _extract_qty,
     _extract_sku,
     _extract_discount,
@@ -623,6 +624,44 @@ class TestBuildPaso2ProductsOnly:
         assert "MATERIAL" in md
         assert "MANO DE OBRA" in md
         assert "GRANITO GRIS MARA" in md
+
+    # ── resolve_material_label_for_db (PR #434) ──────────────────────
+
+    def test_resolve_label_products_only_uses_sinks(self):
+        """**Bug operador (29/04/2026)**: listado mostraba "—" para
+        products_only post-confirm. Causa: handlers de
+        calculate_quote / generate_documents sobrescribían
+        `quote.material = ""` (calc_result.material_name vacío en
+        products_only). Helper unificado evita ese override."""
+        calc = {
+            "_quote_mode": "products_only",
+            "material_name": "",  # ← el bug: handlers usaban esto
+            "sinks": [
+                {"name": "PILETA JOHNSON E50/18", "quantity": 32, "unit_price": 136410},
+            ],
+        }
+        label = resolve_material_label_for_db(calc)
+        assert label == "PILETA JOHNSON E50/18 × 32"
+
+    def test_resolve_label_normal_flow_uses_material_name(self):
+        """Regression: flujo normal sigue usando `material_name`."""
+        calc = {
+            "material_name": "GRANITO GRIS MARA EXTRA 2 ESP",
+            "sinks": [],
+        }
+        label = resolve_material_label_for_db(calc)
+        assert label == "GRANITO GRIS MARA EXTRA 2 ESP"
+
+    def test_resolve_label_no_quote_mode_uses_material_name(self):
+        """Sin `_quote_mode` (calc_result legacy) y con material_name
+        → flujo normal."""
+        calc = {"material_name": "Silestone Blanco"}
+        label = resolve_material_label_for_db(calc)
+        assert label == "Silestone Blanco"
+
+    def test_resolve_label_empty_no_mode(self):
+        """Defensivo: sin nada → string vacío sin crashear."""
+        assert resolve_material_label_for_db({}) == ""
 
     def test_dyscon_full_label(self):
         """Caso DYSCON real: el calc_result que produce


### PR DESCRIPTION
## Bug observado en prod

Listado mostraba `—` en la columna material para quotes products_only post-confirmación. PR #428 puso el label durante el short-circuit del primer turno, pero **dos handlers lo sobrescribían** después:

- `calculate_quote` handler (línea 6883): `material = calc_result.get("material_name")` → `""`.
- `generate_documents` handler (línea 5661): mismo patrón.

Para products_only, `material_name = ""`. Cada turno post-brief lo reseteaba.

## Fix

Helper unificado `resolve_material_label_for_db(calc_result)`:
- `_quote_mode == "products_only"` → label desde sinks.
- Otro → `material_name` directo.

Aplicado en los 3 lugares (incluido refactor del short-circuit del PR #427 para usar el mismo helper como fuente única).

## Tests (4)

- products_only + `material_name=""` → label de sinks ✓.
- Flujo normal con material_name → intacto ✓.
- Sin `_quote_mode` legacy → flujo normal.
- Defensivo: empty dict → "".

Suite: **2467 passing** (+4, 0 regresiones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)