### PR TITLE
feat(detail-view): EditableField inline para Demora y Localidad

### DIFF
--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -1182,7 +1182,34 @@ function DetailView({ quote, breakdown, onSwitchToChat, onGenerate, generating, 
           )}
           <MetaItem label="Material" value={quote.material || DASH} />
           <MetaItem label="Fecha" value={new Date(quote.created_at).toLocaleString("es-AR", { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" })} />
-          <MetaItem label="Demora" value={breakdown?.delivery_days || DASH} />
+          {/* PR #440 (P2.1) — Demora editable inline. Se persiste en
+              `quote_breakdown.delivery_days` (no hay columna). El handler
+              `PATCH /quotes` desde PR #437 acepta el campo. */}
+          {onFieldUpdate ? (
+            <EditableField
+              label="Demora"
+              type="text"
+              value={breakdown?.delivery_days ?? null}
+              placeholder="Ej: 30 días, 4 meses, A confirmar"
+              onSave={(v) => onFieldUpdate({ delivery_days: v })}
+            />
+          ) : (
+            <MetaItem label="Demora" value={breakdown?.delivery_days || DASH} />
+          )}
+          {/* PR #440 (P2.1) — Localidad editable inline. Sync a
+              breakdown desde PR #438. Antes el operador sólo podía
+              cambiarla via chat con Sonnet. */}
+          {onFieldUpdate ? (
+            <EditableField
+              label="Localidad"
+              type="text"
+              value={quote.localidad ?? null}
+              placeholder="Ej: Rosario, Piñero, Cañada de Gómez"
+              onSave={(v) => onFieldUpdate({ localidad: v })}
+            />
+          ) : (
+            <MetaItem label="Localidad" value={quote.localidad || DASH} />
+          )}
           <MetaItem label="Origen" value={quote.source === "web" ? "Web (chatbot)" : "Operador"} />
           <MetaItem label="Total ARS" value={quote.total_ars ? fmtARS(quote.total_ars) : DASH} highlight />
           <MetaItem label="Total USD" value={quote.total_usd ? fmtUSD(quote.total_usd) : DASH} highlight />

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -323,9 +323,11 @@ export type QuoteEditablePatch = Partial<{
   project: string;
   notes: string;
   // PR #437 (P1.2) — delivery_days expuesto en el endpoint REST.
-  // Soportado por el backend; el EditableField del frontend lo
-  // expone en P2.1 (PR siguiente).
+  // P2.1 (PR #440) lo conecta a un EditableField del DetailView.
   delivery_days: string;
+  // PR #440 (P2.1) — localidad editable inline. Soportada por el
+  // endpoint REST desde antes; el sync a breakdown llegó en PR #438.
+  localidad: string;
 }>;
 
 export async function updateQuote(id: string, patch: QuoteEditablePatch): Promise<void> {


### PR DESCRIPTION
**Plan Fase 2 — P2.1** del análisis de modificabilidad.

## Por qué

DetailView solo exponía 3 campos editables (client_name, project, notes). Para cambiar **demora** o **localidad** el operador tenía que pedírselo a Sonnet vía chat — más lento y con riesgo de alucinaciones (Issue #422 + caso DYSCON donde "cambiá la demora" no funcionaba por bug del handler `update_quote` antes del PR #436).

Backend ya listo desde Fase 1: PR #437 (delivery_days en REST), PR #438 (sync a breakdown).

## Cambios (frontend solo)

1. **`api.ts:QuoteEditablePatch`**: agregado `delivery_days` (ya hecho en #437) y `localidad`.
2. **`DetailView`**:
   - **Demora**: `MetaItem` → `EditableField`. Lee de `breakdown?.delivery_days`.
   - **Localidad**: campo nuevo (antes ni aparecía en Resumen). Lee de `quote.localidad`.

Cuando `onFieldUpdate` es null (read-only), muestran `MetaItem` con DASH.

## Flujo end-to-end

1. Click en "Demora" → input → "30 días" → blur.
2. Frontend `PATCH /quotes/{id}` con `{delivery_days: "30 días"}`.
3. Backend persiste en breakdown.
4. Re-fetch + render → muestra "30 días".
5. Re-generar PDF → cabecera con la demora nueva.

Idem localidad (cambia columna + breakdown).

## Lo que NO toca

- Backend: idéntico, todo el plumbing fue Fase 1.
- Otros campos: material, pileta, anafe, colocacion, sink_type, status, totales — siguen no editables inline (chat-only o no editables).

## Tests

- Build frontend ✓ (`npm run build` → 7/7, 0 errors).
- Plumbing PATCH ya cubierto por tests del backend (#437, #438).

## Estado del plan

- Fase 1 ✓ (#437, #438, #439).
- Fase 2 ✓ P2.1. P2.2/P2.3 diferidos.
- Fase 3/4 pendientes según review (P3.1, P4.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)