### PR TITLE
feat(detail-view): banner "PDF desactualizado · Regenerar" tras edits

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -5809,6 +5809,29 @@ class AgentService:
                         QuoteStatus.DRAFT, QuoteStatus.PENDING
                     ):
                         doc_values["status"] = QuoteStatus.VALIDATED.value
+
+                    # PR #442 — append a `change_history` el evento de
+                    # generación para que `_compute_pdf_outdated`
+                    # tenga el timestamp y pueda decidir si el PDF está
+                    # desactualizado tras edits posteriores. Sin esta
+                    # entry, quotes nuevos quedarían sin tracking y el
+                    # banner del frontend no aparecería.
+                    try:
+                        from datetime import datetime as _dt_pdf_track
+                        _gen_history = list(_cur.change_history or []) if _cur else []
+                        _gen_history.append({
+                            "timestamp": _dt_pdf_track.now().isoformat(),
+                            "action": "generate_docs",
+                            "pdf_url": result.get("pdf_url"),
+                            "excel_url": result.get("excel_url"),
+                        })
+                        doc_values["change_history"] = _gen_history
+                    except Exception as _e_hist:
+                        logging.warning(
+                            f"[generate_docs-history] could not append "
+                            f"to change_history for {target_qid}: {_e_hist}"
+                        )
+
                     await db.execute(
                         update(Quote).where(Quote.id == target_qid).values(**doc_values)
                     )

--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, update
 from pydantic import BaseModel
 from typing import Optional, List
+from datetime import datetime
 import json
 import logging
 import re
@@ -223,6 +224,87 @@ async def check_quotes(db: AsyncSession = Depends(get_db)):
 
 # ── GET QUOTE DETAIL ─────────────────────────────────────────────────────────
 
+def _compute_pdf_outdated(quote: Quote) -> tuple[bool, Optional[datetime]]:
+    """Devuelve (pdf_outdated, pdf_generated_at) según change_history.
+
+    PR #442 — banner "PDF desactualizado":
+
+    El operador edita campos del quote (PATCH /quotes) sin regenerar
+    el PDF. El detalle del frontend muestra el cambio (lee de
+    breakdown/columnas), pero el PDF guardado en disco/Drive sigue
+    siendo el viejo. Para no engañar al operador, computamos un flag
+    visible.
+
+    Lógica:
+    - Si NO hay `pdf_url` → False (no hay PDF para comparar).
+    - Buscar en `change_history` el último entry con
+      `action in {"regenerate_docs", "generate_docs"}`. Su
+      `timestamp` es `pdf_generated_at`.
+    - `pdf_outdated = updated_at > pdf_generated_at + tolerance`.
+      Tolerancia = 5s para evitar race del propio regenerate (su
+      `update(Quote).values(...)` triggerea `updated_at`).
+    - Si NO hay entries de regenerate/generate pero hay pdf_url:
+      asumir conservadoramente NOT outdated. Quotes viejos sin
+      tracking no se marcan — el operador puede regenerar manual
+      si quiere. Esto evita ruido en presupuestos legacy.
+
+    Returns:
+        (False, None) si no hay PDF.
+        (False, ts) si está al día.
+        (True, ts) si hay edits posteriores.
+    """
+    from datetime import timedelta as _td
+    if not quote.pdf_url:
+        return False, None
+
+    history = quote.change_history or []
+    REGEN_ACTIONS = {"regenerate_docs", "generate_docs"}
+    last_pdf_ts: Optional[datetime] = None
+    for entry in history:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("action") not in REGEN_ACTIONS:
+            continue
+        ts_raw = entry.get("timestamp")
+        if not ts_raw:
+            continue
+        try:
+            ts = datetime.fromisoformat(ts_raw.replace("Z", "+00:00")) if isinstance(ts_raw, str) else ts_raw
+        except (TypeError, ValueError):
+            continue
+        if last_pdf_ts is None or ts > last_pdf_ts:
+            last_pdf_ts = ts
+
+    if last_pdf_ts is None:
+        # PDF existe pero no hay tracking en history (quote legacy
+        # pre-#442 o flujos que no logueaban). Conservador: no
+        # marcar como outdated para no spamear al operador con
+        # falsos positivos.
+        return False, None
+
+    # Comparar con `updated_at`. Normalizar tz: si updated_at es
+    # naive, asumimos UTC. Si tiene tz, convertimos last_pdf_ts a
+    # la misma referencia (ambos en UTC).
+    updated_at = quote.updated_at
+    if updated_at is None:
+        return False, last_pdf_ts
+    # Defensivo: si las dos son naive o ambas tz-aware, comparar
+    # directo; si una es naive, normalizar.
+    try:
+        if updated_at.tzinfo is None and last_pdf_ts.tzinfo is not None:
+            from datetime import timezone as _tz
+            updated_at = updated_at.replace(tzinfo=_tz.utc)
+        elif updated_at.tzinfo is not None and last_pdf_ts.tzinfo is None:
+            from datetime import timezone as _tz
+            last_pdf_ts = last_pdf_ts.replace(tzinfo=_tz.utc)
+    except Exception:
+        pass
+
+    TOLERANCE = _td(seconds=5)
+    pdf_outdated = updated_at > (last_pdf_ts + TOLERANCE)
+    return pdf_outdated, last_pdf_ts
+
+
 @router.get("/quotes/{quote_id}")
 async def get_quote(quote_id: str, db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(Quote).where(Quote.id == quote_id))
@@ -230,8 +312,13 @@ async def get_quote(quote_id: str, db: AsyncSession = Depends(get_db)):
     if not quote:
         raise HTTPException(status_code=404, detail="Presupuesto no encontrado")
 
+    # PR #442 — computar pdf_outdated antes de armar el response.
+    pdf_outdated, pdf_generated_at = _compute_pdf_outdated(quote)
+
     # For building_parent, include children in the response
     response = QuoteDetailResponse.model_validate(quote)
+    response.pdf_outdated = pdf_outdated
+    response.pdf_generated_at = pdf_generated_at
     if quote.quote_kind == "building_parent":
         children_result = await db.execute(
             select(Quote)

--- a/api/app/modules/agent/schemas.py
+++ b/api/app/modules/agent/schemas.py
@@ -63,6 +63,13 @@ class QuoteDetailResponse(QuoteListResponse):
     # El frontend lo usa para el botón "Copiar solicitud web" — dump literal
     # de lo que mandó el bot externo, útil para debug del bot vs backend.
     web_input: Optional[dict] = None
+    # PR #442 — flag computado: True si el operador editó el quote
+    # después de la última generación/regenerate del PDF. Frontend
+    # muestra banner "PDF desactualizado · Regenerar" cuando se
+    # cumple. Computado en `GET /quotes/{id}` desde change_history
+    # vs updated_at — no es columna persistida.
+    pdf_outdated: Optional[bool] = None
+    pdf_generated_at: Optional[datetime] = None
 
 
 class QuoteCompareItem(BaseModel):

--- a/api/tests/test_pdf_outdated_flag.py
+++ b/api/tests/test_pdf_outdated_flag.py
@@ -1,0 +1,232 @@
+"""Tests para PR #442 — flag `pdf_outdated` computado en
+`GET /quotes/{id}`.
+
+**Por qué este PR:**
+
+Caso DYSCON 29/04/2026: el operador edita un campo via
+EditableField (frontend), el cambio se persiste correctamente,
+pero el PDF guardado en Drive sigue siendo el viejo. La edición
+NO regenera el PDF automáticamente — ese es el comportamiento
+esperado, pero **el operador no se entera** porque el detalle
+muestra el cambio sin warning.
+
+Fix: backend computa `pdf_outdated` comparando `quote.updated_at`
+con el último timestamp de generación/regenerate del PDF (en
+`change_history`). Frontend muestra un banner amarillo
+"PDF desactualizado · Regenerar ahora".
+
+**Tests cubren:**
+
+1. Sin pdf_url → False (no hay PDF para comparar).
+2. Con pdf_url + sin entries en history → False (legacy, no
+   spamear).
+3. Con pdf_url + último regenerate AT updated_at → False
+   (dentro de tolerancia).
+4. Con pdf_url + edits posteriores al regenerate → True.
+5. Con pdf_url + último generate_docs (no regenerate) → True/False
+   según comparison.
+6. Drift guard: ambos action types se reconocen.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Helpers — construimos un Quote-like para invocar el helper
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class _MockQuote:
+    """Mínimo Quote-like para `_compute_pdf_outdated`."""
+
+    def __init__(
+        self,
+        pdf_url=None,
+        change_history=None,
+        updated_at=None,
+    ):
+        self.pdf_url = pdf_url
+        self.change_history = change_history or []
+        self.updated_at = updated_at
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Comportamiento del helper
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestComputePdfOutdated:
+    def _import_helper(self):
+        from app.modules.agent.router import _compute_pdf_outdated
+        return _compute_pdf_outdated
+
+    def test_no_pdf_url_returns_false(self):
+        compute = self._import_helper()
+        q = _MockQuote(pdf_url=None)
+        outdated, ts = compute(q)
+        assert outdated is False
+        assert ts is None
+
+    def test_pdf_url_but_no_history_returns_false(self):
+        """Quote legacy con PDF pero sin tracking en change_history.
+        Conservadoramente NOT outdated (no spamear con falsos
+        positivos en quotes pre-PR #442)."""
+        compute = self._import_helper()
+        now = datetime.now(timezone.utc)
+        q = _MockQuote(
+            pdf_url="/files/x.pdf",
+            change_history=[],
+            updated_at=now,
+        )
+        outdated, ts = compute(q)
+        assert outdated is False
+        assert ts is None
+
+    def test_no_edits_after_regenerate_not_outdated(self):
+        """updated_at == último regenerate (mismo timestamp).
+        Tolerancia 5s evita race del propio regenerate. NOT outdated."""
+        compute = self._import_helper()
+        regen_ts = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+        q = _MockQuote(
+            pdf_url="/files/x.pdf",
+            change_history=[
+                {"action": "regenerate_docs", "timestamp": _iso(regen_ts)},
+            ],
+            updated_at=regen_ts + timedelta(seconds=2),  # dentro de tolerancia
+        )
+        outdated, ts = compute(q)
+        assert outdated is False
+        assert ts == regen_ts
+
+    def test_edit_after_regenerate_is_outdated(self):
+        """updated_at > regenerate + tolerance → outdated."""
+        compute = self._import_helper()
+        regen_ts = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+        edit_ts = regen_ts + timedelta(minutes=5)
+        q = _MockQuote(
+            pdf_url="/files/x.pdf",
+            change_history=[
+                {"action": "regenerate_docs", "timestamp": _iso(regen_ts)},
+            ],
+            updated_at=edit_ts,
+        )
+        outdated, ts = compute(q)
+        assert outdated is True
+        assert ts == regen_ts
+
+    def test_recognizes_generate_docs_action(self):
+        """`generate_docs` (PR #442 lo agrega al flujo de generación
+        inicial) también cuenta como timestamp de PDF actualizado."""
+        compute = self._import_helper()
+        gen_ts = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+        q = _MockQuote(
+            pdf_url="/files/x.pdf",
+            change_history=[
+                {"action": "generate_docs", "timestamp": _iso(gen_ts)},
+            ],
+            updated_at=gen_ts + timedelta(seconds=3),
+        )
+        outdated, ts = compute(q)
+        assert outdated is False  # dentro de tolerancia
+        assert ts == gen_ts
+
+    def test_uses_most_recent_action(self):
+        """Si hay generate_docs OLD + regenerate_docs NEW → usa el
+        más reciente."""
+        compute = self._import_helper()
+        old_ts = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+        new_ts = datetime(2026, 4, 29, 14, 0, 0, tzinfo=timezone.utc)
+        q = _MockQuote(
+            pdf_url="/files/x.pdf",
+            change_history=[
+                {"action": "generate_docs", "timestamp": _iso(old_ts)},
+                {"action": "regenerate_docs", "timestamp": _iso(new_ts)},
+            ],
+            updated_at=new_ts + timedelta(seconds=2),
+        )
+        outdated, ts = compute(q)
+        assert outdated is False
+        assert ts == new_ts  # el más reciente
+
+    def test_ignores_other_action_types(self):
+        """`calculate_quote` NO cuenta como generación de PDF
+        (solo recalcula). Si solo hay esa acción, sin regenerate
+        ni generate, NO hay tracking → False."""
+        compute = self._import_helper()
+        ts = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+        q = _MockQuote(
+            pdf_url="/files/x.pdf",
+            change_history=[
+                {"action": "calculate_quote", "timestamp": _iso(ts)},
+            ],
+            updated_at=ts + timedelta(hours=1),
+        )
+        outdated, ts_out = compute(q)
+        assert outdated is False
+        assert ts_out is None
+
+    def test_handles_malformed_entries(self):
+        """Defensivo: entries sin timestamp / sin action / no-dict
+        no rompen el helper."""
+        compute = self._import_helper()
+        good_ts = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+        q = _MockQuote(
+            pdf_url="/files/x.pdf",
+            change_history=[
+                "not-a-dict",  # ignorado
+                {},  # sin keys
+                {"action": "regenerate_docs"},  # sin timestamp
+                {"timestamp": _iso(good_ts)},  # sin action
+                {"action": "regenerate_docs", "timestamp": "no-es-iso"},  # parse falla
+                {"action": "regenerate_docs", "timestamp": _iso(good_ts)},  # válido
+            ],
+            updated_at=good_ts + timedelta(seconds=1),
+        )
+        outdated, ts = compute(q)
+        # Debe usar el válido y NOT outdated (dentro de tolerancia).
+        assert outdated is False
+        assert ts == good_ts
+
+    def test_naive_updated_at_with_aware_history(self):
+        """Defensivo: si updated_at viene naive (sin tzinfo) y la
+        history tiene timestamps aware, normalizamos para no
+        crashear con TypeError."""
+        compute = self._import_helper()
+        regen_ts = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+        # Naive: simulamos como SQLite a veces devuelve.
+        edit_naive = datetime(2026, 4, 29, 13, 0, 0)  # sin tz
+        q = _MockQuote(
+            pdf_url="/files/x.pdf",
+            change_history=[
+                {"action": "regenerate_docs", "timestamp": _iso(regen_ts)},
+            ],
+            updated_at=edit_naive,
+        )
+        # No debe crashear. Edit posterior → outdated.
+        outdated, ts = compute(q)
+        assert outdated is True or outdated is False  # acepta cualquiera, lo importante es no crashear
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Drift guard del schema
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestSchemaDriftGuard:
+    def test_quote_detail_response_has_pdf_outdated_field(self):
+        """Sin este campo, el frontend no puede saber si mostrar el
+        banner. Drift guard."""
+        from app.modules.agent.schemas import QuoteDetailResponse
+        assert "pdf_outdated" in QuoteDetailResponse.model_fields, (
+            "QuoteDetailResponse debe incluir `pdf_outdated`. "
+            "Si lo borraste, frontend no muestra el banner."
+        )
+        assert "pdf_generated_at" in QuoteDetailResponse.model_fields, (
+            "QuoteDetailResponse debe incluir `pdf_generated_at` para "
+            "que el frontend pueda mostrar tooltip 'última generación'."
+        )

--- a/web/src/app/quote/[id]/page.tsx
+++ b/web/src/app/quote/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useRouter, useParams } from "next/navigation";
-import { fetchQuote, streamChat, markQuoteAsRead, validateQuote, updateQuote, reopenMeasurements, reopenContext, type QuoteDetail, type QuoteEditablePatch } from "@/lib/api";
+import { fetchQuote, streamChat, markQuoteAsRead, validateQuote, updateQuote, regenerateQuoteDocs, reopenMeasurements, reopenContext, type QuoteDetail, type QuoteEditablePatch } from "@/lib/api";
 import { useQuotes } from "@/lib/quotes-context";
 import MessageBubble from "@/components/chat/MessageBubble";
 import CopyButton from "@/components/chat/CopyButton";
@@ -546,8 +546,34 @@ export default function QuotePage() {
   const handleFieldUpdate = useCallback(async (patch: QuoteEditablePatch) => {
     await updateQuote(quoteId, patch);
     setQuote((prev) => (prev ? ({ ...prev, ...patch } as QuoteDetail) : prev));
+    // PR #442 — re-fetch para obtener el flag `pdf_outdated`
+    // computado por el backend tras este edit. Sin esto, el banner
+    // "PDF desactualizado" no aparece hasta el próximo reload.
+    try {
+      const refreshed = await fetchQuote(quoteId);
+      setQuote(refreshed);
+    } catch { /* tolerable, el setQuote anterior ya muestra el cambio */ }
     refreshQuotes();
   }, [quoteId, refreshQuotes]);
+
+  // PR #442 — handler dedicado para "Regenerar PDF" desde el banner
+  // (distinto al handleGenerate que se usa cuando el quote NO tiene
+  // PDF todavía). Después del regenerate exitoso, re-fetch para
+  // limpiar el flag pdf_outdated y mostrar el PDF nuevo.
+  const handleRegenerate = useCallback(async () => {
+    if (generating) return;
+    setGenerating(true);
+    try {
+      await regenerateQuoteDocs(quoteId);
+      const refreshed = await fetchQuote(quoteId);
+      setQuote(refreshed);
+      refreshQuotes();
+    } catch {
+      // Error toast desde api.ts.
+    } finally {
+      setGenerating(false);
+    }
+  }, [quoteId, generating, refreshQuotes]);
 
   const onKey = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); send(); }
@@ -622,7 +648,7 @@ export default function QuotePage() {
       {/* Content */}
       {tab === "detail" ? (
         <div className="flex-1 overflow-y-auto px-4 md:px-7 py-4 md:py-6">
-          <DetailView quote={quote} breakdown={bd} onSwitchToChat={() => setTab("chat")} onGenerate={quote?.status === "pending" || quote?.status === "draft" ? handleGenerate : undefined} generating={generating} onFieldUpdate={handleFieldUpdate} />
+          <DetailView quote={quote} breakdown={bd} onSwitchToChat={() => setTab("chat")} onGenerate={quote?.status === "pending" || quote?.status === "draft" ? handleGenerate : undefined} onRegenerate={handleRegenerate} generating={generating} onFieldUpdate={handleFieldUpdate} />
           {/* Show modifications section only when quote has breakdown and is not sent */}
           {bd && quote?.status !== "sent" && (
             <Section title="Modificaciones" className="mt-5">
@@ -1147,7 +1173,7 @@ export default function QuotePage() {
 
 // ── DETAIL VIEW ─────────────────────────────────────────────────────────────
 
-function DetailView({ quote, breakdown, onSwitchToChat, onGenerate, generating, onFieldUpdate }: { quote: QuoteDetail | null; breakdown: Record<string, any> | null; onSwitchToChat: () => void; onGenerate?: () => void; generating?: boolean; onFieldUpdate?: (patch: QuoteEditablePatch) => Promise<void> }) {
+function DetailView({ quote, breakdown, onSwitchToChat, onGenerate, onRegenerate, generating, onFieldUpdate }: { quote: QuoteDetail | null; breakdown: Record<string, any> | null; onSwitchToChat: () => void; onGenerate?: () => void; onRegenerate?: () => void; generating?: boolean; onFieldUpdate?: (patch: QuoteEditablePatch) => Promise<void> }) {
   if (!quote) return null;
 
   const pieces = breakdown?.sectors?.flatMap((s: any) => s.pieces || []) || [];
@@ -1168,6 +1194,41 @@ function DetailView({ quote, breakdown, onSwitchToChat, onGenerate, generating, 
 
   return (
     <div className="flex flex-col gap-5">
+      {/* PR #442 — Banner "PDF desactualizado". Aparece cuando el
+          backend computó `pdf_outdated=true` (operador editó campos
+          después de la última generación/regenerate). Click en
+          "Regenerar ahora" llama POST /quotes/:id/regenerate y
+          refresca el quote (el flag se limpia automáticamente). */}
+      {quote.pdf_outdated && quote.pdf_url && onRegenerate && (
+        <div
+          className="flex items-center gap-3 px-4 py-3 rounded-[10px]"
+          style={{
+            background: "rgba(212, 161, 38, 0.10)",
+            border: "1px solid rgba(212, 161, 38, 0.40)",
+          }}
+        >
+          <span style={{ fontSize: 18 }}>⚠️</span>
+          <div className="flex-1 min-w-0">
+            <div className="text-[13px] font-semibold" style={{ color: "#d4a126" }}>
+              PDF desactualizado
+            </div>
+            <div className="text-[11.5px] mt-0.5" style={{ color: "var(--t3)" }}>
+              Hubo cambios después de la última generación. Regenerá para que el PDF / Excel reflejen los datos actuales.
+            </div>
+          </div>
+          <button
+            onClick={onRegenerate}
+            disabled={generating}
+            className="shrink-0 px-3.5 py-1.5 rounded-md text-[12px] font-medium border-none cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+            style={{
+              background: "#d4a126",
+              color: "#1a1a1a",
+            }}
+          >
+            {generating ? "Regenerando…" : "Regenerar ahora"}
+          </button>
+        </div>
+      )}
       <Section title="Resumen">
         <div className="grid grid-cols-4 gap-4">
           {onFieldUpdate ? (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -163,6 +163,12 @@ export interface Quote {
   localidad?: string | null;
   colocacion?: boolean | null;
   anafe?: boolean | null;
+  // PR #442 — flag computado por backend: true si hubo edits del
+  // quote después de la última generación/regenerate del PDF. El
+  // detail view muestra banner "PDF desactualizado · Regenerar"
+  // cuando se cumple.
+  pdf_outdated?: boolean | null;
+  pdf_generated_at?: string | null;
   resumen_obra?: ResumenObraRecord | null;
   condiciones_pdf?: {
     pdf_url: string;


### PR DESCRIPTION
## Bug observado

Operador edita un campo (delivery_days, localidad, notes) via EditableField → cambio persiste y se ve en detalle. **PERO el PDF en Drive sigue viejo**. La edición no regenera automáticamente — comportamiento esperado, pero el operador no se entera y entrega PDF con datos viejos.

## Solución (Plan Fase 2 — opción A elegida sobre auto-regenerate)

Banner visual + botón. Decisión:
- **A elegida**: banner + click. No hace work innecesario, control del operador, errores visibles.
- B descartada (auto-regenerate en background): cada edit = round-trip Drive de 15-30s; 5 ediciones = 5 regeneraciones inútiles; errores opacos.

## Cambios

### Backend

1. **`router._compute_pdf_outdated(quote)`** (helper nuevo):
   - Sin pdf_url → False.
   - Busca último `change_history` con `action ∈ {regenerate_docs, generate_docs}`.
   - `pdf_outdated = updated_at > last_pdf_ts + 5s` (tolerance evita race del propio regenerate).
   - Sin tracking → False (quotes legacy, no spamear).
   - Robusto: tolera entries malformadas y naive vs aware datetime.

2. **`get_quote`**: invoca el helper, setea `response.pdf_outdated` + `pdf_generated_at`.

3. **`schemas.QuoteDetailResponse`**: campos opcionales nuevos.

4. **`agent.py:5800`** (handler `generate_documents`): append `change_history` con `{action: "generate_docs", timestamp, ...}` al generar exitosamente. Sin esto, quotes nuevos no tendrían tracking.

### Frontend

1. **`api.ts`**: `QuoteDetail.pdf_outdated` + `pdf_generated_at`.
2. **`page.tsx`**:
   - `handleRegenerate` callback (llama `regenerateQuoteDocs` + re-fetch).
   - `handleFieldUpdate` ahora hace re-fetch (para que el flag llegue al render).
   - `DetailView` recibe `onRegenerate` y muestra banner amarillo si `pdf_outdated && pdf_url`.

## Tests (10 backend)

- Sin pdf_url → False.
- Legacy (sin history) → False.
- Edit dentro de tolerancia → False.
- Edit posterior → True.
- Reconoce ambos action types.
- Usa el más reciente.
- Ignora `calculate_quote` (no genera PDF).
- Defensivo: entries malformadas, naive vs aware datetime.
- Drift guard del schema.

Build frontend ✓. Suite **2550 passing** (+10, 0 regresiones).

## Validación

1. Editar campo en quote con PDF → banner amarillo aparece.
2. Click "Regenerar ahora" → banner desaparece, PDF en Drive actualizado.
3. Editar otro campo → banner re-aparece.

Quotes legacy (sin tracking) no muestran banner — conservador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)