### PR TITLE
fix(agent): patch_quote_mo respeta flete_qty + add_flete idempotente

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -1216,7 +1216,7 @@ TOOLS = [
     {"name": "generate_documents", "description": "Genera PDF+Excel. 1 quote por material.", "input_schema": {"type": "object", "properties": {"quotes": {"type": "array", "items": {"type": "object", "properties": {"client_name": {"type": "string"}, "project": {"type": "string"}, "date": {"type": "string"}, "delivery_days": {"type": "string"}, "material_name": {"type": "string"}, "material_m2": {"type": "number"}, "material_price_unit": {"type": "number"}, "material_currency": {"type": "string", "enum": ["USD", "ARS"]}, "discount_pct": {"type": "number"}, "sectors": {"type": "array", "items": {"type": "object", "properties": {"label": {"type": "string"}, "pieces": {"type": "array", "items": {"type": "string"}}}}}, "sinks": {"type": "array", "items": {"type": "object", "properties": {"name": {"type": "string"}, "quantity": {"type": "integer"}, "unit_price": {"type": "number"}}}}, "mo_items": {"type": "array", "items": {"type": "object", "properties": {"description": {"type": "string"}, "quantity": {"type": "number"}, "unit_price": {"type": "number"}, "total": {"type": "number"}}}}, "total_ars": {"type": "number"}, "total_usd": {"type": "number"}}, "required": ["client_name", "material_name"]}}}, "required": ["quotes"]}},
     {"name": "update_quote", "description": "Actualiza client_name/project/status/delivery_days en DB sin recalcular. Para cambios estructurales (piezas/MO/material) usar calculate_quote.", "input_schema": {"type": "object", "properties": {"quote_id": {"type": "string"}, "updates": {"type": "object", "properties": {"client_name": {"type": "string"}, "project": {"type": "string"}, "material": {"type": "string"}, "total_ars": {"type": "number"}, "total_usd": {"type": "number"}, "status": {"type": "string", "enum": ["draft", "validated", "sent"]}, "delivery_days": {"type": "string", "description": "Plazo/demora — ej: '30 días', '60 días', '4 meses'. Se persiste en quote_breakdown.delivery_days. Para cambiar SOLO la demora sin re-cotizar, usar este campo (no llamar a calculate_quote)."}}}}, "required": ["quote_id", "updates"]}},
     {"name": "calculate_quote", "description": "Calcula m², MO, totales. SIEMPRE usar para cálculos.", "input_schema": {"type": "object", "properties": {"client_name": {"type": "string"}, "project": {"type": "string"}, "material": {"type": "string"}, "pieces": {"type": "array", "items": {"type": "object", "properties": {"description": {"type": "string"}, "largo": {"type": "number"}, "prof": {"type": "number"}, "alto": {"type": "number"}, "quantity": {"type": "integer", "description": "Cantidad de unidades físicas de esta pieza (para edificios con tipologías repetidas). Default 1 si no se pasa."}, "m2_override": {"type": "number", "description": "Usar SOLO cuando el operador declara el m² de la pieza en una Planilla de Cómputo (ej: edificios con valores pre-calculados que incluyen zócalos/frentes). Si se pasa, el calculador NO computa largo×prof — usa directamente este valor. No activar 'fallback de profundidades inversas'."}}, "required": ["description", "largo"]}}, "localidad": {"type": "string"}, "colocacion": {"type": "boolean"}, "is_edificio": {"type": "boolean"}, "pileta": {"type": "string", "enum": ["empotrada_cliente", "empotrada_johnson", "apoyo"]}, "pileta_qty": {"type": "integer"}, "pileta_sku": {"type": "string"}, "anafe": {"type": "boolean"}, "anafe_qty": {"type": "integer", "description": "Cantidad de anafes (para edificios con N tipologías). Default 1."}, "frentin": {"type": "boolean"}, "frentin_ml": {"type": "number"}, "regrueso": {"type": "boolean"}, "regrueso_ml": {"type": "number"}, "inglete": {"type": "boolean"}, "pulido": {"type": "boolean"}, "tomas_qty": {"type": "integer", "description": "Agujeros de toma corriente. REQUIERE alzada en pieces + pedido explícito del operador ('Agujero de toma × N'). NO inferir por anafe/zócalo/revestimiento. Sin alzada el calculator lo ignora con warning."}, "skip_flete": {"type": "boolean", "description": "true SOLO si el cliente retira en fábrica. Default false — siempre cobrar flete."}, "flete_qty": {"type": "integer", "description": "Cantidad de fletes declarada por el operador (ej: '× 5 fletes'). Override del cálculo automático. Usar SOLO cuando el operador lo dice explícito en el enunciado."}, "plazo": {"type": "string"}, "discount_pct": {"type": "number"}, "mo_discount_pct": {"type": "number", "description": "Descuento comercial % sobre MO (excluye flete). Usar SOLO si operador lo pide explícito (ej: '5% sobre MO')."}}, "required": ["client_name", "project", "material", "pieces", "localidad", "plazo"]}},
-    {"name": "patch_quote_mo", "description": "Modifica MO sin recalcular. Para agregar/quitar flete, colocación.", "input_schema": {"type": "object", "properties": {"remove_items": {"type": "array", "items": {"type": "string"}}, "add_colocacion": {"type": "boolean"}, "add_flete": {"type": "string"}}, "required": []}},
+    {"name": "patch_quote_mo", "description": "Modifica MO. Cambiar cant flete: add_flete+flete_qty.", "input_schema": {"type": "object", "properties": {"remove_items": {"type": "array", "items": {"type": "string"}}, "add_colocacion": {"type": "boolean"}, "add_flete": {"type": "string"}, "flete_qty": {"type": "integer"}}, "required": []}},
 ]
 
 
@@ -7063,6 +7063,18 @@ class AgentService:
             remove_keywords = [kw.lower() for kw in inputs.get("remove_items", [])]
             add_colocacion = inputs.get("add_colocacion", False)
             add_flete_localidad = inputs.get("add_flete")
+            # PR #443 — `flete_qty` parameter (caso DYSCON 29/04/2026):
+            # operador escribió "modificá flete a 4 fletes". Sonnet
+            # llamó patch_quote_mo con remove_items=['flete'] (eliminó
+            # el viejo) sin add_flete o con add_flete pero qty=1
+            # hardcodeado. Resultado: flete desaparece de mo_items y
+            # el total queda mal por -$300K. Ahora `flete_qty` se
+            # pasa explícito (default 1) y `add_flete` REEMPLAZA el
+            # flete existente en lugar de skipear.
+            try:
+                add_flete_qty = int(inputs.get("flete_qty") or 1)
+            except (TypeError, ValueError):
+                add_flete_qty = 1
 
             try:
                 q_result = await db.execute(select(Quote).where(Quote.id == target_qid))
@@ -7075,10 +7087,20 @@ class AgentService:
                 new_mo = []
                 removed = []
 
-                # Remove items matching keywords
+                # Remove items matching keywords.
+                # PR #443 — si `add_flete` se pasó, NO eliminar el flete
+                # acá (lo reemplazamos abajo). Sin esto, `remove_items=
+                # ['flete']` + `add_flete` borraba el flete y luego el
+                # `add_flete` se ejecutaba aparte — duplicación de
+                # responsabilidad y confusión.
+                _will_replace_flete = bool(add_flete_localidad)
                 for item in original_mo:
                     desc_lower = (item.get("description") or "").lower()
                     should_remove = any(kw in desc_lower for kw in remove_keywords)
+                    if should_remove and _will_replace_flete and "flete" in desc_lower:
+                        # No eliminar acá — `add_flete` abajo lo reemplaza.
+                        new_mo.append(item)
+                        continue
                     if should_remove:
                         removed.append(item["description"])
                     else:
@@ -7099,16 +7121,45 @@ class AgentService:
                             qty = max(bd.get("material_m2", 1), 1.0)
                             new_mo.append({"description": "Colocación", "quantity": round(qty, 2), "unit_price": price, "base_price": base, "total": round(price * qty)})
 
-                # Add flete if requested
+                # Add/replace flete if requested.
+                # PR #443 — IDEMPOTENTE: si ya hay flete, lo REEMPLAZA
+                # (no skipea). Permite "modificar" cantidad sin tener
+                # que pasar `remove_items` previo. Y respeta `flete_qty`
+                # del operador (default 1).
                 if add_flete_localidad:
-                    has_flete = any("flete" in (m.get("description") or "").lower() for m in new_mo)
-                    if not has_flete:
-                        from app.modules.quote_engine.calculator import _find_flete
-                        flete_result = _find_flete(add_flete_localidad)
-                        if flete_result.get("found"):
-                            price = flete_result.get("price_ars", 0)
-                            base = flete_result.get("price_ars_base", price)
-                            new_mo.append({"description": f"Flete + toma medidas {add_flete_localidad}", "quantity": 1, "unit_price": price, "base_price": base, "total": price})
+                    # Drop cualquier flete existente — vamos a agregar
+                    # uno nuevo limpio con la qty correcta.
+                    new_mo = [
+                        m for m in new_mo
+                        if "flete" not in (m.get("description") or "").lower()
+                    ]
+                    from app.modules.quote_engine.calculator import _find_flete
+                    flete_result = _find_flete(add_flete_localidad)
+                    if flete_result.get("found"):
+                        price = flete_result.get("price_ars", 0)
+                        base = flete_result.get("price_ars_base", price)
+                        # `quantity` viene del operador (flete_qty),
+                        # no hardcodeado a 1. Total = price × qty.
+                        new_mo.append({
+                            "description": f"Flete + toma medidas {add_flete_localidad}",
+                            "quantity": add_flete_qty,
+                            "unit_price": price,
+                            "base_price": base,
+                            "total": price * add_flete_qty,
+                        })
+                    else:
+                        # Localidad inválida — error ruidoso. Sin esto,
+                        # Sonnet podría declarar "flete agregado" pero
+                        # el handler ignora silenciosamente (mismo
+                        # patrón Issue #422).
+                        return {
+                            "ok": False,
+                            "error": (
+                                f"⛔ Localidad '{add_flete_localidad}' no "
+                                f"encontrada en delivery-zones. "
+                                f"Verificar nombre o agregar al catálogo."
+                            ),
+                        }
 
                 # Recalculate totals
                 bd["mo_items"] = new_mo

--- a/api/tests/test_patch_quote_mo_flete_qty.py
+++ b/api/tests/test_patch_quote_mo_flete_qty.py
@@ -1,0 +1,323 @@
+"""Tests para PR #443 — `patch_quote_mo` acepta `flete_qty` y es
+idempotente al reemplazar flete.
+
+**Bug observado en producción (29/04/2026, quote DYSCON 26c73a89):**
+
+Operador escribió "modificá flete a 4 fletes". Resultado: el flete
+DESAPARECIÓ de la tabla MO. Total: $11.962.988 (= original
+$12.262.988 - $300.000 = sin flete). Sonnet declaró en el chat
+"Flete: 3 fletes → 4 fletes" pero el handler eliminó el flete y
+nunca lo agregó de vuelta.
+
+**Tres bugs raíz en el handler `patch_quote_mo`:**
+
+1. No exponía `flete_qty` en el schema → Sonnet no podía pasar 4.
+2. `add_flete` hardcodeaba `quantity: 1`.
+3. Si ya había flete, `add_flete` skipeaba (no reemplazaba con qty
+   nueva). Sonnet "limpiaba" con `remove_items: ['flete']` antes,
+   pero si el `add_flete` posterior fallaba o tenía qty=1, el
+   resultado era inconsistente.
+
+**Fix en este PR:**
+
+- Schema: `flete_qty: int` parámetro nuevo (default 1).
+- Handler: respeta `flete_qty` (quantity + total).
+- Handler idempotente: `add_flete` REEMPLAZA flete existente sin
+  necesidad de `remove_items`. Si `remove_items` incluye flete +
+  `add_flete` viene → el remove se skipea (deduplicación; el add
+  ya hace el reemplazo).
+- Localidad inválida → error ruidoso (antes: skipeo silencioso →
+  flete eliminado del breakdown sin reemplazo).
+
+**Tests:**
+
+1. **Caso DYSCON exacto**: breakdown con flete qty=3 → patch con
+   `add_flete + flete_qty=4` → flete con qty=4, total = 4×price.
+2. Idempotencia: `add_flete` solo (sin remove) reemplaza si ya hay.
+3. Default: `add_flete` sin `flete_qty` → quantity=1 (regression).
+4. `remove_items + add_flete` → solo se aplica el reemplazo (no
+   doble eliminación).
+5. Localidad inválida → error ruidoso.
+6. Drift guard del schema: `flete_qty` está expuesto.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Drift guard del schema
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestSchemaDriftGuard:
+    def test_patch_quote_mo_schema_includes_flete_qty(self):
+        """Si alguien borra `flete_qty` del schema, Sonnet vuelve a
+        no saber cómo pasar la cantidad → bug DYSCON re-aparece."""
+        from app.modules.agent.agent import TOOLS
+        tool = next((t for t in TOOLS if t.get("name") == "patch_quote_mo"), None)
+        assert tool is not None
+        properties = tool["input_schema"]["properties"]
+        assert "flete_qty" in properties, (
+            "Tool `patch_quote_mo` debe exponer `flete_qty` (PR #443). "
+            "Sin esto Sonnet no puede pasar la cantidad de fletes y "
+            "el handler queda en quantity=1 hardcoded → bug DYSCON."
+        )
+        assert properties["flete_qty"]["type"] == "integer"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Helper para crear quote con breakdown que ya tiene flete
+# ═══════════════════════════════════════════════════════════════════════
+
+
+async def _create_quote_with_flete(db_session, flete_qty=3, flete_unit_price=100000):
+    from app.models.quote import Quote, QuoteStatus
+    qid = f"test-flete-{uuid.uuid4()}"
+    breakdown = {
+        "client_name": "DYSCON S.A.",
+        "project": "Unidad Penal N°8",
+        "delivery_days": "30 días",
+        "material_name": "GRANITO GRIS MARA EXTRA 2 ESP",
+        "material_m2": 45.55,
+        "material_price_unit": 224825,
+        "material_price_base": 185806,
+        "material_currency": "ARS",
+        "material_total": 10240678,
+        "discount_pct": 12,
+        "discount_amount": 1228881,
+        "sectors": [{"label": "Cocina", "pieces": ["Mesada"]}],
+        "mo_items": [
+            {
+                "description": "Agujero y pegado pileta",
+                "quantity": 32,
+                "unit_price": 62045,
+                "base_price": 51276,
+                "total": 1985440,
+            },
+            {
+                "description": "Mano de obra regrueso x ml",
+                "quantity": 60.68,
+                "unit_price": 15914,
+                "base_price": 13152,
+                "total": 965662,
+            },
+            {
+                "description": "Flete + toma medidas Piñero",
+                "quantity": flete_qty,
+                "unit_price": flete_unit_price,
+                "base_price": flete_unit_price,  # zone with price_includes_vat
+                "total": flete_unit_price * flete_qty,
+            },
+        ],
+        "sinks": [],
+        "total_ars": 12262988,  # exactly the value before bug
+        "total_usd": 0,
+    }
+    quote = Quote(
+        id=qid,
+        client_name="DYSCON S.A.",
+        project="Unidad Penal N°8",
+        material="GRANITO GRIS MARA EXTRA 2 ESP",
+        total_ars=12262988,
+        total_usd=0,
+        status=QuoteStatus.VALIDATED,
+        quote_breakdown=breakdown,
+        messages=[],
+    )
+    db_session.add(quote)
+    await db_session.commit()
+    return qid
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Caso DYSCON real: modificar flete 3 → 4
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+class TestDysconFleteModification:
+    async def test_modify_flete_3_to_4_via_add_flete_with_qty(
+        self, db_session,
+    ):
+        """**Caso DYSCON exacto**: quote con flete qty=3, operador
+        pide qty=4. Sonnet llama
+        `patch_quote_mo(add_flete='Piñero', flete_qty=4)`.
+
+        Resultado esperado:
+        - El flete sigue presente en mo_items (no se borra).
+        - quantity = 4 (no 1, no 3).
+        - total = 4 × $100.000 = $400.000.
+        - Total ARS del breakdown actualizado consistentemente."""
+        from app.modules.agent.agent import AgentService
+        from app.models.quote import Quote
+        from sqlalchemy import select
+
+        qid = await _create_quote_with_flete(db_session, flete_qty=3)
+        agent = AgentService()
+        result = await agent._execute_tool(
+            "patch_quote_mo",
+            {"add_flete": "Piñero", "flete_qty": 4},
+            quote_id=qid,
+            db=db_session,
+        )
+        assert result["ok"] is True, f"patch failed: {result}"
+
+        await db_session.commit()
+        q_res = await db_session.execute(select(Quote).where(Quote.id == qid))
+        q = q_res.scalar_one()
+        bd = q.quote_breakdown
+        flete_items = [m for m in bd["mo_items"] if "flete" in m["description"].lower()]
+        assert len(flete_items) == 1, f"Esperaba 1 flete, vi {flete_items}"
+        flete = flete_items[0]
+        assert flete["quantity"] == 4, f"qty debe ser 4, vi {flete['quantity']}"
+        # Total = qty × unit_price.
+        assert flete["total"] == flete["quantity"] * flete["unit_price"]
+
+    async def test_flete_qty_default_is_1(self, db_session):
+        """Regression: `add_flete` sin `flete_qty` → quantity=1
+        (comportamiento anterior preservado)."""
+        from app.modules.agent.agent import AgentService
+        from app.models.quote import Quote
+        from sqlalchemy import select
+
+        qid = await _create_quote_with_flete(db_session, flete_qty=3)
+        agent = AgentService()
+        result = await agent._execute_tool(
+            "patch_quote_mo",
+            {"add_flete": "Piñero"},  # sin flete_qty
+            quote_id=qid,
+            db=db_session,
+        )
+        assert result["ok"] is True
+
+        await db_session.commit()
+        q_res = await db_session.execute(select(Quote).where(Quote.id == qid))
+        q = q_res.scalar_one()
+        flete = next(m for m in q.quote_breakdown["mo_items"] if "flete" in m["description"].lower())
+        assert flete["quantity"] == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Idempotencia y reemplazo
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+class TestIdempotency:
+    async def test_add_flete_replaces_existing_no_duplicates(
+        self, db_session,
+    ):
+        """Si ya hay flete en mo_items, `add_flete` debe REEMPLAZARLO
+        (no duplicar). Sin esta idempotencia, pasarlo dos veces
+        agregaba 2 fletes."""
+        from app.modules.agent.agent import AgentService
+        from app.models.quote import Quote
+        from sqlalchemy import select
+
+        qid = await _create_quote_with_flete(db_session, flete_qty=3)
+        agent = AgentService()
+        result = await agent._execute_tool(
+            "patch_quote_mo",
+            {"add_flete": "Piñero", "flete_qty": 5},
+            quote_id=qid,
+            db=db_session,
+        )
+        assert result["ok"] is True
+
+        await db_session.commit()
+        q_res = await db_session.execute(select(Quote).where(Quote.id == qid))
+        q = q_res.scalar_one()
+        flete_items = [m for m in q.quote_breakdown["mo_items"] if "flete" in m["description"].lower()]
+        assert len(flete_items) == 1, "Esperaba 1 flete tras reemplazo, no duplicado"
+        assert flete_items[0]["quantity"] == 5
+
+    async def test_remove_items_with_add_flete_no_double_processing(
+        self, db_session,
+    ):
+        """**Caso DYSCON exacto que causó el bug**: Sonnet pasaba
+        `remove_items: ['flete']` + `add_flete` esperando 'limpiar
+        antes de agregar'. Antes del fix, ambos se ejecutaban: el
+        remove eliminaba el flete viejo y el add NO se ejecutaba
+        (porque `if not has_flete` después del remove → ya no había
+        flete). Ahora: cuando viene `add_flete`, el remove se
+        skipea para flete (lo reemplaza el add). Resultado: flete
+        nuevo correcto."""
+        from app.modules.agent.agent import AgentService
+        from app.models.quote import Quote
+        from sqlalchemy import select
+
+        qid = await _create_quote_with_flete(db_session, flete_qty=3)
+        agent = AgentService()
+        result = await agent._execute_tool(
+            "patch_quote_mo",
+            {
+                "remove_items": ["flete"],  # ← Sonnet "limpia"
+                "add_flete": "Piñero",      # ← y agrega nuevo
+                "flete_qty": 4,             # ← con qty correcta
+            },
+            quote_id=qid,
+            db=db_session,
+        )
+        assert result["ok"] is True
+
+        await db_session.commit()
+        q_res = await db_session.execute(select(Quote).where(Quote.id == qid))
+        q = q_res.scalar_one()
+        flete_items = [m for m in q.quote_breakdown["mo_items"] if "flete" in m["description"].lower()]
+        assert len(flete_items) == 1, (
+            f"Esperaba 1 flete después del replace combinado, vi {len(flete_items)}"
+        )
+        assert flete_items[0]["quantity"] == 4
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Regression — comportamiento original preservado
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+class TestRegression:
+    async def test_remove_items_alone_still_deletes(self, db_session):
+        """Si el operador SÍ quiere eliminar el flete (no modificar),
+        `remove_items: ['flete']` SIN `add_flete` lo elimina como
+        antes."""
+        from app.modules.agent.agent import AgentService
+        from app.models.quote import Quote
+        from sqlalchemy import select
+
+        qid = await _create_quote_with_flete(db_session, flete_qty=3)
+        agent = AgentService()
+        result = await agent._execute_tool(
+            "patch_quote_mo",
+            {"remove_items": ["flete"]},
+            quote_id=qid,
+            db=db_session,
+        )
+        assert result["ok"] is True
+
+        await db_session.commit()
+        q_res = await db_session.execute(select(Quote).where(Quote.id == qid))
+        q = q_res.scalar_one()
+        flete_items = [m for m in q.quote_breakdown["mo_items"] if "flete" in m["description"].lower()]
+        assert flete_items == [], "remove_items solo debería eliminar el flete"
+
+    async def test_invalid_localidad_rejects_loud(self, db_session):
+        """**Caso CRÍTICO**: localidad inválida → error ruidoso. Antes
+        del fix, `_find_flete` devolvía `found: False` y el handler
+        skipeaba silenciosamente. Sonnet creía que se aplicó. Ahora
+        devuelve `ok: False` con error claro."""
+        from app.modules.agent.agent import AgentService
+
+        qid = await _create_quote_with_flete(db_session, flete_qty=3)
+        agent = AgentService()
+        result = await agent._execute_tool(
+            "patch_quote_mo",
+            {"add_flete": "ZONA_INEXISTENTE_XYZ", "flete_qty": 2},
+            quote_id=qid,
+            db=db_session,
+        )
+        assert result["ok"] is False
+        assert "ZONA_INEXISTENTE_XYZ" in result["error"]


### PR DESCRIPTION
## Bug crítico observado en producción

Quote DYSCON `26c73a89...`. Operador "modificá flete a 4 fletes". Sonnet declara en chat:
- Flete: 3 → 4 fletes
- Total: \$12.262.988 → \$12.362.988

Resultado real: **el flete desapareció** de la tabla MO. PRESUPUESTO TOTAL: \$11.962.988 = \$12.262.988 − \$300.000 (flete viejo eliminado, nunca agregado el nuevo).

## Causa raíz (3 bugs en `patch_quote_mo`)

1. **Schema sin `flete_qty`** → Sonnet no podía pasar la cantidad nueva.
2. **`add_flete` hardcodeaba `quantity: 1`** (línea 7111).
3. **`add_flete` skipeaba si ya había flete** (`if not has_flete`) → Sonnet workareaba con `remove_items` previo, pero el orden cruzado perdía el flete.

El detector de alucinaciones (#441) NO lo agarra — sí hubo tool call. Bug en SEMÁNTICA.

## Fix

| Cambio | Comportamiento |
|---|---|
| Schema: `flete_qty: integer` | Sonnet puede pasar la cantidad |
| Handler `add_flete_qty = int(...)` | Defensivo, default 1 |
| `add_flete` IDEMPOTENTE: drop flete existente antes de add | Permite cambiar qty sin remove previo |
| `quantity = flete_qty`, `total = price × qty` | Antes hardcoded a 1 |
| `remove_items + add_flete`: el remove skipea para flete | Sin double-process |
| Localidad inválida → error ruidoso | Antes: skipeo silencioso, flete perdido |

## Tests (7)

- Drift guard del schema.
- **Caso DYSCON exact**: 3→4 fletes con `add_flete + flete_qty=4`.
- Default qty=1 (regression).
- Idempotencia: replace sin duplicar.
- Combo `remove_items + add_flete`: resultado correcto.
- Regression: `remove_items` solo sigue eliminando.
- Localidad inválida → error ruidoso.

Suite: **2557 passing** (+7, 0 regresiones). Token budget: 55499/55500.

## Lo que NO toca

- `calculate_quote`: intacto.
- `update_quote`, validators, renderers: intactos.

## Validación

1. Operador "cambiá flete a 4" en quote con flete qty=3.
2. Tabla MO muestra: Flete · 4 · \$100K · \$400K.
3. PRESUPUESTO TOTAL +\$100K (delta consistente).

## Caso edge

Quotes existentes ya rotos (flete eliminado por el bug): operador debe pedir "agregá flete a Piñero × N" manualmente. No hay migración automática.

🤖 Generated with [Claude Code](https://claude.com/claude-code)