### PR TITLE
fix(audit): habilitar scroll en página de auditoría

### DIFF
--- a/web/src/app/admin/quotes/[id]/audit/page.tsx
+++ b/web/src/app/admin/quotes/[id]/audit/page.tsx
@@ -313,7 +313,8 @@ export default function QuoteAuditPage() {
   const firstEventDate = timeline.coverage.first_event_date;
 
   return (
-    <div className="p-8 max-w-5xl mx-auto">
+    <div className="flex-1 overflow-y-auto p-8 w-full">
+      <div className="max-w-5xl mx-auto">
       <div className="flex items-baseline justify-between mb-2 flex-wrap gap-3">
         <div>
           <button
@@ -393,6 +394,7 @@ export default function QuoteAuditPage() {
           ))}
         </div>
       )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
AppShell tiene overflow-hidden en el main. La página de audit no tenía su propio scroll container — quedaba clippeada después de los primeros eventos.

Fix: wrappear el contenido en flex-1 overflow-y-auto.

Reproducción: https://ia-agent-quote-marble-operator.vercel.app/admin/quotes/{id}/audit con un quote que tenga 28+ eventos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)