### PR TITLE
fix(agent): force generate_documents retry after validation rebound

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -5678,7 +5678,14 @@ class AgentService:
                     error_list = "\n".join(f"❌ {e}" for e in errors)
                     return {
                         "ok": False,
-                        "error": f"Pre-flight fallido para {qdata.get('material_name', '?')}:\n{error_list}\n\nCorregir estos datos antes de generar.",
+                        "error": (
+                            f"Pre-flight fallido para {qdata.get('material_name', '?')}:\n"
+                            f"{error_list}\n\n"
+                            f"PASOS OBLIGATORIOS (en este mismo turno, NO cierres el turno hasta completar):\n"
+                            f"1. Corregí los datos faltantes/incorrectos arriba.\n"
+                            f"2. Llamá `generate_documents` DE NUEVO con los datos completos.\n"
+                            f"NO emitas texto explicativo final hasta que `generate_documents` haya devuelto OK."
+                        ),
                     }
                 all_warnings.extend(warnings)
 
@@ -5688,7 +5695,14 @@ class AgentService:
                     error_list = "\n".join(f"❌ {e}" for e in deep.errors)
                     return {
                         "ok": False,
-                        "error": f"Validación profunda fallida para {qdata.get('material_name', '?')}:\n{error_list}\n\nRecalcular antes de generar.",
+                        "error": (
+                            f"Validación profunda fallida para {qdata.get('material_name', '?')}:\n"
+                            f"{error_list}\n\n"
+                            f"PASOS OBLIGATORIOS PARA CORREGIR (en este mismo turno, NO termines la respuesta hasta completarlos):\n"
+                            f"1. Llamá `calculate_quote` con las piezas correctas para obtener material_m2 y totales actualizados.\n"
+                            f"2. Después del recálculo, llamá `generate_documents` DE NUEVO con los datos del nuevo cálculo.\n"
+                            f"NO emitas texto explicativo ni cierres el turno hasta que `generate_documents` haya devuelto OK."
+                        ),
                     }
                 all_warnings.extend(deep.warnings)
 

--- a/web/src/app/admin/quotes/[id]/audit/page.tsx
+++ b/web/src/app/admin/quotes/[id]/audit/page.tsx
@@ -313,7 +313,8 @@ export default function QuoteAuditPage() {
   const firstEventDate = timeline.coverage.first_event_date;
 
   return (
-    <div className="p-8 max-w-5xl mx-auto">
+    <div className="flex-1 overflow-y-auto p-8 w-full">
+      <div className="max-w-5xl mx-auto">
       <div className="flex items-baseline justify-between mb-2 flex-wrap gap-3">
         <div>
           <button
@@ -393,6 +394,7 @@ export default function QuoteAuditPage() {
           ))}
         </div>
       )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Bug detectado

Audit del quote 31e37930-10f1-478c-b63f-7a13ed8c5ff4 mostró:

```
17:25:23  generate_documents  → FAIL (m²=2.204 vs piezas=1.89)
17:25:29  calculate_quote     → OK ($463.799 ARS / $1,881 USD)
[fin de turno — generate_documents NUNCA se re-llamó]
```

El doc nunca se generó. Sonnet recalculó pero no completó el ciclo.

## Causa raíz

Mensaje de error del validador decía "Recalcular antes de generar" — ambiguo. Sonnet entendió "recalculá" (lo hizo) pero no entendió "y después llamá generate_documents de nuevo".

## Fix

Convertir el mensaje en pasos explícitos numerados con "NO termines la respuesta hasta completar". Aplicado a:

1. **Pre-flight validator** (`_validate_quote_data`) — campos faltantes
2. **Deep validator** (`validate_despiece`) — m² mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)