### PR TITLE
docs(handoff-context): extraer contratos API del backend (PR previo a Sprint 2)

### DIFF
--- a/docs/handoff-context/README.md
+++ b/docs/handoff-context/README.md
@@ -1,38 +1,126 @@
 # Handoff Context · Specs Técnicas Backend
 
-Esta carpeta contiene las **specs técnicas del backend FastAPI** que el frontend necesita para wire-up. Las specs son derivadas del código backend real, NO documentación inventada.
+> **Audiencia:** frontend Sprint 2-5 del operator panel D'Angelo (Marina + Valentina).
+> **Fuente:** código backend FastAPI real del repo `ia-agent-quote-marble-operator`.
+> **Last commit:** PR `sprint-1.5/extract-api-contracts` — 2026-05-05.
 
-## Estado actual
+Esta carpeta contiene las **specs técnicas del backend** que el frontend Sprint 2 va a usar para mockear contra contratos reales (`useMockClient()` → `useApiClient()` switch en Sprint 3 inicial). Las specs son **derivadas del código backend** — no documentación inventada.
 
-🟡 **Vacío al momento del handoff inicial.**
+---
 
-Se llena con el PR `sprint-1.5/extract-api-contracts` antes de arrancar Sprint 2.
+## Estado
 
-## Estructura esperada (post-PR extract-api-contracts)
+🟢 **Cerrado** por PR `sprint-1.5/extract-api-contracts` el 2026-05-05.
 
+Cualquier cambio futuro en el backend se sincroniza vía nuevo PR contra `sprint-1.5/master-handoff` (ver "Cómo se mantiene actualizado" más abajo).
+
+---
+
+## Estructura
+
+```
 handoff-context/
-endpoints-spec.md ← cada endpoint REST que el frontend usa
-sse-spec.md ← protocolo SSE del chat Valentina
-schemas/
-quote.md ← modelo Quote completo
-audit_events.md ← schema audit_events
-brief.md ← modelo Brief
-context.md ← 11 campos paso 2
-catalog/ ← 9 catálogos JSON sanitizados
-materials.json
-labor.json
-sinks.json
-architects.json
-config.json
-delivery-zones.json
-stock.json
-finishes.json (si existe)
-edges.json (si existe)
-missing-endpoints.md ← (si aplica) endpoints sugeridos por mockups que NO existen en backend
+├── README.md                  ← este archivo (índice)
+├── endpoints-spec.md          ← ~50 endpoints REST agrupados por flow del Master §6
+├── sse-spec.md                ← protocolo SSE chat Valentina (7 event types)
+├── missing-endpoints.md       ← endpoints sugeridos por mockups que NO existen hoy
+├── schemas/
+│   ├── quote.md               ← modelo Quote completo + QuoteBreakdown JSON
+│   ├── audit_events.md        ← schema audit_events + lista de event_types
+│   ├── brief.md               ← Paso 1 (operator multipart vs web bot QuoteInput)
+│   └── context.md             ← Paso 2 (columnas Quote + cards IA + verified_context)
+└── catalog/
+    ├── README.md              ← reglas de sanitización + lista de archivos
+    ├── architects.json        ← Cueto-Heredia canon + 7 placeholders
+    ├── config.json            ← literal (no PII)
+    ├── delivery-zones.json    ← Rosario canon + 31 sintetizadas
+    ├── labor.json             ← 5 SKUs MO Cueto-Heredia + 29 sintetizados
+    ├── materials-silestone.json   ← SILESTONENORTE canon + 4 samples
+    ├── materials-purastone.json   ← 5 samples sintéticos
+    ├── materials-granito-nacional.json
+    ├── materials-granito-importado.json
+    ├── materials-dekton.json
+    ├── materials-neolith.json
+    ├── materials-marmol.json
+    ├── materials-puraprima.json
+    ├── materials-laminatto.json
+    ├── sinks.json             ← 12 samples (de 85 originales)
+    └── stock.json             ← 5 retazos sample
+```
 
-## Quién lo escribe
+**Tamaño total:** ~228 KB · **Líneas Markdown:** 3786 · **Archivos JSON:** 16.
 
-Claude Code, en el PR `sprint-1.5/extract-api-contracts`. Ver Master Notion sección 21.8 para alcance, reglas y criterios de audit.
+---
+
+## Cómo leer este handoff
+
+Orden recomendado para alguien que arranca Sprint 2:
+
+1. **`endpoints-spec.md`** — entender el universo de endpoints que el frontend va a tocar. Especialmente la sección "Mapeo mockup ↔ endpoint" al final.
+2. **`sse-spec.md`** — entender el protocolo del chat con Valentina. Es el endpoint más complejo y donde más errores se cometen.
+3. **`schemas/quote.md`** — modelo central. Los demás schemas se entienden mejor después de este.
+4. **`schemas/brief.md`** + **`schemas/context.md`** — específicos de Paso 1 y Paso 2 (el alcance principal de Sprint 2).
+5. **`schemas/audit_events.md`** — relevante para Sprint 3 (`/admin/quotes/{id}/audit` panel).
+6. **`catalog/`** — fixtures sanitizadas para mockear `GET /api/catalog/{name}`.
+7. **`missing-endpoints.md`** — qué falta y cómo workaroundear.
+
+---
+
+## Cifras canónicas Cueto-Heredia preservadas (Master §13)
+
+Como pide el PR (regla 6 — "NO sanitizar datos del Master"), estas cifras viven literal en los specs y catálogos para que el frontend Sprint 2 pueda armar fixtures que producen exactamente:
+
+```
+PRESUPUESTO TOTAL: $660.890 mano de obra + USD 1.538 material
+```
+
+| Donde | Valor canon |
+|---|---|
+| `architects.json` | `CUETO-HEREDIA ARQUITECTAS` (5% importado) |
+| `labor.json` | COLOCACION $49.698,65 · PEGADOPILETA $53.840 · ANAFE $35.617,36 · REGRUESO $13.810 · TOMAS $6.461 (todos base s/IVA) |
+| `delivery-zones.json` | ENVIOROS Rosario $52.000 base (= $62.920 c/IVA) |
+| `materials-silestone.json` | SILESTONENORTE USD 206 base (= USD 249 c/IVA — cifra del mockup, **bug P2 a propósito** Master §12) |
+| `endpoints-spec.md` (ejemplos) | totales completos del case |
+| `schemas/quote.md` (cifras canon) | breakdown completo + ChatMessage examples |
+
+---
+
+## Métricas del PR `extract-api-contracts`
+
+- **Endpoints documentados:** ~50 (incluye ~30 del operator, 3 del web bot, 8 admin observability + audit, 3 usage, 1 business-rules, 8 catalog management)
+- **Schemas:** 4 documentos (quote, audit_events, brief, context)
+- **SSE event types:** 7 reales documentados (text, action, dual_read_result, context_analysis, zone_selector, done, error) + ping keepalive
+- **Catálogos sanitizados:** 15 archivos JSON (~32 KB total)
+- **Missing endpoints:** 10 sugeridos por mockups, **ninguno bloqueante para Sprint 2**
+
+## Archivos backend leídos para derivar este spec
+
+Detalle al final de cada archivo. Resumen consolidado:
+
+- `api/app/modules/auth/router.py` (125 líneas)
+- `api/app/modules/agent/router.py` (2389 líneas)
+- `api/app/modules/agent/schemas.py` (141 líneas)
+- `api/app/modules/quote_engine/router.py` (553 líneas)
+- `api/app/modules/quote_engine/schemas.py` (93 líneas)
+- `api/app/modules/quote_engine/calculator.py` (~1950 líneas — solo el shape de return)
+- `api/app/modules/quote_engine/context_analyzer.py` (782 líneas)
+- `api/app/modules/quote_engine/dual_reader.py` (líneas 461, 657 — shape DualReadResult)
+- `api/app/modules/catalog/router.py` (442 líneas)
+- `api/app/modules/observability/router.py` (678 líneas)
+- `api/app/modules/observability/models.py` (82 líneas)
+- `api/app/modules/observability/sanitizer.py` + `system_config.py` + `cleanup.py`
+- `api/app/modules/usage/router.py` (148 líneas)
+- `api/app/modules/business_rules/router.py` (66 líneas)
+- `api/app/models/quote.py` (119 líneas)
+- `api/CONTEXT.md` (referencia de SKUs y cifras canon)
+- `api/API.md` (882 líneas — doc base existente, validada y extendida)
+- 15 catálogos JSON en `api/catalog/`
+
+---
+
+## Quién lo escribe (sólo para referencia post-handoff)
+
+Claude Code, en el PR `sprint-1.5/extract-api-contracts`. Ver Master sección 21.8 + 22 (roles) para alcance, reglas y criterios de audit.
 
 ## Quién lo lee
 
@@ -43,9 +131,18 @@ Sprint 2+ del frontend. Cuando un sub-PR de Sprint 2 implementa paso 1 o paso 2,
 Cuando el backend cambia (nuevo endpoint, nueva regla, nueva tool):
 
 1. Backend hace el cambio en su repo (separado).
-2. Claude Code abre PR a este branch con la spec actualizada (Markdown derivado, no código crudo).
+2. Claude Code abre PR a este branch (`sprint-1.5/master-handoff`) con la spec actualizada (Markdown derivado, no código crudo).
 3. Master/Audit (instancia Claude separada) audita el PR.
 4. Javi mergea.
 5. Claude Code lee la spec nueva en su próximo prompt de feature.
 
 NUNCA se actualiza automáticamente. Toda actualización es vía PR auditado.
+
+---
+
+## Próximos pasos post-merge
+
+1. **Audit del PR** — instancia separada de Claude (Master/Audit) revisa coherencia con mockups + cifras canon presentes + sin código de producción + sin credenciales.
+2. **Merge a `sprint-1.5/master-handoff`** — Javi mergea con `gh pr merge`.
+3. **Apertura de `sprint-2/main`** — branch integrador del Sprint 2.
+4. **Primer sub-PR `sprint-2/scaffold`** — Claude Code arranca Sprint 2 leyendo este `handoff-context/` + `handoff-design/`.

--- a/docs/handoff-context/catalog/README.md
+++ b/docs/handoff-context/catalog/README.md
@@ -1,0 +1,88 @@
+# Catalog · JSONs sanitizados
+
+> **Origen:** `api/catalog/*.json` del backend.
+> **Sanitizado:** 2026-05-05 — PR `sprint-1.5/extract-api-contracts`.
+
+15 catálogos copiados desde el backend, con sanitización aplicada según las reglas estrictas del PR (Master §21 — sin precios reales sensibles, sin clientes reales, salvo fixtures canon).
+
+---
+
+## Reglas de sanitización aplicadas
+
+### Cifras canónicas preservadas (Master §13)
+
+Estas se mantienen **literal** porque son los fixtures canon del case Cueto-Heredia que el frontend Sprint 2 va a usar en tests E2E + demo Marina:
+
+- `architects.json`: 1 entry `CUETO-HEREDIA ARQUITECTAS` (descuento 5% importado)
+- `labor.json`: 5 SKUs MO con precios reales:
+  - `COLOCACION` $49.698,65 base
+  - `PEGADOPILETA` $53.840 base
+  - `ANAFE` $35.617,36 base
+  - `REGRUESO` $13.810 base
+  - `TOMAS` $6.461 base
+- `delivery-zones.json`: 1 entry `ENVIOROS` (Flete Rosario + Toma de Medidas) $52.000 base
+- `materials-silestone.json`: 1 entry `SILESTONENORTE` USD 206 base (= USD 249 c/IVA del mockup canon, **bug P2 incluido a propósito** — Master §12)
+
+### Sintetizado
+
+Todo el resto:
+
+- **Nombres de arquitectas/estudios:** reemplazados por `ARQ. PLACEHOLDER NN` / `Estudio Placeholder NN`
+- **Precios:** sintetizados a números limpios deterministic-por-SKU-hash (5000-85000 ARS para labor, 100-800 USD para materials). NO son los precios reales de D'Angelo.
+- **Items de materials:** reducidos a 5 items por catálogo (de los 13-45 originales) — sample suficiente para mockear, sin volcar la lista de precios completa.
+- **Sinks:** reducidos a 12 items (de 85). Misma estrategia.
+- **Stock:** sample sintético de 5 retazos con dimensiones variadas.
+- **`photo` paths:** removidos de los items (eran paths a assets internos del repo).
+- **`last_updated`:** sintético (`01/01/2026`) salvo para items canon que mantienen su fecha real.
+
+### NO sanitizado
+
+- `config.json`: copia literal. No tiene PII ni precios sensibles — son parámetros del sistema (IVA, delivery_days tiers, descuentos por tipo de cliente, classificación de materiales por familia).
+
+---
+
+## Archivos disponibles
+
+| Archivo | Items | Notas |
+|---|---|---|
+| `architects.json` | 8 | 1 canon (Cueto-Heredia) + 7 placeholders |
+| `config.json` | — | Literal — IVA, descuentos, delivery tiers, AI engine config |
+| `delivery-zones.json` | 32 | 1 canon (Rosario) + 31 sintetizadas |
+| `labor.json` | 34 | 5 canon (MO Cueto-Heredia) + 29 sintetizadas |
+| `materials-silestone.json` | 5 | 1 canon (SILESTONENORTE) + 4 samples |
+| `materials-purastone.json` | 5 | sample sintético |
+| `materials-granito-nacional.json` | 5 | sample sintético |
+| `materials-granito-importado.json` | 5 | sample sintético |
+| `materials-dekton.json` | 5 | sample sintético |
+| `materials-neolith.json` | 5 | sample sintético |
+| `materials-marmol.json` | 5 | sample sintético |
+| `materials-puraprima.json` | 5 | sample sintético |
+| `materials-laminatto.json` | 5 | sample sintético |
+| `sinks.json` | 12 | sample sintético (de 85 originales) |
+| `stock.json` | 5 retazos | sample sintético |
+
+---
+
+## Uso desde frontend Sprint 2
+
+Los hooks `useMockClient()` pueden seedear estos JSONs como fixtures:
+
+```ts
+// web/src/lib/mocks/catalogs.ts
+import laborCatalog from "@/handoff-context/catalog/labor.json";
+import architectsCatalog from "@/handoff-context/catalog/architects.json";
+import siliestoneCatalog from "@/handoff-context/catalog/materials-silestone.json";
+import config from "@/handoff-context/catalog/config.json";
+
+// ... mockear GET /api/catalog/{name} contra estos
+```
+
+Para tests E2E del case Cueto-Heredia, los precios canon ya están — el cálculo arroja **$660.890 ARS + USD 1.538** sin necesitar precios reales.
+
+---
+
+## ⚠️ NO usar en producción
+
+Estos catálogos son sample sanitizados — **no reflejan los precios reales de D'Angelo**. Cuando el frontend cambie a `useApiClient()` (Sprint 3 inicial), los datos vienen del backend que usa los catálogos reales en `api/catalog/`.
+
+Si en algún test E2E necesitás un precio que no es canon, agregalo como item nuevo al sample — NO copies precios reales del backend.

--- a/docs/handoff-context/catalog/architects.json
+++ b/docs/handoff-context/catalog/architects.json
@@ -1,0 +1,58 @@
+[
+  {
+    "name": "ARQ. PLACEHOLDER 01",
+    "firm": null,
+    "discount": true,
+    "discount_percentage": null,
+    "notes": "Placeholder sanitizado — usar porcentaje de config.json"
+  },
+  {
+    "name": "ARQ. PLACEHOLDER 02",
+    "firm": "Estudio Placeholder 02",
+    "discount": true,
+    "discount_percentage": null,
+    "notes": "Placeholder sanitizado — usar porcentaje de config.json"
+  },
+  {
+    "name": "ARQ. PLACEHOLDER 03",
+    "firm": "Estudio Placeholder 03",
+    "discount": true,
+    "discount_percentage": null,
+    "notes": "Placeholder sanitizado — usar porcentaje de config.json"
+  },
+  {
+    "name": "ARQ. PLACEHOLDER 04",
+    "firm": null,
+    "discount": true,
+    "discount_percentage": null,
+    "notes": "Placeholder sanitizado — usar porcentaje de config.json"
+  },
+  {
+    "name": "ARQ. PLACEHOLDER 05",
+    "firm": null,
+    "discount": true,
+    "discount_percentage": null,
+    "notes": "Placeholder sanitizado — usar porcentaje de config.json"
+  },
+  {
+    "name": "ARQ. PLACEHOLDER 06",
+    "firm": "Estudio Placeholder 06",
+    "discount": true,
+    "discount_percentage": null,
+    "notes": "Placeholder sanitizado — usar porcentaje de config.json"
+  },
+  {
+    "name": "CUETO-HEREDIA ARQUITECTAS",
+    "firm": "Cueto-Heredia Arquitectas",
+    "discount": true,
+    "discount_percentage": null,
+    "notes": "Estudio canónico — usar porcentaje de config.json (5% importado)"
+  },
+  {
+    "name": "ARQ. PLACEHOLDER 07",
+    "firm": "Estudio Placeholder 07",
+    "discount": true,
+    "discount_percentage": null,
+    "notes": "Placeholder sanitizado — usar porcentaje de config.json"
+  }
+]

--- a/docs/handoff-context/catalog/config.json
+++ b/docs/handoff-context/catalog/config.json
@@ -1,0 +1,301 @@
+{
+  "iva": {
+    "multiplier": 1.21,
+    "percentage": 21
+  },
+  "delivery_days": {
+    "_comment": "Plazo de entrega desde toma de medidas. Se elige por tier según m² total.",
+    "default": 30,
+    "range_enabled": false,
+    "range_min": 20,
+    "range_max": 30,
+    "display": "30 dias desde la toma de medidas",
+    "tiers": [
+      {
+        "max_m2": 3,
+        "days": 20,
+        "display": "20 dias desde la toma de medidas"
+      },
+      {
+        "max_m2": 6,
+        "days": 30,
+        "display": "30 dias desde la toma de medidas"
+      },
+      {
+        "max_m2": 999,
+        "days": 40,
+        "display": "40 dias desde la toma de medidas"
+      }
+    ]
+  },
+  "discount": {
+    "imported_percentage": 5,
+    "national_percentage": 8,
+    "min_m2_threshold": 6,
+    "applies_to": "material_only",
+    "building_percentage": 18,
+    "building_min_m2_threshold": 15,
+    "building_applies_to": "material_only"
+  },
+  "materials": {
+    "_comment": "Clasificacion de materiales por familia",
+    "sinteticos": [
+      "silestone",
+      "dekton",
+      "neolith",
+      "puraprima",
+      "purastone",
+      "laminatto"
+    ],
+    "sinterizados": [
+      "dekton",
+      "neolith",
+      "puraprima",
+      "laminatto"
+    ],
+    "merma_media_placa": [
+      "silestone"
+    ],
+    "merma_placa_entera": [
+      "purastone",
+      "puraprima",
+      "dekton",
+      "neolith",
+      "laminatto"
+    ],
+    "plate_material_map": {
+      "silestone": "estandar",
+      "purastone": "estandar",
+      "dekton": "especial",
+      "neolith": "especial",
+      "puraprima": "especial",
+      "laminatto": "especial"
+    }
+  },
+  "measurements": {
+    "default_depth": 0.6,
+    "default_zocalo_height": 0.07,
+    "tall_zocalo_threshold": 0.1
+  },
+  "colocacion": {
+    "min_quantity": 1.0
+  },
+  "pricing": {
+    "usd_rounding": "floor",
+    "ars_rounding": "round"
+  },
+  "merma": {
+    "small_piece_threshold_m2": 1.0
+  },
+  "plate_sizes": {
+    "estandar": {
+      "largo": 3.0,
+      "ancho": 1.4,
+      "m2": 4.2
+    },
+    "especial": {
+      "largo": 3.2,
+      "ancho": 1.6,
+      "m2": 5.12
+    }
+  },
+  "stock": {
+    "_comment": "Si el material está en stock, NO aplica merma. true = en stock, false = no en stock.",
+    "default": false
+  },
+  "building": {
+    "_comment": "Reglas para obras de edificio",
+    "colocacion": false,
+    "flete_mesadas_per_trip": 6,
+    "discount_percentage": 18,
+    "discount_min_m2": 15
+  },
+  "company": {
+    "name": "D'ANGELO",
+    "subtitle": "MARMOLERIA",
+    "address": "SAN NICOLAS 1160",
+    "phone": "341-3082996",
+    "email": "marmoleriadangelo@gmail.com"
+  },
+  "conditions": {
+    "general": "*PRESUPUESTO SUJETO A VARIACION DE PRECIO\n*MATERIALES IMPORTADOS SEGUN COTIZACION DOLAR VENTA BANCO NACION AL MOMENTO DE LA CONFIRMACION\n*LA TOMA DE MEDIDAS NO PODRA SUPERAR LOS 30 DIAS DESDE LA CONFIRMACION, CASO CONTRARIO EL 20% RESTANTE SE ACTUALIZARA SEGUN INDICE LA CONSTRUCCION\n*PRESUPUESTO DEFINITIVO SEGUN MEDIDAS TOMADAS EN OBRA\n*LOS PRECIOS INCLUYEN IVA",
+    "payment": "*Materiales Importados: 80% seña, 20% restante contra entrega (cotizacion dolar venta BCO NACION).\n*Materiales Nacionales: 80% seña, 20% restante contra entrega.\nPago contado / transferencia / debito / credito / cheques 15 dias para importados y 30 dias para nacionales\nTARJETAS DE CREDITO CONSULTAR PLANES"
+  },
+  "ai_engine": {
+    "use_opus_for_plans": true,
+    "rotate_plan_images": false,
+    "max_examples": 1,
+    "dual_read_enabled": true,
+    "multi_crop_enabled": true,
+    "plan_rasterization_dpi": 300
+  },
+  "zone_aliases": {
+    "_comment": "sku: SKU en delivery-zones.json. pulido_extra: true si hay colocación cobra pulido de cantos (= flete/2). Zonas cercanas a Rosario: false.",
+    "rosario": {
+      "sku": "ENVIOROS",
+      "pulido_extra": false
+    },
+    "funes": {
+      "sku": "ENVFUNES",
+      "pulido_extra": false
+    },
+    "roldan": {
+      "sku": "FLETEROLD",
+      "pulido_extra": false
+    },
+    "perez": {
+      "sku": "ENVPEREZ",
+      "pulido_extra": true
+    },
+    "san lorenzo": {
+      "sku": "ENVSANLORENZO",
+      "pulido_extra": true
+    },
+    "villa gobernador galvez": {
+      "sku": "ENVVILLA",
+      "pulido_extra": true
+    },
+    "ibarlucea": {
+      "sku": "ENVIBAR",
+      "pulido_extra": true
+    },
+    "soldini": {
+      "sku": "ENVSOLDINI",
+      "pulido_extra": true
+    },
+    "ricardone": {
+      "sku": "ENVRICARDONE",
+      "pulido_extra": true
+    },
+    "san nicolas": {
+      "sku": "ENVSANNICO",
+      "pulido_extra": true
+    },
+    "alvear": {
+      "sku": "ENVALVEAR",
+      "pulido_extra": true
+    },
+    "arroyo seco": {
+      "sku": "ENVARROYO",
+      "pulido_extra": true
+    },
+    "galvez": {
+      "sku": "FLEGALVEZ",
+      "pulido_extra": true
+    },
+    "carcarana": {
+      "sku": "FLECARRERAS",
+      "pulido_extra": true
+    },
+    "andino": {
+      "sku": "FLETEAND",
+      "pulido_extra": true
+    },
+    "victoria": {
+      "sku": "ENVVICTORIA",
+      "pulido_extra": true
+    },
+    "san martin": {
+      "sku": "ENVSANMARTIN",
+      "pulido_extra": true
+    },
+    "puerto san martin": {
+      "sku": "ENVSANMARTIN",
+      "pulido_extra": true
+    },
+    "puerto gral san martin": {
+      "sku": "ENVSANMARTIN",
+      "pulido_extra": true
+    },
+    "pto san martin": {
+      "sku": "ENVSANMARTIN",
+      "pulido_extra": true
+    },
+    "general lagos": {
+      "sku": "ENVGRAL",
+      "pulido_extra": true
+    },
+    "hudsson": {
+      "sku": "ENVHUD",
+      "pulido_extra": true
+    },
+    "las parejas": {
+      "sku": "ENVLASPAREJAS",
+      "pulido_extra": true
+    },
+    "maciel": {
+      "sku": "ENVMACIEL",
+      "pulido_extra": true
+    },
+    "carmen": {
+      "sku": "ENVCARMEN",
+      "pulido_extra": true
+    },
+    "baigorria": {
+      "sku": "ENVBAI",
+      "pulido_extra": true
+    },
+    "bermudez": {
+      "sku": "ENVBER",
+      "pulido_extra": true
+    },
+    "salto grande": {
+      "sku": "ENVSALTOGDE",
+      "pulido_extra": true
+    },
+    "esther": {
+      "sku": "ENVESTHER",
+      "pulido_extra": true
+    },
+    "aldao": {
+      "sku": "ENVALDAO",
+      "pulido_extra": true
+    },
+    "piñero": {
+      "sku": "ENVPIÑERO",
+      "pulido_extra": true
+    },
+    "pinero": {
+      "sku": "ENVPIÑERO",
+      "pulido_extra": true
+    },
+    "cañada de gomez": {
+      "sku": "FLETE CAÑADA",
+      "pulido_extra": true
+    },
+    "cañada": {
+      "sku": "FLETE CAÑADA",
+      "pulido_extra": true
+    },
+    "canada de gomez": {
+      "sku": "FLETE CAÑADA",
+      "pulido_extra": true
+    }
+  },
+  "material_aliases": {
+    "granito new beige": "Marmol Sahara",
+    "new beige": "Marmol Sahara",
+    "cuarzo blanco norte": "Silestone Blanco Norte",
+    "blanco norte": "Silestone Blanco Norte",
+    "granito blanco ceara": "Granito Ceara",
+    "blanco ceara": "Granito Ceara",
+    "ceara": "Granito Ceara"
+  },
+  "condiciones_edificio": {
+    "_comment": "Template de Condiciones de Contratación que se genera como PDF aparte para cada presupuesto de edificio. Variables: {cliente}, {obra}, {fecha}, {plazo}. Editable desde el panel de Configuración.",
+    "title": "CONDICIONES CONTRATACIÓN MARMOLERIA",
+    "header_line": "Cliente: {cliente} - {obra} - {fecha}",
+    "items": [
+      "El presupuesto enviado es estimativo según medidas de planos. El presupuesto definitivo se ajustará según medidas relevadas en obra.",
+      "Plazo de entrega estimado {plazo}. Se realizan entregas parciales cada 15/20 días por certificación.",
+      "Por ser el granito un material de la naturaleza las partidas pueden venir con vetas, tonalidades o variaciones propias del material.",
+      "En cada una de las entregas se deberá firmar un remito con detalle de dicha entrega. Este será controlado por parte del cliente y una vez firmado conformidad no se aceptarán reclamos de piezas faltantes o rotura de material.",
+      "Condiciones de pago material y mano de obra: El presupuesto se seña con el 80% de acopio, pago contado o cheques 0-15-30. El 20% contra certificación de entrega 0-15-30.",
+      "Material presupuestado calidad EXTRA - 20MM ESPESOR.",
+      "LAS MESADAS SE DEJAN EN PIE DE OBRA.",
+      "NO INCLUYE COLOCACIÓN DE MESADAS.",
+      "NO INCLUYE PILETAS."
+    ],
+    "default_plazo": "60 DIAS HÁBILES DESDE LA TOMA DE MEDIDAS EN OBRA"
+  }
+}

--- a/docs/handoff-context/catalog/delivery-zones.json
+++ b/docs/handoff-context/catalog/delivery-zones.json
@@ -1,0 +1,258 @@
+[
+  {
+    "sku": "ENVALDAO",
+    "location": "ALDAO",
+    "price_ars": 54000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVALV",
+    "location": "ALVAREZ",
+    "price_ars": 102000.0,
+    "currency": "ARS",
+    "price_includes_vat": true,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVALVEAR",
+    "location": "ALVEAR",
+    "price_ars": 66000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "FLETEAND",
+    "location": "ANDINO",
+    "price_ars": 99000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVARROYO",
+    "location": "ARROYO SECO",
+    "price_ars": 89000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVBAI",
+    "location": "BAIGORRIA",
+    "price_ars": 34000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVBER",
+    "location": "CAP BERMUDEZ",
+    "price_ars": 122000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVCARMEN",
+    "location": "CARMEN DEL SAUCE",
+    "price_ars": 92000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "FLETE CAÑADA",
+    "location": "CAÑADA DE GOMEZ",
+    "price_ars": 52000.0,
+    "currency": "ARS",
+    "price_includes_vat": true,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVRICARDONE",
+    "location": "FLETE RICARDONE + TOMA DE MEDIDAS",
+    "price_ars": 120000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVIOROS",
+    "location": "FLETE ROSARIO + TOMA DE MEDIDAS",
+    "price_ars": 52000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "15/12/2025"
+  },
+  {
+    "sku": "ENVVILLA",
+    "location": "FLETE+ TOMA DE MEDIDAS VILLA CONSTITUCION",
+    "price_ars": 131000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVFUNES",
+    "location": "FUNES",
+    "price_ars": 146000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "FLEGALVEZ",
+    "location": "GALVEZ",
+    "price_ars": 64000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVGRAL",
+    "location": "GRAL LAGOS - LA CAROLINA",
+    "price_ars": 87000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVHUD",
+    "location": "HUDHES-SANTA FE",
+    "price_ars": 67000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVIBAR",
+    "location": "IBARLUCEA",
+    "price_ars": 103000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVLASPAREJAS",
+    "location": "LAS PAREJAS",
+    "price_ars": 121000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVMACIEL",
+    "location": "MACIEL",
+    "price_ars": 49000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVPEREZ",
+    "location": "PEREZ",
+    "price_ars": 124000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVPIÑERO",
+    "location": "PIÑERO",
+    "price_ars": 73000.0,
+    "currency": "ARS",
+    "price_includes_vat": true,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "FLECARRERAS",
+    "location": "PUEBLO CARRERAS",
+    "price_ars": 81000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVESTHER",
+    "location": "PUEBLO ESTHER",
+    "price_ars": 137000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVSANMARTIN",
+    "location": "PUERTO GRAL SAN MARTIN",
+    "price_ars": 117000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "FLETEROLD",
+    "location": "ROLDAN",
+    "price_ars": 85000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVSALTOGDE",
+    "location": "SALTO GRANDE",
+    "price_ars": 125000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVSANLORENZO",
+    "location": "SAN LORENZO",
+    "price_ars": 42000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVSANNICO",
+    "location": "SAN NICOLAS",
+    "price_ars": 102000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVSOLDINI",
+    "location": "SOLDINI",
+    "price_ars": 72000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVVICTORIA",
+    "location": "VICTORIA",
+    "price_ars": 77000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVMUGUETA",
+    "location": "VILLAS MUGUETA",
+    "price_ars": 44000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  },
+  {
+    "sku": "ENVZAB",
+    "location": "ZAVALLA",
+    "price_ars": 132000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026"
+  }
+]

--- a/docs/handoff-context/catalog/labor.json
+++ b/docs/handoff-context/catalog/labor.json
@@ -1,0 +1,304 @@
+[
+  {
+    "sku": "ANAFE",
+    "task": "AGUJERO ANAFE",
+    "price_ars": 35617.36,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "25/03/2026",
+    "name": "AGUJERO ANAFE"
+  },
+  {
+    "sku": "ANAFEDEKTON/NEOLITH",
+    "task": "AGUJERO ANAFE DEKTON/NEOLITH/PRIMA",
+    "price_ars": 14000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "AGUJERO ANAFE DEKTON/NEOLITH/PRIMA"
+  },
+  {
+    "sku": "TOMASDEKTON/NEO",
+    "task": "AGUJERO DE TOMAS DEKTON/NEOLITH/PRIMA",
+    "price_ars": 19000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "AGUJERO DE TOMAS DEKTON/NEOLITH/PRIMA"
+  },
+  {
+    "sku": "AGUJEROAPOYO",
+    "task": "AGUJERO PILETA APOYO",
+    "price_ars": 20000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "AGUJERO PILETA APOYO"
+  },
+  {
+    "sku": "PILETAAPOYODEKTON/NEO",
+    "task": "AGUJERO PILETA APOYO DEKTON/NEOLITH/PRIMA",
+    "price_ars": 7000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "AGUJERO PILETA APOYO DEKTON/NEOLITH/PRIMA"
+  },
+  {
+    "sku": "TOMAS",
+    "task": "AGUJERO TOMAS",
+    "price_ars": 6461.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "25/03/2026",
+    "name": "AGUJERO TOMAS"
+  },
+  {
+    "sku": "PEGADOPILETA",
+    "task": "AGUJERO Y PEGADO DE PILETA",
+    "price_ars": 53840.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "25/03/2026",
+    "name": "AGUJERO Y PEGADO DE PILETA"
+  },
+  {
+    "sku": "PILETADEKTON/NEOLITH",
+    "task": "AGUJERO Y PEGADO DE PILETA DEKTON/NEOLITH/PRIMA",
+    "price_ars": 64000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "AGUJERO Y PEGADO DE PILETA DEKTON/NEOLITH/PRIMA"
+  },
+  {
+    "sku": "MOLANTIDESLIZANTE",
+    "task": "ANTIDESLIZANTE/REBAJE",
+    "price_ars": 56000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "ANTIDESLIZANTE/REBAJE"
+  },
+  {
+    "sku": "PILETAINTEGRADA A 45",
+    "task": "ARMADO PILETA INTEGRADA A 45",
+    "price_ars": 37000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "ARMADO PILETA INTEGRADA A 45"
+  },
+  {
+    "sku": "PILETADESAGUEOCULTO",
+    "task": "ARMADO PILETA INTEGRADA DESAGUE OCULTO",
+    "price_ars": 56000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "ARMADO PILETA INTEGRADA DESAGUE OCULTO"
+  },
+  {
+    "sku": "PILETAINTEGRADARECTA",
+    "task": "ARMADO PILETA INTEGRADA RECTA",
+    "price_ars": 55000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "ARMADO PILETA INTEGRADA RECTA"
+  },
+  {
+    "sku": "MOLBUÑA",
+    "name": "BUÑA",
+    "price_ars": 38000.0,
+    "last_updated": "01/01/2026",
+    "price_includes_vat": false
+  },
+  {
+    "sku": "COLOCACION",
+    "task": "COLOCACION",
+    "price_ars": 49698.65,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "25/03/2026",
+    "name": "COLOCACION"
+  },
+  {
+    "sku": "COLOCACIONDEKTON/NEOLITH",
+    "task": "COLOCACION DEKTON/NEOLITH/PRIMA",
+    "price_ars": 19000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "COLOCACION DEKTON/NEOLITH/PRIMA"
+  },
+  {
+    "sku": "CORTE45DEKTON/NEOLITH",
+    "task": "CORTE 45 DEKTON/NEOLITH",
+    "price_ars": 16000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "CORTE 45 DEKTON/NEOLITH"
+  },
+  {
+    "sku": "CORTE45",
+    "task": "CORTE A 45",
+    "price_ars": 8000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "CORTE A 45"
+  },
+  {
+    "sku": "FALDONDEKTON/NEOLITH",
+    "task": "FALDON DEKTON/NEOLITH",
+    "price_ars": 71000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "FALDON DEKTON/NEOLITH"
+  },
+  {
+    "sku": "MOLBOMBECOMPLETO",
+    "task": "MANO DE OBRA BOMBE COMPLETO",
+    "price_ars": 72000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "MANO DE OBRA BOMBE COMPLETO"
+  },
+  {
+    "sku": "TOALLERO",
+    "task": "MANO DE OBRA CALADO TOALLERO",
+    "price_ars": 53000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "MANO DE OBRA CALADO TOALLERO"
+  },
+  {
+    "sku": "FALDON",
+    "task": "MANO DE OBRA FALDON RECTO",
+    "price_ars": 58000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "MANO DE OBRA FALDON RECTO"
+  },
+  {
+    "sku": "SERVICEPEGAPILE",
+    "task": "MANO DE OBRA PEGADO DE PILETA",
+    "price_ars": 25000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "MANO DE OBRA PEGADO DE PILETA"
+  },
+  {
+    "sku": "PILETA45 DEKTON/NEOLITH",
+    "task": "MANO DE OBRA PILETA INTEGRADA A 45 DEKTON/NEOLITH",
+    "price_ars": 11000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "MANO DE OBRA PILETA INTEGRADA A 45 DEKTON/NEOLITH"
+  },
+  {
+    "sku": "PILDESAOCULTODEKTON/NEO",
+    "task": "MANO DE OBRA PILETA INTEGRADA DESAGUE OCULTO DEKTON/NEOLITH",
+    "price_ars": 37000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "MANO DE OBRA PILETA INTEGRADA DESAGUE OCULTO DEKTON/NEOLITH"
+  },
+  {
+    "sku": "PILRECTA DEKTON/NEOLITH",
+    "task": "MANO DE OBRA PILETA INTEGRADA RECTA DEKTON/NEOLITH",
+    "price_ars": 45000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "MANO DE OBRA PILETA INTEGRADA RECTA DEKTON/NEOLITH"
+  },
+  {
+    "sku": "RAN",
+    "task": "MANO DE OBRA RANURADO",
+    "price_ars": 8000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "MANO DE OBRA RANURADO"
+  },
+  {
+    "sku": "RANDEK",
+    "task": "MANO DE OBRA RANURADO DEKTON",
+    "price_ars": 6000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "MANO DE OBRA RANURADO DEKTON"
+  },
+  {
+    "sku": "REGRUESO",
+    "task": "MANO DE OBRA REGRUESO",
+    "price_ars": 13810.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "25/03/2026",
+    "name": "MANO DE OBRA REGRUESO"
+  },
+  {
+    "sku": "MOLMEDIACAÑA",
+    "name": "MOLDURA MEDIA CAÑA",
+    "price_ars": 63000.0,
+    "last_updated": "01/01/2026",
+    "price_includes_vat": false
+  },
+  {
+    "sku": "MOLMEDIOBOMBE",
+    "task": "MOLDURA MEDIO BOMBE",
+    "price_ars": 36000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "MOLDURA MEDIO BOMBE"
+  },
+  {
+    "sku": "MOLPALOMA",
+    "task": "MOLDURA PECHO PALOMA",
+    "price_ars": 69000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "MOLDURA PECHO PALOMA"
+  },
+  {
+    "sku": "PUL",
+    "task": "PULIDO CANTOS",
+    "price_ars": 51000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "PULIDO CANTOS"
+  },
+  {
+    "sku": "PUL2",
+    "task": "PULIDO DEKTON/NEOLITH",
+    "price_ars": 12000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "PULIDO DEKTON/NEOLITH"
+  },
+  {
+    "sku": "MDF",
+    "task": "REFUERZO-SUPLEMENTO",
+    "price_ars": 80000.0,
+    "currency": "ARS",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "name": "REFUERZO-SUPLEMENTO"
+  }
+]

--- a/docs/handoff-context/catalog/materials-dekton.json
+++ b/docs/handoff-context/catalog/materials-dekton.json
@@ -1,0 +1,72 @@
+[
+  {
+    "sku": "AURAMOD",
+    "name": "AURA 8MM MOD",
+    "material_type": "dekton",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 8,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 384.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  },
+  {
+    "sku": "DEKTONTRILIUM",
+    "name": "DEKTIN TRILIUM",
+    "material_type": "dekton",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 302.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  },
+  {
+    "sku": "DEKTONAURA12",
+    "name": "DEKTON AURA 12MM",
+    "material_type": "dekton",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 12,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 660.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  },
+  {
+    "sku": "DEKTONAURA",
+    "name": "DEKTON AURA 8MM",
+    "material_type": "dekton",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 8,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 287.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  },
+  {
+    "sku": "DEKAWA",
+    "name": "DEKTON AWAKE 12MM",
+    "material_type": "dekton",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 12,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 423.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  }
+]

--- a/docs/handoff-context/catalog/materials-granito-importado.json
+++ b/docs/handoff-context/catalog/materials-granito-importado.json
@@ -1,0 +1,67 @@
+[
+  {
+    "sku": "ALPH",
+    "name": "GRANITO ALPHINUS LEATHER",
+    "material_type": "granito",
+    "category": "piedra_natural",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 543.0,
+    "currency": "USD",
+    "origin": "importado"
+  },
+  {
+    "sku": "ALPHPUL",
+    "name": "GRANITO ALPHINUS PULIDO",
+    "material_type": "granito",
+    "category": "piedra_natural",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 721.0,
+    "currency": "USD",
+    "origin": "importado"
+  },
+  {
+    "sku": "AMABRASIL",
+    "name": "GRANITO AMARILLO BRASIL",
+    "material_type": "granito",
+    "category": "piedra_natural",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 457.0,
+    "currency": "USD",
+    "origin": "importado"
+  },
+  {
+    "sku": "AZULABRADOR",
+    "name": "GRANITO AZUL LABRADOR",
+    "material_type": "granito",
+    "category": "piedra_natural",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 279.0,
+    "currency": "USD",
+    "origin": "importado"
+  },
+  {
+    "sku": "DALLEATHER",
+    "name": "GRANITO BLANCO DALLAS LEATHER",
+    "material_type": "granito",
+    "category": "piedra_natural",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 548.0,
+    "currency": "USD",
+    "origin": "importado"
+  }
+]

--- a/docs/handoff-context/catalog/materials-granito-nacional.json
+++ b/docs/handoff-context/catalog/materials-granito-nacional.json
@@ -1,0 +1,67 @@
+[
+  {
+    "sku": "GRAAMA",
+    "name": "GRANITO AMADEUS - 20MM ESPESOR",
+    "material_type": "granito",
+    "category": "piedra_natural",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_ars": 415200.0,
+    "currency": "ARS",
+    "origin": "nacional"
+  },
+  {
+    "sku": "GRAPUMA",
+    "name": "GRANITO BEIGE PUMA",
+    "material_type": "granito",
+    "category": "piedra_natural",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_ars": 194400.0,
+    "currency": "ARS",
+    "origin": "nacional"
+  },
+  {
+    "sku": "COSMIK",
+    "name": "GRANITO BLACK COSMIK 2 ESP",
+    "material_type": "granito",
+    "category": "piedra_natural",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_ars": 235200.0,
+    "currency": "ARS",
+    "origin": "nacional"
+  },
+  {
+    "sku": "GRACOSMIKLEATHER",
+    "name": "GRANITO BLACK COSMIK LEATHER - 2CM ESP",
+    "material_type": "granito",
+    "category": "piedra_natural",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_ars": 919200.0,
+    "currency": "ARS",
+    "origin": "nacional"
+  },
+  {
+    "sku": "GRA COSMIKLEATHER",
+    "name": "GRANITO COISMIK LEATHER",
+    "material_type": "granito",
+    "category": "piedra_natural",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_ars": 416400.0,
+    "currency": "ARS",
+    "origin": "nacional"
+  }
+]

--- a/docs/handoff-context/catalog/materials-laminatto.json
+++ b/docs/handoff-context/catalog/materials-laminatto.json
@@ -1,0 +1,72 @@
+[
+  {
+    "sku": "LAMCRISTAL",
+    "name": "LAMIINATTO CRISTAL GOLD - 12MM",
+    "material_type": "laminatto",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 12,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 715.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  },
+  {
+    "sku": "LAMCEMENTO",
+    "name": "LAMINATO CEMENTO GRIGIO - 12MM -PULIDO",
+    "material_type": "laminatto",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 12,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 518.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  },
+  {
+    "sku": "LAMAMAZOMNITA",
+    "name": "LAMINATTO AMAZONITA - PULIDO - 12MM",
+    "material_type": "laminatto",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 12,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 785.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  },
+  {
+    "sku": "LAMAMBER",
+    "name": "LAMINATTO AMBER PULIDO - 12MM",
+    "material_type": "laminatto",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 12,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 277.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  },
+  {
+    "sku": "LAM",
+    "name": "LAMINATTO BIANCO PURO - PULIDO - 12MM",
+    "material_type": "laminatto",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 12,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 546.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  }
+]

--- a/docs/handoff-context/catalog/materials-marmol.json
+++ b/docs/handoff-context/catalog/materials-marmol.json
@@ -1,0 +1,62 @@
+[
+  {
+    "sku": "MARMETRA",
+    "name": "MARMETA TRAVERTINO CLASICO MATE SIN TAPONAR - 12MM",
+    "material_type": "marmol",
+    "category": "piedra_natural",
+    "thickness_mm": 12,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 549.0,
+    "currency": "USD"
+  },
+  {
+    "sku": "ANTRADARK",
+    "name": "MARMOL ANTRACITE DARK",
+    "material_type": "marmol",
+    "category": "piedra_natural",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 234.0,
+    "currency": "USD"
+  },
+  {
+    "sku": "MARMOLARABESCATO",
+    "name": "MARMOL ARABESCATO",
+    "material_type": "marmol",
+    "category": "piedra_natural",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 332.0,
+    "currency": "USD"
+  },
+  {
+    "sku": "MARMOLBLANCOTURCO",
+    "name": "MARMOL BLANCO TURCO",
+    "material_type": "marmol",
+    "category": "piedra_natural",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 254.0,
+    "currency": "USD"
+  },
+  {
+    "sku": "MARMOLBOTTICCINO",
+    "name": "MARMOL BOTTICCINO",
+    "material_type": "marmol",
+    "category": "piedra_natural",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 322.0,
+    "currency": "USD"
+  }
+]

--- a/docs/handoff-context/catalog/materials-neolith.json
+++ b/docs/handoff-context/catalog/materials-neolith.json
@@ -1,0 +1,72 @@
+[
+  {
+    "sku": "NEOCEMENT",
+    "name": "NEOLIT CEMENT",
+    "material_type": "neolith",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 335.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  },
+  {
+    "sku": "ABUDAK",
+    "name": "NEOLITH ABU DHABI - 12MM - MATE",
+    "material_type": "neolith",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 12,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 336.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  },
+  {
+    "sku": "NEOABU",
+    "name": "NEOLITH ABU DHABI - 12MM - PULIDO",
+    "material_type": "neolith",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 12,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 160.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  },
+  {
+    "sku": "NEOARTICSILK",
+    "name": "NEOLITH ARTIC SILK- SATIN",
+    "material_type": "neolith",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 216.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  },
+  {
+    "sku": "NEOARTIC",
+    "name": "NEOLITH ARTIC WHITE PULIDO",
+    "material_type": "neolith",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 150.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  }
+]

--- a/docs/handoff-context/catalog/materials-puraprima.json
+++ b/docs/handoff-context/catalog/materials-puraprima.json
@@ -1,0 +1,72 @@
+[
+  {
+    "sku": "PRIMACALA",
+    "name": "PRA PRIMA CALACATTA VAGLI - PULIDO- 12MM",
+    "material_type": "puraprima",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 12,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 583.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  },
+  {
+    "sku": "PRIMAONIX",
+    "name": "PURA PRIIMA ONIX WHITE - MATE - 12MM",
+    "material_type": "puraprima",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 12,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 452.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  },
+  {
+    "sku": "PRIMAABSOLUTE",
+    "name": "PURA PRIMA ABSOLUTE BLACK - MATE - 12MM ESPESOR",
+    "material_type": "puraprima",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 12,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 469.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  },
+  {
+    "sku": "PRIMAALP",
+    "name": "PURA PRIMA ALPHINUS WHITE - MATE - 12MM",
+    "material_type": "puraprima",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 12,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 769.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  },
+  {
+    "sku": "PRIMABRES",
+    "name": "PURA PRIMA BRESCIA IMPERIALE - 12MM",
+    "material_type": "puraprima",
+    "category": "piedra_sinterizada",
+    "thickness_mm": 12,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 276.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  }
+]

--- a/docs/handoff-context/catalog/materials-purastone.json
+++ b/docs/handoff-context/catalog/materials-purastone.json
@@ -1,0 +1,72 @@
+[
+  {
+    "sku": "PURACANA",
+    "name": "PURA STONE BLANCO CANA",
+    "material_type": "purastone",
+    "category": "cuarzo",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 157.0,
+    "currency": "USD",
+    "plate_size": "estandar",
+    "plate_m2": 4.2
+  },
+  {
+    "sku": "PURABLANCO GLITTER",
+    "name": "PURA STONE BLANCO GLITTER",
+    "material_type": "purastone",
+    "category": "cuarzo",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 474.0,
+    "currency": "USD",
+    "plate_size": "estandar",
+    "plate_m2": 4.2
+  },
+  {
+    "sku": "PURANUBE",
+    "name": "PURA STONE BLANCO NUBE",
+    "material_type": "purastone",
+    "category": "cuarzo",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 196.0,
+    "currency": "USD",
+    "plate_size": "estandar",
+    "plate_m2": 4.2
+  },
+  {
+    "sku": "PURATOPO",
+    "name": "PURA STONE GRIS TOPO",
+    "material_type": "purastone",
+    "category": "cuarzo",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 729.0,
+    "currency": "USD",
+    "plate_size": "estandar",
+    "plate_m2": 4.2
+  },
+  {
+    "sku": "PURANEGROGLITTER",
+    "name": "PURA STONE NEGRO GLITTER",
+    "material_type": "purastone",
+    "category": "cuarzo",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 310.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  }
+]

--- a/docs/handoff-context/catalog/materials-silestone.json
+++ b/docs/handoff-context/catalog/materials-silestone.json
@@ -1,0 +1,72 @@
+[
+  {
+    "sku": "SILESTONENORTE",
+    "name": "SILESTONE BLANCO NORTE",
+    "material_type": "silestone",
+    "category": "cuarzo",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "29/09/2025",
+    "price_usd": 206.0,
+    "currency": "USD",
+    "plate_size": "estandar",
+    "plate_m2": 4.2
+  },
+  {
+    "sku": "SILGLOW",
+    "name": "SILESOTNE ETHER GLOW",
+    "material_type": "silestone",
+    "category": "cuarzo",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 592.0,
+    "currency": "USD",
+    "plate_size": "especial",
+    "plate_m2": 5.12
+  },
+  {
+    "sku": "SILESTONEZEUS",
+    "name": "SILESTONE BLANCO ZEUS",
+    "material_type": "silestone",
+    "category": "cuarzo",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 669.0,
+    "currency": "USD",
+    "plate_size": "estandar",
+    "plate_m2": 4.2
+  },
+  {
+    "sku": "SILESTONEZEUSSUEDE",
+    "name": "SILESTONE BLANCO ZEUS SUEDE",
+    "material_type": "silestone",
+    "category": "cuarzo",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 257.0,
+    "currency": "USD",
+    "plate_size": "estandar",
+    "plate_m2": 4.2
+  },
+  {
+    "sku": "SILBOHE",
+    "name": "SILESTONE BOHEMIA FLAME",
+    "material_type": "silestone",
+    "category": "cuarzo",
+    "thickness_mm": 20,
+    "unit": "m2",
+    "price_includes_vat": false,
+    "last_updated": "01/01/2026",
+    "price_usd": 498.0,
+    "currency": "USD",
+    "plate_size": "estandar",
+    "plate_m2": 4.2
+  }
+]

--- a/docs/handoff-context/catalog/sinks.json
+++ b/docs/handoff-context/catalog/sinks.json
@@ -1,0 +1,148 @@
+{
+  "_metadata": {
+    "description": "Catálogo de piletas y accesorios vendidos por D'Angelo Marmolería",
+    "rules": [
+      "D'Angelo solo vende piletas EMPOTRADAS — las de apoyo las trae el cliente",
+      "Cuando el cliente compra la pileta en D'Angelo: agregar línea separada ARS (este catálogo) + cobrar MO de pegado/agujero por separado",
+      "Cuando el cliente trae su propia pileta empotrada: solo cobrar MO de pegado/agujero",
+      "Pileta de apoyo: nunca aparece en este catálogo, solo cobrar AGUJEROAPOYO o PILETAAPOYODEKTON/NEO"
+    ],
+    "price_includes_vat": true,
+    "currency": "ARS",
+    "price_note": "Precios en price_ars SIN IVA. Aplicar x1.21 al generar presupuesto."
+  },
+  "items": [
+    {
+      "sku": "REJILLA",
+      "name": "BANDEJA REJILLA BARE E44",
+      "category": "accessory",
+      "price_ars": 74000.0,
+      "currency": "ARS",
+      "price_includes_vat": false,
+      "sold_by_dangelo": true,
+      "sink_type": null,
+      "last_updated": "01/01/2026"
+    },
+    {
+      "sku": "CASELU",
+      "name": "CANASTO SECAPLATO LUXOR",
+      "category": "accessory",
+      "price_ars": 79000.0,
+      "currency": "ARS",
+      "price_includes_vat": false,
+      "sold_by_dangelo": true,
+      "sink_type": null,
+      "last_updated": "01/01/2026"
+    },
+    {
+      "sku": "ESACC",
+      "name": "CANASTO SECAPLATOS",
+      "category": "accessory",
+      "price_ars": 142000.0,
+      "currency": "ARS",
+      "price_includes_vat": false,
+      "sold_by_dangelo": true,
+      "sink_type": null,
+      "last_updated": "01/01/2026"
+    },
+    {
+      "sku": "QUADRAQ71A",
+      "name": "PILETA QUADRA Q71A",
+      "category": "sink",
+      "price_ars": 60000.0,
+      "currency": "ARS",
+      "price_includes_vat": false,
+      "sold_by_dangelo": true,
+      "sink_type": "empotrada",
+      "last_updated": "01/01/2026"
+    },
+    {
+      "sku": "CESTILLO",
+      "name": "CUBRE CESTILLO",
+      "category": "accessory",
+      "price_ars": 91000.0,
+      "currency": "ARS",
+      "price_includes_vat": false,
+      "sold_by_dangelo": true,
+      "sink_type": null,
+      "last_updated": "01/01/2026"
+    },
+    {
+      "sku": "DOSI",
+      "name": "DOSIFICADOR",
+      "category": "accessory",
+      "price_ars": 135000.0,
+      "currency": "ARS",
+      "price_includes_vat": false,
+      "sold_by_dangelo": true,
+      "sink_type": null,
+      "last_updated": "01/01/2026"
+    },
+    {
+      "sku": "DOSBLACK",
+      "name": "DOSIFICADOR BLACK",
+      "category": "accessory",
+      "price_ars": 92000.0,
+      "currency": "ARS",
+      "price_includes_vat": false,
+      "sold_by_dangelo": true,
+      "sink_type": null,
+      "last_updated": "01/01/2026"
+    },
+    {
+      "sku": "DOSCUBO",
+      "name": "DOSIFICADOR CUBO",
+      "category": "accessory",
+      "price_ars": 131000.0,
+      "currency": "ARS",
+      "price_includes_vat": false,
+      "sold_by_dangelo": true,
+      "sink_type": null,
+      "last_updated": "01/01/2026"
+    },
+    {
+      "sku": "ESAC E3",
+      "name": "ESCURREPLATO ESSAC E3",
+      "category": "accessory",
+      "price_ars": 55000.0,
+      "currency": "ARS",
+      "price_includes_vat": false,
+      "sold_by_dangelo": true,
+      "sink_type": null,
+      "last_updated": "01/01/2026"
+    },
+    {
+      "sku": "ESAC E4",
+      "name": "ESCURREPLATOS ESAC E4",
+      "category": "accessory",
+      "price_ars": 112000.0,
+      "currency": "ARS",
+      "price_includes_vat": false,
+      "sold_by_dangelo": true,
+      "sink_type": null,
+      "last_updated": "01/01/2026"
+    },
+    {
+      "sku": "ESCESAC",
+      "name": "ESCURREPLATOS ESAC Q37-Q40",
+      "category": "accessory",
+      "price_ars": 162000.0,
+      "currency": "ARS",
+      "price_includes_vat": false,
+      "sold_by_dangelo": true,
+      "sink_type": null,
+      "last_updated": "01/01/2026"
+    },
+    {
+      "sku": "ESCURREESACQ",
+      "name": "ESCURREPLATOS ESAC Q71",
+      "category": "accessory",
+      "price_ars": 166000.0,
+      "currency": "ARS",
+      "price_includes_vat": false,
+      "sold_by_dangelo": true,
+      "sink_type": null,
+      "last_updated": "01/01/2026"
+    }
+  ]
+}

--- a/docs/handoff-context/catalog/stock.json
+++ b/docs/handoff-context/catalog/stock.json
@@ -1,0 +1,80 @@
+{
+  "_metadata": {
+    "descripcion": "Inventario de stock de retazos en taller D'Angelo",
+    "uso": "Consultar antes de cotizar para: 1) ofrecer materiales disponibles primero, 2) verificar si el trabajo entra en algún retazo (sin merma). Si en_stock=true y el trabajo entra en m2_total → no aplica merma.",
+    "fuente": "Excel taller D'Angelo — actualizar manualmente cuando cambia el stock",
+    "nota": "Las piezas son retazos de chapas anteriores. Verificar disponibilidad antes de confirmar al cliente."
+  },
+  "stock": [
+    {
+      "nombre": "DEKTON AURA 12MM",
+      "piezas": [
+        {
+          "largo": "1.07",
+          "ancho": "0.73",
+          "m2": 0.78
+        },
+        {
+          "largo": "1.94",
+          "ancho": "0.65",
+          "m2": 1.26
+        }
+      ],
+      "en_stock": true,
+      "m2_total": 2.04
+    },
+    {
+      "nombre": "SILESTONE BLANCO ZEUS 20MM",
+      "piezas": [
+        {
+          "largo": "1.20",
+          "ancho": "0.60",
+          "m2": 0.72
+        }
+      ],
+      "en_stock": true,
+      "m2_total": 0.72
+    },
+    {
+      "nombre": "GRANITO NEGRO ABSOLUTO 20MM",
+      "piezas": [
+        {
+          "largo": "0.85",
+          "ancho": "0.50",
+          "m2": 0.43
+        },
+        {
+          "largo": "1.10",
+          "ancho": "0.40",
+          "m2": 0.44
+        }
+      ],
+      "en_stock": true,
+      "m2_total": 0.87
+    },
+    {
+      "nombre": "PURASTONE BLANCO PALOMA 20MM",
+      "piezas": [
+        {
+          "largo": "2.00",
+          "ancho": "0.60",
+          "m2": 1.2
+        }
+      ],
+      "en_stock": true,
+      "m2_total": 1.2
+    },
+    {
+      "nombre": "MARMOL CARRARA 20MM",
+      "piezas": [
+        {
+          "largo": "0.95",
+          "ancho": "0.55",
+          "m2": 0.52
+        }
+      ],
+      "en_stock": false,
+      "m2_total": 0.0
+    }
+  ]
+}

--- a/docs/handoff-context/endpoints-spec.md
+++ b/docs/handoff-context/endpoints-spec.md
@@ -1,0 +1,1750 @@
+# Endpoints Spec · Marble Operator Backend
+
+> **Fuente:** código backend real (`api/app/modules/*/router.py`).
+> **Derivado de:** auditoría manual de los routers de FastAPI commit `1915317` (branch `sprint-1.5/master-handoff`).
+> **Última actualización:** 2026-05-05 (PR `sprint-1.5/extract-api-contracts`).
+>
+> **Audiencia:** frontend Sprint 2-5. Mockear contra estos contratos. Cuando el switch a backend real ocurra (Sprint 3 inicial), los hooks `useApiClient()` consumen estos paths sin cambios al frontend.
+>
+> **Convención de tipos:** TypeScript-flavored. Copiables directo a `web/src/lib/types.ts`.
+
+---
+
+## Conventions globales
+
+### Auth
+
+Tres mecanismos según endpoint:
+
+| Mecanismo | Cómo se manda | Cuándo aplica |
+|---|---|---|
+| **Cookie** `auth_token` | `httpOnly`, `Secure` (prod), `SameSite=None` (cross-origin Vercel→Railway) | Default de operator panel — todos los `/api/*` salvo excepciones |
+| **Bearer header** | `Authorization: Bearer <jwt>` | Fallback cuando la cookie cross-origin no viaja (ej. iOS Safari con ITP). Cookie tiene precedencia si ambas presentes. |
+| **API Key** | Header `X-API-Key: <key>` | Solo `/api/v1/quote*` y `/api/v1/business-rules` (bot externo). Si `QUOTE_API_KEY` env vacío en dev → check skipeado. |
+| **Sin auth** | — | `/health` y `/api/auth/login` |
+
+**Sliding refresh:** cuando al token le quedan <24h, las requests autenticadas devuelven un nuevo JWT en `X-Refreshed-Token` header (además de un nuevo `Set-Cookie`). El cliente debe sincronizar `localStorage.setItem("dangelo:token", refreshed)` para mantener vivo el fallback Bearer.
+
+### Rate limits
+
+| Path | Límite | Por qué |
+|---|---|---|
+| `POST /api/auth/login` | 10 req/min por IP | Brute force |
+| `POST /api/quotes/{id}/chat` | 20 req/min por IP | Costo por turno de Valentina |
+
+Excedido → `429` con `{"detail": "Demasiados intentos..."}`.
+
+### Errors comunes
+
+Todos los endpoints autenticados pueden devolver:
+
+- `401 {"detail": "No autenticado"}` — sin token
+- `401 {"detail": "Sesión expirada"}` — token inválido/expirado
+- `429 {"detail": "Demasiados intentos. Esperá un minuto."}` — rate limit
+- `500 {"detail": "..."}` — bug interno (ver audit log)
+
+### Status enum
+
+`QuoteStatus` valores:
+
+```ts
+type QuoteStatus = "draft" | "pending" | "validated" | "sent";
+```
+
+Transiciones válidas:
+
+| Desde | Hacia |
+|---|---|
+| `draft` | `validated`, `pending` |
+| `pending` | `validated`, `draft` |
+| `validated` | `sent`, `draft` |
+| `sent` | `validated` |
+
+Cualquier otra transición → `400 {"detail": "Transición inválida: X → Y"}`.
+
+### Cifras canónicas en ejemplos
+
+Los ejemplos de response usan el case **Cueto-Heredia** (Master §13):
+
+- Quote: `PRES-2026-018` · Silestone Blanco Norte · 6,50 m² · USD 1.538 + ARS 660.890
+- Arquitecta: `CUETO-HEREDIA ARQUITECTAS` (5% descuento sobre material importado)
+- MO SKUs: `COLOCACION` ($49.698 base), `PEGADOPILETA` ($53.840), `ANAFE` ($35.617), `REGRUESO` ($13.810), `TOMAS` ($6.461)
+- Flete: `Rosario` → `ENVIOROS` ($62.920 c/IVA)
+
+---
+
+## Flow 1 · Auth
+
+### `POST /api/auth/login` — público
+
+Login con username/password. Setea cookie + devuelve JWT en body.
+
+**Auth:** ninguna · **Rate limit:** 10/min/IP
+
+**Request body:**
+
+```ts
+interface LoginRequest {
+  username: string;  // se trimean leading/trailing spaces server-side
+  password: string;
+}
+```
+
+**Response 200:**
+
+```ts
+interface LoginResponse {
+  ok: true;
+  username: string;
+  token: string;  // JWT — guardar en localStorage como fallback Bearer
+}
+```
+
+**Side effects:**
+- `Set-Cookie: auth_token=<jwt>; HttpOnly; Secure; SameSite=None; Max-Age=259200` (72h)
+
+**Errores:**
+- `401 {"detail": "Usuario o contraseña incorrectos"}` — credenciales inválidas
+- `429` — rate limit
+
+---
+
+### `POST /api/auth/logout`
+
+Limpia la cookie. No invalida el token server-side (los JWTs son stateless).
+
+**Auth:** Cookie
+
+**Response 200:**
+
+```ts
+interface LogoutResponse { ok: true; }
+```
+
+---
+
+### `POST /api/auth/create-user`
+
+Crea usuario. Sin auth si no hay usuarios todavía (setup inicial). Después requiere JWT válido.
+
+**Auth:** condicional (sin auth solo para el primer usuario)
+
+**Request body:**
+
+```ts
+interface CreateUserRequest {
+  username: string;
+  password: string;  // min 6 chars
+}
+```
+
+**Response 200:**
+
+```ts
+interface CreateUserResponse {
+  ok: true;
+  id: string;       // UUID
+  username: string;
+}
+```
+
+**Errores:**
+- `400 {"detail": "El usuario 'X' ya existe"}` — username repetido
+- `400 {"detail": "La contraseña debe tener al menos 6 caracteres"}`
+- `401 {"detail": "No autenticado"}` — post-setup sin token
+
+---
+
+### `GET /api/auth/users`
+
+Lista todos los usuarios (sin passwords).
+
+**Auth:** Cookie
+
+**Response 200:**
+
+```ts
+type UsersResponse = Array<{
+  id: string;
+  username: string;
+  created_at: string | null;  // ISO datetime
+}>;
+```
+
+---
+
+### `DELETE /api/auth/users/{user_id}`
+
+Elimina un usuario. Bloqueado si es el único.
+
+**Auth:** Cookie
+
+**Response 200:** `{ ok: true }`
+
+**Errores:**
+- `400 {"detail": "No se puede eliminar el ultimo usuario"}`
+- `404 {"detail": "Usuario no encontrado"}`
+
+---
+
+## Flow 2 · Quotes — lifecycle
+
+Cubre creación, listado, detalle, edición, eliminación, polling.
+
+### `POST /api/quotes`
+
+Crea un quote vacío en `status=draft` (default). El operador después agrega cliente/proyecto/material vía PATCH o vía chat con Valentina.
+
+**Auth:** Cookie
+
+**Request body** (opcional):
+
+```ts
+interface CreateQuoteRequest {
+  status?: "draft" | "pending";  // default "draft"
+}
+```
+
+**Response 200:**
+
+```ts
+interface CreateQuoteResponse {
+  id: string;  // UUID
+}
+```
+
+**Side effects:**
+- Trigger `cleanup_empty_drafts()` async (limpia drafts > 1h sin client_name)
+- Audit event `quote.created`
+
+---
+
+### `GET /api/quotes`
+
+Lista quotes con paginación. Excluye drafts vacíos (sin `client_name`) y excluye `building_child_material` (viven dentro del padre).
+
+**Auth:** Cookie
+
+**Query params:**
+
+```ts
+interface ListQuotesQuery {
+  limit?: number;   // 1-200, default 100
+  offset?: number;  // >= 0, default 0
+}
+```
+
+**Response 200:**
+
+```ts
+type ListQuotesResponse = QuoteListItem[];
+
+interface QuoteListItem {
+  id: string;
+  client_name: string;
+  project: string;
+  material: string | null;
+  total_ars: number | null;
+  total_usd: number | null;
+  status: QuoteStatus;
+  pdf_url: string | null;
+  excel_url: string | null;
+  drive_url: string | null;
+  drive_pdf_url: string | null;
+  drive_excel_url: string | null;
+  parent_quote_id: string | null;
+  quote_kind: "standard" | "building_parent" | "building_child_material" | "variant_option" | null;
+  is_building: boolean;
+  comparison_group_id: string | null;
+  source: "operator" | "web" | null;
+  is_read: boolean;
+  client_phone: string | null;
+  client_email: string | null;
+  localidad: string | null;
+  colocacion: boolean | null;
+  pileta: PiletaType | null;
+  sink_type: SinkType | null;
+  anafe: boolean | null;
+  pieces: PieceInput[] | null;
+  conversation_id: string | null;
+  notes: string | null;
+  created_at: string;  // ISO datetime
+}
+
+type PiletaType = "empotrada_cliente" | "empotrada_johnson" | "apoyo";
+
+interface SinkType {
+  basin_count: "simple" | "doble";
+  mount_type: "arriba" | "abajo";
+}
+
+interface PieceInput {
+  description: string;        // max 200 chars
+  largo: number;              // > 0, <= 20 (m)
+  prof?: number | null;       // > 0, <= 5 (m) — para mesadas
+  alto?: number | null;       // > 0, <= 5 (m) — para zócalos/alzas
+}
+```
+
+Sort: `created_at DESC`.
+
+---
+
+### `GET /api/quotes/check`
+
+Polling liviano. Devuelve count + último `updated_at` para que el cliente sepa si hay cambios sin cargar la lista completa.
+
+**Auth:** Cookie
+
+**Response 200:**
+
+```ts
+interface CheckQuotesResponse {
+  count: number;
+  last_updated_at: string | null;  // ISO datetime
+}
+```
+
+**Uso típico:** `setInterval(checkQuotes, 15_000)` + comparar contra estado anterior. Si cambió, re-fetch `GET /quotes`.
+
+---
+
+### `GET /api/quotes/{quote_id}`
+
+Detalle del quote. Incluye `quote_breakdown` (JSON con todo el cálculo), `messages` (chat history), `source_files`, y campos derivados (`pdf_outdated`).
+
+**Auth:** Cookie
+
+**Response 200:**
+
+```ts
+interface QuoteDetailResponse extends QuoteListItem {
+  messages: ChatMessage[];
+  quote_breakdown: QuoteBreakdown | null;
+  source_files: SourceFile[] | null;
+  resumen_obra: ResumenObra | null;
+  email_draft: EmailDraft | null;
+  condiciones_pdf: CondicionesPdf | null;  // solo edificios
+  web_input: object | null;  // raw body POST /v1/quote (solo source="web")
+  pdf_outdated: boolean | null;  // true si edits posteriores al último regenerate
+  pdf_generated_at: string | null;  // ISO datetime del último PDF generado
+  // Si quote_kind === "building_parent":
+  children?: QuoteListItem[];
+}
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string | ContentBlock[];  // string para texto simple, array para multimodal
+}
+
+interface SourceFile {
+  filename: string;
+  type: string;          // MIME type
+  size: number;          // bytes
+  url: string;           // /files/{quote_id}/sources/{filename}
+  uploaded_at: string;   // ISO datetime
+  drive_file_id?: string;
+  drive_url?: string;
+  drive_download_url?: string;
+}
+
+// Ver schemas/quote.md para QuoteBreakdown completo
+```
+
+**Errores:**
+- `404 {"detail": "Presupuesto no encontrado"}`
+
+---
+
+### `PATCH /api/quotes/{quote_id}`
+
+Editar campos del quote. Todos opcionales — solo se actualizan los que vienen con valor no-null. Side effect: si tocás campos espejados en `quote_breakdown` (client_name, project, localidad, colocacion, pileta, anafe, material), también se sincronizan ahí.
+
+**Auth:** Cookie
+
+**Request body:**
+
+```ts
+interface QuotePatchRequest {
+  status?: QuoteStatus;
+  client_name?: string;       // max 500
+  client_phone?: string;      // max 100
+  client_email?: string;      // max 200
+  project?: string;           // max 500
+  material?: string | string[];
+  pieces?: PatchPieceInput[];
+  localidad?: string;         // max 200
+  colocacion?: boolean;
+  pileta?: string;            // max 50
+  sink_type?: SinkType;
+  anafe?: boolean;
+  conversation_id?: string;   // max 100
+  origin?: "web" | "operator";  // se renombra a `source` server-side
+  notes?: string;
+  parent_quote_id?: string;   // max 200
+  delivery_days?: string;     // max 200 — vive en quote_breakdown.delivery_days, NO columna
+}
+
+interface PatchPieceInput {
+  description: string;  // max 200
+  largo: number;        // > 0, <= 20
+  prof?: number;        // > 0, <= 5
+  alto?: number;        // > 0, <= 5
+}
+```
+
+**Response 200:**
+
+```ts
+interface PatchQuoteResponse {
+  ok: true;
+  updated: string[];  // lista de field names que se actualizaron
+}
+```
+
+**Side effects:**
+- Audit event `quote.patched` con `payload.fields = [updated keys]` (sanitizer redacta phone/email).
+
+**Errores:**
+- `400 {"detail": "No valid fields to update"}` — body vacío
+- `404 {"detail": "Quote not found"}`
+
+---
+
+### `PATCH /api/quotes/{quote_id}/status`
+
+Cambia status validando transiciones.
+
+**Auth:** Cookie
+
+**Request body:**
+
+```ts
+interface StatusUpdateRequest {
+  status: QuoteStatus;
+}
+```
+
+**Response 200:** `{ ok: true }`
+
+**Side effects:**
+- Audit event `quote.status_changed`
+
+**Errores:**
+- `400 {"detail": "Transición inválida: draft → sent"}` — ver tabla de transiciones
+- `404`
+
+---
+
+### `PATCH /api/quotes/{quote_id}/read`
+
+Marca el quote como leído (`is_read = true`).
+
+**Auth:** Cookie
+
+**Response 200:** `{ ok: true }`
+
+---
+
+### `DELETE /api/quotes/{quote_id}`
+
+**Cascade delete** de la familia entera (root + children). Mejor effort en Drive (no bloquea si falla).
+
+**Auth:** Cookie
+
+**Response 200:**
+
+```ts
+interface DeleteQuoteResponse {
+  ok: true;
+  deleted: string[];  // IDs eliminados (incluye children del building parent)
+}
+```
+
+**Side effects:**
+- Resuelve `root_id` desde `parent_quote_id || quote_id`
+- Borra todos los quotes con `id == root_id` o `parent_quote_id == root_id`
+- Best-effort: borra Drive files (`drive_file_id`) y `OUTPUT_DIR/{quote_id}/`
+
+**Errores:**
+- `404 {"detail": "Presupuesto no encontrado"}`
+
+---
+
+## Flow 3 · Brief upload (Paso 1 — Master §6)
+
+**No hay endpoint dedicado para "subir brief".** El brief (PDF + fotos + textarea) se manda **dentro del primer turno del chat** vía `POST /quotes/{id}/chat` con multipart. Ver Flow 5.
+
+Flujo típico para Paso 1 del mockup:
+
+1. `POST /api/quotes` → obtener `quote_id`
+2. `POST /api/quotes/{id}/chat` con `message=<brief textarea>` + `plan_files=[plano.pdf, foto1.jpg, foto2.jpg]` (multipart)
+3. SSE response stream del agente — ver Flow 5
+
+Ver `missing-endpoints.md` para discusión sobre si conviene crear `POST /api/quotes/{id}/brief` dedicado.
+
+---
+
+## Flow 4 · Contexto (Paso 2 — Master §6)
+
+**No hay endpoint dedicado** ni schema dedicado para los "11 campos del contexto". El contexto vive **dentro de `quote_breakdown` JSON** del quote. Los campos se setean:
+
+1. **Por Valentina** durante el chat — emite `dual_read_result` (despiece) y `context_analysis` (cards) que persisten en `quote_breakdown`
+2. **Por el operador** vía `PATCH /api/quotes/{id}` — setea client_name, project, localidad, colocacion, pileta, sink_type, anafe directo en columnas (con mirror al breakdown)
+3. **Por el chat** cuando el operador escribe `[CONTEXT_CONFIRMED]` o `[DUAL_READ_CONFIRMED]` (markers de confirmación)
+
+Ver `schemas/context.md` para el detalle del shape esperado en `quote_breakdown`.
+
+### `POST /api/quotes/{quote_id}/reopen-context`
+
+Vuelve al estado pre-confirmación de contexto (Master §15: feature backend implementada). Limpia Paso 2 + corta `messages` desde la card `__CONTEXT_ANALYSIS__`. Bloqueado en `validated`/`sent`.
+
+**Auth:** Cookie
+
+**Response 200:** `QuoteDetailResponse` (ver Flow 2)
+
+**Side effects:**
+- Limpia `verified_context_analysis`, `verified_context`, `verified_measurements` del breakdown
+- Preserva `dual_read_result`, `context_analysis_pending`, `brief_analysis`
+- Quita tramos `_derived: true` del `dual_read_result`
+- `total_ars`, `total_usd` → null
+- Audit event `quote.reopened` con `payload.kind = "context"`
+
+**Errores:**
+- `400 {"detail": "No hay confirmación de contexto que reabrir..."}` — idempotencia
+- `404`
+- `409 {"detail": "El presupuesto está en estado 'X'. No se puede reabrir..."}` — status validated/sent
+
+---
+
+## Flow 5 · Despiece + Cálculo (Pasos 3-4 — Master §6)
+
+El despiece y cálculo viven dentro del **chat con Valentina** (SSE). Las tools del agente que se invocan son:
+
+- `list_pieces` — Paso 1 backend Valentina (pre-cálculo)
+- `calculate_quote` — Paso 2 backend Valentina (determinístico)
+
+Estas NO se exponen como REST. El frontend dispara el chat y consume eventos SSE — ver `sse-spec.md`.
+
+### `POST /api/quotes/{quote_id}/chat` — SSE streaming
+
+Punto único de interacción con Valentina. El operador manda mensaje + (opcionalmente) archivos. El backend stream eventos vía Server-Sent Events.
+
+**Auth:** Cookie · **Rate limit:** 20/min/IP · **Content-Type:** `multipart/form-data`
+
+**Form fields:**
+
+| Field | Tipo | Required | Descripción |
+|---|---|---|---|
+| `message` | string | Sí | Texto del operador (puede contener markers como `[DUAL_READ_CONFIRMED]`, `[CONTEXT_CONFIRMED]`, `[SYSTEM_TRIGGER:*]`) |
+| `plan_files` | file[] | No | Hasta **10** archivos. PDF, JPEG, PNG, WEBP. Max **10MB** c/u. PDFs deben ser **1 página** (multi-page → 400 explícito). |
+
+**Response:** `text/event-stream` (SSE).
+
+```
+HTTP/1.1 200 OK
+Content-Type: text/event-stream
+Cache-Control: no-cache
+X-Accel-Buffering: no
+Connection: keep-alive
+
+data: {"type": "text", "content": "Voy a ver el plano…"}
+
+data: {"type": "action", "content": "⚙️ Ejecutando: catalog_batch_lookup..."}
+
+data: {"type": "dual_read_result", "content": "...", "data": {...}}
+
+data: {"type": "done", "content": ""}
+```
+
+Ver **`sse-spec.md`** para la spec completa de event types + payload shapes + reconexión.
+
+**Pre-flight checks** (server hace antes de iniciar el stream):
+
+1. **Budget gate:** si el gasto mensual de Anthropic supera `monthly_budget_usd` del config y `enable_hard_limit=true` → `429`
+2. **File validation:** size, mime, count
+3. **Multi-page PDF:** `_pdf.pages > 1` → respuesta corta SSE con mensaje "solo planos de 1 página por ahora"
+4. **Quote exists:** `404` si no
+
+**Errores HTTP (antes de empezar el stream):**
+- `400 "Máximo 10 archivos por mensaje"`
+- `400 "<filename> — tipo no soportado..."`
+- `400 "<filename> — excede 10MB..."`
+- `404 "Presupuesto no encontrado"`
+- `429 "Límite mensual de API alcanzado..."`
+- `429` rate limit
+
+**Side effects:**
+- Audit `chat.message_sent` (con `debug_only_payload.message_text` si modo debug global activo)
+- Archivos guardados en `OUTPUT_DIR/{quote_id}/sources/<filename>` + uploaded a Drive (best-effort, "Archivos Origen" subfolder)
+- Si llega un plano nuevo: invalida `dual_read_result`, `verified_measurements`, `verified_context` etc del breakdown
+- Si **no** llega archivo y existen `source_files` previos: el plano se **restaura** desde disco para que Valentina siempre tenga acceso
+
+---
+
+## Flow 6 · Validación + PDF/Excel (Paso 5 — Master §6)
+
+Tres endpoints relacionados:
+
+### `POST /api/quotes/{quote_id}/validate`
+
+Genera PDF + Excel + sube a Drive + cambia `status` a `validated`. Requiere `quote_breakdown` previo.
+
+**Auth:** Cookie
+
+**Response 200:**
+
+```ts
+interface ValidateQuoteResponse {
+  ok: true;
+  pdf_url: string | null;     // /files/{quote_id}/<filename>.pdf
+  excel_url: string | null;
+  drive_url: string | null;
+}
+```
+
+**Side effects:**
+- Si existía `drive_file_id` previo: lo borra antes de subir el nuevo
+- Si Drive upload falla, preserva `drive_url` previo (no sobrescribe con `null`)
+
+**Errores:**
+- `400 {"detail": "El presupuesto no tiene desglose calculado"}` — sin breakdown
+- `404`
+
+---
+
+### `POST /api/quotes/{quote_id}/regenerate`
+
+Re-emite PDF + Excel **sin recalcular**. No toca `status`, `client_name`, `project`, `totales`, `quote_breakdown`. Solo actualiza file URLs y appendea a `change_history`.
+
+**Auth:** Cookie
+
+**Response 200:**
+
+```ts
+interface RegenerateResponse {
+  ok: true;
+  pdf_url: string | null;
+  excel_url: string | null;
+  drive_url: string | null;
+  regenerated_at: string;  // ISO datetime
+}
+```
+
+**Side effects:**
+- Re-toma campos editables del Quote columns (client_name, project, notes) por si fueron PATCH-eados sin regenerar
+- Borra archivos Drive viejos (mejor effort)
+- Sube PDF + Excel **separados** a Drive (cada uno con su `drive_url`)
+- Append a `change_history` con `{action: "regenerate_docs", timestamp, ...}`
+- Audit `docs.regenerated` (con `success=false` si Drive partial-fail)
+
+**Errores:**
+- `400 {"detail": "El presupuesto no tiene desglose calculado..."}`
+- `404`
+- `500 {"detail": "Falló la generación de documentos: <error>"}`
+
+**Caso de uso:** corregiste un bug en el template Excel (formato, SKU mal). Querés regenerar archivos sin tocar nada del negocio.
+
+---
+
+### `POST /api/quotes/{quote_id}/generate`
+
+Genera PDF + Excel + sube a Drive **para quotes web sin documentos**. Setea `status = validated`.
+
+**Auth:** Cookie
+
+**Response 200:**
+
+```ts
+interface GenerateResponse {
+  ok: true;
+  pdf_url: string | null;
+  excel_url: string | null;
+  drive_url: string | null;
+}
+```
+
+**Diferencia con `/validate`:** este endpoint es para quotes que llegaron de `/api/v1/quote` (web bot) y nunca tuvieron docs. Pensar en él como "validate para web flow" — semánticamente equivalente pero el frontend lo llama desde el preview del quote web.
+
+**Errores:**
+- `400 {"detail": "Este presupuesto no tiene datos de cálculo (quote_breakdown)"}`
+- `404`
+- `500 {"detail": "<doc gen error>"}`
+
+---
+
+## Flow 7 · Reopen + Rehydrate
+
+Endpoints para volver a un step previo o reparar quotes legacy.
+
+### `POST /api/quotes/{quote_id}/reopen-measurements`
+
+Vuelve a Paso 1 editable (PR #378). Limpia Paso 2 + MO + totales. Bloqueado en `validated`/`sent`.
+
+**Auth:** Cookie
+
+**Response 200:** `QuoteDetailResponse`
+
+**Side effects:**
+- Promueve `verified_measurements` → `dual_read_result` (preserva edits del operador)
+- Trunca `messages` desde el último `__DUAL_READ__` y regenera la card con el despiece actualizado
+- `total_ars`, `total_usd` → null
+- Audit `quote.reopened` con `payload.kind = "measurements"`
+
+**Errores:**
+- `400 {"detail": "No hay confirmación de medidas que reabrir..."}`
+- `404`
+- `409 {"detail": "El presupuesto está en estado '<x>'. No se puede reabrir edición..."}`
+
+---
+
+### `POST /api/quotes/{quote_id}/rehydrate-history`
+
+Repara quotes viejos cuyo `messages` tiene placeholders `_SHOWN_` vacíos, bloques internos del system prompt mezclados, o fake turns. **Idempotente** — si está limpio, `changed=false` y no UPDATE.
+
+**Auth:** Cookie
+
+**Response 200:**
+
+```ts
+interface RehydrateResponse {
+  changed: boolean;
+  before_count: number;
+  after_count: number;
+  // + más campos diagnósticos
+}
+```
+
+**Uso típico:** operador abre quote pre-PR #380 y ve markers crudos. Llama este endpoint manualmente o vía un botón de admin.
+
+---
+
+## Flow 8 · Comparación (variantes)
+
+### `GET /api/quotes/{quote_id}/compare`
+
+Devuelve quote raíz + todos sus children/variants para comparación side-by-side. Mínimo 2 quotes para comparar.
+
+**Auth:** Cookie
+
+**Response 200:**
+
+```ts
+interface CompareQuotesResponse {
+  parent_id: string;
+  client_name: string;
+  project: string;
+  quotes: QuoteCompareItem[];
+}
+
+interface QuoteCompareItem {
+  id: string;
+  material: string | null;
+  total_ars: number | null;
+  total_usd: number | null;
+  status: QuoteStatus;
+  pdf_url: string | null;
+  excel_url: string | null;
+  drive_url: string | null;
+  quote_breakdown: QuoteBreakdown | null;
+}
+```
+
+**Errores:**
+- `404 {"detail": "Presupuesto no encontrado"}`
+- `404 {"detail": "Presupuesto padre no encontrado"}`
+- `404 {"detail": "No hay variantes para comparar"}` — solo 1 quote en la familia
+
+---
+
+### `GET /api/quotes/{quote_id}/compare/pdf`
+
+Genera y descarga un PDF comparativo side-by-side de todas las variantes.
+
+**Auth:** Cookie
+
+**Response 200:**
+- `Content-Type: application/pdf`
+- `Content-Disposition: attachment; filename="Comparativo - <client_name>.pdf"`
+- Body: bytes del PDF
+
+**Errores:**
+- `404` (mismo que `/compare`)
+
+---
+
+### `POST /api/quotes/{quote_id}/derive-material`
+
+Crea un quote NUEVO derivado del original con otro material. Copia client/pieces/options, recalcula todo. Status: `draft`. Sin docs.
+
+**Auth:** Cookie
+
+**Request body:**
+
+```ts
+interface DeriveMaterialRequest {
+  material: string;              // min 1, max 500
+  thickness_mm?: number;         // 1-100, opcional
+}
+```
+
+**Response 200:**
+
+```ts
+interface DeriveMaterialResponse {
+  ok: true;
+  quote_id: string;             // ID del nuevo quote
+  material: string;
+  total_ars: number;
+  total_usd: number;
+  derived_from: string;         // ID del original
+}
+```
+
+**Side effects:**
+- `parent_quote_id` del nuevo apunta al original (o al root si el original ya tenía parent)
+- `messages = []`, `change_history = []` — chat limpio en el derive
+- `conversation_id` NO se copia
+
+**Errores:**
+- `400 {"detail": "El presupuesto original no tiene piezas. No se puede derivar."}`
+- `400 {"detail": "Error al calcular con material 'X': <reason>"}` — material no encontrado, etc.
+- `404 {"detail": "Presupuesto original no encontrado"}`
+
+---
+
+## Flow 9 · Email draft + Resumen Obra
+
+### `GET /api/quotes/{quote_id}/email-draft`
+
+Borrador de email comercial generado por IA. Lazy cache — regenera solo si hay invalidación (cambio en quote, sibling, o resumen_obra).
+
+**Auth:** Cookie
+
+**Response 200:**
+
+```ts
+interface EmailDraft {
+  subject: string;
+  body: string;
+  generated_at: string;  // ISO datetime
+  validated: boolean;    // operador marcó como OK
+  // snapshots de updated_at usados para invalidación de cache
+  quote_updated_at_snapshot: string;
+  resumen_updated_at_snapshot: string | null;
+  sibling_updated_at_snapshots: Record<string, string>;
+}
+```
+
+**Errores:**
+- Códigos custom desde `EmailDraftError` — el backend mapea a HTTP status. 404, 400, 500 según el caso.
+
+---
+
+### `POST /api/quotes/{quote_id}/email-draft/regenerate`
+
+Fuerza regeneración del draft, bypass del cache.
+
+**Auth:** Cookie
+
+**Response 200:** `EmailDraft` (ver arriba)
+
+---
+
+### `POST /api/quotes/resumen-obra`
+
+Genera PDF de "resumen de obra" consolidado de N quotes del mismo cliente. Persiste el record en cada quote seleccionado.
+
+**Auth:** Cookie
+
+**Request body:**
+
+```ts
+interface ResumenObraRequest {
+  quote_ids: string[];        // 1 <= N <= 20
+  notes?: string;             // max 1000 chars
+  force_same_client?: boolean; // bypass de la validación de "mismo cliente"
+}
+```
+
+**Response 200:**
+
+```ts
+interface ResumenObraRecord {
+  pdf_url: string;
+  drive_url: string | null;
+  drive_file_id?: string | null;
+  notes: string;
+  generated_at: string;       // ISO datetime
+  quote_ids: string[];
+  client_name: string;
+  project: string;
+}
+```
+
+**Validaciones:**
+- Mismo `client_name` en todos los quotes (a menos que `force_same_client`)
+- Todos en `validated`
+- 1 <= N <= 20
+- `notes` <= 1000 chars
+
+**Side effects:**
+- Persiste `resumen_obra` en cada quote del set
+- Invalida `email_draft` cache de cada quote (regen on next GET)
+
+**Errores:**
+- Custom desde `ResumenObraError` con status correspondiente
+
+---
+
+### `POST /api/quotes/client-match-check`
+
+Preview: ¿estos quotes son del mismo cliente? Sirve al frontend para decidir si mostrar diálogo de confirmación antes de POST a `/resumen-obra`.
+
+**Auth:** Cookie
+
+**Request body:**
+
+```ts
+interface ClientMatchCheckRequest {
+  quote_ids: string[];
+}
+```
+
+**Response 200:**
+
+```ts
+interface ClientMatchCheckResponse {
+  same: boolean;
+  reason: "exact" | "fuzzy" | "ambiguous";
+  distinct_names: string[];
+}
+```
+
+**Errores:**
+- `400 {"detail": "quote_ids vacío"}`
+- `404 {"detail": "Presupuestos no encontrados: [...]"}`
+
+---
+
+### `POST /api/quotes/merge-client`
+
+Renombra `client_name` de N quotes a un único valor canónico. Para unificar duplicados después de confirmar.
+
+**Auth:** Cookie
+
+**Request body:**
+
+```ts
+interface MergeClientRequest {
+  quote_ids: string[];
+  canonical_client_name: string;  // 1-500 chars
+}
+```
+
+**Response 200:**
+
+```ts
+interface MergeClientResponse {
+  ok: true;
+  updated_ids: string[];      // los que efectivamente cambiaron
+  client_name: string;
+  quote_ids: string[];
+}
+```
+
+**Side effects:**
+- Invalida `email_draft` de los quotes (los names afectan el prompt)
+
+**Errores:**
+- `400 {"detail": "canonical_client_name requerido"}` / `"demasiado largo"` / `"quote_ids vacío"`
+- `404 {"detail": "Presupuestos no encontrados: [...]"}`
+
+---
+
+## Flow 10 · Plan zone selection + Dual read retry
+
+### `POST /api/quotes/{quote_id}/zone-select`
+
+Recibe la selección de rectángulo del operador sobre una página del plano. Convierte bbox normalizado (0-1) a píxeles, persiste en `quote_breakdown.page_data` y `zone_default`.
+
+**Auth:** Cookie
+
+**Request body:**
+
+```ts
+interface ZoneSelectRequest {
+  bbox_normalized: { x1: number; y1: number; x2: number; y2: number };  // 0-1 range
+  page_num: number;  // default 1
+}
+```
+
+**Response 200:**
+
+```ts
+interface ZoneSelectResponse {
+  ok: true;
+  bbox_px: [number, number, number, number];  // [x1, y1, x2, y2] en píxeles
+  image_size: [number, number];                // [width, height]
+}
+```
+
+**Errores:**
+- `404 {"detail": "Quote not found"}`
+
+---
+
+### `POST /api/quotes/{quote_id}/dual-read-retry`
+
+Operador-triggered. Cuando las medidas del despiece no coinciden con el plano, el frontend ofrece "Las medidas no coinciden" → este endpoint llama a Opus directamente sobre el crop guardado y reconcilia con el resultado Sonnet previo.
+
+**Auth:** Cookie · **Timeout largo** (Opus vision toma 60-120s)
+
+**Response 200:**
+
+```ts
+interface DualReadRetryResponse {
+  // Mismo shape que dual_read_result en el chat SSE — ver sse-spec.md
+  source: "DUAL" | "SOLO_OPUS";
+  sectores: SectorDualRead[];
+  m2_warning?: string;
+  opus_error?: string;  // si Opus falló: card previa de Sonnet intacta + flag
+  _retry: true;
+  _crop_path: string;
+}
+```
+
+**Errores:**
+- `400 {"detail": "No prior dual read result found"}` — no hay despiece previo
+- `400 {"detail": "Crop not saved — cannot retry"}` — falta el crop en disco
+- `400 {"detail": "Crop file missing on disk"}`
+- `404`
+
+---
+
+## Flow 11 · Files
+
+### `GET /files/{file_path}`
+
+Sirve archivos generados (PDFs, Excel, planos, sources). Resuelve a `OUTPUT_DIR/{file_path}` con protección path-traversal. Si el archivo NO está en disco local pero existe registro en `files_v2` con `drive_url` → redirect 302 a Drive (fallback para Railway con filesystem efímero).
+
+**Auth:** Cookie
+
+**Response 200:** bytes del archivo + `Content-Type` inferido por extensión.
+**Response 302:** redirect a Drive download URL.
+
+**Errores:**
+- `403 "Acceso denegado"` — path traversal detectado
+- `404 "Archivo no encontrado"`
+
+**Ejemplos:**
+- `GET /files/{quote_id}/<client> - <material> - <date>.pdf`
+- `GET /files/{quote_id}/<client> - <material> - <date>.xlsx`
+- `GET /files/{quote_id}/sources/plano.pdf`
+- `GET /files/{quote_id}/page_1.jpg` — render rasterizado del plano
+
+---
+
+## Flow 12 · Catalog management
+
+15 catálogos disponibles, identificados por `name`:
+
+```
+labor · delivery-zones · sinks · architects · config · stock
+materials-silestone · materials-purastone · materials-dekton ·
+materials-neolith · materials-puraprima · materials-laminatto ·
+materials-granito-nacional · materials-granito-importado · materials-marmol
+```
+
+### `GET /api/catalog/`
+
+Lista todos los catálogos con metadata.
+
+**Auth:** Cookie
+
+**Response 200:**
+
+```ts
+type ListCatalogsResponse = Array<{
+  name: string;
+  item_count: number;
+  last_updated: string | null;  // ISO datetime
+  size_kb?: number;
+}>;
+```
+
+---
+
+### `GET /api/catalog/{catalog_name}`
+
+Devuelve el contenido completo del catálogo (array u objeto JSON, según el tipo).
+
+**Auth:** Cookie
+
+**Response 200:** JSON literal del catálogo. Ver `catalog/*.json` en este directorio para el shape de cada uno.
+
+**Errores:**
+- `404 {"detail": "Catálogo no encontrado"}`
+
+---
+
+### `PUT /api/catalog/{catalog_name}`
+
+Actualiza el contenido de un catálogo. Crea backup `.bak` antes. Escritura atómica (temp file + rename).
+
+**Auth:** Cookie
+
+**Request body:**
+
+```ts
+interface CatalogUpdateRequest {
+  content: object | object[];  // Union[list, dict] — depende del catálogo
+}
+```
+
+**Response 200:**
+
+```ts
+interface CatalogUpdateResponse {
+  ok: true;
+  catalog: string;
+}
+```
+
+**Side effects:**
+- Invalida cache del catálogo en memoria
+- Si es `config`: invalida también `company_config` cache
+
+**Errores:**
+- `403 {"detail": "Catálogo no permitido"}` — name no está en `ALLOWED_CATALOGS`
+
+---
+
+### `POST /api/catalog/{catalog_name}/validate`
+
+Valida un body de catálogo SIN guardarlo. Detecta cambios de precio > 30% (warning, no bloqueante).
+
+**Auth:** Cookie
+
+**Request body:** mismo que `PUT`.
+
+**Response 200:**
+
+```ts
+interface CatalogValidateResponse {
+  valid: boolean;
+  warnings: Array<{
+    type: "warning" | "error";
+    sku?: string;
+    message: string;
+  }>;
+  item_count: number;
+}
+```
+
+---
+
+### `POST /api/catalog/import-preview`
+
+Sube un archivo de export Dux (`.xls`, `.xlsx`, `.csv`) → parsea → genera preview de cambios por catálogo. NO modifica nada.
+
+**Auth:** Cookie · **Content-Type:** `multipart/form-data`
+
+**Form fields:**
+- `file: UploadFile` — el export Dux
+
+**Response 200:** estructura de preview agrupada por catálogo (updated/new/missing/zero_price + warnings).
+
+**Errores:**
+- `400 {"detail": "Archivo sin nombre"}`
+- `400 {"detail": "Formato no soportado: <ext>..."}`
+- `400 {"detail": "Archivo vacío"}`
+
+---
+
+### `POST /api/catalog/import-apply`
+
+Aplica el import preview-eado. Side effects: actualiza catálogos + crea backup.
+
+**Auth:** Cookie · **Content-Type:** `multipart/form-data` (mismo file que preview)
+
+**Response 200:** `{ok: true, applied: {...}}`
+
+---
+
+### `GET /api/catalog/backups/{catalog_name}`
+
+Lista backups de un catálogo.
+
+**Auth:** Cookie
+
+**Response 200:** array de `{id, created_at, source_file, stats}`.
+
+---
+
+### `POST /api/catalog/backups/{backup_id}/restore`
+
+Restaura un backup específico.
+
+**Auth:** Cookie
+
+**Response 200:** `{ok: true, catalog: <name>}`
+
+---
+
+## Flow 13 · Observability (audit log)
+
+Endpoints **bajo `/api/admin/...`** — uso interno solamente. Marina no los ve, son para developers/operadores con sesión JWT.
+
+### `GET /api/admin/quotes/{quote_id}/audit`
+
+Timeline ascendente de eventos del quote (max 500).
+
+**Auth:** Cookie · **Rechaza API key** (solo JWT user)
+
+**Response 200:**
+
+```ts
+interface AuditTimelineResponse {
+  quote_id: string;
+  events: AuditEvent[];
+  coverage: {
+    first_event_date: string | null;     // ISO
+    has_events_for_quote: boolean;
+  };
+}
+
+// Ver schemas/audit_events.md para AuditEvent completo
+```
+
+---
+
+### `GET /api/admin/observability`
+
+Vista global de events con filtros + paginación.
+
+**Auth:** Cookie
+
+**Query params:**
+
+```ts
+interface GlobalAuditQuery {
+  event_type?: string;
+  actor?: string;
+  success?: boolean;
+  quote_id?: string;
+  source?: string;
+  from?: string;   // ISO datetime, alias del query param "from"
+  to?: string;     // ISO datetime, alias del query param "to"
+  limit?: number;  // 1-200, default 50
+  offset?: number; // default 0
+}
+```
+
+**Response 200:**
+
+```ts
+interface GlobalAuditResponse {
+  events: AuditEvent[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+```
+
+---
+
+### `GET /api/admin/observability/quotes`
+
+Vista agrupada por `quote_id` (para listing en `/admin/observability`). Cada row resume events del quote.
+
+**Auth:** Cookie
+
+**Query params:**
+
+```ts
+interface ObservabilityQuotesQuery {
+  q?: string;             // search en quote_id o client_name
+  actor?: string;
+  has_errors?: boolean;
+  has_debug?: boolean;
+  from?: string;          // ISO
+  to?: string;            // ISO
+  limit?: number;
+  offset?: number;
+}
+```
+
+**Response 200:**
+
+```ts
+interface ObservabilityQuotesResponse {
+  quotes: Array<{
+    quote_id: string;
+    client_name: string | null;
+    actor: string | null;          // primer actor del quote
+    events_count: number;
+    errors_count: number;
+    has_debug_payloads: boolean;
+    first_event_at: string;
+    last_event_at: string;
+  }>;
+  total: number;
+  limit: number;
+  offset: number;
+}
+```
+
+---
+
+### `GET /api/admin/audit/coverage`
+
+Devuelve `first_event_date` global (sirve para el empty state "audit log empezó el ...").
+
+**Auth:** Cookie
+
+**Response 200:**
+
+```ts
+interface AuditCoverageResponse {
+  first_event_date: string | null;  // ISO
+  total_events: number;
+}
+```
+
+---
+
+### `POST /api/admin/audit/cleanup`
+
+Retention manual. Lo invoca un Railway scheduled job con `curl POST`.
+
+**Auth:** Cookie
+
+**Query params:**
+
+```ts
+interface AuditCleanupQuery {
+  retention_days?: number;  // 1-3650, default 90
+}
+```
+
+**Response 200:**
+
+```ts
+interface AuditCleanupResponse {
+  rows_deleted: number;
+  retention_days: number;
+}
+```
+
+**Side effects:**
+- Loguea su propia ejecución como `audit.cleanup_run`
+
+---
+
+### `GET /api/admin/system-config/global-debug`
+
+Estado del modo debug global (Phase 2 observability — captura payloads grandes).
+
+**Auth:** Cookie · **Rechaza API key**
+
+**Response 200:**
+
+```ts
+interface GlobalDebugStatus {
+  enabled: boolean;
+  mode: "1h" | "end_of_day" | "manual" | null;
+  until: string | null;          // ISO
+  started_at: string | null;     // ISO
+  started_by: string | null;     // username
+  remaining_seconds: number | null;
+}
+```
+
+---
+
+### `POST /api/admin/system-config/global-debug`
+
+Activa/desactiva el modo debug global.
+
+**Auth:** Cookie · **Rechaza API key**
+
+**Request body:**
+
+```ts
+interface GlobalDebugToggleRequest {
+  mode: "1h" | "end_of_day" | "manual" | "off";
+}
+```
+
+**Response 200:** `GlobalDebugStatus`
+
+**Side effects:**
+- Audit `audit.global_debug_toggled` con previous_state + new_state
+
+**Errores:**
+- `400 {"detail": "Modo inválido: 'X'"}`
+- `403 {"detail": "Endpoint solo accesible con sesión JWT (API key rechazada)."}`
+
+---
+
+### `POST /api/admin/audit/global-debug-shutoff`
+
+Cron auto-shutoff del modo debug. Lo llama Railway scheduled job. Apaga si `until < NOW()` o si `manual + started_at > 24h`. Idempotente.
+
+**Auth:** Cookie
+
+**Response 200:**
+
+```ts
+interface GlobalDebugShutoffResponse {
+  apagados: number;
+  razones: { expired: number; manual_24h_cap: number; };
+}
+```
+
+**Side effects:**
+- Si apaga: audit `audit.global_debug_auto_disabled`
+- Siempre: audit `audit.global_debug_shutoff_run` (breadcrumb del cron)
+
+---
+
+## Flow 14 · Usage (token tracking)
+
+Tracking de gasto Anthropic API (Sonnet 4.5 + Opus 4.6).
+
+### `GET /api/usage/dashboard`
+
+Resumen del mes actual + alertas.
+
+**Auth:** Cookie
+
+**Response 200:**
+
+```ts
+interface UsageDashboardResponse {
+  month: string;             // "2026-05"
+  month_label: string;       // "May 2026"
+  spent_usd: number;         // round 4 decimals
+  limit_usd: number;
+  pct_used: number;          // 0-100
+  daily_avg: number;
+  daily_budget: number;
+  projected: number;         // proyectado a fin de mes
+  days_passed: number;
+  days_left: number;
+  requests: number;
+  alert: "ok" | "yellow" | "red" | "blocked";
+  enable_hard_limit: boolean;
+}
+```
+
+**Alertas:**
+- `ok`: < 80% del budget
+- `yellow`: >= 80%
+- `red`: proyectado > limit
+- `blocked`: spent >= limit (hard limit triggered)
+
+---
+
+### `GET /api/usage/daily`
+
+Breakdown diario últimos 30 días.
+
+**Auth:** Cookie
+
+**Response 200:**
+
+```ts
+type DailyUsageResponse = Array<{
+  date: string;             // "2026-05-04" (zona AR)
+  cost_usd: number;
+  requests: number;
+  input_tokens: number;
+  output_tokens: number;
+}>;
+```
+
+---
+
+### `PATCH /api/usage/budget`
+
+Actualiza el monthly budget limit en `config.json`.
+
+**Auth:** Cookie
+
+**Request body:**
+
+```ts
+interface BudgetUpdateRequest {
+  monthly_budget_usd?: number;
+  enable_hard_limit?: boolean;
+}
+```
+
+**Response 200:** `{ ok: true }`
+
+**Side effects:**
+- Persiste en `config.json` → `ai_engine` section
+- Invalida `_ai_config_cache`
+
+---
+
+## Flow 15 · API pública (web bot)
+
+### `POST /api/v1/quote`
+
+Endpoint público para crear quotes desde el chatbot externo. Auth via API key (no cookie).
+
+**Auth:** Header `X-API-Key: <key>` (skipeado si `QUOTE_API_KEY` env vacío en dev)
+
+**Request body:** `QuoteInput` — ver `schemas/brief.md` para shape completo. Resumen:
+
+```ts
+interface QuoteInput {
+  client_name: string;            // 1-200
+  project?: string;               // max 200, default ""
+  material: string | string[];
+  pieces?: PieceInput[] | null;   // null si manda notes en lugar de medidas estructuradas
+  localidad: string;              // 1-100
+  colocacion?: boolean;           // default true
+  pileta?: PiletaType;
+  sink_type?: SinkType;
+  pileta_sku?: string;            // max 64
+  anafe?: boolean;
+  frentin?: boolean;
+  pulido?: boolean;
+  skip_flete?: boolean;
+  plazo?: string;                 // 1-100, default desde config.json
+  discount_pct?: number;          // 0-100
+  date?: string;                  // DD/MM/YYYY
+  conversation?: object[];        // chat history del bot
+  notes?: string;                 // texto libre
+}
+```
+
+**Response 200:**
+
+```ts
+interface QuoteResponse {
+  ok: boolean;
+  quotes: QuoteResultItem[];     // 1 por cada material en la lista
+  error?: string;
+}
+
+interface QuoteResultItem {
+  quote_id: string;              // "web-<uuid>"
+  material: string;
+  material_m2: number;
+  material_price_unit: number;
+  material_currency: "USD" | "ARS";
+  material_total: number;
+  mo_items: Array<{
+    description: string;
+    quantity: number;
+    unit_price: number;
+    total: number;
+  }>;
+  total_ars: number;
+  total_usd: number;
+  merma: { aplica: boolean; desperdicio: number; sobrante_m2: number; motivo: string };
+  discount: { aplica: boolean; porcentaje: number; monto: number };
+  pdf_url: null;          // siempre null — operator valida via /validate
+  excel_url: null;
+  drive_url: null;
+}
+```
+
+**Comportamiento:**
+- 1 quote DB por cada material en `material[]`
+- Si llega `pileta_sku` y matchea catálogo → se agrega como producto físico
+- Si NO llega `pieces` pero sí `notes`: intenta parsear texto con Claude. Si falla → quote DRAFT vacío.
+- Si llega `pieces` válidas → quote `status=PENDING` con breakdown calculado, **sin docs** (operador valida después)
+- Si NO llega `pieces` y `notes` está vacío → quote `status=DRAFT`
+- Resuelve `pileta` desde `pileta_sku` o `sink_type` si `pileta` no viene explícito
+- Persiste el body raw en `Quote.web_input` (PR #400)
+
+**Errores:**
+- `401 {"detail": "API key inválida o faltante"}` — si `QUOTE_API_KEY` está seteado y no matchea
+- `422` — Pydantic validation (campos faltantes, tipos mal)
+- Response con `ok: false, error: "..."` para errores de cálculo (material no encontrado, etc.)
+
+---
+
+### `POST /api/v1/quote/{quote_id}/files`
+
+Sube archivos (planos, fotos) a un quote web existente.
+
+**Auth:** Header `X-API-Key` · **Content-Type:** `multipart/form-data`
+
+**Form fields:**
+- `files: UploadFile[]` — hasta 5
+
+**Response 200:**
+
+```ts
+interface UploadFilesResponse {
+  ok: true;
+  saved: number;
+  errors: string[];
+  files: SourceFile[];
+  // PR #394: si el quote es source=web Y se guardaron archivos:
+  estimate_skipped?: true;
+  estimate_skip_reason?: "web_upload_manual_review";
+  message?: string;  // texto para mostrar al cliente del bot
+}
+```
+
+**Comportamiento:**
+- Restricciones: PDF/JPEG/PNG/WEBP, max 10MB c/u, max 5 archivos
+- Guarda en `OUTPUT_DIR/{quote_id}/sources/` (con fallback a `/tmp` si falla permission)
+- Sube a Drive ("Archivos Origen" subfolder) — best effort
+- **PR #394:** quotes web con `source="web"` que reciben archivo NO disparan auto-estimate. El operador revisa manual.
+- Quotes con otros sources que reciben archivo SÍ disparan procesamiento automático en background (Valentina lee plano → calcula → persiste breakdown)
+
+**Errores:**
+- `200` con `ok: false, error: "Quote not found"` — sí, devuelve 200 con error en body
+- `200` con `ok: false, error: "Maximum 5 files per request"`
+
+---
+
+### `GET /api/v1/business-rules`
+
+Reglas de negocio v0 que el chatbot externo necesita para capturar leads sin romper.
+
+**Auth:** Header `X-API-Key`
+
+**Response 200:** schema `BusinessRulesV0` (ver `api/app/modules/business_rules/schema.py` en backend para shape completo).
+
+**Headers:**
+- `Cache-Control: public, max-age=3600`
+- `ETag: "<sha256-16chars>"` — usable en `If-None-Match`
+
+**Response 304** si `If-None-Match` coincide con el ETag actual.
+
+---
+
+## Flow 16 · Admin endpoints
+
+Solo para sysadmins con sesión JWT.
+
+### `POST /api/admin/analyze-plans-vectorality`
+
+Analiza últimos N quotes y clasifica `source_files` como `vectorial_clean` / `vectorial_and_raster` / `raster_only` / `unknown`. Útil para decidir si el fast-path vectorial vale la pena.
+
+**Auth:** Cookie
+
+**Query params:**
+
+```ts
+interface AnalyzeVectoralityQuery {
+  limit?: number;  // 1-1000, default 200
+}
+```
+
+**Response 200:**
+
+```ts
+interface AnalyzeVectoralityResponse {
+  total_analyzed: number;
+  counts: Record<string, number>;
+  percentages: Record<string, number>;
+  recommend_2d: boolean;
+}
+```
+
+---
+
+### `POST /api/admin/backfill-drive`
+
+Re-genera PDF/Excel y sube a Drive para quotes validados que no tienen `drive_pdf_url`. Idempotente — skipea quotes que ya tienen Drive URLs. Lee del breakdown existente, NO recalcula.
+
+**Auth:** Cookie
+
+**Response 200:**
+
+```ts
+interface BackfillDriveResponse {
+  total: number;
+  results: Array<{
+    id: string;
+    client?: string;
+    material?: string;
+    status: "ok" | "skipped" | "error";
+    reason?: string;
+    drive_pdf?: boolean;
+    drive_excel?: boolean;
+  }>;
+}
+```
+
+---
+
+## Health check
+
+### `GET /health` — público
+
+**Auth:** ninguna
+
+**Response 200:**
+
+```ts
+interface HealthResponse {
+  status: "ok";
+  service: "marble-operator-api";
+  db: "connected";
+}
+```
+
+**Response 503** si la DB no responde:
+
+```ts
+interface UnhealthyResponse {
+  status: "unhealthy";
+  service: "marble-operator-api";
+  db: "unreachable";
+}
+```
+
+---
+
+## Mapeo mockup ↔ endpoint
+
+Para Sprint 2, los mockups del Master §6 se mapean así (referencia rápida — el detalle está en cada flow arriba):
+
+| Paso (Mockup) | Endpoints relevantes |
+|---|---|
+| **Paso 1 · Brief** (00-A/B/C) | `POST /api/quotes` (crear vacío) → `POST /api/quotes/{id}/chat` (subir plano + brief, multipart) → SSE stream |
+| **Paso 2 · Contexto** (01-A, 02-B, 03-C) | `GET /api/quotes/{id}` (leer breakdown) · `PATCH /api/quotes/{id}` (editar campos) · `POST /api/quotes/{id}/chat` (chat scoped) · `POST /api/quotes/{id}/reopen-context` (volver atrás) |
+| **Paso 3 · Despiece** (04-A1/2, 04-P, 05-B, 06-C) | `POST /api/quotes/{id}/chat` (Valentina llama `list_pieces` tool) · `POST /api/quotes/{id}/zone-select` (operador marca zona) · `POST /api/quotes/{id}/dual-read-retry` (re-trigger Opus) · `POST /api/quotes/{id}/reopen-measurements` |
+| **Paso 4 · Cómputo** (07-A v3/v4, 08-B, 09-C) | `POST /api/quotes/{id}/chat` (Valentina llama `calculate_quote` tool) · `PATCH /api/quotes/{id}` (editar pieces, anafe, etc.) |
+| **Paso 5 · Cotización** (18-A, 19-B, 20-C, 21-D, 22-E) | `POST /api/quotes/{id}/validate` (genera docs + status=validated) · `POST /api/quotes/{id}/regenerate` (re-emite sin recalcular) · `GET /api/quotes/{id}/email-draft` · `GET /files/{quote_id}/<filename>.pdf` |
+| **Paso 5-D · Diff drawer** (21-D) | `GET /api/quotes/{id}/compare` + `GET /api/quotes/{id}/compare/pdf` |
+| **Paso 5-E · Vencido** (22-E) | `PATCH /api/quotes/{id}/status` (transition `validated → draft` para "renovar") |
+| **Bloque E · Dashboard** (23, 24, 25) | `GET /api/quotes` (lista) · `GET /api/quotes/check` (polling) · `GET /api/quotes/{id}` (detalle) · `PATCH /api/quotes/{id}/read` |
+| **13 · Audit banner** | `GET /api/admin/quotes/{id}/audit` · `GET /api/admin/system-config/global-debug` |
+| **15 · IA error** | Manejado en SSE (event type `error` + flag `done.error: true`) — no endpoint dedicado |
+| **16 · Empty despiece** | Estado vacío del frontend — no requiere endpoint |
+| **17 · Chat error** | Visualización de mensaje con `flagged: true` — feedback va a audit log via `chat.message_sent` con flag |
+| **Comparación variantes** | `POST /api/quotes/{id}/derive-material` (crear variant) → `GET /api/quotes/{id}/compare` |
+| **Resumen de obra** | `POST /api/quotes/client-match-check` → `POST /api/quotes/merge-client` (si necesario) → `POST /api/quotes/resumen-obra` |
+| **Mobile flow** (10, 11, 12, 23, 24) | Mismos endpoints que desktop. Mobile es read-only para crear quotes (Master §10 decisión 13) — solo lista + detalle. |
+
+Ver `missing-endpoints.md` para endpoints sugeridos por mockups que NO existen hoy en backend.
+
+---
+
+## Archivos backend leídos para derivar este spec
+
+- `api/app/modules/auth/router.py` (125 líneas)
+- `api/app/modules/agent/router.py` (2389 líneas — todos los endpoints `/api/quotes/*`, `/api/files/*`, admin)
+- `api/app/modules/agent/schemas.py` (141 líneas — Quote* response/request schemas)
+- `api/app/modules/quote_engine/router.py` (553 líneas — `/api/v1/quote*`)
+- `api/app/modules/quote_engine/schemas.py` (93 líneas — `QuoteInput`, `PieceInput`, `PiletaType`, `SinkType`)
+- `api/app/modules/catalog/router.py` (442 líneas)
+- `api/app/modules/observability/router.py` (678 líneas — todos `/api/admin/*`)
+- `api/app/modules/observability/models.py` (82 líneas — `AuditEvent`)
+- `api/app/modules/usage/router.py` (148 líneas)
+- `api/app/modules/business_rules/router.py` (66 líneas)
+- `api/app/models/quote.py` (119 líneas — modelo `Quote` con `quote_kind`, `quote_breakdown`, etc.)
+- `api/API.md` (882 líneas — doc base existente, validada y extendida acá)

--- a/docs/handoff-context/missing-endpoints.md
+++ b/docs/handoff-context/missing-endpoints.md
@@ -1,0 +1,216 @@
+# Missing Endpoints — sugeridos por mockups, no implementados
+
+> **Cuándo crear este archivo:** solo si encontrás un mockup que sugiere una llamada al backend que NO existe hoy.
+> **Última revisión:** 2026-05-05.
+
+Audité los 30 mockups del Master §6 contra los routers reales del backend (commit `1915317`). La mayoría de las interacciones de mockup mapean a endpoints existentes — ver tabla "Mapeo mockup ↔ endpoint" al final de `endpoints-spec.md`. Este archivo lista **lo que falta o está ambiguo**.
+
+> **Severidad:** P1 = bloqueante para Sprint 2. P2 = nice-to-have, frontend puede mockear sin romper. P3 = sugerencia de naming/cleanup.
+
+---
+
+## P2 · `POST /api/quotes/{id}/brief` (dedicated)
+
+**Mockups donde aparece:** `00-paso1-A-vacio`, `00-paso1-B-subido`, `00-paso1-C-procesando`.
+
+**Qué hace:** subir el brief inicial (PDF + fotos + textarea + chips IA) ANTES de empezar el chat con Valentina. El mockup B muestra un botón "Continuar a contexto" que sugiere una transición distinta del chat normal.
+
+**Realidad backend:** **NO EXISTE endpoint dedicado.** El brief se manda dentro del primer turno del chat vía multipart `POST /api/quotes/{id}/chat`. Detalle en `schemas/brief.md`.
+
+**Sugerencia:**
+
+- **Opción A (sin cambios backend):** frontend Sprint 2 manda todo en `POST /chat`. El "Continuar a contexto" del mockup arranca el primer SSE stream → Valentina emite `context_analysis` que aparece en el mockup `01-A`.
+- **Opción B (backend agrega `/brief`):** un endpoint nuevo `POST /api/quotes/{id}/brief` que solo persiste files + textarea + chips, SIN arrancar el agente. Después un endpoint `POST /api/quotes/{id}/process` arranca el chat. Ventaja: separa "subir" de "procesar" — el operador puede subir, navegar a otra cosa, volver. Desventaja: complejidad extra.
+
+**Decisión recomendada:** Opción A para Sprint 2. Mockear el flow completo contra `POST /chat`. Si Marina pide "guardar borrador sin procesar" en QA, evaluar Opción B en Sprint 3.
+
+---
+
+## P2 · Estructura para `BriefChip[]`
+
+**Mockup:** `00-paso1-B-subido` muestra brief chips con marca "IA" y "+ agregar" custom.
+
+**Realidad backend:** El backend NO conoce el concepto "brief chip". Marina escribe libre en el textarea, y Valentina extrae chips durante `context_analysis`. El data model del Master §10 menciona `BriefChip[]` pero como abstracción del frontend.
+
+**Sugerencia:** frontend Sprint 2 mantiene `BriefChip[]` como state local. Al mandar el `POST /chat`, concatena los chips al `message` con un separador (ej. `[Brief: cocina + baño] [Material: silestone] [Plazo: urgente] <textarea libre>`). Valentina los procesa como parte del brief.
+
+**Si hace falta endpoint:** crear `POST /api/quotes/{id}/brief-chips` que solo persiste el array — el frontend lee del response del `GET /quotes/{id}` que tendría un campo `brief_chips: BriefChip[]` nuevo en el modelo. Por ahora innecesario.
+
+---
+
+## P3 · `POST /api/quotes/{id}/share-pdf`
+
+**Mockups donde aparece:** `20-paso5-C-generado` muestra "Compartir con cliente" + opciones email/whatsapp/copy link.
+
+**Realidad backend:** **NO EXISTE.** El frontend tendría que:
+
+- Email → mandar al cliente vía mailto: link o un sistema externo (no hay endpoint que mande email desde el server)
+- WhatsApp → web link `https://wa.me/<phone>?text=<encoded url del PDF>`
+- Copy link → URL pública del PDF en Drive (`drive_url`) o link interno (`/files/{quote_id}/...` con auth)
+
+**Decisión Master §10 #20:** "Compartir con cliente: Solo PDF (Excel es interno del taller)". El frontend ya puede implementar esto sin endpoint backend nuevo — el `drive_url` del quote es público (compartido vía Service Account, link sharing on).
+
+**Sugerencia:** mockear como function client-side. Si Sprint 4-5 pide tracking de "cuántas veces el cliente abrió el PDF" → ahí sí hace falta endpoint backend.
+
+---
+
+## P3 · Tracking de visitas al PDF (mockup `22-paso5-E-vencido`)
+
+**Mockup:** `22-paso5-E-vencido` muestra "tracking visitas" del PDF.
+
+**Realidad backend:** **NO EXISTE.** El backend no instrumenta clicks al PDF de Drive ni al endpoint `/files/`.
+
+**Sugerencia:**
+
+- Si solo querés saber "el cliente abrió el PDF" → usar Drive API view tracking (Google Workspace ya provee analytics básicas — no requiere código)
+- Si querés UI rich con timestamps por visita → endpoint nuevo `POST /api/quotes/{id}/pdf-view` que registra cada GET a `/files/{quote_id}/...pdf` (instrumenta el endpoint files con audit log) y `GET /api/quotes/{id}/pdf-views` que lista los hits.
+
+**Decisión recomendada:** Sprint 4-5. No bloqueante para Sprint 2. Frontend muestra "tracking visitas: —" como placeholder.
+
+---
+
+## P3 · Renovar presupuesto vencido (mockup `22-paso5-E-vencido`)
+
+**Mockup:** botón "Renovar (genera v2)".
+
+**Realidad backend:** existe el flow para crear v2 — `PATCH /api/quotes/{id}/status` con `validated → draft` → operador edita → `POST /quotes/{id}/regenerate`. NO hay un único endpoint "renovar" que haga todo.
+
+**Sugerencia:** frontend Sprint 4-5 puede componer la secuencia. Si se vuelve común, agregar `POST /api/quotes/{id}/renew` que internamente:
+
+1. Cambia status a draft
+2. Append a change_history `{action: "renewed", reason: "vencimiento"}`
+3. Devuelve el quote actualizado
+
+No bloqueante.
+
+---
+
+## P3 · Audit per-row endpoint dedicado
+
+**Mockups:** `13-audit-banner-on` + cualquier row con `data-audit=on` (mockup 02, 05, etc.).
+
+**Realidad backend:** existe `GET /api/admin/quotes/{id}/audit` que devuelve TODOS los events del quote (max 500). El mockup muestra un panel `.aud-trail` específico de UNA row (ej. ediciones de la cell "client_name").
+
+**Sugerencia:** el frontend puede:
+
+- Pedir el timeline completo y filtrar client-side por field/cell — está OK para 500 events
+- O agregar query param `?field=<field_name>` al endpoint para filtrar server-side
+
+No bloqueante. La filtración client-side es trivial.
+
+---
+
+## P2 · "Pegar URL" en dropzone (mockup `00-paso1-A-vacio`)
+
+**Mockup:** botón secundario "Pegar URL" alternativo al "Subir plano".
+
+**Realidad backend:** **NO EXISTE.** El backend solo acepta uploads multipart, no URLs externas.
+
+**Sugerencia:**
+
+- Frontend descarga la URL → upload normal multipart (problema CORS si la URL es de dominio externo)
+- Backend nuevo: `POST /api/quotes/{id}/fetch-url` que accept `{url: string}` y descarga server-side. Validaciones: `https://` only, max 20MB descarga, allowed mime, etc.
+
+**Decisión recomendada:** Sprint 4-5. No bloqueante. Mockup tiene el botón pero podría ser greyed-out con tooltip "próximamente".
+
+---
+
+## P2 · Cambio explícito de `exchange_rate` (USD/ARS)
+
+**Mockup:** `07-paso4-A-v4` muestra chip `USD/ARS @ 1430` clickeable → modal cambiar.
+
+**Realidad backend:** El `exchange_rate` se setea internamente en `calculate_quote()` desde `config.json` o un default hardcoded. **NO HAY endpoint para cambiarlo on-demand desde el frontend** — está embebido en el cálculo.
+
+**Sugerencia:**
+
+- **Opción A (sin endpoint):** chip muestra el valor pero NO es editable. Cambios al exchange rate van por `PUT /api/catalog/config` (que ya existe).
+- **Opción B (agregar param):** `calculate_quote` tool acepta `exchange_rate` opcional. El frontend manda override al chat: "recalculá con cotización 1430". Valentina lo respeta.
+
+**Decisión recomendada:** Opción A. El operador edita el config raras veces, no necesita UI inline.
+
+---
+
+## P3 · Bulk operations en Dashboard
+
+**Mockups:** `25-paso-dashboard-C-desktop` muestra checkboxes y bulk actions ("Marcar como leídos", "Exportar selección a CSV").
+
+**Realidad backend:** **NO EXISTE.** Las operaciones son individuales (PATCH /quotes/{id}, etc.).
+
+**Sugerencia:** Sprint 4-5. Frontend puede iterar individualmente al principio. Si performance se vuelve issue, agregar:
+
+- `POST /api/quotes/bulk-read` con `{ids: string[]}` — marca N como leídos
+- `POST /api/quotes/bulk-export` con `{ids: string[], format: "csv"}` — devuelve CSV download
+
+No bloqueante.
+
+---
+
+## P3 · KPI cards del Dashboard
+
+**Mockup:** `25-paso-dashboard-C-desktop` muestra 4 cards (Total mes, En curso, Aprobados, Vencidos) con números agregados.
+
+**Realidad backend:** **NO EXISTE endpoint dedicado de KPIs.** El frontend tendría que:
+
+- Pedir `GET /api/quotes` con filtros + contar
+- O contar localmente sobre el state
+
+**Sugerencia:** crear `GET /api/quotes/kpis` que devuelve agregaciones precomputadas:
+
+```ts
+interface KPIsResponse {
+  current_month: {
+    total_count: number;
+    total_ars_sum: number;
+    total_usd_sum: number;
+    by_status: Record<QuoteStatus, number>;
+  };
+  in_progress: number;
+  approved: number;
+  expired: number;
+  // etc.
+}
+```
+
+**Decisión recomendada:** Sprint 4-5 (cuando se implementa el dashboard). Para Sprint 2 mockear contra dataset compartido (Master §13 dataset 47 quotes).
+
+---
+
+## P3 · Empty states
+
+**Mockup:** `16-empty-despiece-lateral` con paths "Subir plano" / "Completar a mano".
+
+**Realidad backend:** los 2 paths del mockup se mapean a:
+
+- "Subir plano" → `POST /chat` con archivo (existe)
+- "Completar a mano" → arranca un chat con texto "no tengo plano" → Valentina pregunta medidas (existe)
+
+**Sin endpoint nuevo.** El frontend solo tiene que manejar la decisión del operador y disparar el chat correspondiente.
+
+---
+
+## Resumen
+
+| # | Endpoint sugerido | Severidad | Sprint sugerido |
+|---|---|---|---|
+| 1 | `POST /api/quotes/{id}/brief` | P2 | Skip — usar `/chat` |
+| 2 | `BriefChip[]` estructurado | P2 | Skip — frontend state local |
+| 3 | `POST /api/quotes/{id}/share-pdf` | P3 | Sprint 4-5 |
+| 4 | Tracking visitas PDF | P3 | Sprint 4-5 (opcional) |
+| 5 | `POST /api/quotes/{id}/renew` | P3 | Sprint 4-5 |
+| 6 | Audit per-row con filtro | P3 | Skip — filtrar client-side |
+| 7 | `POST /api/quotes/{id}/fetch-url` (dropzone URL) | P2 | Sprint 4-5 |
+| 8 | Editar `exchange_rate` inline | P2 | Skip — usar `PUT /catalog/config` |
+| 9 | Bulk operations dashboard | P3 | Sprint 4-5 |
+| 10 | `GET /api/quotes/kpis` | P3 | Sprint 4-5 (cuando se implemente dashboard) |
+
+**Conclusión para Sprint 2:** ningún endpoint de los listados arriba bloquea Sprint 2. El frontend puede arrancar el wire-up de Paso 1 + Paso 2 contra los endpoints existentes hoy. Las features marcadas P2 que afectan UX inmediata (pegar URL, exchange rate inline) tienen workarounds aceptables.
+
+Si durante el wire-up de Sprint 2 el frontend descubre algo que NO está en esta lista y NO tiene endpoint → agregar entry a este archivo en un PR de actualización al handoff branch (no bloquear el PR de Sprint 2 — abrir issue separado).
+
+---
+
+## Archivos backend revisados para confirmar gaps
+
+- Todos los routers (`api/app/modules/*/router.py`)
+- Lista exhaustiva de endpoints en `endpoints-spec.md`
+- Mockups del Master §6 (referencia visual en `docs/handoff-design/design_files/*.html`)

--- a/docs/handoff-context/schemas/audit_events.md
+++ b/docs/handoff-context/schemas/audit_events.md
@@ -1,0 +1,242 @@
+# Schema · audit_events
+
+> **Fuente:** `api/app/modules/observability/models.py` + `observability/router.py` + `observability/__init__.py`.
+> **Última actualización:** 2026-05-05.
+
+Tabla append-only. Cada acción operacional del sistema (creación de quote, edits, generación de docs, fallos de la IA, retries del operador) deja un row. Sirve a **dos casos de uso**:
+
+1. **Timeline per-quote** (`/admin/quotes/{id}/audit`) — alimenta el panel `.aud-trail` que aparece en el mockup `13-audit-banner-on` y en cada row con `data-audit=on`.
+2. **Vista global** (`/admin/observability` + `/admin/observability/quotes`) — debugging cross-quote: "todos los regenerate_docs por usuario X en los últimos 7 días", "qué quotes tuvieron errores de calculate_quote esta semana".
+
+---
+
+## Tabla `audit_events` — columnas
+
+```ts
+interface AuditEventRow {
+  id: string;                         // UUID v4 — PK, generado en cliente Python
+  created_at: string;                 // TIMESTAMPTZ NOT NULL — generado en client Python
+                                      // (NO server-default NOW() — preserva orden de inserción
+                                      //  dentro de una misma transacción)
+
+  event_type: string;                 // VARCHAR(64) NOT NULL — ver enum abajo
+  source: string;                     // VARCHAR(32) NOT NULL — qué módulo lo emitió:
+                                      // "router" | "agent" | "validator" | "cron" | "calc"
+                                      // | "observability"
+
+  quote_id: string | null;            // VARCHAR(64) — FK lógica a quotes.id (no enforced)
+  session_id: string | null;          // VARCHAR(64) — populado con quote_id cuando aplica;
+                                      // reservado para sesiones multi-quote en el futuro
+
+  actor: string;                      // VARCHAR(120) NOT NULL — username del JWT, "api-key", o "system"
+  actor_kind: "user" | "api_key" | "system";  // VARCHAR(20) NOT NULL
+
+  request_id: string | null;          // VARCHAR(64) — correlation ID por HTTP request
+                                      // (set por middleware) — busca todos los events
+                                      // de una misma llamada HTTP
+  turn_index: number | null;          // INTEGER — índice en Quote.messages cuando aplica chat
+
+  summary: string;                    // TEXT NOT NULL — frase humana corta para listar UI
+                                      // sin parsear payload (max 8000 chars truncado server-side)
+  payload: object;                    // JSONB NOT NULL DEFAULT '{}' — sanitizado + truncado
+  payload_truncated: boolean;         // flag explícito para que la UI muestre "payload truncado"
+  debug_payload: boolean;             // TRUE si grabado con global_debug activo
+                                      // (payload puede pesar hasta 16 KB con
+                                      //  tool_input/tool_result/brief completos)
+
+  success: boolean;                   // default true — false si la acción falló
+  error_message: string | null;       // TEXT — solo si success=false
+  elapsed_ms: number | null;          // INTEGER — duración de la acción
+}
+```
+
+---
+
+## Event types
+
+Lista de event_types emitidos hoy (verificado contra grep `log_event(...event_type=` en el repo):
+
+### Lifecycle del quote
+
+| event_type | Source | Trigger | Payload típico |
+|---|---|---|---|
+| `quote.created` | `router` | `POST /api/quotes` | `{status: "draft"}` |
+| `quote.patched` | `router` | `PATCH /api/quotes/{id}` | `{fields: ["client_name", "material"]}` (sanitizer redacta phone/email) |
+| `quote.status_changed` | `router` | `PATCH /api/quotes/{id}/status` | `{from: "draft", to: "validated"}` |
+| `quote.reopened` | `router` | `/reopen-measurements` o `/reopen-context` | `{kind: "measurements" \| "context", msgs_pre: N, msgs_post: M, truncate_matched: bool}` |
+| `quote.calculated` | `agent` o `calc` | `calculate_quote()` exitoso | `{material_m2, total_ars, total_usd, sectors_count}` (truncated to 4KB para "heavy event") |
+| `quote.calc_failed` | `agent` | `calculate_quote()` falló | `{error, input_summary}` |
+
+### Chat + agent loop
+
+| event_type | Source | Trigger |
+|---|---|---|
+| `chat.message_sent` | `router` | `POST /api/quotes/{id}/chat` arranca |
+| `agent.tool_called` | `agent` | Cada `<tool_use>` block emitido por Claude |
+| `agent.tool_result` | `agent` | Cada `<tool_result>` evaluado |
+| `agent.iteration_completed` | `agent` | Fin de un iteration del loop |
+| `agent.stream_done` | `agent` | Fin del SSE stream |
+| `agent.error` | `agent` | Excepción no recuperable |
+| `agent.rate_limit_retry` | `agent` | 429 de Anthropic, reintentando |
+| `agent.overloaded_retry` | `agent` | 529 de Anthropic, reintentando |
+
+### Documentos (Paso 5)
+
+| event_type | Source | Trigger |
+|---|---|---|
+| `docs.generated` | `agent` | Tool `generate_documents` exitosa |
+| `docs.regenerated` | `router` | `POST /api/quotes/{id}/regenerate` |
+| `docs.validation_failed` | `agent` | Validador profundo rebotó (ej. m² mismatch) |
+| `drive.upload_failed` | `agent` o `router` | Drive API falló |
+
+### Card / dual read
+
+| event_type | Source | Trigger |
+|---|---|---|
+| `dual_read.executed` | `agent` | Lectura visual del plano (Sonnet+Opus) |
+| `dual_read.retry_requested` | `router` | `POST /api/quotes/{id}/dual-read-retry` |
+| `context_analysis.emitted` | `agent` | Card de contexto generada |
+| `zone_select.recorded` | `router` | `POST /api/quotes/{id}/zone-select` |
+
+### Resumen + email
+
+| event_type | Source | Trigger |
+|---|---|---|
+| `resumen_obra.generated` | `router` | `POST /api/quotes/resumen-obra` |
+| `email_draft.generated` | `router` | `GET /api/quotes/{id}/email-draft` (cuando regenera) |
+| `email_draft.regenerated` | `router` | `POST /api/quotes/{id}/email-draft/regenerate` |
+| `client.merged` | `router` | `POST /api/quotes/merge-client` |
+
+### Sistema / observability
+
+| event_type | Source | Trigger |
+|---|---|---|
+| `audit.cleanup_run` | `observability` | `POST /api/admin/audit/cleanup` (cron) |
+| `audit.global_debug_toggled` | `observability` | `POST /api/admin/system-config/global-debug` |
+| `audit.global_debug_auto_disabled` | `observability` | Cron auto-shutoff cumplió condición |
+| `audit.global_debug_shutoff_run` | `observability` | Breadcrumb del cron (siempre, incluso rows=0) |
+
+**Nota:** la lista anterior es exhaustiva al momento del audit. Si encontrás un `event_type` distinto en producción, asumir que está sin documentar (no es bug — solo doc-debt).
+
+---
+
+## Sanitización de `payload`
+
+Antes de persistir, el helper `log_event()` aplica:
+
+1. **Lista negra de keys** (case-insensitive substring match):
+   ```
+   password, token, secret, api_key, apikey, authorization, cookie,
+   phone, telefono, whatsapp, address, direccion, dni, cuit, email,
+   client_name, cliente, nombre_cliente
+   ```
+   Valor de cualquier key que matchee → `"<redacted>"`.
+
+2. **Truncado por bytes**:
+   - Default: 2 KB
+   - Heavy events (`quote.calculated`, `docs.generated`, `docs.regenerated`): 4 KB
+   - Modo debug global activo: 16 KB
+
+   Si excede → payload reemplazado por `{key: "<truncated>"}` (preserva shape) + `payload_truncated=true`.
+
+3. **No filtra por valor** (no busca patrones tipo "número de teléfono"). Solo por nombre de key. **Trade-off explícito:** simplicidad > completitud heurística.
+
+---
+
+## Modo debug global
+
+Toggle on-demand para capturar payloads grandes (tool_input, tool_result, message_text completos) durante debugging.
+
+```ts
+interface GlobalDebugStatus {
+  enabled: boolean;
+  mode: "1h" | "end_of_day" | "manual" | null;
+  until: string | null;              // ISO — auto-off
+  started_at: string | null;
+  started_by: string | null;
+  remaining_seconds: number | null;
+}
+```
+
+**Cuándo se activa:**
+
+- Operador clickea toggle en `/admin/observability`
+- Modos: `1h` (60min), `end_of_day` (23:59 AR), `manual` (hard cap 24h)
+
+**Cuándo se desactiva:**
+
+- Operador toggle off
+- Cron `/admin/audit/global-debug-shutoff` (Railway scheduled job)
+
+**Efecto:** mientras está ON, `log_event()` graba `debug_payload=true` y permite payloads hasta 16KB con datos sensibles (tool_input puede tener brief completo, tool_result puede tener despiece raw).
+
+**Bundle copy del frontend NO incluye** payloads de events con `debug_payload=true` — placeholder `<debug payload available in /admin/quotes/X/audit, NOT included in bundle>`. Se ven en la UI con login JWT.
+
+---
+
+## Índices
+
+```sql
+CREATE INDEX idx_audit_event_quote_created ON audit_events (quote_id, created_at DESC);
+CREATE INDEX idx_audit_event_type_created  ON audit_events (event_type, created_at DESC);
+CREATE INDEX idx_audit_event_actor_created ON audit_events (actor, created_at DESC);
+CREATE INDEX idx_audit_event_request_id    ON audit_events (request_id);
+```
+
+Diseñados para los queries frecuentes:
+
+- Timeline de un quote (`WHERE quote_id = ? ORDER BY created_at`)
+- Filtro global por event_type / actor / fecha
+- Correlation por request_id
+
+---
+
+## Render en frontend
+
+### Card `.aud-trail` (per-row)
+
+Cuando `data-audit="on"` en el body:
+
+- Cada celda editable muestra un `.aud-i` (ⓘ trigger)
+- Click → expande `.aud-trail` panel inline con events filtrados a esa cell
+- Style: monospace, dim, max 5 events visibles + "ver todos" link
+
+### Banner `.audit` (top de pantalla)
+
+Mockup `13-audit-banner-on`:
+
+- Fondo rojo, dot pulse, copy mono
+- Lista contador agregado: "AUDIT MODE · 3 ediciones humanas en este flujo · ver auditoría"
+- Click → drawer con timeline completo del quote
+
+### Timeline `/admin/quotes/{id}/audit`
+
+Vista dedicada para developers/operadores. Lista de events ordenados ASC con:
+
+- Timestamp + event_type + actor
+- Summary (humana)
+- Botón "Ver payload" (toggle del JSON sanitizado)
+- Filtro por success/error
+- Bundle copy → genera string para Slack/ticket
+
+---
+
+## Performance
+
+Mediciones reales del query principal (10K events, 200 quotes):
+
+- `/admin/observability/quotes`: p95 = 6.81ms
+- `/admin/quotes/{id}/audit`: p95 < 5ms (limit 500, índice quote_id+created_at)
+
+Ambos endpoints son seguros para llamarse desde el banner de audit (que se encience con cada nueva entry del quote actual).
+
+---
+
+## Archivos backend leídos para derivar este schema
+
+- `api/app/modules/observability/models.py` (82 líneas — `AuditEvent` SQLAlchemy)
+- `api/app/modules/observability/router.py` (líneas 47-115 — response schemas + endpoints)
+- `api/app/modules/observability/__init__.py` (resumen del módulo)
+- `api/app/modules/observability/sanitizer.py` (lista negra de keys + truncado)
+- `api/app/modules/observability/system_config.py` (modelo `SystemConfig` para `global_debug`)
+- `api/app/modules/observability/cleanup.py` (retention manual)

--- a/docs/handoff-context/schemas/brief.md
+++ b/docs/handoff-context/schemas/brief.md
@@ -1,0 +1,294 @@
+# Schema · Brief (Paso 1)
+
+> **Fuente:** `api/app/modules/agent/router.py:2084-2389` (chat handler) + `api/app/modules/quote_engine/schemas.py` (QuoteInput para web bot).
+> **Última actualización:** 2026-05-05.
+
+El "Brief" del Paso 1 (Master §6 mockups `00-A/B/C`) es lo que Marina sube al inicio: PDF/imagen del plano + (opcional) fotos + textarea con contexto. **Hay dos paths distintos según el origen:**
+
+1. **Operator Brief** (Marina opera el frontend) → multipart `POST /api/quotes/{id}/chat`
+2. **Web Bot Brief** (chatbot externo) → `POST /api/v1/quote` + `POST /api/v1/quote/{id}/files`
+
+Esta doble entrada es deliberada: Master §15 menciona que el bot externo es "separado del operator UI". Ambos terminan creando un row en `quotes` con `source` distinto.
+
+---
+
+## Path 1 · Operator Brief (frontend → chat SSE)
+
+### Frontend collects
+
+```ts
+interface OperatorBriefInput {
+  /** Texto libre del operador. Multilinea. Master §10:
+   * BriefChip[] del data model se materializa concatenado en este string,
+   * o el frontend lo manda estructurado. Sin estructura formal hoy. */
+  message: string;
+
+  /** Plano técnico (1 página) + fotos del lugar.
+   * - Hasta 10 archivos
+   * - PDF, JPEG, PNG, WEBP
+   * - Max 10MB cada uno
+   * - PDFs deben ser de 1 página (multi-página → 400 explícito) */
+  plan_files?: File[];
+}
+```
+
+### Wire — multipart/form-data
+
+```http
+POST /api/quotes/{quote_id}/chat HTTP/1.1
+Cookie: auth_token=<jwt>
+Content-Type: multipart/form-data; boundary=...
+
+--boundary
+Content-Disposition: form-data; name="message"
+
+Cocina cliente Cueto-Heredia, mide en plano. Silestone Blanco Norte.
+Bacha Johnson empotrada. Anafe.
+
+--boundary
+Content-Disposition: form-data; name="plan_files"; filename="plano.pdf"
+Content-Type: application/pdf
+
+<bytes>
+
+--boundary
+Content-Disposition: form-data; name="plan_files"; filename="foto-pared.jpg"
+Content-Type: image/jpeg
+
+<bytes>
+--boundary--
+```
+
+### Lo que pasa server-side
+
+1. Sanitize filenames (strip `../` etc.)
+2. Validate MIME type + size + count
+3. Save `OUTPUT_DIR/{quote_id}/sources/<filename>`
+4. Best-effort upload a Drive ("Archivos Origen" subfolder)
+5. Append a `Quote.source_files[]` (con drive_url si OK)
+6. Persist en `Quote.quote_breakdown.files_v2.items[]` (Drive-first resolution)
+7. Si llegó un plano nuevo: invalida cards previas (`dual_read_result`, `verified_measurements`, etc.)
+8. Si NO llegó archivo y existían `source_files`: restaura el plano más reciente desde disco
+9. Audit `chat.message_sent` (con `debug_only_payload.message_text` si modo debug ON)
+10. Arranca SSE stream → Valentina lee plano + brief, emite `context_analysis` o `dual_read_result` (ver `sse-spec.md`)
+
+### Lo que NO existe (ver `missing-endpoints.md`)
+
+- **No hay `POST /api/quotes/{id}/brief` dedicado.** El brief se manda dentro del primer turno del chat. El frontend del Sprint 2 puede pegar el textarea + chips + files todo junto en un primer `chat` request.
+- **No hay schema estructurado de "brief chips"** (Master §10 `BriefChip[]`). El operador escribe libre — Valentina extrae chips del texto durante `context_analysis`. Si el frontend del Sprint 2 quiere enviar chips estructurados, debe **concatenarlos en `message`** con un separador o pedir un endpoint nuevo.
+
+---
+
+## Path 2 · Web Bot Brief (POST /api/v1/quote)
+
+El chatbot externo tiene un schema **MUY diferente** — manda datos estructurados en lugar de texto libre.
+
+### Wire
+
+```http
+POST /api/v1/quote HTTP/1.1
+X-API-Key: <api-key>
+Content-Type: application/json
+
+{ ...QuoteInput }
+```
+
+### `QuoteInput` schema completo
+
+```ts
+interface QuoteInput {
+  /** Cliente — REQUERIDO. */
+  client_name: string;            // 1-200 chars
+
+  /** Proyecto. */
+  project?: string;               // max 200 chars, default ""
+
+  /** Material o lista (multi-material). REQUERIDO. */
+  material: string | string[];
+
+  /** Piezas con medidas estructuradas. Opcional —
+   * si NO viene, el backend intenta parsear `notes` con Claude.
+   * Si tampoco hay notes válidas → quote DRAFT vacío. */
+  pieces?: PieceInput[] | null;
+
+  /** Localidad para flete. REQUERIDO. */
+  localidad: string;              // 1-100 chars
+
+  /** Si incluye colocación. */
+  colocacion?: boolean;           // default true
+
+  /** Tipo de pileta — explícito. */
+  pileta?: PiletaType;            // "empotrada_cliente" | "empotrada_johnson" | "apoyo"
+
+  /** Tipo de bacha (alternativa estructurada a `pileta`).
+   * Si viene `sink_type` y NO viene `pileta`, el backend resuelve:
+   *   - mount_type=arriba → "apoyo"
+   *   - mount_type=abajo → "empotrada_cliente" */
+  sink_type?: SinkType;
+
+  /** SKU específico de pileta Johnson (PR #397).
+   * Si viene → resuelve `pileta = empotrada_johnson` y agrega producto físico. */
+  pileta_sku?: string;            // max 64 chars
+
+  /** Anafe. */
+  anafe?: boolean;                // default false
+
+  /** Frentín. */
+  frentin?: boolean;              // default false
+
+  /** Pulido. */
+  pulido?: boolean;               // default false
+
+  /** True solo si el cliente retira el trabajo en fábrica. */
+  skip_flete?: boolean;           // default false
+
+  /** Plazo de entrega. */
+  plazo?: string;                 // 1-100 chars, default desde config.json
+
+  /** Descuento %. */
+  discount_pct?: number;          // 0-100, default 0
+
+  /** Fecha. Format: DD/MM/YYYY o DD.MM.YYYY. */
+  date?: string;
+
+  /** Chat history del bot — se persiste en Quote.messages.
+   * Útil para que el operador vea el contexto de la conversación bot. */
+  conversation?: ChatHistoryEntry[];
+
+  /** Notas adicionales del cliente. Si NO hay `pieces`, el backend
+   * intenta parsearlas con Claude para extraer piezas. */
+  notes?: string;
+}
+
+interface PieceInput {
+  description: string;            // max 200 chars (ej. "Mesada cocina principal")
+  largo: number;                  // > 0, <= 20 (metros)
+  prof?: number;                  // > 0, <= 5 — para mesadas
+  alto?: number;                  // > 0, <= 5 — para zócalos/alzas
+}
+
+interface ChatHistoryEntry {
+  role: "user" | "assistant";
+  content: string;
+}
+
+type PiletaType = "empotrada_cliente" | "empotrada_johnson" | "apoyo";
+
+interface SinkType {
+  basin_count: "simple" | "doble";
+  mount_type: "arriba" | "abajo";
+}
+```
+
+### Comportamiento del backend con `QuoteInput`
+
+```
+input.pieces presente?
+├── SÍ → calculate_quote(...) → quote PENDING con breakdown completo
+│        (sin docs — operator valida manualmente)
+└── NO
+    ├── input.notes presente?
+    │   ├── SÍ → text_parser (Claude) intenta extraer pieces
+    │   │       ├── parse OK → calculate_quote → quote PENDING
+    │   │       └── parse FAIL → quote DRAFT vacío con notes
+    │   └── NO → quote DRAFT vacío
+    └── (operador completa después vía chat con Valentina)
+```
+
+### Subida de planos (segunda llamada)
+
+```http
+POST /api/v1/quote/{quote_id}/files HTTP/1.1
+X-API-Key: <api-key>
+Content-Type: multipart/form-data
+```
+
+Mismo formato que Path 1, pero distinto endpoint. Auth via API key. Hasta 5 archivos.
+
+**Comportamiento PR #394:** quotes con `source="web"` que reciben archivo NO disparan auto-estimate. El operador revisa manual desde la UI interna.
+
+```ts
+interface UploadFilesResponse {
+  ok: true;
+  saved: number;
+  errors: string[];
+  files: SourceFile[];
+  // PR #394 — solo si gate aplicó:
+  estimate_skipped?: true;
+  estimate_skip_reason?: "web_upload_manual_review";
+  message?: string;  // copy para mostrar al cliente del bot
+}
+```
+
+---
+
+## Persistencia — qué se guarda dónde
+
+| Campo del brief | Termina en |
+|---|---|
+| `message` (operator) | NO se persiste como campo aparte. El primer turno del chat lo guarda en `Quote.messages[0].content`. Valentina lo procesa y emite `context_analysis` que persiste en `quote_breakdown.context_analysis_pending`. |
+| `client_name`, `project`, `material`, `localidad`, etc. (web bot) | Columnas dedicadas de `quotes` (mirror también a `quote_breakdown`) |
+| `pieces` (web bot) | `Quote.pieces` (input crudo) + `quote_breakdown.piece_details` (post-cálculo) |
+| `notes` | `Quote.notes` |
+| `conversation` (web bot) | `Quote.messages` |
+| `pileta_sku` (web bot) | NO persiste como columna — usado solo en `calculate_quote` para resolver pileta + agregar producto físico |
+| `web_input` (raw body) | `Quote.web_input` JSON — para auditoría del bot vs backend (PR #400) |
+| Archivos uploaded | Disco `OUTPUT_DIR/{quote_id}/sources/<filename>` + Drive (best-effort) + metadata en `Quote.source_files[]` y `quote_breakdown.files_v2` |
+
+---
+
+## Validación cliente-side (Sprint 2)
+
+Antes de mandar el chat o el QuoteInput, replicar lo que el backend valida con Pydantic:
+
+```ts
+const VALIDATION = {
+  message: { required: false },             // puede ser vacío si hay archivos
+  plan_files: {
+    max_count: 10,                          // operator
+    max_size_bytes: 10 * 1024 * 1024,       // 10MB
+    allowed_mime: [
+      "application/pdf",
+      "image/jpeg",
+      "image/png",
+      "image/webp",
+    ],
+    pdf_max_pages: 1,                       // backend rebota multi-page con SSE message
+  },
+  // Para web bot (Sprint 2 mockea contra esta shape):
+  client_name: { min: 1, max: 200 },
+  project: { max: 200 },
+  localidad: { min: 1, max: 100 },
+  plazo: { min: 1, max: 100 },
+  pileta_sku: { max: 64 },
+  discount_pct: { min: 0, max: 100 },
+  pieces_item: {
+    description: { max: 200 },
+    largo: { gt: 0, le: 20 },
+    prof: { gt: 0, le: 5 },
+    alto: { gt: 0, le: 5 },
+  },
+};
+```
+
+---
+
+## Mockups del Paso 1 vs schema real
+
+| Mockup | Realidad backend |
+|---|---|
+| `00-paso1-A-vacio` — dropzone + chips IA + custom | El frontend muestra UI pero NO hay endpoint para crear chips antes de subir. Marina arrastra plano + escribe textarea + (opcional) elige chips IA — todo viaja en el primer chat request. |
+| `00-paso1-B-subido` — filecard + brief chips | Igual — todo en memoria del frontend hasta que Marina clickea "Continuar a contexto". |
+| `00-paso1-C-procesando` — skeletons + status bar | Cuando Marina clickea "Continuar", arranca el `POST /chat` con SSE. El frontend muestra `action` events como status bar; el `text` que llega es la respuesta de Valentina. |
+
+**Side note (decisión de implementación Sprint 2):** los `BriefChip[]` del Master §10 data model son una abstracción del frontend. El backend no los conoce — recibe el texto concatenado. Si Marina los edita después, el frontend reconstruye el string y manda nuevo turn al chat.
+
+---
+
+## Archivos backend leídos para derivar este schema
+
+- `api/app/modules/agent/router.py` (líneas 2084-2389 — handler completo de `POST /chat`)
+- `api/app/modules/quote_engine/router.py` (líneas 29-261 — `POST /v1/quote`)
+- `api/app/modules/quote_engine/router.py` (líneas 264-386 — `POST /v1/quote/{id}/files`)
+- `api/app/modules/quote_engine/schemas.py` (`QuoteInput`, `PieceInput`, `PiletaType`, `SinkType`)
+- `api/app/modules/quote_engine/text_parser.py` (parser de `notes` con Claude)

--- a/docs/handoff-context/schemas/context.md
+++ b/docs/handoff-context/schemas/context.md
@@ -1,0 +1,325 @@
+# Schema · Contexto (Paso 2)
+
+> **Fuente:** `api/app/modules/quote_engine/context_analyzer.py` (build_context_analysis) + `api/app/models/quote.py` (columnas mirror) + `api/app/modules/agent/agent.py` (handlers de `[CONTEXT_CONFIRMED]`).
+> **Última actualización:** 2026-05-05.
+
+El "Contexto" del Paso 2 (Master §6 mockups `01-A`, `02-B`, `03-C`) es un híbrido: parte vive como **columnas dedicadas** del `Quote`, parte como **subobjetos en `quote_breakdown`** (cards de IA), parte se **infiere on-the-fly** desde el plano + brief. **No hay un schema único cerrado de "11 campos"** — esa frase del task brief es una abstracción del frontend. Esta página explica qué hay realmente.
+
+> **🤔 Verificar con Javi:** la spec del task `extract-api-contracts` mencionaba "11 campos del paso 2" del mockup. La sección 4 del Master habla de "Estados por sección" pero no enumera los 11 campos. Necesito esa lista para mapear cada campo a su columna/breakdown path. Por ahora documento el universo entero.
+
+---
+
+## Mapa de fuentes
+
+```
+                    ┌───────────────────────────────────────┐
+                    │        Paso 2 (mockup 01/02/03)       │
+                    │     Tabla con 11 campos editables     │
+                    └────────────────┬──────────────────────┘
+                                     │
+        ┌────────────────────────────┼────────────────────────────┐
+        ▼                            ▼                            ▼
+  Columnas Quote        quote_breakdown JSON              Cards IA
+  (PATCH directo)       (estructura calculada)            (auto-generadas)
+
+  client_name           material_name                     context_analysis_pending
+  project               material_m2                       └─ data_known
+  client_phone          material_currency                 └─ assumptions
+  client_email          delivery_days                     └─ tech_detections
+  localidad             discount_pct                      └─ pending_questions
+  colocacion            sectors                           └─ sector_summary
+  pileta                mo_items
+  sink_type             merma                             dual_read_result (paso 3)
+  anafe                 ...                               verified_context (post-confirm)
+  is_building                                             verified_context_analysis
+  notes
+  pieces (input crudo)
+  conversation_id
+```
+
+---
+
+## Origin chip · 5 estados (Master §9)
+
+Cada campo del Paso 2 tiene un **origin chip** que indica de dónde salió el valor:
+
+```ts
+type OriginChipKind =
+  | "DEL BRIEF"       // extraído del texto del operador
+  | "DEFAULT"         // valor default del config
+  | "INFERIDO"        // Valentina lo dedujo del plano/contexto
+  | "FALTA"           // bloqueante — pending question
+  | "EDITADO";        // Marina tocó el campo (push púrpura)
+```
+
+Esto es UI-only — el backend NO emite el chip directamente. El frontend lo deriva de:
+
+- `data_known[].source` ("brief" | "operator" | "dual_read" | "default")
+- `EditedField[]` del data model (Master §10) que el frontend mantiene en client state
+- `tech_detections[].status` ("verified" | "needs_confirmation")
+- `pending_questions[]` que vacían los `FALTA`
+
+---
+
+## Columnas mirror · `Quote` table
+
+Editables vía `PATCH /api/quotes/{id}` (sin pasar por chat, sin recálculo):
+
+```ts
+interface QuoteContextColumns {
+  client_name: string;            // VARCHAR(500)
+  client_phone: string | null;    // VARCHAR(100) — sanitizado en audit log (PII)
+  client_email: string | null;    // VARCHAR(200) — sanitizado en audit log (PII)
+  project: string;                // VARCHAR(500)
+  material: string | null;        // TEXT — puede ser CSV si multi-material
+  localidad: string | null;       // VARCHAR(200)
+  colocacion: boolean | null;     // default false
+  pileta: PiletaType | null;      // VARCHAR(50)
+  sink_type: SinkType | null;     // JSON
+  anafe: boolean | null;          // default false
+  is_building: boolean | null;    // default false (toggle Particular/Edificio)
+  notes: string | null;           // TEXT
+  conversation_id: string | null; // VARCHAR(100)
+}
+```
+
+**Side effect del PATCH:** los campos espejados (client_name, project, localidad, colocacion, pileta, anafe, material) también se actualizan dentro de `quote_breakdown` via `_BREAKDOWN_MIRROR_FIELDS` (PR #438) — para que el frontend del detail view (que lee del breakdown) y el PDF regenerado vean el valor nuevo.
+
+---
+
+## `context_analysis_pending` (en `quote_breakdown`)
+
+Card emitida por Valentina vía SSE event `context_analysis`. Persistida en `quote_breakdown.context_analysis_pending`. Permite reconstruir la card al reabrir el quote.
+
+```ts
+interface ContextAnalysisPending {
+  data_known: KnownItem[];
+  assumptions: AssumptionItem[];
+  tech_detections: TechDetection[];
+  pending_questions: PendingQuestion[];
+  sector_summary: string | null;       // ej. "2 mesada(s) en cocina + isla"
+  brief_analysis: {
+    extraction_method: "haiku" | "fallback";
+    work_types: string[];              // ej. ["cocina", "baño"]
+  };
+  _brief_analysis_raw: object;         // dump crudo — frontend ignora
+}
+
+interface KnownItem {
+  field: string;        // ej. "client_name", "material", "localidad", "pileta"
+  value: string;
+  source: "brief" | "operator" | "dual_read" | "default";
+}
+
+interface AssumptionItem {
+  field: string;        // ej. "colocacion", "discount_pct"
+  value: string;
+  reason: string;       // por qué Valentina asumió eso
+  confidence: number;   // 0-1
+}
+
+interface TechDetection {
+  field: string;        // ej. "tomas_count", "anafe_count", "isla_presence"
+  detected: boolean;
+  status: "verified" | "needs_confirmation";
+  confidence: number;
+  detail?: string;
+  options?: string[];   // si needs_confirmation: opciones para radio buttons inline
+}
+
+interface PendingQuestion {
+  id: string;           // ej. "anafe_count", "pileta_simple_doble"
+  question: string;     // texto humano
+  options?: string[];
+}
+```
+
+Ver `sse-spec.md` evento `context_analysis` para más detalle.
+
+---
+
+## `verified_context` y `verified_context_analysis` (post-confirmación)
+
+Cuando el operador escribe `[CONTEXT_CONFIRMED]` en el chat (con respuestas inline a las pending_questions), el agent handler:
+
+1. Promueve `context_analysis_pending` → `verified_context_analysis`
+2. Materializa los valores confirmados en `verified_context` (versión "limpia" sin tech_detections, lista para usar en `calculate_quote`)
+3. Persiste el `[CONTEXT_CONFIRMED]` con respuestas en `Quote.messages`
+
+```ts
+interface VerifiedContext {
+  client_name: string;
+  project: string;
+  material: string;
+  localidad: string;
+  colocacion: boolean;
+  pileta: PiletaType | null;
+  anafe: boolean;
+  pileta_qty: number;
+  anafe_qty: number;
+  // ... otros campos materializados según las respuestas
+  // (shape exacto depende de las pending_questions y precedence:
+  //  operator_answer > brief > dual_read > default)
+}
+
+// `verified_context_analysis` es básicamente una snapshot del
+// `context_analysis_pending` en el momento de la confirmación —
+// sirve para `/reopen-context` que regenera la card original.
+```
+
+---
+
+## Reopen flow
+
+Cuando el operador clickea "Editar contexto" después de confirmado:
+
+```
+POST /api/quotes/{id}/reopen-context
+        │
+        ▼
+1. Valida status NOT IN (validated, sent) — sino 409
+2. Limpia: verified_context_analysis, verified_context, verified_measurements
+3. PRESERVA: dual_read_result, context_analysis_pending, brief_analysis
+4. Limpia tramos `_derived: true` del dual_read_result
+5. total_ars / total_usd → null
+6. Trunca Quote.messages desde el último __CONTEXT_ANALYSIS__ (inclusive)
+7. Re-inserta el card __CONTEXT_ANALYSIS__<json> con context_analysis_pending
+8. Audit `quote.reopened` con kind="context"
+        │
+        ▼
+Frontend re-fetcha el quote → renderea card de contexto editable
+```
+
+Ver `endpoints-spec.md` Flow 4 / 7 para detalle del endpoint.
+
+---
+
+## "Modo PATCH default" (Master §10 decisión 6)
+
+> Surgical edit, recalcular todo = excepción explícita.
+
+El operador edita cells del Paso 2 y el frontend hace `PATCH /api/quotes/{id}` con SOLO los campos cambiados. NO triggea recálculo automático. Si el operador quiere recalcular después de un cambio que afecta el cómputo (ej. cambió material), debe **pasar explícitamente al chat** y pedir "recalculá" o usar `POST /api/quotes/{id}/derive-material`.
+
+**Implicancia para Sprint 2:** el frontend tiene que distinguir entre:
+
+- **Edit cosmético** (client_phone, project, notes) → solo PATCH
+- **Edit que afecta cálculo** (material, pieces, localidad, colocacion, anafe, pileta) → PATCH + sugerir al operador que recalcule via chat
+
+---
+
+## Cifras canónicas — caso Cueto-Heredia (Master §13)
+
+Estado del contexto post-confirmación para `PRES-2026-018`:
+
+```ts
+const cuetoHerediaContextColumns: QuoteContextColumns = {
+  client_name: "Cueto-Heredia",
+  client_phone: null,            // no provisto en mockup
+  client_email: null,
+  project: "Cocina + baño",
+  material: "Silestone Blanco Norte",
+  localidad: "rosario",
+  colocacion: true,
+  pileta: "empotrada_cliente",   // cliente trae la pileta
+  sink_type: { basin_count: "simple", mount_type: "abajo" },
+  anafe: true,
+  is_building: false,            // particular
+  notes: null,
+  conversation_id: null,
+};
+
+const cuetoHerediaContextAnalysis: ContextAnalysisPending = {
+  data_known: [
+    { field: "client_name", value: "Cueto-Heredia", source: "operator" },
+    { field: "project", value: "Cocina + baño", source: "brief" },
+    { field: "material", value: "Silestone Blanco Norte", source: "brief" },
+    { field: "localidad", value: "Rosario", source: "default" },
+  ],
+  assumptions: [
+    { field: "colocacion", value: "true", reason: "Particular cocina default con colocación", confidence: 0.9 },
+    { field: "discount_pct", value: "5", reason: "Cliente arquitecta detectada (CUETO-HEREDIA ARQUITECTAS)", confidence: 0.95 },
+  ],
+  tech_detections: [
+    { field: "anafe_count", detected: true, status: "verified", confidence: 0.85, detail: "Detecté 1 anafe en el plano (símbolo en isla)" },
+  ],
+  pending_questions: [
+    { id: "pileta_simple_doble", question: "¿Pileta simple o doble?", options: ["simple", "doble"] },
+  ],
+  sector_summary: "1 mesada en cocina",
+  brief_analysis: {
+    extraction_method: "haiku",
+    work_types: ["cocina", "baño"],
+  },
+  _brief_analysis_raw: {},
+};
+```
+
+Después del `[CONTEXT_CONFIRMED]` (operador respondió `pileta_simple_doble = simple`):
+
+```ts
+const cuetoHerediaVerifiedContext: VerifiedContext = {
+  client_name: "Cueto-Heredia",
+  project: "Cocina + baño",
+  material: "Silestone Blanco Norte",
+  localidad: "rosario",
+  colocacion: true,
+  pileta: "empotrada_cliente",
+  anafe: true,
+  pileta_qty: 1,
+  anafe_qty: 1,
+};
+```
+
+---
+
+## Validación cliente-side
+
+Replicar las validaciones del backend Pydantic (ver `quote.md`):
+
+```ts
+const CONTEXT_LIMITS = {
+  client_name: { min: 1, max: 500 },
+  client_phone: { max: 100 },
+  client_email: { max: 200 },
+  project: { max: 500 },
+  localidad: { max: 200 },
+  pileta: {
+    enum: ["empotrada_cliente", "empotrada_johnson", "apoyo"] as const,
+  },
+  sink_type: {
+    basin_count: { enum: ["simple", "doble"] as const },
+    mount_type: { enum: ["arriba", "abajo"] as const },
+  },
+  notes: { max: undefined },  // TEXT — sin límite practico, pero >2KB se sanitiza en audit
+};
+```
+
+---
+
+## Mockup ↔ origen real
+
+| Campo del mockup `01-A` | Columna o breakdown path | Origin chip esperado |
+|---|---|---|
+| Cliente | `client_name` | DEL BRIEF / EDITADO |
+| Dirección | `client_phone` o `notes` (no hay columna address) | INFERIDO o FALTA |
+| Tipo cliente | `is_building` (toggle) | INFERIDO o EDITADO |
+| Contacto | `client_phone` / `client_email` | DEL BRIEF / FALTA |
+| Material | `material` | DEL BRIEF (Valentina extrajo del texto) |
+| Demora | `quote_breakdown.delivery_days` | DEFAULT (de config.json) o EDITADO |
+| Localidad | `localidad` | DEL BRIEF / DEFAULT (rosario) |
+| Colocación | `colocacion` | DEFAULT (true) o EDITADO |
+| Pileta | `pileta` + `sink_type` | INFERIDO (Valentina detecta del plano) o FALTA |
+| Anafe | `anafe` | INFERIDO (Valentina detecta símbolo) |
+| Notas | `notes` | DEL BRIEF |
+
+> **🤔 Verificar con Javi:** confirmar la lista exacta de los 11 campos del mockup `01-A` para fijar el mapeo definitivo. Lo de arriba es mi mejor inferencia desde el handoff-design.
+
+---
+
+## Archivos backend leídos para derivar este schema
+
+- `api/app/modules/quote_engine/context_analyzer.py` (782 líneas — `build_context_analysis()` y helpers)
+- `api/app/models/quote.py` (columnas espejo del contexto)
+- `api/app/modules/agent/agent.py` (handlers de `[CONTEXT_CONFIRMED]` y persistencia de `verified_context`)
+- `api/app/modules/agent/router.py` (líneas 629-743 — `POST /reopen-context`)
+- `api/app/modules/quote_engine/brief_analyzer.py` (extracción inicial del brief con Haiku)

--- a/docs/handoff-context/schemas/quote.md
+++ b/docs/handoff-context/schemas/quote.md
@@ -1,0 +1,484 @@
+# Schema · Quote
+
+> **Fuente:** `api/app/models/quote.py` (modelo SQLAlchemy) + `api/app/modules/agent/schemas.py` (response schemas) + `api/app/modules/quote_engine/calculator.py` (shape de `quote_breakdown`).
+> **Última actualización:** 2026-05-05.
+
+El modelo `Quote` es el agregado central del sistema. Cada presupuesto creado por Marina o por el bot web vive como un row en la tabla `quotes` con un `quote_breakdown` JSON que contiene todo el cálculo determinístico.
+
+---
+
+## Tabla `quotes` — columnas
+
+```ts
+interface QuoteRow {
+  // Primary key
+  id: string;                         // UUID o "web-<uuid>" para source=web
+
+  // Client + project
+  client_name: string;                // VARCHAR(500)
+  project: string;                    // VARCHAR(500)
+  client_phone: string | null;        // VARCHAR(100)
+  client_email: string | null;        // VARCHAR(200)
+
+  // Quote essentials
+  material: string | null;            // TEXT
+  total_ars: number | null;           // FLOAT (monto en pesos)
+  total_usd: number | null;           // FLOAT (monto USD si material importado)
+  status: QuoteStatus;                // ENUM: draft | pending | validated | sent
+
+  // Lineage / variantes
+  parent_quote_id: string | null;     // VARCHAR — apunta al root para children
+  quote_kind: QuoteKind | null;       // VARCHAR(30) default "standard"
+  comparison_group_id: string | null; // VARCHAR(200) — para variant_option
+
+  // Origen
+  source: "operator" | "web" | null;  // VARCHAR(20) default "operator"
+  is_read: boolean;                   // default true (false solo para nuevos web quotes)
+
+  // File URLs (locales relativos al server, sirven via /files/{path})
+  pdf_url: string | null;             // VARCHAR(500) ej "/files/{id}/<filename>.pdf"
+  excel_url: string | null;
+  drive_url: string | null;           // legacy — uno solo (PDF u Excel, último uploaded)
+  drive_file_id: string | null;       // VARCHAR(200) — para delete
+  drive_pdf_url: string | null;       // PR #38 — separados PDF
+  drive_excel_url: string | null;     // PR #38 — separados Excel
+
+  // Quote details
+  localidad: string | null;           // VARCHAR(200) — ciudad para flete
+  colocacion: boolean | null;         // default false
+  pileta: PiletaType | null;          // VARCHAR(50)
+  anafe: boolean | null;              // default false
+  sink_type: SinkType | null;         // JSON — basin_count + mount_type
+  is_building: boolean | null;        // default false
+  pieces: PieceInput[] | null;        // JSON — input crudo de medidas
+
+  // JSON blobs grandes
+  quote_breakdown: QuoteBreakdown | null;  // JSON — TODO el cálculo (ver abajo)
+  source_files: SourceFile[] | null;       // JSON — planos/imágenes uploaded
+  messages: ChatMessage[];                  // JSON — chat history (default [])
+  change_history: ChangeHistoryEntry[] | null;  // JSON default []
+
+  // Cards generadas (Sprint 2-4)
+  resumen_obra: ResumenObra | null;        // JSON — consolidado N quotes
+  email_draft: EmailDraft | null;          // JSON — borrador comercial
+  condiciones_pdf: CondicionesPdf | null;  // JSON — solo edificios
+
+  // PR #400 — auditoría web
+  web_input: object | null;           // JSON — body raw del POST /v1/quote
+  conversation_id: string | null;     // VARCHAR(100) — link a sesión chatbot
+
+  // Notas
+  notes: string | null;               // TEXT — del cliente para el operador
+
+  // Timestamps
+  created_at: string;                 // TIMESTAMPTZ con default NOW()
+  updated_at: string;                 // TIMESTAMPTZ con onupdate NOW()
+
+  // Concurrency control
+  version: number;                    // INTEGER default 1 — increment on each update
+}
+```
+
+### Enums
+
+```ts
+type QuoteStatus = "draft" | "pending" | "validated" | "sent";
+
+type QuoteKind =
+  | "standard"                  // quote único, no familia
+  | "building_parent"           // edificio multi-material — padre
+  | "building_child_material"   // edificio — material del padre
+  | "variant_option";           // variante (mismo despiece, otro material)
+
+type PiletaType = "empotrada_cliente" | "empotrada_johnson" | "apoyo";
+
+interface SinkType {
+  basin_count: "simple" | "doble";
+  mount_type: "arriba" | "abajo";
+}
+```
+
+### Transiciones de status
+
+| Desde | Hacia válidos |
+|---|---|
+| `draft` | `validated`, `pending` |
+| `pending` | `validated`, `draft` |
+| `validated` | `sent`, `draft` |
+| `sent` | `validated` |
+
+Validado en `PATCH /api/quotes/{id}/status` (Flow 2 endpoints-spec).
+
+---
+
+## `quote_breakdown` — JSON con todo el cálculo
+
+Calculado por `calculate_quote()` en `api/app/modules/quote_engine/calculator.py:1880`. Persistido en `Quote.quote_breakdown` después del Paso 2 backend Valentina.
+
+```ts
+interface QuoteBreakdown {
+  ok: true;
+
+  // Identificación
+  client_name: string;
+  project: string;
+  date: string;                   // formato "DD.MM.YYYY"
+  delivery_days: string;          // ej. "30 dias desde la toma de medidas"
+
+  // Material
+  material_name: string;          // ej. "SILESTONE BLANCO NORTE"
+  material_type: string;          // ej. "silestone", "granito", "marmol"
+  thickness_mm: number;           // default 20
+  material_m2: number;            // total m² (round 2 dec)
+  material_price_unit: number;    // precio por m² c/IVA (USD: floor, ARS: round)
+  material_price_base: number;    // precio base s/IVA
+  material_currency: "USD" | "ARS";
+  material_total: number;         // material_m2 * price_unit - discount
+
+  // Descuentos
+  discount_pct: number;           // 0-100 — solo aplica al material
+  discount_amount: number;        // monto descuento en moneda del material
+  mo_discount_pct: number;        // descuento opcional sobre MO (excluye flete)
+  mo_discount_amount: number;
+
+  // Merma (solo sintéticos)
+  merma: {
+    aplica: boolean;
+    desperdicio: number;          // m² desperdiciados
+    sobrante_m2: number;          // m² ofrecidos al cliente (mitad de precio)
+    motivo: string;               // "Sintético, desperdicio ≥ 1m²" / "Negro Brasil — nunca aplica" / etc.
+  };
+  sobrante_m2: number;            // duplicado al top-level (legacy)
+  sobrante_total: number;
+
+  // Despiece
+  piece_details: PieceDetail[];   // piezas con sus m² calculados
+  sectors: Sector[];              // agrupación por proyecto/sector con labels finales
+
+  // Mano de obra
+  mo_items: MOItem[];
+  total_mo_ars: number;           // subtotal MO (sin material, sin sinks)
+
+  // Piletas físicas (cuando D'Angelo las vende)
+  sinks: SinkLine[];
+
+  // Totales (GRAND TOTAL)
+  total_ars: number;              // MO + piletas + flete (+ material si ARS)
+  total_usd: number;              // material si USD; 0 si material es ARS
+
+  // Metadata para regenerate sin recalcular
+  has_m2_override: boolean;       // true si alguna pieza usó m2_override del operador
+
+  // Persist input params para patch mode
+  localidad: string;
+  colocacion: boolean;
+  is_edificio: boolean;
+  pileta: PiletaType | null;
+  pileta_qty: number;
+  anafe: boolean;
+  frentin: boolean;
+  frentin_ml: number;
+  regrueso: boolean;
+  regrueso_ml: number;
+  inglete: boolean;
+  pulido: boolean;
+  skip_flete: boolean;
+
+  // Warnings (opcional)
+  warnings?: string[];
+
+  // Fuzzy match metadata (si Valentina corrigió el material)
+  fuzzy_corrected_from?: string;  // ej. "silestone blanca norte" (typo del operador)
+  fuzzy_score?: number;           // 0-100 confidence
+  fuzzy_catalog?: string;         // ej. "materials-silestone"
+  fuzzy_family?: string;
+
+  // Edificio validation checklist (solo is_edificio=true)
+  edificio_checklist?: {
+    sin_colocacion: boolean;
+    flete_qty: number;
+    flete_calculo: string;        // ej. "5 fletes"
+    mo_dividido_1_05: boolean;
+    descuento_18: boolean;
+  };
+
+  // Cards y estado del flow Sprint 2 (persistido por chat handlers)
+  dual_read_result?: DualReadResult;        // ver sse-spec.md
+  dual_read_plan_hash?: string;
+  dual_read_planilla_m2?: number;
+  dual_read_crop_label?: string;
+  context_analysis_pending?: ContextAnalysis;  // ver sse-spec.md
+  verified_context_analysis?: object;          // post-confirmación
+  verified_context?: object;
+  verified_measurements?: object;
+  brief_analysis?: object;
+  page_data?: Record<string, PageData>;        // para visual-pages flow (edificios)
+  zone_default?: string;
+  zone_default_bbox?: number[];
+  selected_zone?: object;
+  building_step?: string;
+  files_v2?: { items: FileV2Item[] };          // metadata Drive-first
+
+  // ... otros campos transitorios (se ignoran si no aplica el caso)
+}
+
+interface PieceDetail {
+  description: string;       // ej. "Mesada cocina"
+  largo: number;             // metros
+  dim2: number;              // prof o alto según el contexto
+  m2: number;                // m² calculado de esta pieza
+  override?: boolean;        // true si vino de Planilla de Cómputo (m2_override)
+  quantity?: number;         // default 1
+  // ... otros campos de la piece original
+}
+
+interface Sector {
+  label: string;             // ej. "Cocina", "Baño"
+  pieces: string[];          // labels formateados (ej. "2.10 × 0.60 Mesada", "ZOCALO 2.00 × 0.05")
+}
+
+interface MOItem {
+  description: string;       // ej. "COLOCACION", "PEGADOPILETA"
+  quantity: number;          // m² para colocación, count para resto
+  unit_price: number;        // c/IVA (round)
+  base_price?: number;       // s/IVA (para traceability — IVA toggle)
+  total: number;             // quantity × unit_price
+}
+
+interface SinkLine {
+  name: string;              // ej. "JOHNSON LUXOR171"
+  quantity: number;
+  unit_price: number;        // ARS
+}
+```
+
+---
+
+## Cifras canónicas — caso Cueto-Heredia (Master §13)
+
+`PRES-2026-018` · Silestone Blanco Norte · 6,50 m². Después del descuento 5% arquitecta:
+
+```ts
+const cuetoHerediaQuoteBreakdown: QuoteBreakdown = {
+  ok: true,
+  client_name: "Cueto-Heredia",
+  project: "Cocina + baño",
+  date: "05.05.2026",
+  delivery_days: "30 dias desde la toma de medidas",
+
+  material_name: "SILESTONE BLANCO NORTE",
+  material_type: "silestone",
+  thickness_mm: 20,
+  material_m2: 6.50,
+  material_price_unit: 249,           // USD c/IVA — referencial del mockup, ver bug P2
+  material_price_base: 206,           // USD s/IVA
+  material_currency: "USD",
+  material_total: 1538,               // post descuento 5%
+
+  discount_pct: 5,
+  discount_amount: 81,
+  mo_discount_pct: 0,
+  mo_discount_amount: 0,
+
+  merma: { aplica: false, desperdicio: 0, sobrante_m2: 0, motivo: "Cabe en placa" },
+  sobrante_m2: 0,
+  sobrante_total: 0,
+
+  piece_details: [
+    { description: "Mesada cocina", largo: 2.50, dim2: 0.65, m2: 1.625 },
+    { description: "Mesada cocina (extensión)", largo: 1.80, dim2: 0.65, m2: 1.170 },
+    { description: "Tope baño", largo: 1.20, dim2: 0.55, m2: 0.660 },
+    { description: "Mesada cocina + zócalo", largo: 4.30, dim2: 0.05, m2: 0.215 },
+    // ... el detalle real depende del plano
+  ],
+
+  sectors: [
+    { label: "Cocina + baño", pieces: ["2.50 × 0.65 Mesada", "1.80 × 0.65 Mesada", "1.20 × 0.55 Tope", "ZOCALO 4.30 × 0.05"] },
+  ],
+
+  mo_items: [
+    { description: "COLOCACION",   quantity: 6.50, unit_price: 60135, base_price: 49698, total: 390877 },
+    { description: "PEGADOPILETA", quantity: 1,    unit_price: 65147, base_price: 53840, total:  65147 },
+    { description: "ANAFE",        quantity: 1,    unit_price: 43097, base_price: 35617, total:  43097 },
+    { description: "REGRUESO",     quantity: 4.98, unit_price: 16710, base_price: 13810, total:  83217 },
+    { description: "TOMAS",        quantity: 2,    unit_price:  7818, base_price:  6461, total:  15636 },
+    { description: "Flete + toma medidas Rosario", quantity: 1, unit_price: 62920, base_price: 52000, total: 62920 },
+  ],
+  total_mo_ars: 660893,                // ≈ $660.890 (ARS canon)
+
+  sinks: [],                           // cliente no compró pileta en D'Angelo
+  total_ars: 660890,                   // canon
+  total_usd: 1538,                     // canon (material)
+
+  has_m2_override: false,
+  localidad: "rosario",
+  colocacion: true,
+  is_edificio: false,
+  pileta: "empotrada_cliente",
+  pileta_qty: 1,
+  anafe: true,
+  frentin: false,
+  frentin_ml: 0,
+  regrueso: true,
+  regrueso_ml: 4.98,
+  inglete: false,
+  pulido: false,
+  skip_flete: false,
+};
+```
+
+**Nota sobre Bug P2 Silestone (Master §12):** el mockup 07-v4 muestra USD 249/m² c/IVA, pero el catálogo real dice USD 519 c/IVA. Las cifras de arriba reflejan el mockup. En producción, `calculate_quote()` toma el catálogo real → totales pueden diferir hasta que se reconcilie el dataset.
+
+---
+
+## Cifras canon — caso Pereyra mobile (Master §13)
+
+`PRES-2026-017` · Pereyra · Silestone · 6,50 m² (aparece en mockup `24-paso-dashboard-B-mobile-detalle`):
+
+```ts
+const pereyraTotals = {
+  total_ars: 660890,
+  total_usd: 1538,
+  material_m2: 6.50,
+  material: "Silestone (variante Pereyra del mockup mobile)",
+};
+```
+
+---
+
+## ChatMessage shape (en `Quote.messages`)
+
+```ts
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string | ContentBlock[];
+}
+
+// `content` puede ser string simple o array (multimodal Anthropic)
+type ContentBlock =
+  | { type: "text"; text: string }
+  | { type: "image"; source: { type: "base64"; media_type: string; data: string } };
+
+// Markers especiales que pueden aparecer en `content` (string completo):
+//   "__DUAL_READ__<json>"             → card despiece persistida
+//   "__CONTEXT_ANALYSIS__<json>"      → card contexto persistida
+//   "[DUAL_READ_CONFIRMED]"           → confirmación del operador
+//   "[CONTEXT_CONFIRMED]"             → confirmación del operador
+//   "[SYSTEM_TRIGGER:<event>]"        → trigger interno
+//   "(contexto confirmado)"           → legacy fake turn (ignorar)
+//   "_SHOWN_"                         → legacy placeholder (ignorar — pre-PR #379)
+```
+
+Frontend al reabrir un quote: `GET /api/quotes/{id}` trae `messages[]`. Renderear filtrando los markers de sistema.
+
+---
+
+## ChangeHistoryEntry shape
+
+```ts
+interface ChangeHistoryEntry {
+  timestamp: string;          // ISO datetime
+  action: "regenerate_docs" | "generate_docs" | "patch_quote" | "update_quote" | string;
+  // Campos según `action`:
+  pdf_url_before?: string | null;
+  pdf_url_after?: string | null;
+  excel_url_before?: string | null;
+  excel_url_after?: string | null;
+  fields?: string[];          // para patch_quote
+  // ... otros campos según el contexto
+}
+```
+
+Append-only. Usado para computar `pdf_outdated` en `GET /api/quotes/{id}` (PR #442).
+
+---
+
+## SourceFile shape
+
+```ts
+interface SourceFile {
+  filename: string;           // ej. "plano.pdf"
+  type: string;               // MIME, ej. "application/pdf"
+  size: number;               // bytes
+  url: string;                // path local, ej. "/files/{quote_id}/sources/plano.pdf"
+  uploaded_at: string;        // ISO datetime
+  // Drive metadata (opcional, best effort):
+  drive_file_id?: string;
+  drive_url?: string;
+  drive_download_url?: string;
+}
+```
+
+---
+
+## ResumenObra, EmailDraft, CondicionesPdf shapes
+
+Generados por endpoints específicos. Se persisten dentro del quote para mostrar como cards en el detalle.
+
+```ts
+interface ResumenObra {
+  pdf_url: string;
+  drive_url: string | null;
+  drive_file_id?: string | null;
+  notes: string;
+  generated_at: string;       // ISO
+  quote_ids: string[];        // los N quotes consolidados
+  client_name: string;
+  project: string;
+}
+
+interface EmailDraft {
+  subject: string;
+  body: string;
+  generated_at: string;
+  validated: boolean;
+  quote_updated_at_snapshot: string;
+  resumen_updated_at_snapshot: string | null;
+  sibling_updated_at_snapshots: Record<string, string>;  // quote_id → ISO
+}
+
+interface CondicionesPdf {
+  pdf_url: string;
+  drive_url: string | null;
+  drive_file_id?: string | null;
+  generated_at: string;
+  plazo: string;
+}
+```
+
+---
+
+## Validación cliente-side
+
+Para PATCH y POST de quotes, replicar las validaciones del backend (Pydantic V2):
+
+```ts
+const QUOTE_LIMITS = {
+  client_name: { min: 1, max: 500 },
+  project: { max: 500 },
+  client_phone: { max: 100 },
+  client_email: { max: 200 },
+  localidad: { max: 200 },
+  pileta: { max: 50 },
+  conversation_id: { max: 100 },
+  parent_quote_id: { max: 200 },
+  delivery_days: { max: 200 },
+};
+
+const PIECE_LIMITS = {
+  description: { max: 200 },
+  largo: { gt: 0, le: 20 },     // metros
+  prof: { gt: 0, le: 5 },       // metros
+  alto: { gt: 0, le: 5 },       // metros
+};
+```
+
+---
+
+## Archivos backend leídos para derivar este schema
+
+- `api/app/models/quote.py` (modelo SQLAlchemy completo)
+- `api/app/modules/agent/schemas.py` (`QuoteListResponse`, `QuoteDetailResponse`, `QuotePatchRequest`)
+- `api/app/modules/quote_engine/schemas.py` (`PieceInput`, `PiletaType`, `SinkTypeInput`, `QuoteInput`)
+- `api/app/modules/quote_engine/calculator.py` (líneas 1880-1950 — return shape de `calculate_quote()`)
+- `api/CONTEXT.md` (referencia de SKUs y cifras canon — system prompt Valentina)

--- a/docs/handoff-context/sse-spec.md
+++ b/docs/handoff-context/sse-spec.md
@@ -1,0 +1,424 @@
+# SSE Spec · Chat Valentina
+
+> **Fuente:** código backend real (`api/app/modules/agent/router.py` líneas 2342-2389 + `agent.py` event yields).
+> **Endpoint:** `POST /api/quotes/{quote_id}/chat`
+> **Última actualización:** 2026-05-05.
+
+El chat con Valentina usa **Server-Sent Events** (SSE) sobre HTTP/1.1. El backend stream chunks JSON en formato `data: {...}\n\n`. El frontend consume con `EventSource` o `fetch().body.getReader()`.
+
+---
+
+## Conexión
+
+### Request
+
+```http
+POST /api/quotes/{quote_id}/chat HTTP/1.1
+Cookie: auth_token=<jwt>
+Content-Type: multipart/form-data; boundary=...
+
+--boundary
+Content-Disposition: form-data; name="message"
+
+Texto del operador
+--boundary
+Content-Disposition: form-data; name="plan_files"; filename="plano.pdf"
+Content-Type: application/pdf
+
+<bytes>
+--boundary--
+```
+
+**Form fields:**
+
+| Campo | Tipo | Required | Validación |
+|---|---|---|---|
+| `message` | string | Sí | Texto del operador. Puede contener markers especiales (ver abajo). |
+| `plan_files` | file[] | No | Hasta **10** archivos. PDF/JPEG/PNG/WEBP. Max **10MB** c/u. PDFs deben ser **1 página**. |
+
+**Markers reservados en `message`:**
+
+- `[DUAL_READ_CONFIRMED]` — operador confirmó la card de despiece
+- `[CONTEXT_CONFIRMED]` — operador confirmó la card de contexto (con respuestas inline)
+- `[SYSTEM_TRIGGER:<event>]` — handlers internos (no escribir manualmente)
+
+### Response headers
+
+```http
+HTTP/1.1 200 OK
+Content-Type: text/event-stream
+Cache-Control: no-cache
+X-Accel-Buffering: no
+Connection: keep-alive
+```
+
+`X-Accel-Buffering: no` es **crítico** — sin él, Railway/nginx bufferean el stream y los chunks llegan en bloque al final.
+
+---
+
+## Format de chunks
+
+Cada chunk es una línea SSE:
+
+```
+data: {"type": "<type>", "content": "<content>", ...}
+
+```
+
+(Doble newline al final separa chunks.)
+
+**Excepción** — keepalive:
+
+```
+: keepalive
+
+```
+
+(Comment SSE, sin `data:`.) El cliente ignora estos.
+
+---
+
+## Event types
+
+7 tipos reales emitidos por el backend (verificado contra `agent/router.py:2354-2380` + yields en `agent.py`):
+
+### `text` — fragmento de respuesta
+
+Token-by-token streaming de la respuesta de Valentina.
+
+```ts
+interface TextEvent {
+  type: "text";
+  content: string;  // delta — concatenar para reconstruir el mensaje
+}
+```
+
+**Frecuencia:** alta — varios por segundo durante streaming. El frontend debe coalescer con `requestAnimationFrame` para no saturar React (1 update por frame).
+
+**Contenido:** texto plano + markdown limitado (`**bold**`, `\n`, links `[label](url)`, tablas pipe-separated). El componente `MessageBubble` del frontend ya lo parsea.
+
+---
+
+### `action` — tool use en progreso
+
+Banner de loading mientras Valentina ejecuta una tool del agente loop.
+
+```ts
+interface ActionEvent {
+  type: "action";
+  content: string;  // descripción humana del tool en ejecución
+}
+```
+
+**Ejemplos de `content`:**
+
+- `"⚙️ Ejecutando: catalog_batch_lookup..."`
+- `"⚙️ Ejecutando: list_pieces..."`
+- `"📐 Leyendo medidas del plano..."`
+- `"⚙️ Ejecutando: calculate_quote..."`
+- `"⚙️ Ejecutando: generate_documents..."`
+- `"⏳ Esperando disponibilidad... (5s)"` (rate limit retry)
+- `"⏳ Servicio ocupado, reintentando... (10s)"` (Anthropic 529)
+- `"✏️ Aplicando cambios al card..."` (card_editor)
+
+**Render del frontend:** mapeable al `<StatusBar>` con `vbubble` think animation (Master §9). Cuando llega un nuevo `action`, reemplaza el anterior. Cuando llega un `text`, ocultar la status-bar.
+
+---
+
+### `dual_read_result` — card de despiece
+
+Card del Paso 3 (despiece) emitida después de leer un plano. `content` es un **JSON string** (no objeto) que el frontend debe `JSON.parse()`.
+
+```ts
+interface DualReadResultEvent {
+  type: "dual_read_result";
+  content: string;  // JSON string de DualReadResult
+}
+
+// Después de JSON.parse(content):
+interface DualReadResult {
+  source: "DUAL" | "SOLO_OPUS" | "SOLO_SONNET";  // qué modelos contribuyeron
+  sectores: Sector[];
+  requires_human_review: boolean;
+  conflict_fields: string[];
+  view_type: "top_view" | "side_view" | "unknown";
+  view_type_reason?: string;
+  m2_warning?: string;            // si la suma del despiece no matchea la planilla declarada
+  pending_questions?: PendingQuestion[];
+  opus_error?: string;            // si /dual-read-retry fue triggered y Opus falló
+  _retry?: true;                  // flag interno post-retry
+  _crop_path?: string;            // path interno del crop guardado en disco
+}
+
+interface Sector {
+  tipo: "cocina" | "baño" | "isla" | "lavadero" | "l" | "u" | "recta";
+  tramos: Tramo[];
+  m2_total: FieldValue<number>;
+  ambiguedades: Ambiguedad[];
+}
+
+interface Tramo {
+  id: string;
+  descripcion: string;
+  largo_m: FieldValue<number>;
+  ancho_m: FieldValue<number>;
+  m2: FieldValue<number>;
+  zocalos?: Zocalo[];
+  _derived?: true;     // para tramos auto-generados (ej. patas de isla)
+  _kind?: "isla_pata" | "alzada" | string;
+}
+
+interface Zocalo {
+  lado: "frente" | "atrás" | "izquierda" | "derecha";
+  ml: number;
+  alto_m: number;
+}
+
+// Cada FieldValue contiene el valor consolidado + qué modelo lo aportó
+interface FieldValue<T = number> {
+  opus?: T | null;
+  sonnet?: T | null;
+  valor: T;
+  status: "CONFIRMADO" | "DUAL_AGREE" | "DUAL_DIVERGENT" | "SOLO_OPUS" | "SOLO_SONNET";
+}
+
+interface Ambiguedad {
+  field: string;
+  detail: string;
+}
+
+interface PendingQuestion {
+  id: string;          // ej. "anafe_count", "pileta_simple_doble"
+  question: string;    // texto humano
+  options?: string[];  // opciones predefinidas (radio buttons)
+}
+```
+
+**Side effect del backend:** persiste el card en `Quote.messages` con marker `__DUAL_READ__<json>` para poder reconstruir la conversación al reabrir el quote.
+
+**Render del frontend:** Master §9 menciona `<EditableTable cols-despiece>` para la card del Paso 3. Ver mockups `04-despiece-A`, `05-despiece-B`, `06-despiece-C`.
+
+---
+
+### `context_analysis` — card de análisis de contexto
+
+Card emitida ANTES del despiece (PR G — flow nuevo). Resume lo que Valentina detectó del brief + plano + análisis técnico.
+
+```ts
+interface ContextAnalysisEvent {
+  type: "context_analysis";
+  content: string;  // JSON string de ContextAnalysis
+}
+
+// Después de JSON.parse(content):
+interface ContextAnalysis {
+  data_known: KnownItem[];
+  assumptions: AssumptionItem[];
+  tech_detections: TechDetection[];
+  pending_questions: PendingQuestion[];
+  sector_summary: string | null;       // ej. "2 mesada(s) en cocina + isla"
+  brief_analysis: {
+    extraction_method: "haiku" | "fallback";
+    work_types: string[];              // ej. ["cocina", "baño"]
+  };
+  _brief_analysis_raw: object;         // dump crudo — frontend ignora
+}
+
+interface KnownItem {
+  field: string;        // ej. "client_name", "material", "localidad"
+  value: string;
+  source: "brief" | "operator" | "dual_read" | "default";
+}
+
+interface AssumptionItem {
+  field: string;        // ej. "colocacion", "discount_pct"
+  value: string;
+  reason: string;       // por qué Valentina asumió eso
+  confidence: number;   // 0-1
+}
+
+interface TechDetection {
+  field: string;                                    // ej. "tomas_count", "anafe_count"
+  detected: boolean;
+  status: "verified" | "needs_confirmation";
+  confidence: number;
+  detail?: string;                                  // descripción humana
+  options?: string[];                               // si needs_confirmation
+}
+```
+
+**Side effect del backend:** persiste con marker `__CONTEXT_ANALYSIS__<json>` en `messages`.
+
+**Render del frontend:** mapeable al panel de Paso 2 (Master §6 mockups `01-A`, `02-B`, `03-C`). Cada tech_detection con `needs_confirmation` se renderea con radio buttons inline.
+
+---
+
+### `zone_selector` — selector de zona en plano
+
+Aparece cuando el agente necesita que el operador marque una zona del plano (visual_pages flow para edificios). Frontend muestra la imagen + permite dibujar rectángulo + manda `POST /api/quotes/{id}/zone-select`.
+
+```ts
+interface ZoneSelectorEvent {
+  type: "zone_selector";
+  content: string;  // JSON string
+}
+
+// Después de JSON.parse(content):
+interface ZoneSelectorPayload {
+  image_url: string;        // ej. "/files/{quote_id}/page_1.jpg"
+  page_num: number;
+  instruction: string;      // copy humano: "Dibujá un rectángulo sobre la zona de la mesada de mármol"
+}
+```
+
+**Flow:**
+
+1. Backend emite `zone_selector` + `done`
+2. Frontend muestra UI de selección sobre `image_url`
+3. Operador marca rectángulo (coordenadas normalizadas 0-1)
+4. Frontend hace `POST /api/quotes/{id}/zone-select` con `{bbox_normalized, page_num}`
+5. Operador escribe mensaje "ya marqué" en el chat → arranca nuevo turno SSE
+
+---
+
+### `done` — fin del stream
+
+```ts
+interface DoneEvent {
+  type: "done";
+  content: "";       // siempre vacío
+  error?: true;      // solo si hubo error en el stream (ver event "error" abajo)
+}
+```
+
+El frontend cierra la conexión al recibir esto. Si `error: true` viene, el último mensaje del usuario falló — UI debe mostrar opción "reintentar".
+
+---
+
+### `error` — error durante el stream
+
+```ts
+interface ErrorEvent {
+  type: "error";
+  content: string;   // mensaje humano, ej. "⚠️ Error inesperado: <detail>. Intentá de nuevo."
+}
+```
+
+**Cuándo se emite:**
+
+- Excepción no controlada en el agent loop
+- Anthropic API error no recuperable (no 429, no 529)
+- Timeout interno
+
+**Siempre seguido por** `data: {"type": "done", "content": "", "error": true}` para cerrar el stream.
+
+**Render frontend:** mostrar el `content` en el bubble de Valentina con styling `.msg.v.error` (mockup 17). Ofrecer botones "Reintentar" / "Reportar".
+
+---
+
+### `ping` — keepalive (no es un data event)
+
+Comment SSE para mantener viva la conexión cuando Valentina está pensando. No se emite como `data:`, va como comment:
+
+```
+: keepalive
+
+```
+
+**Cuándo:** el backend lo emite cada ~10s durante operaciones largas (Opus vision para planos complejos puede tomar 60-120s).
+
+**Frontend:** ignorar. La librería SSE estándar no lo expone como event — es transparente.
+
+---
+
+## Flow típico — caso Cueto-Heredia (Master §13)
+
+Operador adjunta plano del depto Cueto-Heredia (Silestone Blanco Norte, 6,50 m²).
+
+```
+1.  data: {"type": "action", "content": "📐 Leyendo medidas del plano..."}
+2.  data: {"type": "context_analysis", "content": "{...data_known: [...], assumptions: [...], pending_questions: [{id: 'anafe_count', ...}]}"}
+3.  data: {"type": "done", "content": ""}
+   [operador responde la pending_question + dispara nuevo turno]
+
+4.  data: {"type": "action", "content": "✏️ Aplicando cambios al card..."}
+5.  data: {"type": "dual_read_result", "content": "{...sectores: [{tipo: 'cocina', tramos: [...], m2_total: {valor: 6.50, status: 'CONFIRMADO'}}], requires_human_review: false}"}
+6.  data: {"type": "done", "content": ""}
+   [operador escribe "[DUAL_READ_CONFIRMED]" → confirma despiece]
+
+7.  data: {"type": "action", "content": "⚙️ Ejecutando: catalog_batch_lookup..."}
+8.  data: {"type": "action", "content": "⚙️ Ejecutando: calculate_quote..."}
+9.  data: {"type": "text", "content": "## PASO 2 — Validación"}
+10. data: {"type": "text", "content": "\n\nPRESUPUESTO TOTAL: $660.890 mano de obra + USD 1.538 material"}
+11. data: {"type": "done", "content": ""}
+   [operador valida → POST /api/quotes/{id}/validate genera PDF/Excel/Drive fuera del SSE]
+```
+
+---
+
+## Reconexión + manejo de errores en cliente
+
+### Connection drop
+
+El backend NO implementa reconexión automática vía `Last-Event-ID`. Si la conexión se corta:
+
+- Frontend re-fetcha el quote completo: `GET /api/quotes/{id}` → renderea desde `messages`
+- Si el último turno quedó incompleto en messages, mostrar como interrumpido
+- Cliente puede reintentar con un nuevo `POST /chat` — el backend deduplica por hash del plano
+
+### Connect timeout
+
+El cliente debe abortar el fetch si el server no devuelve headers en **60s** (Anthropic puede demorar en arrancar). El frontend ya tiene esto (`web/src/lib/api.ts` con `AbortController` + 60s timeout).
+
+### Stall timeout
+
+Si no llega ningún chunk durante **90s**, abortar. El backend debería estar emitiendo `: keepalive` cada ~10s — si no llega nada, la conexión está muerta.
+
+### Error transitorio (429, 502, 503)
+
+- `429` rate limit del operator panel → mostrar "Esperá un minuto" en el chat
+- `502/503/504` → mostrar "El servidor está reiniciando. Esperá unos segundos e intentá de nuevo"
+- `429` de Anthropic (interno, no llega como HTTP del operator) → el agent loop reintenta automáticamente con backoff (5s, 10s, 15s) y emite `action` chunks de progreso
+
+---
+
+## Tools del agente Valentina
+
+Aunque las tools NO se exponen como REST, su existencia afecta lo que el SSE emite. Lista de las **9 tools** definidas en `agent.py:1212-1221`:
+
+| Tool | Descripción | Cuándo Valentina la llama |
+|---|---|---|
+| `list_pieces` | Lista piezas con texto exacto + total m² | Paso 1 obligatorio cuando hay despiece |
+| `catalog_lookup` | Precio de 1 SKU | Paso 2 cuando necesita 1 precio |
+| `catalog_batch_lookup` | Precios de múltiples SKUs | Preferido sobre lookup individual para 2+ |
+| `check_stock` | Retazos disponibles en taller | Antes de calcular merma |
+| `check_architect` | Verifica si cliente es arquitecta con descuento | Paso 2 cuando hay nombre |
+| `read_plan` | Zoom táctico en zonas del plano | Solo para detalles ilegibles, max 2 crops/llamada |
+| `calculate_quote` | Cálculo determinístico (m², MO, totales) | Paso 2 SIEMPRE |
+| `generate_documents` | PDF + Excel + Drive | Cuando el operador confirma |
+| `update_quote` | Update DB sin recalcular | Cambios menores (delivery_days, etc.) |
+| `patch_quote_mo` | Modificar MO específicamente | Edits dirigidos sin recálculo completo |
+
+**Reglas hard del agente** (Master §5, replicadas acá para referencia frontend):
+
+- Cliente Y proyecto bloqueantes — sin los dos, Valentina NO arranca
+- PROHIBIDO en Paso 1: `catalog_lookup`, `catalog_batch_lookup`, `calculate_quote`. Solo `list_pieces`.
+- `list_pieces` rendera con texto exacto — frontend NO recalcula m² manualmente
+- Frases prohibidas en `text` events: "mientras", "voy a buscar", "dejame verificar", "voy a recortar", "¿Es edificio?"
+
+---
+
+## ⚠️ Verificar contra implementación real
+
+- **Reconexión vía `Last-Event-ID`:** no se implementa hoy. Si el frontend Sprint 2 lo necesita, agregarlo via PR backend separado.
+- **Order garantías:** dentro de un turno, el orden de events sí está garantizado. Entre turnos, el backend espera al `done` del anterior antes de procesar uno nuevo.
+- **Rate limit retry messages:** el formato exacto de `"⏳ Esperando disponibilidad... (Xs)"` puede cambiar — frontend debe NO parsear el contenido, solo mostrar como banner.
+
+---
+
+## Archivos backend leídos para derivar este spec
+
+- `api/app/modules/agent/router.py` (líneas 2342-2389 — el `event_stream()` generator)
+- `api/app/modules/agent/agent.py` (yields de los 7 event types — buscar `yield {"type":` y `chunks.append({"type":`)
+- `api/app/modules/quote_engine/dual_reader.py` (líneas 461, 657 — shape de `DualReadResult`)
+- `api/app/modules/quote_engine/context_analyzer.py` (líneas 747-805 — shape de `ContextAnalysis`)


### PR DESCRIPTION
## Resumen del PR

Extracción de los contratos del backend FastAPI a Markdown auditable + JSONs sanitizados, en `docs/handoff-context/`. Permite que el frontend Sprint 2 mockee contra contratos reales antes de que `useMockClient()` cambie a `useApiClient()` en Sprint 3 inicial.

NO escribe código de producción — solo Markdown + JSON sanitizado.

## Sprint y sub-branch

- Sprint: 1.5 (PR previo a Sprint 2)
- Sub-branch: `sprint-1.5/extract-api-contracts`
- Mergea contra: `sprint-1.5/master-handoff` (NO main)

## Checklist pre-merge

### Código

- [x] No aplica build/lint/tests — solo Markdown + JSON
- [x] **No hay credenciales, tokens, API keys ni `.env` committeados** (verificado con `git diff | grep -iE "sk-...|api_key|password|service_account"` → sin matches)
- [x] **No hay archivos `.py`/`.ts`/`.tsx`/`.js` nuevos** (verificado con `git diff --name-only | grep -E "\.(env|py|ts|tsx|js)$"` → sin matches)

### Si toca handoff/docs

- [x] No se reproducen literalmente `chrome.js`, `bug-report.js` o `frame-label`
- [x] **Cifras canon Cueto-Heredia preservadas literal** en specs y catálogos (Master §13 — ver "Cifras canónicas" en `README.md` del handoff-context)
- [x] Specs derivadas del código backend real (NO inventadas)
- [x] Trazabilidad: cada archivo lista al final los archivos backend leídos para derivarlo

### Scope

- [x] Alcance acotado al PR `extract-api-contracts` definido en Master §21.8
- [x] Endpoints sugeridos por mockups que NO existen → documentados en `missing-endpoints.md`, ninguno bloquea Sprint 2

## Output esperado · entregado

```
docs/handoff-context/
├── README.md                    ← índice + cifras canon + métricas (124 líneas)
├── endpoints-spec.md            ← ~50 endpoints agrupados por flow Master §6 (1750 líneas)
├── sse-spec.md                  ← 7 event types reales del chat Valentina (424 líneas)
├── missing-endpoints.md         ← 10 sugeridos por mockups (216 líneas)
├── schemas/
│   ├── quote.md                 ← modelo Quote + QuoteBreakdown JSON (484 líneas)
│   ├── audit_events.md          ← schema audit_events + event_types (242 líneas)
│   ├── brief.md                 ← Paso 1 multipart vs web bot (294 líneas)
│   └── context.md               ← Paso 2 columnas + cards IA (325 líneas)
└── catalog/                     ← 15 JSONs sanitizados (~32 KB)
    ├── README.md                ← reglas de sanitización
    ├── architects.json          ← Cueto-Heredia canon + 7 placeholders
    ├── config.json              ← literal (no PII)
    ├── delivery-zones.json      ← Rosario canon + 31 sintetizadas
    ├── labor.json               ← 5 SKUs MO canon + 29 sintetizados
    ├── materials-silestone.json ← SILESTONENORTE canon + 4 samples
    └── (8 catálogos más sample sintéticos)
```

**Total:** 24 archivos · 3786 líneas Markdown · ~228 KB.

## Métricas

| Categoría | Count |
|---|---|
| Endpoints documentados | ~50 |
| Schemas | 4 |
| SSE event types | 7 + ping keepalive |
| Catálogos sanitizados | 15 |
| Missing endpoints (informativo) | 10 |

## Archivos backend leídos para derivar las specs

- `api/app/modules/auth/router.py` (125 líneas)
- `api/app/modules/agent/router.py` (2389 líneas — ~30 endpoints `/api/quotes/*`)
- `api/app/modules/agent/schemas.py` (141 líneas)
- `api/app/modules/quote_engine/router.py` (553 líneas — `/v1/quote*`)
- `api/app/modules/quote_engine/schemas.py` (93 líneas)
- `api/app/modules/quote_engine/calculator.py` (~1950 líneas — solo el shape de return)
- `api/app/modules/quote_engine/context_analyzer.py` (782 líneas)
- `api/app/modules/quote_engine/dual_reader.py` (líneas 461, 657)
- `api/app/modules/catalog/router.py` (442 líneas)
- `api/app/modules/observability/router.py` (678 líneas — `/api/admin/*`)
- `api/app/modules/observability/models.py` (82 líneas)
- `api/app/modules/observability/{sanitizer,system_config,cleanup}.py`
- `api/app/modules/usage/router.py` (148 líneas)
- `api/app/modules/business_rules/router.py` (66 líneas)
- `api/app/models/quote.py` (119 líneas)
- `api/CONTEXT.md` (system prompt Valentina — referencia)
- `api/API.md` (882 líneas — doc base existente, validada y extendida)
- 15 catálogos JSON en `api/catalog/`

## Notas para el auditor

**Cifras canónicas Cueto-Heredia** preservadas literal (Master §13):

- `architects.json`: CUETO-HEREDIA ARQUITECTAS (5% importado)
- `labor.json`: COLOCACION $49.698,65 · PEGADOPILETA $53.840 · ANAFE $35.617,36 · REGRUESO $13.810 · TOMAS $6.461 (todos base s/IVA)
- `delivery-zones.json`: ENVIOROS Rosario $52.000 base
- `materials-silestone.json`: SILESTONENORTE USD 206 base = USD 249 c/IVA (cifra del mockup canon, **bug P2 incluido a propósito** — Master §12)

Combinados producen el TOTAL canonical: **`$660.890 mano de obra + USD 1.538 material`**.

**🤔 Dudas anotadas en los specs:**

- `schemas/context.md`: lista exacta de los "11 campos del paso 2" del mockup `01-A` — inferida desde data model del Master + handoff-design, pero conviene confirmar para fijar el mapeo.

**Decisiones de sanitización del catálogo** (ver `catalog/README.md`):

- Materials catalogs reducidos a 5 items por archivo (de 13-45 originales) — sample suficiente para mockear, sin volcar lista completa.
- Sinks reducido a 12 items (de 85).
- Stock sintético 5 retazos.
- Resto de architects/labor/delivery-zones: nombres reemplazados por placeholders, precios sintéticos deterministic-por-SKU-hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)