### PR TITLE
Sprint 2 · paso-1-brief-upload: estados A/B/C + mock client + 9 E2E

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -25,6 +25,7 @@
         "postcss": "^8.4.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
+        "react-dropzone": "^14.4.1",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.4.0"
       },
@@ -2683,6 +2684,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
@@ -4281,6 +4291,18 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-selector": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/fill-range": {
@@ -6502,7 +6524,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -6565,11 +6586,27 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-dropzone": {
+      "version": "14.4.1",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.4.1.tgz",
+      "integrity": "sha512-QDuV76v3uKbHiH34SpwifZ+gOLi1+RdsCO1kl5vxMT4wW8R82+sthjvBw4th3NHF/XX6FBsqDYZVNN+pnhaw0g==",
+      "license": "MIT",
+      "dependencies": {
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/read-cache": {

--- a/web/package.json
+++ b/web/package.json
@@ -35,6 +35,7 @@
     "postcss": "^8.4.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
+    "react-dropzone": "^14.4.1",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.4.0"
   },

--- a/web/src/app/v2/page.tsx
+++ b/web/src/app/v2/page.tsx
@@ -5,7 +5,12 @@
  * operator-shared.css están cableados. Texto y estilos son demo
  * exclusivamente del sistema de design — no datos funcionales. El
  * dashboard real va en Sprint 4 (mockups 23/25 del Master §6).
+ *
+ * Sprint 2 paso-1-brief-upload: agregamos CTA "Nuevo presupuesto"
+ * para que el flow paso 1 sea navegable desde la home v2.
  */
+import Link from "next/link";
+
 export default function V2HomePage() {
   return (
     <main className="p-8">
@@ -21,11 +26,11 @@ export default function V2HomePage() {
         DEMO · token mono
       </p>
 
-      {/* Botones demo de la convención IA-celeste / Humano-púrpura */}
+      {/* CTA "Nuevo presupuesto" — entry point al paso 1 */}
       <div className="mt-6 flex gap-2">
-        <button type="button" className="rounded-r-md bg-accent px-4 py-2 text-bg">
-          Acción IA
-        </button>
+        <Link href="/v2/quotes/new" className="btn primary" data-testid="cta-new-quote">
+          + Nuevo presupuesto
+        </Link>
         <button
           type="button"
           className="rounded-r-md border border-human bg-human-bg px-4 py-2 text-human"

--- a/web/src/app/v2/quotes/new/layout.tsx
+++ b/web/src/app/v2/quotes/new/layout.tsx
@@ -1,0 +1,30 @@
+/**
+ * Chrome shell light para `/v2/quotes/new` (paso 1).
+ *
+ * No hay quote todavía, entonces NO renderea Qhead ni Stepper —
+ * solo Sidebar + Topbar minimalista + body. Esto evita reutilizar
+ * el layout `[id]/layout.tsx` que asume CANONICAL_QUOTE.
+ *
+ * Reusa las clases legacy de operator-shared.css (.page, .main,
+ * .topbar, .crumbs, .body.no-chat) sin modificar.
+ */
+import Link from "next/link";
+import { Sidebar } from "@/components/v2/chrome/Sidebar";
+
+export default function NewQuoteLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="page">
+      <Sidebar />
+      <main className="main">
+        <div className="topbar">
+          <div className="crumbs">
+            <Link href="/v2">Presupuestos</Link>
+            <span className="sep">/</span>
+            <span className="now">Nuevo</span>
+          </div>
+        </div>
+        <div className="body no-chat">{children}</div>
+      </main>
+    </div>
+  );
+}

--- a/web/src/app/v2/quotes/new/page.tsx
+++ b/web/src/app/v2/quotes/new/page.tsx
@@ -1,0 +1,16 @@
+/**
+ * `/v2/quotes/new` — paso 1 del flujo (brief upload).
+ *
+ * Renderiza el container client `BriefView` que coordina los 3
+ * estados (A vacío / B form cargado / C procesando).
+ *
+ * Mock-first: el `createDraftQuote` del lib/v2/api.ts simula el
+ * response del backend. Cuando el endpoint dedicado del paso 1
+ * se implemente (ver docs/handoff-context/missing-endpoints.md),
+ * se hace el swap del cliente sin tocar este componente.
+ */
+import { BriefView } from "@/components/v2/brief/BriefView";
+
+export default function NewQuotePage() {
+  return <BriefView />;
+}

--- a/web/src/components/v2/brief/BriefDropzone.tsx
+++ b/web/src/components/v2/brief/BriefDropzone.tsx
@@ -1,0 +1,74 @@
+/**
+ * Estado A — dropzone vacío del paso 1.
+ *
+ * Renderiza el hero Valentina (`.brief-hero` + `.vbubble-lg`) +
+ * dropzone PDF (`.dropzone` con clases legacy de operator-shared.css).
+ * Reusa react-dropzone para drag-and-drop.
+ *
+ * Validaciones inline: si el usuario suelta múltiples archivos, solo
+ * el primer PDF se acepta. Errores de tipo/tamaño se exponen al
+ * container via onValidationError.
+ */
+"use client";
+
+import { useDropzone, type FileRejection } from "react-dropzone";
+import { VALIDATION } from "@/lib/v2/api";
+
+interface Props {
+  onFile: (file: File) => void;
+  onValidationError?: (message: string) => void;
+}
+
+export function BriefDropzone({ onFile, onValidationError }: Props) {
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    accept: { "application/pdf": [".pdf"] },
+    maxSize: VALIDATION.PLAN_MAX_BYTES,
+    maxFiles: 1,
+    multiple: false,
+    onDrop: (accepted, rejected) => {
+      if (rejected.length > 0 && onValidationError) {
+        const msg = mapRejection(rejected[0]);
+        onValidationError(msg);
+        return;
+      }
+      if (accepted[0]) onFile(accepted[0]);
+    },
+  });
+
+  return (
+    <div className="col brief-stage" data-step="brief" data-state="A">
+      <div className="brief-hero">
+        <div className="vbubble-lg" />
+        <div className="hero-text">
+          <div className="eyebrow">Paso 1 de 5 · Brief</div>
+          <h2>Subí lo que tengas y arranco</h2>
+          <div className="lead">
+            Soy <em>Valentina</em>. Si me das el plano y un brief — aunque sea informal — extraigo
+            cliente, ambiente, medidas, material y armo el contexto del paso 2 sola.
+          </div>
+        </div>
+      </div>
+
+      <div
+        {...getRootProps()}
+        className={`dropzone ${isDragActive ? "is-dragging" : ""}`}
+        data-testid="brief-dropzone"
+      >
+        <input {...getInputProps()} data-testid="brief-dropzone-input" />
+        <div className="dz-icon">↑</div>
+        <div className="dz-title">
+          {isDragActive ? "Soltá el plano acá" : "Arrastrá el plano (PDF) o hacé click para elegir"}
+        </div>
+        <div className="dz-sub">PDF · máx. 20 MB · podés sumar hasta 5 fotos del lugar después</div>
+      </div>
+    </div>
+  );
+}
+
+function mapRejection(rejection: FileRejection): string {
+  const code = rejection.errors[0]?.code;
+  if (code === "file-invalid-type") return "El plan debe ser un PDF";
+  if (code === "file-too-large") return "El plan supera 20 MB";
+  if (code === "too-many-files") return "Solo se acepta un plano (el primer PDF)";
+  return rejection.errors[0]?.message ?? "Archivo inválido";
+}

--- a/web/src/components/v2/brief/BriefForm.tsx
+++ b/web/src/components/v2/brief/BriefForm.tsx
@@ -1,0 +1,149 @@
+/**
+ * Estado B — form completo del paso 1 (mockup 00-paso1-B-subido).
+ *
+ * Renderiza:
+ *   - hero Valentina (texto distinto: "Tengo todo lo que necesito")
+ *   - dropzone `.loaded` con metadata del PDF + acciones reemplazar/quitar
+ *   - textarea brief libre
+ *   - PhotoUploader (hasta 5 fotos opcionales)
+ *   - brief-cta con helper + botón primario "Procesar con Valentina →"
+ *
+ * Validaciones inline expuestas via mensaje en `.brief-cta .helper`
+ * cuando `error` está seteado.
+ */
+"use client";
+
+import { useState } from "react";
+import { VALIDATION } from "@/lib/v2/api";
+import type { BriefFormData } from "@/lib/v2/types";
+import { PhotoUploader } from "./PhotoUploader";
+
+interface Props {
+  form: BriefFormData;
+  onChange: (form: BriefFormData) => void;
+  onSubmit: () => void;
+  onResetPlan: () => void;
+  error: string | null;
+}
+
+export function BriefForm({ form, onChange, onSubmit, onResetPlan, error }: Props) {
+  const [localError, setLocalError] = useState<string | null>(null);
+  const displayedError = error ?? localError;
+  const remainingChars = VALIDATION.BRIEF_MAX_CHARS - form.briefText.length;
+  const briefOver = form.briefText.length > VALIDATION.BRIEF_MAX_CHARS;
+  const canSubmit = !!form.planFile && !briefOver;
+
+  return (
+    <div className="col brief-stage" data-step="brief" data-state="B">
+      <div className="brief-hero">
+        <div className="vbubble-lg" />
+        <div className="hero-text">
+          <div className="eyebrow">Paso 1 de 5 · Brief</div>
+          <h2>Tengo todo lo que necesito</h2>
+          <div className="lead">
+            Cuando le des dale, voy a leer el plano, extraer medidas, identificar ambiente y armar
+            el contexto del paso 2. Te aviso si encuentro algo raro.
+          </div>
+        </div>
+      </div>
+
+      {/* Dropzone .loaded con metadata del PDF */}
+      {form.planFile && (
+        <div className="dropzone loaded" data-testid="brief-plan-loaded" role="status">
+          <div className="dz-thumb">
+            <span>PDF</span>
+          </div>
+          <div className="dz-meta">
+            <span className="name" data-testid="brief-plan-name">
+              {form.planFile.name}
+            </span>
+            <span className="info">{formatSize(form.planFile.size)}</span>
+          </div>
+          <div className="dz-actions">
+            <button
+              type="button"
+              className="dz-x destructive"
+              onClick={onResetPlan}
+              data-testid="brief-plan-reset"
+            >
+              ✕ Quitar
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Textarea brief libre */}
+      <div className="brief-textarea-wrap">
+        <span className="lbl">
+          Brief libre <span style={{ color: "var(--ink-mute)" }}>· opcional</span>
+        </span>
+        <textarea
+          data-testid="brief-text"
+          placeholder="Pegá acá el WhatsApp del cliente, mensaje del estudio, mail con el pedido, lo que tengas. Yo extraigo lo importante."
+          value={form.briefText}
+          onChange={(e) => {
+            setLocalError(null);
+            onChange({ ...form, briefText: e.target.value });
+          }}
+          maxLength={VALIDATION.BRIEF_MAX_CHARS + 200}
+          rows={6}
+        />
+        <span
+          className="font-mono"
+          style={{
+            fontSize: 11,
+            color: briefOver ? "var(--error)" : "var(--ink-mute)",
+            display: "block",
+            marginTop: 4,
+          }}
+          data-testid="brief-char-counter"
+        >
+          {remainingChars} caracteres restantes
+        </span>
+      </div>
+
+      {/* Photo uploader */}
+      <PhotoUploader
+        photos={form.photos}
+        onChange={(photos) => {
+          setLocalError(null);
+          onChange({ ...form, photos });
+        }}
+        onValidationError={setLocalError}
+      />
+
+      {/* CTA bar */}
+      <div className="brief-cta">
+        <span
+          className="helper"
+          data-testid="brief-helper"
+          style={displayedError ? { color: "var(--error)" } : undefined}
+        >
+          {displayedError ? (
+            displayedError
+          ) : (
+            <>
+              <em>Valentina</em> tarda ~12 segundos en procesar un plano de este tamaño.
+            </>
+          )}
+        </span>
+        <button
+          type="button"
+          className={`btn primary${canSubmit ? "" : " disabled"}`}
+          disabled={!canSubmit}
+          onClick={onSubmit}
+          data-testid="brief-submit"
+        >
+          Procesar con Valentina →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function formatSize(bytes: number): string {
+  const mb = bytes / (1024 * 1024);
+  if (mb >= 1) return `${mb.toFixed(1).replace(".", ",")} MB`;
+  const kb = bytes / 1024;
+  return `${Math.round(kb)} KB`;
+}

--- a/web/src/components/v2/brief/BriefProcessing.tsx
+++ b/web/src/components/v2/brief/BriefProcessing.tsx
@@ -1,0 +1,65 @@
+/**
+ * Estado C — procesando del paso 1 (mockup 00-paso1-C-procesando).
+ *
+ * Hero Valentina con copy distinto + status-bar inferior + skeleton
+ * filas + botón cancelar. NO hay spinner full-screen (Master §
+ * comportamientos transversales).
+ *
+ * Cancel callback aborta el AbortController del hook → vuelve a
+ * estado B con el form preservado.
+ */
+"use client";
+
+interface Props {
+  onCancel: () => void;
+  planName?: string;
+}
+
+export function BriefProcessing({ onCancel, planName }: Props) {
+  return (
+    <div className="col brief-stage" data-step="brief" data-state="C">
+      <div className="brief-hero">
+        <div className="vbubble-lg" />
+        <div className="hero-text">
+          <div className="eyebrow">Paso 1 de 5 · Brief · procesando</div>
+          <h2>Estoy leyendo el plano</h2>
+          <div className="lead">
+            Extraigo medidas reales (no las marcadas), identifico ambiente, busco el cliente en mi
+            base de arquitectos y armo el contexto del paso 2.
+          </div>
+        </div>
+      </div>
+
+      <div className="status-bar slow" data-testid="brief-status-bar">
+        <div className="dot" />
+        <div className="status-msg">
+          <em>Valentina</em> está leyendo el plano y extrayendo medidas…
+        </div>
+      </div>
+
+      <div className="processing-stage" data-testid="brief-processing">
+        <div className="preview-card">
+          <div className="ph-head">
+            <span>📄 {planName ?? "Plano en proceso"}</span>
+          </div>
+          <div className="ph-rows">
+            <div className="skel short" />
+            <div className="skel long" />
+            <div className="skel medium" />
+            <div className="skel long" />
+            <div className="skel short" />
+            <div className="skel medium" />
+            <div className="skel long" />
+          </div>
+        </div>
+
+        <div className="cancel-row">
+          <span className="spacer" />
+          <button type="button" className="btn ghost" onClick={onCancel} data-testid="brief-cancel">
+            Cancelar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/v2/brief/BriefView.tsx
+++ b/web/src/components/v2/brief/BriefView.tsx
@@ -1,0 +1,75 @@
+/**
+ * Container del paso 1 — coordina los 3 estados visuales (A/B/C).
+ *
+ * Stateflow:
+ *   - sin planFile → estado A (BriefDropzone)
+ *   - con planFile, hook idle/error → estado B (BriefForm)
+ *   - hook submitting → estado C (BriefProcessing)
+ *
+ * Decisión: el form (planFile + photos + briefText) vive en este
+ * container, NO en el hook. Así sobrevive al ciclo cancel→retry sin
+ * perder lo que el usuario tipeó. El hook solo coordina submit/cancel/
+ * navigation.
+ */
+"use client";
+
+import { useState } from "react";
+import type { BriefFormData } from "@/lib/v2/types";
+import { useBriefUpload } from "@/lib/v2/hooks/useBriefUpload";
+import { BriefDropzone } from "./BriefDropzone";
+import { BriefForm } from "./BriefForm";
+import { BriefProcessing } from "./BriefProcessing";
+
+const EMPTY_FORM: BriefFormData = {
+  planFile: null,
+  photos: [],
+  briefText: "",
+};
+
+export function BriefView() {
+  const { state, error, submit, cancel } = useBriefUpload();
+  const [form, setForm] = useState<BriefFormData>(EMPTY_FORM);
+  const [dropzoneError, setDropzoneError] = useState<string | null>(null);
+
+  if (state === "submitting") {
+    return <BriefProcessing onCancel={cancel} planName={form.planFile?.name} />;
+  }
+
+  if (form.planFile) {
+    return (
+      <BriefForm
+        form={form}
+        onChange={setForm}
+        onSubmit={() => submit(form)}
+        onResetPlan={() => setForm({ ...form, planFile: null })}
+        error={error}
+      />
+    );
+  }
+
+  return (
+    <>
+      <BriefDropzone
+        onFile={(file) => {
+          setDropzoneError(null);
+          setForm({ ...form, planFile: file });
+        }}
+        onValidationError={setDropzoneError}
+      />
+      {dropzoneError && (
+        <p
+          data-testid="brief-dropzone-error"
+          className="font-mono"
+          style={{
+            color: "var(--error)",
+            fontSize: 12,
+            marginTop: 12,
+            paddingLeft: 4,
+          }}
+        >
+          {dropzoneError}
+        </p>
+      )}
+    </>
+  );
+}

--- a/web/src/components/v2/brief/PhotoUploader.tsx
+++ b/web/src/components/v2/brief/PhotoUploader.tsx
@@ -1,0 +1,81 @@
+/**
+ * Sub-componente del estado B — uploader de hasta 5 fotos opcionales.
+ *
+ * Reusa clases legacy `.img-row`, `.img-thumb`, `.x-btn` y
+ * `.img-thumb.placeholder` de operator-shared.css. Validaciones de
+ * tipo/tamaño/cantidad se exponen via onValidationError.
+ */
+"use client";
+
+import { useDropzone, type FileRejection } from "react-dropzone";
+import { VALIDATION } from "@/lib/v2/api";
+
+interface Props {
+  photos: File[];
+  onChange: (photos: File[]) => void;
+  onValidationError?: (message: string) => void;
+}
+
+export function PhotoUploader({ photos, onChange, onValidationError }: Props) {
+  const remaining = VALIDATION.PHOTOS_MAX_COUNT - photos.length;
+
+  const { getRootProps, getInputProps } = useDropzone({
+    accept: { "image/jpeg": [".jpg", ".jpeg"], "image/png": [".png"] },
+    maxSize: VALIDATION.PHOTO_MAX_BYTES,
+    maxFiles: remaining,
+    multiple: true,
+    disabled: remaining <= 0,
+    onDrop: (accepted, rejected) => {
+      if (rejected.length > 0 && onValidationError) {
+        onValidationError(mapRejection(rejected[0]));
+      }
+      if (accepted.length === 0) return;
+      const next = [...photos, ...accepted].slice(0, VALIDATION.PHOTOS_MAX_COUNT);
+      onChange(next);
+    },
+  });
+
+  function removeAt(index: number) {
+    onChange(photos.filter((_, i) => i !== index));
+  }
+
+  return (
+    <div className="brief-textarea-wrap">
+      <span className="lbl">Fotos del lugar · opcional (hasta {VALIDATION.PHOTOS_MAX_COUNT})</span>
+      <div className="img-row" data-testid="photo-row">
+        {photos.map((photo, i) => (
+          <div key={`${photo.name}-${i}`} className="img-thumb">
+            <span data-testid="photo-name">{photo.name}</span>
+            <button
+              type="button"
+              className="x-btn"
+              aria-label={`quitar ${photo.name}`}
+              onClick={() => removeAt(i)}
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+        {remaining > 0 && (
+          <div
+            {...getRootProps()}
+            className="img-thumb placeholder"
+            data-testid="photo-placeholder"
+            role="button"
+            tabIndex={0}
+          >
+            <input {...getInputProps()} data-testid="photo-input" />+
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function mapRejection(rejection: FileRejection): string {
+  const code = rejection.errors[0]?.code;
+  if (code === "file-invalid-type") return "Las fotos deben ser JPG o PNG";
+  if (code === "file-too-large") return "Cada foto debe ser menor a 5 MB";
+  if (code === "too-many-files") return "Máximo 5 fotos";
+  return rejection.errors[0]?.message ?? "Foto inválida";
+}

--- a/web/src/lib/v2/api.ts
+++ b/web/src/lib/v2/api.ts
@@ -1,24 +1,107 @@
 /**
- * HTTP client placeholder para v2.
+ * Mock client v2 — Sprint 2 paso 1 brief upload.
  *
- * Sprint 2 scaffold: stub vacío. La implementación real (mock-first
- * según Master §21.7 decisión 4) se construye en
- * `sprint-2/paso-1-brief-upload` cuando arrancan los primeros hooks
- * que consumen endpoints reales.
+ * Mock-first per Master §21.7 decisión 4 + endpoint dedicado del paso 1
+ * marcado como "P2 · NO EXISTE" en docs/handoff-context/missing-endpoints.md
+ * (`POST /api/quotes/{id}/brief`). Este client simula el response de
+ * creación de draft con latencia 2-5s y soporte de AbortController.
+ * Retorna las cifras canon Cueto-Heredia (Master §13).
  *
- * Cuando se implemente:
- *   - `useMockClient()` en Sprint 2 → fixtures locales basadas en
- *     `docs/handoff-context/catalog/*.json` y cifras canon Cueto-Heredia
- *     (Master §13).
- *   - `useApiClient()` en Sprint 3 inicial → swap a HTTP real contra
- *     los endpoints documentados en
- *     `docs/handoff-context/endpoints-spec.md`.
- *
- * NO importar este archivo desde producción todavía — los tipos no
- * están finalizados. Ver sub-PRs para spec definitiva.
+ * TODO sprint-3/api-integration: switch al cliente HTTP real cuando
+ * el backend implemente el endpoint dedicado, o cuando se decida
+ * pasarlo dentro del primer turno del chat (Opción A en
+ * missing-endpoints.md).
  */
+import { CANONICAL_QUOTE } from "./mocks/canonicalQuote";
 
 export const V2_API_BASE = "/api";
 
-// Sentinel para detectar uso accidental durante el scaffold.
-export const V2_SCAFFOLD_PLACEHOLDER = true as const;
+export interface CreateDraftQuoteInput {
+  planFile: File;
+  photos?: File[];
+  briefText?: string;
+}
+
+export interface CreateDraftQuoteResponse {
+  id: string;
+  status: "draft";
+  createdAt: string;
+}
+
+export class ApiError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public status?: number,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+/** Validaciones declarativas (defensa en profundidad — la UI también valida). */
+export const VALIDATION = {
+  PLAN_MAX_BYTES: 20 * 1024 * 1024, // 20 MB
+  PLAN_MIME: ["application/pdf"] as const,
+  PHOTO_MAX_BYTES: 5 * 1024 * 1024, // 5 MB
+  PHOTO_MIME: ["image/jpeg", "image/png"] as const,
+  PHOTOS_MAX_COUNT: 5,
+  BRIEF_MAX_CHARS: 2000,
+} as const;
+
+function validateInput(input: CreateDraftQuoteInput): void {
+  if (!VALIDATION.PLAN_MIME.includes(input.planFile.type as "application/pdf")) {
+    throw new ApiError("INVALID_MIME", "El plan debe ser un PDF", 422);
+  }
+  if (input.planFile.size > VALIDATION.PLAN_MAX_BYTES) {
+    throw new ApiError("FILE_TOO_LARGE", "El plan supera 20MB", 413);
+  }
+  if (input.photos) {
+    if (input.photos.length > VALIDATION.PHOTOS_MAX_COUNT) {
+      throw new ApiError("TOO_MANY_PHOTOS", "Máximo 5 fotos", 422);
+    }
+    for (const photo of input.photos) {
+      if (!VALIDATION.PHOTO_MIME.includes(photo.type as "image/jpeg" | "image/png")) {
+        throw new ApiError("INVALID_PHOTO_MIME", "Las fotos deben ser JPG o PNG", 422);
+      }
+      if (photo.size > VALIDATION.PHOTO_MAX_BYTES) {
+        throw new ApiError("PHOTO_TOO_LARGE", "Cada foto debe ser menor a 5MB", 413);
+      }
+    }
+  }
+  if (input.briefText && input.briefText.length > VALIDATION.BRIEF_MAX_CHARS) {
+    throw new ApiError("BRIEF_TOO_LONG", "El brief no puede superar 2000 caracteres", 422);
+  }
+}
+
+/**
+ * Crea un draft quote a partir de un PDF + fotos + brief.
+ *
+ * Mock: simula latencia 2-5s. Si llega `signal.aborted`, rechaza con
+ * `AbortError` para que el UI pueda volver al estado B (form cargado).
+ */
+export async function createDraftQuote(
+  input: CreateDraftQuoteInput,
+  options?: { signal?: AbortSignal },
+): Promise<CreateDraftQuoteResponse> {
+  validateInput(input);
+
+  const latency = 2000 + Math.random() * 3000;
+  await new Promise<void>((resolve, reject) => {
+    if (options?.signal?.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const timeout = setTimeout(resolve, latency);
+    options?.signal?.addEventListener("abort", () => {
+      clearTimeout(timeout);
+      reject(new DOMException("Aborted", "AbortError"));
+    });
+  });
+
+  return {
+    id: CANONICAL_QUOTE.id,
+    status: "draft",
+    createdAt: new Date().toISOString(),
+  };
+}

--- a/web/src/lib/v2/hooks/useBriefUpload.ts
+++ b/web/src/lib/v2/hooks/useBriefUpload.ts
@@ -1,0 +1,71 @@
+/**
+ * Hook que coordina el state machine del paso 1 (mockups 00 A/B/C).
+ *
+ * Estados:
+ *   - idle: estado A o B (depende de si el form tiene planFile o no,
+ *     manejado por el container).
+ *   - submitting: estado C (procesando) — UI muestra skeleton +
+ *     status-bar + botón cancelar.
+ *   - error: cancel/error de validación o fallo del mock — UI vuelve
+ *     a estado B con mensaje.
+ *
+ * Cancelación: `cancel()` aborta el AbortController. La promise del
+ * mock client rechaza con AbortError, capturado abajo, y volvemos a
+ * `idle` (el container preserva el form, así que el usuario sigue
+ * en estado B).
+ */
+"use client";
+
+import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ApiError, createDraftQuote } from "../api";
+import type { BriefFormData, BriefUploadState } from "../types";
+
+export function useBriefUpload() {
+  const router = useRouter();
+  const [state, setState] = useState<BriefUploadState>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  async function submit(form: BriefFormData) {
+    if (!form.planFile) return;
+    setState("submitting");
+    setError(null);
+    abortRef.current = new AbortController();
+
+    try {
+      const result = await createDraftQuote(
+        {
+          planFile: form.planFile,
+          photos: form.photos.length > 0 ? form.photos : undefined,
+          briefText: form.briefText || undefined,
+        },
+        { signal: abortRef.current.signal },
+      );
+      router.push(`/v2/quotes/${result.id}/contexto`);
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") {
+        // Cancelación voluntaria → vuelta a estado B (form preservado)
+        setState("idle");
+        return;
+      }
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError("Error inesperado. Intentá de nuevo.");
+      }
+      setState("error");
+    }
+  }
+
+  function cancel() {
+    abortRef.current?.abort();
+  }
+
+  function reset() {
+    setError(null);
+    setState("idle");
+  }
+
+  return { state, error, submit, cancel, reset };
+}

--- a/web/src/lib/v2/types.ts
+++ b/web/src/lib/v2/types.ts
@@ -1,11 +1,17 @@
 /**
  * Tipos compartidos del v2.
  *
- * Sprint 2 scaffold: stub vacío. Los tipos canon van a salir de
- * `docs/handoff-context/schemas/*.md` cuando los primeros hooks los
- * consuman (`sprint-2/paso-1-brief-upload`, `sprint-2/paso-2-contexto`).
+ * Sprint 2 paso-1-brief-upload: tipos del state machine del paso 1.
+ * Más tipos van a salir de `docs/handoff-context/schemas/*.md` en
+ * sub-PRs siguientes (paso-2-contexto, paso-3-despiece, etc.).
  */
 
-// Sentinel — marca al scaffold como activo. Removido cuando se
-// agreguen los tipos reales.
-export type V2ScaffoldMarker = "scaffold";
+/** Estado del state machine del paso 1 (mockups 00 A/B/C). */
+export type BriefUploadState = "idle" | "submitting" | "error";
+
+/** Form data del paso 1 antes de submit. */
+export interface BriefFormData {
+  planFile: File | null;
+  photos: File[];
+  briefText: string;
+}

--- a/web/tests/e2e/brief-upload.spec.ts
+++ b/web/tests/e2e/brief-upload.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * E2E del paso 1 — brief upload.
+ *
+ * Cubre los 3 estados visuales (mockups 00 A/B/C), validaciones,
+ * cancel y success path.
+ *
+ * El "backend" es el mock client en lib/v2/api.ts con latencia
+ * 2-5s + AbortController. NO toca backend real.
+ */
+import { expect, test, type Page } from "@playwright/test";
+import path from "node:path";
+
+const FIXTURE_PDF = path.join(__dirname, "..", "fixtures", "sample.pdf");
+
+async function uploadPdf(page: Page, file: string = FIXTURE_PDF) {
+  await page.locator('[data-testid="brief-dropzone-input"]').setInputFiles(file);
+}
+
+test("estado A — dropzone vacío al cargar /v2/quotes/new", async ({ page }) => {
+  await page.goto("/v2/quotes/new");
+  await expect(page.locator('[data-testid="brief-dropzone"]')).toBeVisible();
+  await expect(page.locator('[data-testid="brief-plan-loaded"]')).not.toBeVisible();
+  await expect(page.locator('[data-testid="brief-status-bar"]')).not.toBeVisible();
+  await expect(page.locator(".brief-hero h2")).toContainText("Subí lo que tengas");
+});
+
+test("estado A → B — al subir un PDF aparece el form con el filename", async ({ page }) => {
+  await page.goto("/v2/quotes/new");
+  await uploadPdf(page);
+  await expect(page.locator('[data-testid="brief-plan-loaded"]')).toBeVisible();
+  await expect(page.locator('[data-testid="brief-plan-name"]')).toHaveText("sample.pdf");
+  await expect(page.locator(".brief-hero h2")).toContainText("Tengo todo lo que necesito");
+  await expect(page.locator('[data-testid="brief-submit"]')).toBeEnabled();
+});
+
+test("validación — PDF tipo inválido (txt) rechazado en estado A", async ({ page }) => {
+  await page.goto("/v2/quotes/new");
+  await page.locator('[data-testid="brief-dropzone-input"]').setInputFiles({
+    name: "wrong.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("no soy un PDF"),
+  });
+  await expect(page.locator('[data-testid="brief-dropzone-error"]')).toBeVisible();
+  await expect(page.locator('[data-testid="brief-dropzone-error"]')).toContainText("PDF");
+  // Sigue en estado A (no avanzó)
+  await expect(page.locator('[data-testid="brief-plan-loaded"]')).not.toBeVisible();
+});
+
+test("validación — PDF > 20MB rechazado en estado A", async ({ page }) => {
+  await page.goto("/v2/quotes/new");
+  // Buffer de 21MB en memoria — react-dropzone rechaza por size sin
+  // necesidad de un PDF real
+  const big = Buffer.alloc(21 * 1024 * 1024, 0);
+  await page.locator('[data-testid="brief-dropzone-input"]').setInputFiles({
+    name: "huge.pdf",
+    mimeType: "application/pdf",
+    buffer: big,
+  });
+  await expect(page.locator('[data-testid="brief-dropzone-error"]')).toBeVisible();
+  await expect(page.locator('[data-testid="brief-dropzone-error"]')).toContainText("20");
+});
+
+test("validación — foto tipo inválido rechazada", async ({ page }) => {
+  await page.goto("/v2/quotes/new");
+  await uploadPdf(page);
+  await page.locator('[data-testid="photo-input"]').setInputFiles({
+    name: "wrong.gif",
+    mimeType: "image/gif",
+    buffer: Buffer.from("fake"),
+  });
+  await expect(page.locator('[data-testid="brief-helper"]')).toContainText(/JPG|PNG/);
+});
+
+test("estado B → C — click Procesar muestra skeleton + status-bar", async ({ page }) => {
+  await page.goto("/v2/quotes/new");
+  await uploadPdf(page);
+  await page.locator('[data-testid="brief-submit"]').click();
+  await expect(page.locator('[data-testid="brief-status-bar"]')).toBeVisible();
+  await expect(page.locator('[data-testid="brief-processing"]')).toBeVisible();
+  await expect(page.locator(".skel").first()).toBeVisible();
+});
+
+test("cancel — estado C → vuelve a B con planFile preservado", async ({ page }) => {
+  await page.goto("/v2/quotes/new");
+  await uploadPdf(page);
+  await page.locator('[data-testid="brief-submit"]').click();
+  await expect(page.locator('[data-testid="brief-status-bar"]')).toBeVisible();
+  await page.locator('[data-testid="brief-cancel"]').click();
+  // Vuelve a estado B con el form intacto
+  await expect(page.locator('[data-testid="brief-plan-loaded"]')).toBeVisible();
+  await expect(page.locator('[data-testid="brief-plan-name"]')).toHaveText("sample.pdf");
+  await expect(page.locator('[data-testid="brief-status-bar"]')).not.toBeVisible();
+});
+
+test("success path — completar el flujo navega a /v2/quotes/PRES-2026-018/contexto", async ({
+  page,
+}) => {
+  await page.goto("/v2/quotes/new");
+  await uploadPdf(page);
+  await page.locator('[data-testid="brief-text"]').fill("Cocina U + isla, 3,20m");
+  await page.locator('[data-testid="brief-submit"]').click();
+  // Mock simula latencia 2-5s — esperar redirect (timeout 10s safety)
+  await page.waitForURL("**/quotes/PRES-2026-018/contexto", { timeout: 10000 });
+  // Confirmar que el chrome del [id] layout está activo
+  await expect(page.locator(".stepper")).toHaveAttribute("data-current-step", "contexto");
+});
+
+test("CTA en /v2 navega a /v2/quotes/new", async ({ page }) => {
+  await page.goto("/v2");
+  await page.locator('[data-testid="cta-new-quote"]').click();
+  await page.waitForURL("**/v2/quotes/new");
+  await expect(page.locator('[data-testid="brief-dropzone"]')).toBeVisible();
+});

--- a/web/tests/fixtures/sample.pdf
+++ b/web/tests/fixtures/sample.pdf
@@ -1,0 +1,14 @@
+%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Resources<<>>>>endobj
+xref
+0 4
+0000000000 65535 f
+0000000009 00000 n
+0000000053 00000 n
+0000000098 00000 n
+trailer<</Size 4/Root 1 0 R>>
+startxref
+170
+%%EOF


### PR DESCRIPTION
## Resumen del PR

Implementa el **paso 1 del flujo** (mockups 00 A/B/C): Marina sube un PDF, opcionalmente fotos y un brief libre, y al procesar se crea un draft quote. Mock-first: cliente HTTP simulado con latencia 2-5s + AbortController. Al éxito, navega a `/v2/quotes/PRES-2026-018/contexto` (chrome shell del PR #456).

## Sprint y sub-branch

- Sprint: 2
- Sub-branch: `sprint-2/paso-1-brief-upload`
- Mergea contra: `sprint-2/main`

## Componentes creados

| Archivo | LOC |
|---------|-----|
| `lib/v2/api.ts` (reescrito · mock client) | 107 |
| `lib/v2/types.ts` (BriefUploadState + BriefFormData) | 16 |
| `lib/v2/hooks/useBriefUpload.ts` | 71 |
| `components/v2/brief/BriefDropzone.tsx` (estado A) | 74 |
| `components/v2/brief/BriefForm.tsx` (estado B) | 149 |
| `components/v2/brief/PhotoUploader.tsx` | 81 |
| `components/v2/brief/BriefProcessing.tsx` (estado C) | 65 |
| `components/v2/brief/BriefView.tsx` (container) | 75 |
| `app/v2/quotes/new/layout.tsx` (chrome light) | 30 |
| `app/v2/quotes/new/page.tsx` | 16 |
| `tests/e2e/brief-upload.spec.ts` (9 tests) | 113 |
| `tests/fixtures/sample.pdf` (313 bytes) | binary |
| **Total código** | **~797** |

## Decisiones técnicas

1. **Endpoint del paso 1 está marcado como NO EXISTE** en `docs/handoff-context/missing-endpoints.md` (P2 · `POST /api/quotes/{id}/brief`). El mock client cubre la brecha temporalmente. Cuando el backend implemente el endpoint dedicado o se decida pasarlo via `POST /chat` multipart, se hace swap del cliente sin tocar componentes.

2. **Layout dedicado en `app/v2/quotes/new/layout.tsx`** (no reusa `[id]/layout.tsx`). Razón: `/quotes/new` no tiene id ni quote → no hay Qhead ni Stepper. Reusa el `Sidebar` del PR #456 sin modificar.

3. **Form vive en BriefView container, no en el hook.** Sobrevive al ciclo cancel→retry sin perder lo que el usuario subió/tipeó. El hook solo coordina submit/cancel/navigation.

4. **Hero Valentina con clases legacy** (`.brief-hero`, `.vbubble-lg`) — copy distinto en cada estado: "Subí lo que tengas y arranco" (A) / "Tengo todo lo que necesito" (B) / "Estoy leyendo el plano" (C). Matches mockups del handoff.

5. **Validaciones en 2 capas**: react-dropzone client-side (UX inmediato) + `VALIDATION` constants en api.ts (defensa en profundidad antes del mock submit). Constantes compartidas: `PLAN_MAX_BYTES=20MB`, `PHOTO_MAX_BYTES=5MB`, `PHOTOS_MAX_COUNT=5`, `BRIEF_MAX_CHARS=2000`.

6. **Cancel preserva form**: `AbortController.abort()` rechaza con `AbortError` que el hook trata como cancelación voluntaria (sin setear error). El container preserva planFile/photos/briefText → vuelve a estado B intacto.

7. **PRES-2026-018 no hardcodeado en componentes**: el id viene del response del mock (que internamente usa `CANONICAL_QUOTE.id`). Cuando el backend real entre, el id real saldrá del response sin tocar UI.

## Verificación local

| Check | Status |
|-------|--------|
| `npm run lint:v2` | ✅ clean |
| `npm run typecheck` | ✅ clean |
| `npm run test:unit` | ✅ 1/1 |
| `npm run test:e2e` | ✅ 13/13 (4 prev + 9 nuevos brief-upload) |
| `npm run build` | ✅ legacy + v2 + nueva ruta `/v2/quotes/new` (20.6 kB · 108 kB First Load JS) |
| `diff -q operator-shared.css handoff` | ✅ sin cambios |

## Scope (qué NO incluye)

- ❌ Backend real (mock client cubre el endpoint que está marcado como faltante)
- ❌ Chat scoped panel — sub-PR `paso-2-contexto`
- ❌ Procesamiento real del PDF (extracción IA de medidas/ambiente)
- ❌ Upload real a Drive
- ❌ Audit log
- ❌ Brief chips IA (sub-PR siguiente, ver missing-endpoints.md P2 BriefChip[])
- ❌ State management global (Zustand etc.) — useState alcanza
- ❌ Reemplazar plan inline (botón Quitar elimina y vuelve a estado A)
- ❌ Mobile responsive (desktop-only, intencional Sprint 2)

## Edge cases manejados

- Múltiples archivos en dropzone PDF → solo el primero (react-dropzone `maxFiles: 1`)
- 6ta foto rechazada con mensaje "Máximo 5 fotos"
- Foto con tipo no soportado (gif, webp) → mensaje "Las fotos deben ser JPG o PNG"
- PDF > 20MB rechazado por size antes de tocar el mock
- Brief > 2000 chars: char counter en rojo + botón Procesar disabled
- Cancel durante latencia → vuelve a estado B con form intacto
- Quitar plan en estado B → resetea planFile, vuelve a estado A
- Errores de validación local (dropzone) NO persisten al pasar a estado B (estado separado del hook)

## Test plan

- [ ] Vercel preview `/v2` muestra CTA "Nuevo presupuesto" celeste
- [ ] Click CTA navega a `/v2/quotes/new` con sidebar + topbar minimal + estado A
- [ ] Drag-and-drop o click en dropzone permite seleccionar PDF (sample.pdf de fixture)
- [ ] Estado B muestra el filename + size + textarea + sección de fotos + botón Procesar
- [ ] Subir un .txt en estado A muestra error "El plan debe ser un PDF"
- [ ] Tipear > 2000 chars en brief muestra char counter en rojo
- [ ] Subir gif como foto muestra error "JPG o PNG"
- [ ] Click Procesar muestra estado C: hero copy distinto + status-bar slow + 7 skel rows + botón Cancelar
- [ ] Cancel vuelve a estado B con planFile preservado
- [ ] Esperar 2-5s sin cancelar → redirect a `/v2/quotes/PRES-2026-018/contexto` (chrome con stepper paso 2 activo)
- [ ] Vercel preview legacy intacto: `/`, `/quote/[id]`, `/admin/observability`, `/config`

## Checklist pre-merge

### Código

- [x] Build verde sin warnings
- [x] Lint pass (`npm run lint:v2`)
- [x] Tests verdes (`npm run test:unit` + `npm run test:e2e` 13/13)
- [x] TypeScript strict, sin `any`
- [x] No credenciales committeadas
- [x] react-dropzone es la única dep nueva (justificada: drag-and-drop estándar)

### UI

- [x] Tokens importados via CSS vars (no hardcoded)
- [x] Copy en español rioplatense ("vos", "subí", "podés")
- [x] Convención IA-celeste / Humano-púrpura respetada (CTA Procesar = .btn.primary celeste)
- [x] Mockups 00-A/B/C reproducidos fielmente en estructura HTML

### Reglas Sprint 2

- [x] `operator-shared.css` NO se modificó (`diff -q` clean)
- [x] Chrome shell del PR #456 NO se tocó (Sidebar/Topbar/Qhead/Stepper intactos)
- [x] No mobile responsive (desktop-only intencional)
- [x] CANONICAL_QUOTE no se modificó

🤖 Generated with [Claude Code](https://claude.com/claude-code)