### PR TITLE
Sprint 2 · paso-2-contexto: 11 campos editables + chat scoped streaming · CIERRE SPRINT 2

### DIFF
--- a/web/src/app/v2/quotes/[id]/contexto/page.tsx
+++ b/web/src/app/v2/quotes/[id]/contexto/page.tsx
@@ -1,18 +1,20 @@
 /**
- * Paso 2 · Contexto — placeholder.
+ * Paso 2 · Contexto — implementación del flujo (mockups 01/02/03).
  *
- * Implementación real (chat scoped panel + extracción de cliente/
- * ambiente/medidas) en sub-PR `sprint-2/paso-2-contexto`.
+ * Reemplaza el placeholder del PR #456 chrome-refactor. Renderiza el
+ * container client `ContextView` que coordina el form de 11 campos
+ * con el chat scoped 480px.
+ *
+ * Mock-first: el client simulado en lib/v2/api.ts cubre los endpoints
+ * dedicados que están marcados como faltantes en
+ * docs/handoff-context/missing-endpoints.md (PATCH context + chat scoped).
  */
-export default function ContextoPage() {
-  return (
-    <div className="col placeholder-section">
-      <h2 className="font-serif italic" style={{ marginBottom: 8 }}>
-        Paso 2 · Contexto
-      </h2>
-      <p className="font-serif italic text-ink-soft">
-        Placeholder. Implementación viene en sprint-2/paso-2-contexto.
-      </p>
-    </div>
-  );
+import { ContextView } from "@/components/v2/contexto/ContextView";
+
+interface Props {
+  params: { id: string };
+}
+
+export default function ContextoPage({ params }: Props) {
+  return <ContextView quoteId={params.id} />;
 }

--- a/web/src/components/v2/contexto/ChatPanel.tsx
+++ b/web/src/components/v2/contexto/ChatPanel.tsx
@@ -1,0 +1,145 @@
+/**
+ * ChatPanel — chat scoped 480px (mockup 03-C).
+ *
+ * Estructura legacy operator-shared.css:
+ *   .chat
+ *     .head      → vbubble + título "Ayuda con Contexto" + close
+ *     .scope     → "Lo que veo" + pills (scope · campos editados)
+ *     .stream    → mensajes user/valentina
+ *     .sugs      → 3 chips de sugerencia rápida
+ *     .composer  → input + botón send
+ */
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { ChatMessage, ChatPanelState } from "@/lib/v2/types";
+import { UserMessage } from "./UserMessage";
+import { ValentinaMessage } from "./ValentinaMessage";
+
+interface Props {
+  messages: ChatMessage[];
+  panelState: ChatPanelState;
+  editedCount: number;
+  onSend: (text: string) => void;
+  onClose: () => void;
+}
+
+const SUGGESTIONS = [
+  "¿Por qué pusiste anafe?",
+  "¿Cómo aplicás el descuento de la arquitecta?",
+  "Apoyo vs empotrada en cocina",
+];
+
+export function ChatPanel({ messages, panelState, editedCount, onSend, onClose }: Props) {
+  const [draft, setDraft] = useState("");
+  const streamRef = useRef<HTMLDivElement>(null);
+  const isStreaming = panelState === "streaming";
+
+  // Auto-scroll al fondo cuando llegan mensajes
+  useEffect(() => {
+    if (streamRef.current) {
+      streamRef.current.scrollTop = streamRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  function submit() {
+    const text = draft.trim();
+    if (!text || isStreaming) return;
+    onSend(text);
+    setDraft("");
+  }
+
+  return (
+    <aside className="chat" data-testid="chat-panel" data-panel-state={panelState}>
+      <div className="head">
+        <div className="vbubble" />
+        <div>
+          <div className="title">Ayuda con Contexto</div>
+          <div className="sub">Scoped · viendo 11 campos</div>
+        </div>
+        <button
+          type="button"
+          className="x-btn"
+          onClick={onClose}
+          data-testid="chat-close"
+          aria-label="cerrar chat"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="scope">
+        <span className="lbl">Lo que veo</span>
+        <span className="pill">Contexto · 11 campos</span>
+        {editedCount > 0 && <span className="pill scope-pill-human">{editedCount} editados</span>}
+        <span className="pill">Brief original</span>
+      </div>
+
+      <div className="stream" ref={streamRef} data-testid="chat-stream">
+        {messages.length === 0 && (
+          <div
+            className="font-mono"
+            style={{ color: "var(--ink-mute)", fontSize: 12, textAlign: "center" }}
+            data-testid="chat-empty"
+          >
+            Hacé una pregunta o usá una sugerencia.
+          </div>
+        )}
+        {messages.map((msg) =>
+          msg.role === "user" ? (
+            <UserMessage key={msg.id} message={msg} />
+          ) : (
+            <ValentinaMessage key={msg.id} message={msg} />
+          ),
+        )}
+      </div>
+
+      <div className="sugs">
+        {SUGGESTIONS.map((s) => (
+          <span
+            key={s}
+            className="sug"
+            data-testid="chat-suggestion"
+            role="button"
+            tabIndex={0}
+            onClick={() => !isStreaming && onSend(s)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                if (!isStreaming) onSend(s);
+              }
+            }}
+          >
+            {s}
+          </span>
+        ))}
+      </div>
+
+      <div className="composer">
+        <div className="field">
+          <input
+            type="text"
+            placeholder="Preguntale algo a Valentina sobre el contexto…"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") submit();
+            }}
+            disabled={isStreaming}
+            data-testid="chat-input"
+          />
+          <button
+            type="button"
+            className="send"
+            onClick={submit}
+            disabled={isStreaming || !draft.trim()}
+            data-testid="chat-send"
+          >
+            Enviar
+          </button>
+        </div>
+        <div className="hint">Borra al cerrar · respuestas usan el contexto de los 11 campos</div>
+      </div>
+    </aside>
+  );
+}

--- a/web/src/components/v2/contexto/ContextField.tsx
+++ b/web/src/components/v2/contexto/ContextField.tsx
@@ -1,0 +1,146 @@
+/**
+ * Campo individual editable del contexto (Master §4 #3).
+ *
+ * Comportamiento:
+ *   - Click en el value → entra a edit mode (input visible, autoFocus)
+ *   - Tab / Enter / blur → guarda + sale de edit mode
+ *   - Esc → cancela + revierte al value original
+ *
+ * Visual:
+ *   - field.edited === true → row con clase `.row-edited` (borde
+ *     izquierdo púrpura · operator-shared.css) + chip "EDITADO" en
+ *     la columna de origen + ícono ✏ en label.
+ */
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { ContextField as ContextFieldData } from "@/lib/v2/api";
+
+interface Props {
+  name: string;
+  label: string;
+  hint?: string;
+  field: ContextFieldData;
+  type?: "text" | "boolean";
+  onCommit: (value: string | number | boolean | null) => void;
+}
+
+export function ContextField({ name, label, hint, field, type = "text", onCommit }: Props) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(() => formatForInput(field.value));
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  // Si el field cambia por update remoto (mock), refrescar draft
+  useEffect(() => {
+    if (!editing) setDraft(formatForInput(field.value));
+  }, [field.value, editing]);
+
+  function commit() {
+    setEditing(false);
+    const cleaned = draft.trim();
+    const original = formatForInput(field.value);
+    if (cleaned === original) return;
+    if (type === "boolean") {
+      const lower = cleaned.toLowerCase();
+      onCommit(lower === "sí" || lower === "si" || lower === "true");
+      return;
+    }
+    onCommit(cleaned || null);
+  }
+
+  function cancel() {
+    setDraft(formatForInput(field.value));
+    setEditing(false);
+  }
+
+  const isEdited = field.edited === true;
+  const displayValue = formatForDisplay(field.value);
+
+  return (
+    <div
+      className={`row${isEdited ? " row-edited" : ""}`}
+      data-testid={`context-row-${name}`}
+      data-edited={isEdited}
+    >
+      <div className="cell label-cell">
+        {label}
+        {isEdited && (
+          <span aria-hidden="true" data-testid={`edit-icon-${name}`}>
+            {" "}
+            ✏
+          </span>
+        )}
+        {hint && <span className="sub">{hint}</span>}
+      </div>
+      <div className={`cell${isEdited ? " edited" : ""}`}>
+        {editing ? (
+          <input
+            ref={inputRef}
+            className="input"
+            data-testid={`context-input-${name}`}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commit}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === "Tab") {
+                if (e.key === "Enter") e.preventDefault();
+                commit();
+              } else if (e.key === "Escape") {
+                e.preventDefault();
+                cancel();
+              }
+            }}
+          />
+        ) : (
+          <span
+            className="value-clickable"
+            data-testid={`context-value-${name}`}
+            onClick={() => setEditing(true)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                setEditing(true);
+              }
+            }}
+            role="button"
+            tabIndex={0}
+            style={{ cursor: "pointer" }}
+          >
+            {displayValue}
+          </span>
+        )}
+      </div>
+      <div className="cell">
+        {isEdited ? (
+          <span className="k k-edited" data-testid={`origin-chip-${name}`}>
+            EDITADO
+          </span>
+        ) : (
+          <span className="k" data-testid={`origin-chip-${name}`}>
+            {field.origin}
+          </span>
+        )}
+      </div>
+      <div className="cell action">⋯</div>
+    </div>
+  );
+}
+
+function formatForInput(value: string | number | boolean | null): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "boolean") return value ? "sí" : "no";
+  return String(value);
+}
+
+function formatForDisplay(value: string | number | boolean | null): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "boolean") return value ? "Sí" : "No";
+  return String(value);
+}

--- a/web/src/components/v2/contexto/ContextForm.tsx
+++ b/web/src/components/v2/contexto/ContextForm.tsx
@@ -1,0 +1,181 @@
+/**
+ * ContextForm — grid de los 11 campos del paso 2 (mockup 01-A / 02-B).
+ *
+ * Estructura:
+ *   - section-head + botón "Abrir chat"
+ *   - banner ia-banner (estado A) o muted (estado B con N editados)
+ *   - 3 grupos (Cliente · Proyecto · Material) con .ctx-group-head
+ *   - .etable.cols-220-1fr-140-60 con 1 .row por campo
+ *   - confirm-bar inferior con CTA "Confirmar y continuar a despiece"
+ */
+"use client";
+
+import { useRouter } from "next/navigation";
+import type { ContextData, ContextResponse } from "@/lib/v2/api";
+import { ContextField } from "./ContextField";
+
+interface FieldDef {
+  name: keyof ContextData;
+  label: string;
+  hint: string;
+  type?: "text" | "boolean";
+}
+
+interface Group {
+  title: string;
+  fields: FieldDef[];
+}
+
+const GROUPS: Group[] = [
+  {
+    title: "Cliente",
+    fields: [
+      { name: "cliente", label: "Cliente", hint: "arquitecta / razón social" },
+      { name: "contacto", label: "Contacto", hint: "teléfono / email" },
+      { name: "localidad", label: "Localidad", hint: "obra · ciudad" },
+      { name: "plazo", label: "Plazo de entrega", hint: "desde confirmación de medidas" },
+    ],
+  },
+  {
+    title: "Proyecto",
+    fields: [
+      { name: "tipologia", label: "Tipología", hint: "cocina, baño, mesa, etc." },
+      { name: "tipo_obra", label: "Tipo de obra", hint: "define colocación + flete" },
+      { name: "material", label: "Material", hint: "piedra o engineered" },
+    ],
+  },
+  {
+    title: "Detalles",
+    fields: [
+      { name: "pileta", label: "Pileta", hint: "tipo + origen" },
+      { name: "zocalo", label: "Zócalo", hint: "contra pared · si/no + alto" },
+      { name: "regrueso", label: "Frentín / Regrueso", hint: "borde frontal grueso" },
+      { name: "anafe", label: "Anafe", hint: "define MO ANAFE en paso 3", type: "boolean" },
+    ],
+  },
+];
+
+interface Props {
+  quoteId: string;
+  context: ContextResponse;
+  isDirty: boolean;
+  editedCount: number;
+  saving: boolean;
+  onUpdateField: <K extends keyof ContextData>(key: K, value: ContextData[K]) => void;
+  onOpenChat: () => void;
+  chatOpen: boolean;
+}
+
+export function ContextForm({
+  quoteId,
+  context,
+  isDirty,
+  editedCount,
+  saving,
+  onUpdateField,
+  onOpenChat,
+  chatOpen,
+}: Props) {
+  const router = useRouter();
+
+  return (
+    <div className="col" data-testid="context-form" data-state={isDirty ? "B" : "A"}>
+      <div className="section-head">
+        <div>
+          <div className="meta">Paso 2 de 5 · Contexto</div>
+          <h2>Contexto del presupuesto</h2>
+        </div>
+        <div className="right">
+          {!chatOpen && (
+            <button
+              type="button"
+              className="btn ghost"
+              onClick={onOpenChat}
+              data-testid="open-chat"
+            >
+              Abrir chat con Valentina
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Banner: cambia copy según pristine/dirty */}
+      <div className={`ia-banner${isDirty ? " muted" : ""}`} data-testid="context-banner">
+        <div className="vbubble" />
+        <div className="text">
+          {isDirty ? (
+            <>
+              <em>Marina</em> editó {editedCount} campo{editedCount === 1 ? "" : "s"}. Los cambios
+              se aplican al cálculo del paso 3.
+              <div className="sub">
+                Click en cualquier campo para seguir editando · ✏ marca los editados
+              </div>
+            </>
+          ) : (
+            <>
+              <em>Valentina</em> extrajo del brief: <strong>cliente Cueto-Heredia</strong> (match
+              arquitecta · −5%) · cocina con <strong>pileta empotrada</strong> · zócalo 12cm activa{" "}
+              <strong>TOMAS automático</strong>. Revisalo y editá lo que haga falta.
+              <div className="sub">
+                Click en cualquier campo para editar · Tab/Enter confirma · Esc cancela
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      {GROUPS.map((group) => (
+        <div key={group.title}>
+          <div className="ctx-group-head">
+            <span>{group.title}</span>
+            <span className="ctx-count">{group.fields.length} campos</span>
+          </div>
+          <div className="etable cols-220-1fr-140-60 mb-16">
+            <div className="colh">
+              <div>Campo</div>
+              <div>Valor</div>
+              <div>Origen</div>
+              <div />
+            </div>
+            {group.fields.map((f) => (
+              <ContextField
+                key={f.name}
+                name={f.name}
+                label={f.label}
+                hint={f.hint}
+                type={f.type}
+                field={context[f.name]}
+                onCommit={(value) => onUpdateField(f.name, value as ContextData[typeof f.name])}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+
+      <div className="confirm-bar">
+        <div className="summary">
+          {saving ? (
+            <span className="font-mono" style={{ fontSize: 12 }}>
+              guardando…
+            </span>
+          ) : isDirty ? (
+            <>
+              <strong>{editedCount}</strong> campo{editedCount === 1 ? "" : "s"} editado
+              {editedCount === 1 ? "" : "s"} · listo para despiece
+            </>
+          ) : (
+            <>Contexto extraído por Valentina · listo para despiece</>
+          )}
+        </div>
+        <button
+          type="button"
+          className="btn primary"
+          data-testid="confirm-context"
+          onClick={() => router.push(`/v2/quotes/${quoteId}/despiece`)}
+        >
+          Confirmar y continuar a despiece →
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/v2/contexto/ContextView.tsx
+++ b/web/src/components/v2/contexto/ContextView.tsx
@@ -1,0 +1,91 @@
+/**
+ * Container del paso 2 — coordina ContextForm + ChatPanel.
+ *
+ * Layout: el chrome [id]/layout.tsx renderea el children dentro de
+ * `<div class="body no-chat">` (one-column padding). Acá montamos
+ * un grid interno que alterna 1 col / 2 cols (1fr 480px) según el
+ * panelState del chat. Así no necesitamos modificar el layout del
+ * chrome (regla absoluta del PR #456).
+ */
+"use client";
+
+import { useContextForm } from "@/lib/v2/hooks/useContextForm";
+import { useChatScoped } from "@/lib/v2/hooks/useChatScoped";
+import { ContextForm } from "./ContextForm";
+import { ChatPanel } from "./ChatPanel";
+
+interface Props {
+  quoteId: string;
+}
+
+export function ContextView({ quoteId }: Props) {
+  const { context, state, error, updateField, isDirty, editedCount } = useContextForm(quoteId);
+  const chat = useChatScoped(quoteId, "contexto");
+  const chatOpen = chat.panelState !== "closed";
+
+  if (state === "loading" && !context) {
+    return (
+      <div className="col" data-testid="context-loading">
+        <div className="section-head">
+          <div>
+            <div className="meta">Paso 2 de 5 · Contexto</div>
+            <h2>Cargando contexto…</h2>
+          </div>
+        </div>
+        <div className="ph-rows">
+          <div className="skel long" />
+          <div className="skel medium" />
+          <div className="skel long" />
+          <div className="skel short" />
+          <div className="skel long" />
+        </div>
+      </div>
+    );
+  }
+
+  if (state === "error" || !context) {
+    return (
+      <div className="col" data-testid="context-error">
+        <div className="section-head">
+          <h2>No pude cargar el contexto</h2>
+        </div>
+        <p className="font-mono" style={{ fontSize: 12, color: "var(--error)" }}>
+          {error ?? "Error desconocido"}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="context-view"
+      data-chat-open={chatOpen ? "true" : "false"}
+      style={{
+        display: "grid",
+        gridTemplateColumns: chatOpen ? "1fr 480px" : "1fr",
+        gap: 24,
+        minHeight: 0,
+      }}
+    >
+      <ContextForm
+        quoteId={quoteId}
+        context={context}
+        isDirty={isDirty}
+        editedCount={editedCount}
+        saving={state === "saving"}
+        onUpdateField={updateField}
+        onOpenChat={chat.open}
+        chatOpen={chatOpen}
+      />
+      {chatOpen && (
+        <ChatPanel
+          messages={chat.messages}
+          panelState={chat.panelState}
+          editedCount={editedCount}
+          onSend={chat.send}
+          onClose={chat.close}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/components/v2/contexto/UserMessage.tsx
+++ b/web/src/components/v2/contexto/UserMessage.tsx
@@ -1,0 +1,17 @@
+/**
+ * Mensaje de Marina (role=user) en el chat scoped.
+ * Reusa clases legacy `.msg.user` (alineado a la derecha, sans serif).
+ */
+import type { ChatMessage } from "@/lib/v2/types";
+
+interface Props {
+  message: ChatMessage;
+}
+
+export function UserMessage({ message }: Props) {
+  return (
+    <div className="msg user" data-testid="chat-msg-user">
+      {message.content}
+    </div>
+  );
+}

--- a/web/src/components/v2/contexto/ValentinaMessage.tsx
+++ b/web/src/components/v2/contexto/ValentinaMessage.tsx
@@ -1,0 +1,42 @@
+/**
+ * Mensaje de Valentina (role=valentina) en el chat scoped.
+ *
+ * Reusa clases legacy `.msg.v` (sans serif para body, .name uppercase
+ * mono, em → serif italic accent). Si message.partial=true, agregamos
+ * un cursor parpadeante al final del texto durante streaming.
+ */
+import type { ChatMessage } from "@/lib/v2/types";
+
+interface Props {
+  message: ChatMessage;
+}
+
+export function ValentinaMessage({ message }: Props) {
+  return (
+    <div
+      className="msg v"
+      data-testid="chat-msg-valentina"
+      data-partial={message.partial ? "true" : "false"}
+    >
+      <div className="name">Valentina</div>
+      <div className="body">
+        {message.content}
+        {message.partial && (
+          <span
+            aria-hidden="true"
+            data-testid="chat-cursor"
+            style={{
+              display: "inline-block",
+              width: 8,
+              height: 14,
+              marginLeft: 2,
+              background: "var(--accent)",
+              verticalAlign: "middle",
+              animation: "blink 1s steps(2) infinite",
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/v2/api.ts
+++ b/web/src/lib/v2/api.ts
@@ -105,3 +105,175 @@ export async function createDraftQuote(
     createdAt: new Date().toISOString(),
   };
 }
+
+/* ════════════════════════════════════════════════════════════════════════
+   Sprint 2 paso-2-contexto · mock client de contexto + chat scoped
+   ════════════════════════════════════════════════════════════════════════
+   Endpoints `PATCH /api/v1/quotes/{id}/context` y `POST /api/v1/quotes/{id}/chat`
+   marcados como missing/parcial en docs/handoff-context/missing-endpoints.md.
+   El mock cubre la brecha temporal hasta sprint-3/api-integration. */
+
+/** Origen del valor de cada campo del contexto (Master §10 data model). */
+export type ContextOrigin =
+  | "BRIEF" // extraído del brief original (PDF + textarea)
+  | "INFERIDO" // inferido por Valentina al cruzar catálogos / regla
+  | "DEFAULT" // valor por defecto (ej. zócalo 5cm)
+  | "EDITADO" // Marina lo tocó manualmente
+  | "FALTA"; // no extraído ni inferido — requiere input humano
+
+export interface ContextField<T = string | number | boolean | null> {
+  value: T;
+  origin: ContextOrigin;
+  edited?: boolean;
+}
+
+/** Los 11 campos del contexto (Master §6 mockup 01-A). */
+export interface ContextData {
+  cliente: string; // arquitecta / razón social
+  contacto: string; // teléfono / email
+  localidad: string; // obra · ciudad
+  plazo: string; // desde confirmación de medidas
+  tipologia: string; // cocina, baño, mesa
+  tipo_obra: "particular" | "edificio";
+  material: string; // piedra o engineered
+  pileta: string; // tipo + origen
+  zocalo: string; // contra pared · si/no + alto
+  regrueso: string; // borde frontal grueso
+  anafe: boolean; // define MO ANAFE en paso 3
+}
+
+export type ContextResponse = {
+  [K in keyof ContextData]: ContextField<ContextData[K]>;
+};
+
+/** In-memory store para que updates persistan dentro de la sesión del browser. */
+const _contextStore = new Map<string, ContextResponse>();
+
+/** Reset helper (útil para tests / reset entre quotes en dev). */
+export function _resetContextStore() {
+  _contextStore.clear();
+}
+
+async function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const t = setTimeout(resolve, ms);
+    signal?.addEventListener("abort", () => {
+      clearTimeout(t);
+      reject(new DOMException("Aborted", "AbortError"));
+    });
+  });
+}
+
+/**
+ * GET context para un quote. Mock retorna CANONICAL_CONTEXT (Master §13)
+ * la primera vez, luego cualquier estado guardado en la sesión.
+ */
+export async function getContextForQuote(
+  quoteId: string,
+  options?: { signal?: AbortSignal },
+): Promise<ContextResponse> {
+  await delay(150 + Math.random() * 200, options?.signal);
+  const existing = _contextStore.get(quoteId);
+  if (existing) return existing;
+  // Lazy import para evitar circular en build (canonicalQuote re-importa types).
+  const { CANONICAL_CONTEXT } = await import("./mocks/canonicalQuote");
+  const seeded = JSON.parse(JSON.stringify(CANONICAL_CONTEXT)) as ContextResponse;
+  _contextStore.set(quoteId, seeded);
+  return seeded;
+}
+
+/**
+ * PATCH parcial del contexto. Marca cada campo recibido como
+ * `origin: 'EDITADO'` + `edited: true` (regla Master §4 #3).
+ */
+export async function updateContextForQuote(
+  quoteId: string,
+  partial: Partial<ContextData>,
+  options?: { signal?: AbortSignal },
+): Promise<ContextResponse> {
+  await delay(120 + Math.random() * 180, options?.signal);
+  const current = await getContextForQuote(quoteId);
+  // Cast a Record para permitir asignación dinámica por key — la mapped
+  // type ContextResponse rechaza writes heterogéneos sin narrowing.
+  const next = { ...current } as Record<keyof ContextData, ContextField>;
+  for (const k of Object.keys(partial) as (keyof ContextData)[]) {
+    const value = partial[k];
+    if (value === undefined) continue;
+    next[k] = {
+      value: value as string | number | boolean | null,
+      origin: "EDITADO",
+      edited: true,
+    };
+  }
+  const result = next as ContextResponse;
+  _contextStore.set(quoteId, result);
+  return result;
+}
+
+/* ─── Chat scoped streaming (mock SSE via ReadableStream) ─────────── */
+
+export type ChatScope = "contexto" | "despiece" | "calculo" | "pdf";
+
+export interface ChatStreamChunk {
+  type: "text" | "done" | "error";
+  content?: string;
+  message?: string;
+}
+
+/** Frases canónicas rioplatenses para mock — varían según scope. */
+function pickResponse(scope: ChatScope, message: string): string {
+  const lower = message.toLowerCase();
+  if (scope === "contexto") {
+    if (lower.includes("anafe")) {
+      return "Marqué anafe porque en el plano se ve el dibujo del símbolo en la mesada. Si no es así, lo desmarcás vos y se recalcula la MO en el paso 3.";
+    }
+    if (lower.includes("descuento") || lower.includes("arquitec")) {
+      return "Cueto-Heredia matchea con architects.json (5% sobre material importado). Lo aplico solo en el material que sea importado, no sobre la MO ni el flete.";
+    }
+    if (lower.includes("pileta") || lower.includes("bacha")) {
+      return "Inferí pileta empotrada porque el brief dice que la trae el cliente. Si fuera apoyada cambia el corte y tengo que rehacer despiece.";
+    }
+    if (lower.includes("material") || lower.includes("silestone")) {
+      return "Silestone Blanco Norte salió del brief textual. Es engineered importado, así que aplica descuento arquitecta y NO tiene merma cero (sintéticos sí mermean a diferencia de Negro Brasil).";
+    }
+  }
+  return "Te puedo ayudar con eso. Decime qué campo querés revisar y te explico de dónde lo saqué.";
+}
+
+/**
+ * Mock SSE del chat scoped — emite chunks de texto cada 50-100ms para
+ * simular streaming token-por-token. Soporta abort via signal.
+ */
+export function streamChat(
+  _quoteId: string,
+  message: string,
+  scope: ChatScope,
+  options?: { signal?: AbortSignal },
+): ReadableStream<ChatStreamChunk> {
+  const text = pickResponse(scope, message);
+  const tokens = text.split(/(\s+)/); // split conservando whitespace
+
+  return new ReadableStream<ChatStreamChunk>({
+    async start(controller) {
+      try {
+        for (const token of tokens) {
+          await delay(50 + Math.random() * 50, options?.signal);
+          controller.enqueue({ type: "text", content: token });
+        }
+        controller.enqueue({ type: "done" });
+        controller.close();
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          controller.close();
+          return;
+        }
+        controller.enqueue({ type: "error", message: "stream-error" });
+        controller.close();
+      }
+    },
+  });
+}

--- a/web/src/lib/v2/hooks/useChatScoped.ts
+++ b/web/src/lib/v2/hooks/useChatScoped.ts
@@ -1,0 +1,94 @@
+/**
+ * Hook que gestiona el chat scoped del paso 2.
+ *
+ * Persistencia (Master §10 #1): los mensajes se borran al cerrar el
+ * panel. open() nuevo arranca con stream vacío. Esto es por diseño —
+ * el chat es por-pregunta, no historial persistente.
+ *
+ * Streaming: cada send() abre un ReadableStream del mock SSE y va
+ * concatenando los chunks `text` al mensaje de Valentina hasta
+ * recibir `done`. AbortController cancela el stream en curso (cierre
+ * de panel o componente desmontado).
+ */
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { streamChat, type ChatScope } from "../api";
+import type { ChatMessage, ChatPanelState } from "../types";
+
+function makeId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function useChatScoped(quoteId: string, scope: ChatScope) {
+  const [panelState, setPanelState] = useState<ChatPanelState>("closed");
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const open = useCallback(() => setPanelState("open"), []);
+
+  const close = useCallback(() => {
+    abortRef.current?.abort();
+    setPanelState("closed");
+    setMessages([]); // borra al cerrar (Master §10 #1)
+  }, []);
+
+  const send = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      const userMsg: ChatMessage = {
+        id: makeId(),
+        role: "user",
+        content: trimmed,
+        timestamp: new Date().toISOString(),
+      };
+      const valentinaId = makeId();
+      const valentinaMsg: ChatMessage = {
+        id: valentinaId,
+        role: "valentina",
+        content: "",
+        timestamp: new Date().toISOString(),
+        partial: true,
+      };
+      setMessages((prev) => [...prev, userMsg, valentinaMsg]);
+      setPanelState("streaming");
+      abortRef.current?.abort();
+      const ctrl = new AbortController();
+      abortRef.current = ctrl;
+      try {
+        const stream = streamChat(quoteId, trimmed, scope, { signal: ctrl.signal });
+        const reader = stream.getReader();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value.type === "text" && value.content) {
+            const chunk = value.content;
+            setMessages((prev) =>
+              prev.map((m) => (m.id === valentinaId ? { ...m, content: m.content + chunk } : m)),
+            );
+          } else if (value.type === "done") {
+            setMessages((prev) =>
+              prev.map((m) => (m.id === valentinaId ? { ...m, partial: false } : m)),
+            );
+          }
+        }
+      } catch {
+        // AbortError o error de stream: marcar como no-partial
+        setMessages((prev) =>
+          prev.map((m) => (m.id === valentinaId ? { ...m, partial: false } : m)),
+        );
+      } finally {
+        // Si seguimos abiertos, volver a estado open. Si close() ya
+        // disparó (panelState='closed'), no pisar el estado.
+        setPanelState((curr) => (curr === "streaming" ? "open" : curr));
+      }
+    },
+    [quoteId, scope],
+  );
+
+  return { panelState, messages, open, close, send };
+}

--- a/web/src/lib/v2/hooks/useContextForm.ts
+++ b/web/src/lib/v2/hooks/useContextForm.ts
@@ -1,0 +1,79 @@
+/**
+ * Hook que gestiona el form del paso 2 (contexto):
+ *   - load inicial via getContextForQuote
+ *   - updateField parcial via updateContextForQuote
+ *   - flag isDirty (algún field tiene `edited: true`)
+ *   - estado loading | idle | saving | error
+ *
+ * Cancela cualquier load/save pendiente al desmontar (AbortController).
+ */
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  getContextForQuote,
+  updateContextForQuote,
+  type ContextData,
+  type ContextResponse,
+} from "../api";
+import type { ContextFormState } from "../types";
+
+export function useContextForm(quoteId: string) {
+  const [context, setContext] = useState<ContextResponse | null>(null);
+  const [state, setState] = useState<ContextFormState>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const saveAbortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    let aborted = false;
+    const ctrl = new AbortController();
+    setState("loading");
+    setError(null);
+    getContextForQuote(quoteId, { signal: ctrl.signal })
+      .then((data) => {
+        if (aborted) return;
+        setContext(data);
+        setState("idle");
+      })
+      .catch((err) => {
+        if (aborted || (err instanceof DOMException && err.name === "AbortError")) {
+          return;
+        }
+        setError(err instanceof Error ? err.message : "Error al cargar el contexto");
+        setState("error");
+      });
+    return () => {
+      aborted = true;
+      ctrl.abort();
+    };
+  }, [quoteId]);
+
+  const updateField = useCallback(
+    async <K extends keyof ContextData>(key: K, value: ContextData[K]) => {
+      saveAbortRef.current?.abort();
+      const ctrl = new AbortController();
+      saveAbortRef.current = ctrl;
+      setState("saving");
+      setError(null);
+      try {
+        const updated = await updateContextForQuote(
+          quoteId,
+          { [key]: value } as Partial<ContextData>,
+          { signal: ctrl.signal },
+        );
+        setContext(updated);
+        setState("idle");
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setError(err instanceof Error ? err.message : "Error al guardar");
+        setState("error");
+      }
+    },
+    [quoteId],
+  );
+
+  const isDirty = context ? Object.values(context).some((f) => f.edited === true) : false;
+  const editedCount = context ? Object.values(context).filter((f) => f.edited === true).length : 0;
+
+  return { context, state, error, updateField, isDirty, editedCount };
+}

--- a/web/src/lib/v2/mocks/canonicalQuote.ts
+++ b/web/src/lib/v2/mocks/canonicalQuote.ts
@@ -65,3 +65,27 @@ export function getCurrentStep(pathname: string): StepId {
   if (pathname.includes("/pdf")) return "pdf";
   return "brief"; // default · paso 1 si no matchea ninguno
 }
+
+/* ════════════════════════════════════════════════════════════════════════
+   Sprint 2 paso-2-contexto · CANONICAL_CONTEXT
+   ════════════════════════════════════════════════════════════════════════
+   Espejo de Master §13 cifras canon Cueto-Heredia + mockup 01-A
+   (11 campos visibles en el grid del paso 2). Los `origin` reflejan el
+   path de extracción que Valentina usaría: BRIEF (texto/PDF directo) o
+   INFERIDO (cruzando catálogos / reglas). */
+
+import type { ContextResponse } from "../api";
+
+export const CANONICAL_CONTEXT: ContextResponse = {
+  cliente: { value: "Cueto-Heredia Arquitectura", origin: "BRIEF" },
+  contacto: { value: "estudio@cueto-heredia.ar", origin: "INFERIDO" },
+  localidad: { value: "Belgrano · CABA", origin: "BRIEF" },
+  plazo: { value: "3 semanas", origin: "BRIEF" },
+  tipologia: { value: "cocina U + isla", origin: "BRIEF" },
+  tipo_obra: { value: "particular", origin: "INFERIDO" },
+  material: { value: "Silestone Blanco Norte 20mm", origin: "BRIEF" },
+  pileta: { value: "empotrada · Franke FX110-50 (cliente)", origin: "BRIEF" },
+  zocalo: { value: "contra pared · 12 cm", origin: "BRIEF" },
+  regrueso: { value: "frontal · 4 cm", origin: "INFERIDO" },
+  anafe: { value: true, origin: "INFERIDO" },
+};

--- a/web/src/lib/v2/types.ts
+++ b/web/src/lib/v2/types.ts
@@ -15,3 +15,18 @@ export interface BriefFormData {
   photos: File[];
   briefText: string;
 }
+
+/* ─── Sprint 2 paso-2-contexto · chat scoped + context form ─────────── */
+
+export type ContextFormState = "loading" | "idle" | "saving" | "error";
+
+export interface ChatMessage {
+  id: string;
+  role: "user" | "valentina";
+  content: string;
+  timestamp: string;
+  /** true mientras la respuesta de Valentina se está streameando. */
+  partial?: boolean;
+}
+
+export type ChatPanelState = "closed" | "open" | "streaming";

--- a/web/tests/e2e/contexto.spec.ts
+++ b/web/tests/e2e/contexto.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * E2E del paso 2 — contexto + chat scoped.
+ *
+ * Cubre los 3 estados visuales (mockups 01 A / 02 B / 03 C),
+ * edit mode (Tab/Enter/Esc), chat streaming, persistencia
+ * borra-al-cerrar (Master §10 #1) y routing al paso 3.
+ */
+import { expect, test, type Page } from "@playwright/test";
+
+const QUOTE_URL = "/v2/quotes/PRES-2026-018/contexto";
+
+async function gotoContexto(page: Page) {
+  await page.goto(QUOTE_URL);
+  await expect(page.locator('[data-testid="context-form"]')).toBeVisible();
+}
+
+test("estado A — 11 campos canon visibles, banner pristine", async ({ page }) => {
+  await gotoContexto(page);
+  await expect(page.locator('[data-testid="context-form"]')).toHaveAttribute("data-state", "A");
+  // 11 rows de contexto
+  const rows = page.locator('[data-testid^="context-row-"]');
+  await expect(rows).toHaveCount(11);
+  // Cifras canon Cueto-Heredia
+  await expect(page.locator('[data-testid="context-value-cliente"]')).toContainText(
+    "Cueto-Heredia",
+  );
+  await expect(page.locator('[data-testid="context-value-material"]')).toContainText("Silestone");
+  await expect(page.locator('[data-testid="context-value-tipologia"]')).toContainText("cocina");
+  // Banner pristine menciona "Valentina extrajo"
+  await expect(page.locator('[data-testid="context-banner"]')).toContainText("Valentina");
+});
+
+test("edit mode — click → input con foco, Esc cancela", async ({ page }) => {
+  await gotoContexto(page);
+  await page.locator('[data-testid="context-value-localidad"]').click();
+  const input = page.locator('[data-testid="context-input-localidad"]');
+  await expect(input).toBeVisible();
+  await expect(input).toBeFocused();
+  await input.fill("Palermo · CABA");
+  await page.keyboard.press("Escape");
+  // Vuelve al value original (Esc revierte)
+  await expect(page.locator('[data-testid="context-value-localidad"]')).toContainText("Belgrano");
+  // Row sigue sin clase edited
+  await expect(page.locator('[data-testid="context-row-localidad"]')).toHaveAttribute(
+    "data-edited",
+    "false",
+  );
+});
+
+test("estado A → B — editar 1 campo aplica row-edited + chip EDITADO", async ({ page }) => {
+  await gotoContexto(page);
+  await page.locator('[data-testid="context-value-localidad"]').click();
+  await page.locator('[data-testid="context-input-localidad"]').fill("Palermo · CABA");
+  await page.keyboard.press("Enter");
+  // Espera al save mock (~150ms + delay)
+  await expect(page.locator('[data-testid="context-row-localidad"]')).toHaveAttribute(
+    "data-edited",
+    "true",
+    { timeout: 3000 },
+  );
+  await expect(page.locator('[data-testid="origin-chip-localidad"]')).toContainText("EDITADO");
+  await expect(page.locator('[data-testid="edit-icon-localidad"]')).toBeVisible();
+  // Form cambia a estado B
+  await expect(page.locator('[data-testid="context-form"]')).toHaveAttribute("data-state", "B");
+  // Banner se vuelve muted con copy distinto
+  await expect(page.locator('[data-testid="context-banner"]')).toContainText("Marina");
+});
+
+test("chat panel — abrir, enviar, recibir streaming, cerrar borra mensajes", async ({ page }) => {
+  await gotoContexto(page);
+  // Panel cerrado al inicio
+  await expect(page.locator('[data-testid="chat-panel"]')).not.toBeVisible();
+  // Abrir
+  await page.locator('[data-testid="open-chat"]').click();
+  await expect(page.locator('[data-testid="chat-panel"]')).toBeVisible();
+  await expect(page.locator('[data-testid="chat-empty"]')).toBeVisible();
+
+  // Enviar mensaje
+  await page.locator('[data-testid="chat-input"]').fill("¿Por qué pusiste anafe?");
+  await page.locator('[data-testid="chat-send"]').click();
+
+  // User message visible
+  await expect(page.locator('[data-testid="chat-msg-user"]').first()).toContainText("anafe");
+  // Valentina responde — esperar al menos un chunk de texto
+  const valentina = page.locator('[data-testid="chat-msg-valentina"]').first();
+  await expect(valentina).toBeVisible();
+  // Esperar a que termine el stream (panel-state vuelve a "open")
+  await expect(page.locator('[data-testid="chat-panel"]')).toHaveAttribute(
+    "data-panel-state",
+    "open",
+    { timeout: 10000 },
+  );
+  await expect(valentina).toContainText(/plano|símbolo|mesada/);
+
+  // Cerrar panel
+  await page.locator('[data-testid="chat-close"]').click();
+  await expect(page.locator('[data-testid="chat-panel"]')).not.toBeVisible();
+
+  // Reabrir → mensajes vacíos (Master §10 #1)
+  await page.locator('[data-testid="open-chat"]').click();
+  await expect(page.locator('[data-testid="chat-empty"]')).toBeVisible();
+  await expect(page.locator('[data-testid="chat-msg-user"]')).toHaveCount(0);
+});
+
+test("chat — sugerencia rápida envía pregunta", async ({ page }) => {
+  await gotoContexto(page);
+  await page.locator('[data-testid="open-chat"]').click();
+  await page.locator('[data-testid="chat-suggestion"]').first().click();
+  await expect(page.locator('[data-testid="chat-msg-user"]').first()).toContainText("anafe");
+});
+
+test("confirm — click navega a /v2/quotes/PRES-2026-018/despiece", async ({ page }) => {
+  await gotoContexto(page);
+  await page.locator('[data-testid="confirm-context"]').click();
+  await page.waitForURL("**/quotes/PRES-2026-018/despiece");
+  await expect(page.locator(".stepper")).toHaveAttribute("data-current-step", "despiece");
+});


### PR DESCRIPTION
## Resumen del PR

Implementa el **paso 2 del flujo** (mockups 01 A / 02 B / 03 C): grid de 11 campos del contexto extraídos por Valentina, edición inline con Tab/Enter/Esc + visual EDITADO (borde púrpura · ✏ · chip), chat scoped 480px con streaming mock SSE y persistencia borra-al-cerrar. Click "Confirmar y continuar" navega al paso 3.

**ÚLTIMO PR DEL SPRINT 2.** Después del merge, Sprint 2 está cerrado.

## Sprint y sub-branch

- Sprint: 2 · CIERRE
- Sub-branch: `sprint-2/paso-2-contexto`
- Mergea contra: `sprint-2/main`

## Componentes creados (LOC)

| Archivo | LOC |
|---------|-----|
| `lib/v2/api.ts` (extendido · +172 líneas) | +172 |
| `lib/v2/mocks/canonicalQuote.ts` (extendido · +24) | +24 |
| `lib/v2/types.ts` (extendido · +15) | +15 |
| `lib/v2/hooks/useContextForm.ts` | 79 |
| `lib/v2/hooks/useChatScoped.ts` | 94 |
| `components/v2/contexto/ContextField.tsx` | 146 |
| `components/v2/contexto/ContextForm.tsx` | 181 |
| `components/v2/contexto/ChatPanel.tsx` | 145 |
| `components/v2/contexto/UserMessage.tsx` | 17 |
| `components/v2/contexto/ValentinaMessage.tsx` | 42 |
| `components/v2/contexto/ContextView.tsx` | 91 |
| `app/v2/quotes/[id]/contexto/page.tsx` (reemplazo · 22) | 22 |
| `tests/e2e/contexto.spec.ts` (6 tests nuevos) | 117 |
| **Total código nuevo** | **~1145** |

## Decisiones técnicas

1. **Endpoints reales NO existen** — `PATCH /api/v1/quotes/{id}/context` y el chat scoped están marcados como missing/parcial en `docs/handoff-context/missing-endpoints.md`. Mock client en `api.ts` cubre la brecha. Switch real en `sprint-3/api-integration`.

2. **Mock SSE via `ReadableStream<ChatStreamChunk>`** — emite chunks `{type: 'text' | 'done' | 'error'}` cada 50-100ms simulando token-streaming. Frases canónicas en rioplatense según scope + keywords del mensaje (anafe, descuento, pileta, material). Soporta abort.

3. **Chat layout: grid interno, no modificar chrome** — el chrome `[id]/layout.tsx` del PR #456 renderea children dentro de `<div class="body no-chat">`. Para no tocarlo, ContextView monta un grid inline (`gridTemplateColumns: chatOpen ? '1fr 480px' : '1fr'`) que alterna entre 1 y 2 columnas. Resultado: el chrome shell queda intacto y el chat se adapta.

4. **Form vive en hook (`useContextForm`), no en container** — distinto del paso 1 (donde el form vive en BriefView). Razón: en paso 2 cada update va al backend (mock) inmediatamente vía `updateField` y el response es la fuente de verdad. No hay "submit" final del form.

5. **In-memory store para mock** — `_contextStore: Map<quoteId, ContextResponse>` permite que los updates persistan entre re-mounts dentro de la misma sesión. Reset entre tests via reload de página (Playwright fresh context).

6. **Cifras canon Cueto-Heredia (Master §13)**:
   - `cliente: 'Cueto-Heredia Arquitectura'` (BRIEF)
   - `material: 'Silestone Blanco Norte 20mm'` (BRIEF)
   - `localidad: 'Belgrano · CABA'` (BRIEF)
   - `pileta: 'empotrada · Franke FX110-50 (cliente)'` (BRIEF)
   - 7 más (contacto, plazo, tipologia, tipo_obra, zocalo, regrueso, anafe) con origin BRIEF/INFERIDO

7. **Persistencia chat = borra al cerrar (Master §10 #1)** — close() abortea stream + setea panelState=closed + vacía messages. Reabrir empieza con stream limpio. Es por diseño: el chat es por-pregunta, no historial persistente.

8. **`quoteId` viene de `params.id`** (no hardcodeado en componentes) — la prop pasa por ContextView → useContextForm/useChatScoped → mock client. Cuando el backend real entre, los endpoints reciben el id correcto sin tocar UI.

## Verificación local

| Check | Status |
|-------|--------|
| `npm run lint:v2` | ✅ clean |
| `npm run typecheck` | ✅ clean |
| `npm run test:unit` | ✅ 1/1 |
| `npm run test:e2e` | ✅ **19/19** (10 previos + 6 contexto + ñ verifica fonts.spec) |
| `npm run build` | ✅ legacy + v2 + nueva ruta `/v2/quotes/[id]/contexto` (6.32 kB · 93.6 kB First Load) |
| `diff -q operator-shared.css handoff` | ✅ sin cambios |

## Scope (qué NO incluye · todo va a Sprint 3+)

- ❌ Backend real (mock client cubre los endpoints missing)
- ❌ Re-generate IA (botón "↻ Re-generar campos no editados" del mockup) — Sprint 3
- ❌ Audit log per-row (Master §10 #8) — Sprint 3
- ❌ IVA toggle — Sprint 4
- ❌ Multi-material — Sprint 4
- ❌ State management global (useState alcanza)
- ❌ Mobile responsive (desktop-only intencional)
- ❌ Brief chips IA (origin "MATCH" del mockup) — paso 3 o sub-PR siguiente

## Edge cases manejados

- Esc durante edit revierte al value original sin tocar el field (`data-edited` queda en `false`)
- Tab/Enter committea + sale de edit. Blur también committea.
- Editar un field 2 veces seguido → último valor gana (AbortController cancela el save anterior)
- Cerrar chat durante streaming → aborta el stream + vacía messages
- send() vacío (whitespace) → no-op
- Reabrir chat después de cerrar → empty state visible (mensajes vacíos)
- ContextView durante loading inicial muestra skeletons; durante error muestra mensaje legible

## Test plan (Vercel preview post-push)

- [ ] `/v2/quotes/PRES-2026-018/contexto` carga con 11 rows (3 grupos: Cliente 4 / Proyecto 3 / Detalles 4)
- [ ] Stepper muestra paso 2 activo (Contexto highlighted)
- [ ] Banner pristine: "Valentina extrajo del brief: cliente Cueto-Heredia (match arquitecta · −5%)…"
- [ ] Click en cualquier value → input con foco automático
- [ ] Esc → revierte al value original, sin marca edited
- [ ] Tab/Enter → guarda + chip cambia a EDITADO en púrpura, ícono ✏ aparece
- [ ] Banner cambia a estado B con copy "Marina editó N campos"
- [ ] Click "Abrir chat con Valentina" → panel 480px aparece a la derecha
- [ ] Empty state visible con copy "Hacé una pregunta o usá una sugerencia"
- [ ] Click en sugerencia "¿Por qué pusiste anafe?" → user msg + Valentina streamea respuesta token-por-token
- [ ] Cursor parpadea al final de Valentina mientras `partial=true`
- [ ] Cerrar chat (✕) → panel desaparece
- [ ] Reabrir → mensajes vacíos (Master §10 #1 confirmado)
- [ ] Click "Confirmar y continuar a despiece →" → navega a `/v2/quotes/PRES-2026-018/despiece` con paso 3 activo
- [ ] Vercel preview legacy intacto: `/`, `/admin/observability`, `/quote/[id]`, `/login`, `/config`

## Checklist pre-merge

### Código

- [x] Build verde sin warnings
- [x] Lint pass (`npm run lint:v2`)
- [x] Tests verdes (`npm run test:unit` + `npm run test:e2e` 19/19)
- [x] TypeScript strict, sin `any`
- [x] No credenciales committeadas
- [x] No paquetes nuevos

### UI

- [x] Tokens importados via CSS vars (no hardcoded)
- [x] Copy en español rioplatense ("editá", "te puedo decir", "decime")
- [x] Convención IA-celeste (.ia-banner) / Humano-púrpura (.row-edited · k-edited) respetada
- [x] Mockups 01-A / 02-B / 03-C reproducidos en estructura HTML

### Reglas Sprint 2

- [x] `operator-shared.css` NO se modificó (`diff -q` clean)
- [x] Chrome shell del PR #456 NO se tocó
- [x] `lib/v2/mocks/canonicalQuote.ts` solo se EXTENDIÓ (CANONICAL_CONTEXT nuevo · CANONICAL_QUOTE intacto)
- [x] `lib/v2/api.ts` solo se EXTENDIÓ (createDraftQuote intacto)
- [x] No mobile responsive (desktop-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)