### PR TITLE
Sprint 3 · PR previo · extract-calc-contracts (docs del motor de cálculo)

### DIFF
--- a/docs/handoff-context/README.md
+++ b/docs/handoff-context/README.md
@@ -24,6 +24,13 @@ handoff-context/
 ├── endpoints-spec.md          ← ~50 endpoints REST agrupados por flow del Master §6
 ├── sse-spec.md                ← protocolo SSE chat Valentina (7 event types)
 ├── missing-endpoints.md       ← endpoints sugeridos por mockups que NO existen hoy
+├── calculator.md              ← [Sprint 3] overview del motor de cálculo
+├── calculator-rules.md        ← [Sprint 3] 12 reglas explícitas del motor + deuda
+├── calculator-examples.md     ← [Sprint 3] ejemplos worked input→output (de tests reales)
+├── tools/
+│   ├── list_pieces.md         ← [Sprint 3] tool spec extracción de piezas (paso 1)
+│   ├── calculate_quote.md     ← [Sprint 3] tool spec cálculo (paso 4)
+│   └── validate_quote.md      ← [Sprint 3] validate_despiece (validación interna)
 ├── schemas/
 │   ├── quote.md               ← modelo Quote completo + QuoteBreakdown JSON
 │   ├── audit_events.md        ← schema audit_events + lista de event_types
@@ -63,6 +70,13 @@ Orden recomendado para alguien que arranca Sprint 2:
 5. **`schemas/audit_events.md`** — relevante para Sprint 3 (`/admin/quotes/{id}/audit` panel).
 6. **`catalog/`** — fixtures sanitizadas para mockear `GET /api/catalog/{name}`.
 7. **`missing-endpoints.md`** — qué falta y cómo workaroundear.
+
+### Para Sprint 3 (paso 3 despiece + paso 4 cálculo)
+
+8. **`calculator.md`** — overview del motor `calculate_quote()`: inputs, outputs, flujo, regla de moneda (USD/ARS nativos sin conversión).
+9. **`calculator-rules.md`** — las 12 reglas explícitas (merma, IVA, descuentos, MO, flete, edificio, redondeo) con line refs.
+10. **`calculator-examples.md`** — ejemplos worked reproducibles (de `api/tests/`) + ⚠️ discrepancia de las cifras canon del Master §13.
+11. **`tools/`** — contratos de los 3 tools: `list_pieces` (paso 1), `calculate_quote` (paso 4), `validate_quote`/`validate_despiece` (validación).
 
 ---
 

--- a/docs/handoff-context/calculator-examples.md
+++ b/docs/handoff-context/calculator-examples.md
@@ -1,0 +1,174 @@
+# Ejemplos worked del motor de cálculo
+
+> **Fuente:** tests reales del backend (`api/tests/test_quote_engine.py`, `test_validation.py`, `test_regrueso_mo.py`, `test_zocalo_m2_quantity.py`, `conftest.py`) + ejemplos validados en `api/examples/`.
+> **Derivado de:** lectura en `sprint-3/extract-calc-contracts`.
+> **Última actualización:** 2026-05-13.
+>
+> **Cantidad real:** el Master §16 menciona "34 examples". Los 34 archivos en `api/examples/` (quote-001…034) son **narrativas de razonamiento** (input + tablas + totales en prosa), NO fixtures ejecutables — `CONTEXT.md:178` lo dice explícito ("son REFERENCIAS de formato/lógica, NO datos para copiar"). Los ejemplos **reproducibles** (asertados en tests Python) son los de abajo. Marco cada uno como `[TEST]` (asertado en código) o `[EJEMPLO]` (de `api/examples/`, prosa) o `[MOCK]` (solo en docs de design, no reproducible).
+
+---
+
+## A · m² (`calculate_m2`) `[TEST]`
+
+`api/tests/test_quote_engine.py:14-41`
+
+| Input | Output |
+|---|---|
+| `[{largo:2.0, prof:0.6}]` | `1.2 m²` |
+| mesada + zócalo `[{2.0×0.6}, {2.0, alto:0.05}]` | `1.3 m²` |
+| mesada en L `[{2.41×0.6}, {1.37×0.6}]` | `2.27 m²` (1.446+0.822=2.268 → half-up 2dp) |
+| `[]` | `0` |
+
+## B · Merma (`calculate_merma`) `[TEST]`
+
+`api/tests/test_quote_engine.py:44-74`
+
+| Input | `aplica` | Nota |
+|---|---|---|
+| `(1.80, "SILESTONE BLANCO NORTE")` | `False` | desperdicio < 1.0 m² |
+| `(0.80, "SILESTONE BLANCO NORTE")` | `True` | `sobrante_m2 ≈ desperdicio/2` |
+| `(0.5, "GRANITO NEGRO BRASIL")` | `False` | motivo: "Negro Brasil" (nunca merma) |
+| `(2.0, "GRANITO GRIS MARA")` | `False` | motivo: "natural" |
+| `(2.0, "PURASTONE BLANCO PALOMA")` | `True` | placa entera 4.20 m² ref |
+
+## C · Resolución de material (`_find_material`) `[TEST]`
+
+`api/tests/test_quote_engine.py:80-90`
+
+| Input | Resultado |
+|---|---|
+| `"Silestone Blanco Norte"` | `found:True, currency:USD` |
+| `"GRANITO"` / `"Silestone"` / `"Dekton"` (bare) | `found:False, ambiguous_family:True` → pide SKU |
+
+---
+
+## 1 · Quote completo · Silestone Blanco Norte `[TEST]`
+
+`api/tests/test_validation.py:26-100` — golden válido, IVA-consistente.
+
+**Inputs (resumidos):**
+```json
+{
+  "client_name": "Juan Carlos", "project": "Cocina",
+  "material": "SILESTONE BLANCO NORTE", "material_currency": "USD",
+  "pieces": [
+    {"description": "Mesada", "largo": 2.0, "prof": 0.60},
+    {"description": "Zocalo", "largo": 2.0, "alto": 0.05}
+  ],
+  "pileta": "empotrada_johnson", "colocacion": true, "localidad": "Rosario"
+}
+```
+
+**Cálculo (IVA = 1.21):**
+- Material: base USD 519/m² → `unit = floor(519 × 1.21) = 627`; m² = 1.30 → `material_total = round(1.30 × 627) = 815 USD`
+- MO pileta: base 53.840 → `round(×1.21) = 65.146`
+- MO colocación: base 49.699 → `60.136`, × 1.30 m²
+- MO flete Rosario: base 42.975 → `51.999`
+
+**Expected output:**
+```json
+{ "material_total": 815, "total_usd": 815, "total_ars": 245458 }
+```
+
+## 2 · Quote completo · Silestone + anafe (fixture e2e) `[TEST]`
+
+`api/tests/conftest.py:110-136` (`sample_quote_data`), reusado en `test_e2e_flow.py`.
+
+- Material Silestone Blanco Norte, m² 1.30, `material_price_unit = 628 USD`
+- MO: pileta 65.147 + anafe 43.097 + colocación @1.30 → 60.135 + flete 52.000
+- **`total_ars: 238420`, `total_usd: 816`**
+
+## 3 · Multi-material (agrega Purastone) `[TEST]`
+
+`api/tests/conftest.py:141-147` + `test_e2e_flow.py`.
+
+- Segundo material Purastone Blanco Paloma: `material_price_unit = 407 USD` → `total_usd: 529`
+- Un quote independiente por material (no se suman).
+
+## 4 · Regrueso por metro lineal `[TEST]`
+
+`api/tests/test_regrueso_mo.py` (PR #401/#403).
+
+**Inputs:** Silestone Blanco Norte, 1 mesada 2.0×0.6, Rosario, `regrueso=True, regrueso_ml=60.68`.
+**Cálculo:**
+- MO regrueso: base 13.810,06 ARS/ml → `unit = round(×1.21) = 16.710`; `total = round(16.710 × 60.68)`
+- Material: regrueso suma m² → 42.39 + (60.68 × 0.05 = 3.034) = **45.424 m²**
+- Auto-detección de variante: piezas con "Regrueso" largos 1.5+0.6 → qty 2.1 ml
+
+## 5 · Zócalos round half-up `[TEST]`
+
+`api/tests/test_zocalo_m2_quantity.py` (PR #408/409).
+
+- Zócalo M6: `round(0.155, 2) = 0.16` (NO 0.15 banker's)
+- DYSCON zócalos M1×24 / M6×2 / M7×2 → suma **42.39 m²** (no 37.71)
+
+## 6 · Negro Brasil (sin merma) `[EJEMPLO]`
+
+`api/examples/quote-030-*.md` (Juan Carlos, Negro Brasil Extra).
+
+- 2 mesadas, SKU `GRANITONEGROBRASIL`, base USD 228 → `floor(228 × 1.21) = 275 USD/m²`
+- total 3.71 m²; **"NUNCA merma"** aplicado (Regla 1 excepción)
+
+## 7 · Silestone con anafe (referencia formato) `[EJEMPLO]`
+
+`api/examples/quote-017-*.md`.
+
+- Input: mesada 2.10 ml + zócalo, anafe; m² = 1.395
+- Material: base 429 → `floor(×1.21) = 519 USD/m²` (⚠️ catálogo viejo decía 429; hoy 519); total `round(1.395 × 519) = 724 USD`
+- MO total ARS $228.267,15
+
+## 8 · Validación · Negro Brasil + merma = ERROR `[TEST]`
+
+`api/tests/test_validation.py` (`_check_merma_rules`).
+
+- Si un qdata tiene `material_name` Negro Brasil y `merma.aplica = true` → `validate_despiece` retorna **error** (Negro Brasil nunca mermea).
+
+## 9 · Validación · IVA mismatch = ERROR `[TEST]`
+
+`api/tests/test_validation.py:113-127`.
+
+- `material_price_unit = 999` con base 519 USD → error (esperaba `floor(519×1.21)=627`).
+- `material_price_unit = round(519×1.21)=628` para USD → **error** igual (USD usa `floor`, no `round`).
+
+## 10 · Validación · PEGADOPILETA cuenta `[TEST]`
+
+`api/tests/test_validation.py` (`_check_pegadopileta`).
+
+- Pileta empotrada con 0 líneas de "Agujero y pegado pileta" → error.
+- Con > 1 → warning. Debe ser exactamente 1 por pileta.
+
+---
+
+## ⚠️ Discrepancia cifras canon (Cueto-Heredia · Pereyra)
+
+> **Reportado para audit.** Las cifras "canon" del Master §13 **NO son reproducibles ejecutando `calculator.py`**. Detalle:
+
+### `[MOCK]` ARS 660.890 + USD 1.538 (Pereyra / Silestone)
+
+- Solo aparecen en `docs/master.md:392` (breakdown mock), `docs/handoff-context/schemas/quote.md:307-340`, y mocks del frontend (`web/src/lib/mocks/canonicalQuote.ts:34`, `dashboardDataset.ts`).
+- El breakdown del Master usa **Silestone a USD 249/m²**, pero el catálogo real (`materials-silestone.json`) tiene **USD 429/m² sin IVA → 519 con IVA** (el Master lo marca como bug P2, "−52% diff"). Con el precio real, el material NO da USD 1.538.
+- **No hay test Python que asierte 660890 ni 1538.** Solo los E2E del frontend (`web/tests/e2e/dashboard.spec.ts`) verifican el texto, contra **mock data**, no contra un cálculo real.
+
+### `[MOCK]` USD 2.184 (Cueto-Heredia / Negro Brasil)
+
+- **No tiene derivación en ningún lado del repo.** Es un número suelto en `master.md:432` sin breakdown ni test.
+
+### Contradicción interna del Master §13
+
+- `master.md:430` → PRES-2026-017 = Pereyra / Silestone / 6.50 m² / **$660.890**
+- `master.md:432` → PRES-2026-018 = Cueto-Heredia / **Negro Brasil** / 8.40 m² / **USD 2.184**
+- pero el breakdown canónico (`master.md:392`) y `endpoints-spec.md:69` etiquetan **PRES-2026-018** como Silestone Blanco Norte / 660.890.
+
+→ El spec se contradice sobre qué ID/material/total van juntos.
+
+### Recomendación
+
+Para Sprint 3 (paso 3/4), mockear contra los **ejemplos `[TEST]` de arriba** (reproducibles del motor real). Tratar las cifras canon del Master §13 como **placeholders de design**, no como output esperado del motor. Si se necesita un caso canon reproducible, derivarlo ejecutando `calculate_quote` con inputs reales del catálogo vigente y documentar el resultado obtenido — no forzar el motor a matchear 2.184 / 660.890.
+
+### Fuente de precios (catálogo, sin IVA)
+
+| Material | Catálogo | Precio | Moneda |
+|---|---|---|---|
+| Negro Brasil Extra | `materials-granito-importado.json` | 228 | USD |
+| Negro Brasil Leather | `materials-granito-importado.json` | 252 | USD |
+| Silestone Blanco Norte | `materials-silestone.json` | 429 | USD |

--- a/docs/handoff-context/calculator-rules.md
+++ b/docs/handoff-context/calculator-rules.md
@@ -1,0 +1,154 @@
+# Reglas del motor de cálculo
+
+> **Fuente:** `api/app/modules/quote_engine/calculator.py` + `api/app/modules/agent/tools/validation_tool.py`.
+> **Derivado de:** lectura del código en `sprint-3/extract-calc-contracts`.
+> **Última actualización:** 2026-05-13.
+>
+> Cada regla cita las líneas exactas (`calculator.py:LXX-LYY`). Las constantes (`merma.*`, `discount.*`, etc.) salen de `api/catalog/config.json`; los valores entre paréntesis son los defaults vigentes.
+
+El Master §16 menciona "7 reglas". El código real implementa **más de 7**. Abajo van todas las encontradas; al final se listan las que el Master define pero el código NO implementa (deuda).
+
+---
+
+## Regla 1 · Merma (desperdicio de placa)
+
+**Descripción:** material extra que se factura por el recorte de placa en materiales sintéticos.
+**Trigger:** material es sintético (silestone, dekton, neolith, puraprima, purastone, laminatto) y NO es edificio.
+**Excepciones (nunca merma):** edificio (`:949-950`), Granito Negro Brasil (`:954-956`), cualquier piedra natural fuera de `SINTETICOS` (`:958-961`).
+**Cálculo:** `:942-1000`
+- Silestone usa **media placa** como referencia (`MERMA_MEDIA_PLACA`, placa default 4.20 m² → 2.10) (`:964-967`).
+- Resto de sintéticos usan **placa entera** (4.20 m²) (`:971-981`).
+- `desperdicio = ceil(needed / ref) × ref − needed` (`:983`).
+- Si `desperdicio < small_piece_threshold_m2` (default 1.0) → no se factura sobrante (`:985-992`).
+- Si no, **`sobrante = desperdicio / 2`** (se factura la mitad del recorte) (`:994`).
+**Código:** `calculator.py:942-1000`
+
+---
+
+## Regla 2 · IVA (×1.21)
+
+**Descripción:** todos los catálogos guardan precios sin IVA; el motor los lleva a precio final.
+**Trigger:** siempre, al construir cada línea (material + cada MO).
+**Cálculo:**
+- Material USD: `price_unit = floor(price_base × 1.21)` (validado en `validation_tool.py:64`).
+- Material ARS: `price_unit = round(price_base × 1.21)`.
+- MO (ARS): `unit_price = round(base_price × 1.21)` (`validation_tool.py:89`).
+- Líneas con `price_includes_vat: true` → `unit == base` (no se re-aplica).
+**Edge case:** ítems de edificio se dividen ÷1.05 (ver Regla 9) ANTES o en combinación con IVA — el validador espera `round(base×1.21)/1.05`.
+**Código:** material `calculator.py:1388-1393`; MO en construcción `:1477-1704`; verificación `validation_tool.py:64-140`
+
+---
+
+## Regla 3 · Descuento arquitecta
+
+**Descripción:** descuento sobre el material para clientes que matchean en `architects.json`.
+**Trigger:** `check_architect(client_name)` encuentra match (`calculator.py:1268-1278`), o `discount_pct` pasado explícito.
+**Cálculo:** `:1442-1466`
+- Material **USD** (importado) → `discount.imported_percentage` (default **5%**).
+- Material **ARS** (nacional) → `discount.national_percentage` (default **8%**).
+- `discount_amount = round(material_total × pct / 100)` — **solo sobre material**, nunca sobre MO ni flete.
+**Código:** `calculator.py:1268-1278, 1442-1466`
+
+---
+
+## Regla 4 · Descuento edificio
+
+**Descripción:** descuento por volumen para obras de edificio grandes.
+**Trigger:** `is_edificio = true` + `total_m2 ≥ building_min_m2_threshold` (default 15) + sin descuento previo.
+**Cálculo:** `discount_pct = building_percentage` (default **18%**) (`:1449-1460`).
+**Código:** `calculator.py:1449-1460`
+
+---
+
+## Regla 5 · Mano de obra (MO) — piletas
+
+**Descripción:** costo de agujero/pegado/apoyo de pileta según tipo.
+**Trigger:** `pileta` en `{empotrada_cliente, empotrada_johnson, apoyo}` y `pileta_qty > 0`.
+**Cálculo:** `:1485-1494`
+- Empotrada (cliente o johnson): SKU `PILETADEKTON/NEOLITH` (sintético) o `PEGADOPILETA` (resto), "Agujero y pegado pileta" × `pileta_qty`.
+- Apoyo: `PILETAAPOYODEKTON/NEO` o `AGUJEROAPOYO`.
+- **1 PEGADOPILETA por pileta, no por mesada** (regla de negocio del Master).
+- `pileta_qty = 0` → sin línea de pileta.
+**Código:** `calculator.py:1485-1494`
+
+---
+
+## Regla 6 · MO — anafe, frentín, inglete, regrueso, tomas, pulido
+
+**Descripción:** líneas de MO opcionales según opciones de obra.
+**Cálculo:**
+- **Anafe:** `ANAFEDEKTON/NEOLITH`/`ANAFE` × `anafe_qty` (`:1496-1506`).
+- **Frentín (faldón):** por metro lineal — `FALDONDEKTON/NEOLITH`/`FALDON`, qty = `frentin_ml` (`:1550-1566`).
+- **Inglete (corte 45°):** `CORTE45*`, qty = `frentin_ml × 2` (ambos lados) (`:1567-1572`).
+- **Regrueso:** SKU `REGRUESO`, "Mano de obra regrueso x ml", qty = `regrueso_ml` (`:1574-1591`). Además suma material: `regrueso_m2 = regrueso_ml × 0.05` (`:1411-1436`).
+- **Tomas (toma corriente):** `TOMAS*`, **requiere alzada** en piezas — sin alzada se ignora + warning (`:1664-1704`).
+- **Pulido de cantos:** si hay colocación y la zona tiene `pulido_extra=true` → unit = `round(flete_price/2)` (`:1654-1659`).
+**Código:** `calculator.py:1496-1704`
+
+---
+
+## Regla 7 · Colocación
+
+**Descripción:** costo de instalación, por m².
+**Trigger:** `colocacion = true` (forzado a `false` en edificios).
+**Cálculo:** `COLOCACIONDEKTON/NEOLITH`/`COLOCACION`, por m² con mínimo `colocacion.min_quantity` (default 1.0). Si se detectan ≥2 ambientes, se reparte por ambiente; si no, una línea sobre `total_m2` (`:1508-1548`).
+**Código:** `calculator.py:1508-1548`
+
+---
+
+## Regla 8 · Flete
+
+**Descripción:** costo de transporte + toma de medidas según zona.
+**Trigger:** siempre salvo `skip_flete = true` (cliente retira en fábrica).
+**Cálculo:** `:1593-1662`
+- Zona vía `_find_flete(localidad)`, fallback a Rosario.
+- Cantidad:
+  - Override del operador (`flete_qty`) si está presente.
+  - Edificio: `ceil(physical_pieces / building.flete_mesadas_per_trip)` (default **6**), excluye zócalo/frentín, mínimo 1, warning si > 20.
+  - Residencial: 1.
+- Descripción: "Flete + toma medidas {localidad}".
+- **El flete nunca recibe descuento** (ni ÷1.05 de edificio ni `mo_discount_pct`).
+**Código:** `calculator.py:1593-1662`
+
+---
+
+## Regla 9 · Ajuste de MO para edificios (÷1.05)
+
+**Descripción:** los precios de MO de edificio se dividen por 1.05.
+**Trigger:** `is_edificio = true`.
+**Cálculo:** cada `mo_item` (excepto flete) → `unit / 1.05`, luego `total = round(unit × qty)` (`:1750-1764`). Edificio además fuerza `colocacion = false` y no aplica merma.
+**Código:** `calculator.py:1280-1285, 1750-1764`
+
+---
+
+## Regla 10 · Descuento comercial sobre MO
+
+**Descripción:** descuento porcentual sobre la mano de obra (no flete).
+**Trigger:** `mo_discount_pct` pasado explícito por el operador.
+**Cálculo:** `mo_discount_amount` sobre `total_mo_ars` excluyendo flete; se resta del subtotal MO (`:1766-1784`).
+**Código:** `calculator.py:1766-1784`
+
+---
+
+## Regla 11 · Zócalos en metros lineales
+
+**Descripción:** los zócalos se computan por ml, no por m².
+**Trigger:** descripción de pieza empieza con "zócalo"/"zoc".
+**Cálculo:** label `"{largo}ML X {prof} ZOC"`; el largo en ml contribuye al m² total (`:837-838, 1805-1815`).
+**Código:** `calculator.py:837-838, 1805-1815`
+
+---
+
+## Regla 12 · Redondeo half-up
+
+**Descripción:** redondeo comercial (no banker's rounding) para evitar el bug de float de Python.
+**Cálculo:** `_round_half_up` usa `Decimal`/string (`:12-22`). m² por pieza → half-up a 2 decimales antes de sumar (`:778-780`); totales → `round()`.
+**Edge case validado:** zócalo M6 `round(0.155, 2)` debe dar **0.16**, no 0.15 (banker's) — ver `test_zocalo_m2_quantity.py`.
+**Código:** `calculator.py:12-22, 778-780`
+
+---
+
+## Reglas del Master §16 NO implementadas en el motor (deuda)
+
+- **Redondeo a múltiplos comerciales** (ej. "Negro Brasil debe redondear a entero"): el Master lo menciona como regla, pero **NO existe en `calculator.py`**. El único redondeo es half-up a 2 decimales (Regla 12). Si esta regla se requiere, es trabajo nuevo de un sub-PR de Sprint 3+. — `DEFINIDA EN MASTER PERO NO IMPLEMENTADA`.
+- **Conversión USD↔ARS por exchange rate:** el Master §13 muestra cifras canon que parecen mezclar monedas, pero el motor NO convierte (Regla de moneda en `calculator.md`). Los dos totales son nativos. — `DEFINIDA EN MOCK PERO NO IMPLEMENTADA`.

--- a/docs/handoff-context/calculator.md
+++ b/docs/handoff-context/calculator.md
@@ -1,0 +1,118 @@
+# Motor de cálculo · `api/app/modules/quote_engine/calculator.py`
+
+> **Fuente:** código backend real (`api/app/modules/quote_engine/calculator.py`, 2258 líneas).
+> **Derivado de:** lectura completa del motor en branch `sprint-3/extract-calc-contracts` (commit base `dc94e8d`).
+> **Última actualización:** 2026-05-13 (PR `sprint-3/extract-calc-contracts`).
+>
+> **Audiencia:** sub-PRs del Sprint 3 que implementan paso 3 (despiece) y paso 4 (cálculo). Mockear contra estos contratos; el switch a backend real consume el mismo shape.
+>
+> **Importante:** este motor NO usa LLM. Es Python puro y determinístico — mismo input ⇒ mismo output. La IA (Valentina) sólo arma el input (extrae piezas del plano) y narra el output.
+
+---
+
+## Overview
+
+`calculator.py` es el motor que convierte una lista de piezas + un material + opciones de obra en un presupuesto completo con desglose por rubro y dos totales (ARS y USD nativos, sin conversión cruzada).
+
+El flujo del producto lo invoca en dos momentos:
+
+- **Paso 1 (despiece):** `list_pieces()` formatea las piezas y calcula el total de m². No cotiza precios — solo arma la tabla de piezas que Marina revisa.
+- **Paso 4 (cálculo):** `calculate_quote()` toma esas piezas + material + opciones y produce el desglose monetario completo.
+
+Los precios salen de los 15 catálogos JSON en `api/catalog/` (material, MO/labor, piletas, fletes, descuentos de arquitectas). Todos los catálogos guardan precios **sin IVA** (`price_includes_vat: false`); el motor aplica IVA ×1.21 al construir cada línea.
+
+## Archivos del motor
+
+El cálculo vive principalmente en `calculator.py`, pero el flujo lo orquesta el agente:
+
+| Archivo | Rol |
+|---|---|
+| `api/app/modules/quote_engine/calculator.py` | Motor: `list_pieces`, `calculate_m2`, `calculate_merma`, `calculate_quote`, `_find_material`, `_find_flete`, renderers paso1/paso2 |
+| `api/app/modules/agent/agent.py` | Define los tools Anthropic (`list_pieces` `:1212`, `calculate_quote` `:1220`) y sus handlers que invocan el motor |
+| `api/app/modules/agent/tools/validation_tool.py` | `validate_despiece()` — valida el output del motor antes de generar documentos |
+| `api/app/modules/agent/tools/catalog_tool.py` | Lookup de precios de material + `check_architect` (descuento) |
+
+## Inputs
+
+`calculate_quote(input_data: dict) -> dict` — entry point en `calculator.py:1178`.
+
+Campos del input (ver `tools/calculate_quote.md` para el schema completo del tool):
+
+- **Requeridos:** `client_name`, `project`, `material`, `pieces[]`, `localidad`, `plazo`
+- **Piezas:** cada una `{description, largo, prof|alto, quantity?, m2_override?}` — `largo`/`prof` en metros
+- **Opciones de obra:** `colocacion`, `is_edificio`, `pileta` (enum), `pileta_qty`, `anafe`, `anafe_qty`, `frentin`/`frentin_ml`, `regrueso`/`regrueso_ml`, `inglete`, `pulido`, `tomas_qty`
+- **Comerciales:** `discount_pct`, `mo_discount_pct`, `skip_flete`, `flete_qty`
+
+## Outputs
+
+Output dict (éxito, `calculator.py:1880-1945`). Campos principales:
+
+| Campo | Tipo | Notas |
+|---|---|---|
+| `ok` | bool | `false` + `error` en fallo |
+| `material_name` / `material_type` | str | resuelto vía `_find_material` |
+| `material_m2` | float | suma de m² de piezas (incl. zócalos en ml, regrueso) |
+| `material_price_unit` / `material_price_base` | number | con IVA / sin IVA |
+| `material_currency` | "USD" \| "ARS" | define en qué total cae el material |
+| `material_total` | int | neto, post-descuento |
+| `discount_pct` / `discount_amount` | number | descuento sobre material |
+| `mo_discount_pct` / `mo_discount_amount` | number | descuento comercial sobre MO (excl. flete) |
+| `merma` | dict | `{aplica, desperdicio, sobrante_m2, motivo}` |
+| `sobrante_m2` / `sobrante_total` | number | material extra facturado |
+| `piece_details` | dict[] | piezas con m² individual |
+| `mo_items` | dict[] | líneas de MO: `{description, quantity, unit_price, base_price, total}` |
+| `total_mo_ars` | int | subtotal MO |
+| `total_ars` | int | **total general** (MO + material/sinks ARS) |
+| `total_usd` | int | total material si currency USD, si no `0` |
+| `sectors` / `sinks` | list | para el PDF |
+
+### Regla de moneda (crítica)
+
+**No hay conversión USD↔ARS en el motor.** Los dos totales conviven en su moneda nativa (`calculator.py:1786-1791`):
+
+- Material **USD** → `total_usd` = material neto + sobrante; `total_ars` = MO + piletas (ARS)
+- Material **ARS** → todo va a `total_ars`; `total_usd = 0`
+
+Esto significa que un quote típico de material importado tiene **dos totales que NO se suman entre sí**: el cliente paga USD por el material y ARS por la mano de obra + flete.
+
+## Flujo del cálculo
+
+1. **Validación de inputs** (`:1185-1217`) — `client_name`/`project` no vacíos ni placeholder.
+2. **Detección products-only** (`:1234-1243`) — si no hay piezas pero sí sinks/pileta → branch `_calculate_quote_products_only`.
+3. **Resolución de material** (`_find_material`, `:373-674`) — fuzzy match family-gated; error si ambiguo.
+4. **Cálculo de m²** (`calculate_m2`) — suma piezas, zócalos en ml, regrueso, con `_round_half_up` a 2 decimales.
+5. **Merma** (`calculate_merma`, `:942-1000`) — solo sintéticos; Negro Brasil y naturales nunca.
+6. **Descuentos** (`:1442-1460`) — arquitecta (5% USD / 8% ARS) o edificio (18% si ≥15 m²).
+7. **Construcción de MO** (`:1477-1704`) — pileta, anafe, colocación, frentín/inglete, regrueso, flete, pulido, tomas. IVA ×1.21 por línea.
+8. **Ajuste edificio** (`:1750-1764`) — MO ÷1.05 excepto flete.
+9. **Descuento MO comercial** (`:1766-1784`) — si `mo_discount_pct`, sobre MO excl. flete.
+10. **Serialización** (`:1880-1945`) — arma el output dict + renderers markdown paso1/paso2.
+
+## Edge cases manejados
+
+- `client_name`/`project` placeholder o vacío → `ok:false`
+- Material no encontrado → `ok:false`; family ambigua ("GRANITO" sin SKU) → pide aclaración al operador
+- `variant_negated` (ej. "no leather") → warning, igual cotiza
+- Edificio con piezas sin dimensiones → warning
+- Flete sin zona (ni fallback Rosario) → warning, sin flete
+- `tomas_qty > 0` sin alzada en piezas → ignora + warning
+- Regrueso: guard anti-doble-conteo de m² (`:1411-1436`)
+- `pileta_qty = 0` → respetado (no cotiza pileta fantasma)
+- Sink con shape inválido → se saltea + warning
+
+## Cifras canon de referencia
+
+> ⚠️ **Las cifras "canon" del Master §13 NO son reproducibles ejecutando este motor.** Ver `calculator-examples.md` § "Discrepancia cifras canon" para el detalle completo. Resumen:
+>
+> - **USD 2.184** (Cueto-Heredia / Negro Brasil) no tiene derivación en ningún lado del repo — es un número suelto en `master.md:432` sin breakdown.
+> - **ARS 660.890 + USD 1.538** (Pereyra / Silestone) solo se reproducen contra el breakdown **mock** documentado en `master.md:392`, que usa un precio de Silestone desactualizado (USD 249/m², cuando el catálogo real es USD 519/m² — bug P2 conocido).
+> - `master.md` se contradice: §13 línea 430 mapea PRES-2026-017→Pereyra/Silestone; línea 432 mapea PRES-2026-018→Cueto/Negro Brasil/2.184; pero el breakdown canónico (línea 392) y `endpoints-spec.md:69` etiquetan PRES-2026-018 como Silestone/660.890.
+>
+> Para ejemplos **reproducibles de verdad**, usar los del motor real documentados en `calculator-examples.md` (derivados de `api/tests/`).
+
+## Docs relacionados
+
+- `calculator-rules.md` — las reglas de negocio explícitas con line refs
+- `calculator-examples.md` — ejemplos worked input → output (de tests reales)
+- `tools/list_pieces.md` · `tools/calculate_quote.md` · `tools/validate_quote.md` — contratos de los tools del agente
+- `schemas/quote.md` — modelo Quote persistido

--- a/docs/handoff-context/tools/calculate_quote.md
+++ b/docs/handoff-context/tools/calculate_quote.md
@@ -1,0 +1,103 @@
+# Tool · `calculate_quote`
+
+> **Fuente:** definición en `api/app/modules/agent/agent.py:1220`; handler en `agent.py:6170`; motor en `calculator.py:1178`.
+> **Derivado de:** lectura en `sprint-3/extract-calc-contracts`.
+> **Última actualización:** 2026-05-13.
+
+## Propósito
+
+Paso 4 del flow. Envuelve el motor `calculate_quote()` de `calculator.py` para uso del agente. Toma las piezas + material + opciones de obra y produce el desglose monetario completo (material, merma, MO, piletas, flete) con dos totales nativos (ARS + USD).
+
+Es la **única** vía para cálculos — la descripción del tool dice "SIEMPRE usar para cálculos". Para cambios de metadata sin recalcular (cliente, status, plazo) se usa `update_quote`; para tocar solo MO, `patch_quote_mo`.
+
+## Input schema
+
+`agent.py:1220`. Required: `["client_name", "project", "material", "pieces", "localidad", "plazo"]`.
+
+```jsonc
+{
+  "client_name": "string",
+  "project": "string",
+  "material": "string",
+  "pieces": [
+    {
+      "description": "string",
+      "largo": 2.4,          // metros (required)
+      "prof": 0.6,
+      "alto": 0.05,
+      "quantity": 1,         // unidades físicas (edificios); default 1
+      "m2_override": 0.0     // si se pasa, NO computa largo×prof — usa este m²
+    }
+  ],
+  "localidad": "string",
+  "colocacion": true,
+  "is_edificio": false,
+  "pileta": "empotrada_cliente | empotrada_johnson | apoyo",
+  "pileta_qty": 1,
+  "pileta_sku": "string",
+  "anafe": false,
+  "anafe_qty": 1,
+  "frentin": false,
+  "frentin_ml": 0.0,
+  "regrueso": false,
+  "regrueso_ml": 0.0,
+  "inglete": false,
+  "pulido": false,
+  "tomas_qty": 0,            // requiere alzada + pedido explícito del operador
+  "skip_flete": false,       // true solo si retira en fábrica
+  "flete_qty": 1,            // override del operador
+  "plazo": "string",
+  "discount_pct": 0,
+  "mo_discount_pct": 0       // descuento comercial sobre MO (excl. flete)
+}
+```
+
+Notas de campos clave:
+- `m2_override`: usar SOLO cuando el operador declara el m² en una planilla de cómputo (edificios con valores pre-calculados). Desactiva el fallback de profundidades inversas.
+- `tomas_qty`: requiere `alzada` en `pieces` + pedido explícito. Sin alzada el calculador lo ignora con warning.
+- `mo_discount_pct`: solo si el operador lo pide explícito (ej. "5% sobre MO").
+
+## Output schema
+
+Motor `calculator.py:1880-1940`. Ver `calculator.md` § Outputs para la tabla completa. Forma resumida:
+
+```jsonc
+{
+  "ok": true,
+  "material_name": "SILESTONE BLANCO NORTE",
+  "material_currency": "USD",
+  "material_m2": 1.30,
+  "material_price_unit": 627,      // con IVA
+  "material_price_base": 519,      // sin IVA
+  "material_total": 815,           // neto, post-descuento
+  "discount_pct": 0, "discount_amount": 0,
+  "mo_discount_pct": 0, "mo_discount_amount": 0,
+  "merma": { "aplica": false, "desperdicio": 0.80, "sobrante_m2": 0, "motivo": "..." },
+  "sobrante_m2": 0, "sobrante_total": 0,
+  "piece_details": [ /* ... */ ],
+  "mo_items": [
+    { "description": "Agujero y pegado pileta", "quantity": 1, "unit_price": 65146, "base_price": 53840, "total": 65146 }
+  ],
+  "total_mo_ars": 177281,
+  "total_ars": 245458,             // total general
+  "total_usd": 815                 // material si USD; 0 si ARS
+}
+```
+
+En fallo: `{ "ok": false, "error": "..." }` (cliente faltante `:1189`, project faltante `:1209`, material no encontrado `:1371`).
+
+**Modo products-only** (piezas vacías + sinks/pileta, sin colocación/regrueso/anafe): retorno separado `calculator.py:1129-1160` con `material_m2: 0`, `mo_items: []`, `_quote_mode: "products_only"`.
+
+## Comportamientos importantes
+
+- **Compute delegado al motor:** el handler llama `calculate_quote(inputs)` (`agent.py:6943`), importado en `agent.py:21` (`from app.modules.quote_engine.calculator import calculate_quote`).
+- **Quote independiente por material:** si el material difiere y el quote ya tiene docs generados, el handler auto-crea/reusa un quote separado (`agent.py:6171-6209`).
+- **Validación post-cálculo:** corre `validate_despiece(calc_result)` (`agent.py:7061`); si falla adjunta `_validation_errors/_validation_warnings/_validation_note` y NO permite generar documentos. Ver `tools/validate_quote.md`.
+- **Render:** siempre arma `_paso2_rendered` (markdown vía `build_deterministic_paso2`) y persiste breakdown + change log (`agent.py:7084+`).
+
+## Código
+
+- Definición tool: `api/app/modules/agent/agent.py:1220`
+- Handler: `api/app/modules/agent/agent.py:6170-7090`
+- Motor: `calculator.py:1178` (`calculate_quote`)
+- Reglas: ver `calculator-rules.md`

--- a/docs/handoff-context/tools/list_pieces.md
+++ b/docs/handoff-context/tools/list_pieces.md
@@ -1,0 +1,75 @@
+# Tool · `list_pieces`
+
+> **Fuente:** definición en `api/app/modules/agent/agent.py:1212`; handler en `agent.py:5497`; motor en `calculator.py:809`.
+> **Derivado de:** lectura en `sprint-3/extract-calc-contracts`.
+> **Última actualización:** 2026-05-13.
+
+## Propósito
+
+Paso 1 obligatorio del flow. Formatea la lista de piezas (mesadas, zócalos, alzadas, frentines) que Valentina extrajo del plano/brief y calcula el total de m². **No cotiza precios** — solo arma la tabla de piezas que Marina revisa en el paso 1 (despiece).
+
+Zócalos salen en metros lineales; el total de m² los incluye.
+
+## Input schema
+
+`agent.py:1212`. Required top-level: `["pieces"]`.
+
+```json
+{
+  "pieces": [
+    {
+      "description": "string",
+      "largo": 2.4,
+      "prof": 0.6,
+      "alto": 0.05,
+      "tipo": "mesada | zocalo | alzada | frentin"
+    }
+  ]
+}
+```
+
+- Por pieza, required: `["description", "largo"]`.
+- `tipo` es **OBLIGATORIO cuando hay plano adjunto** (imagen/PDF), opcional en briefs de texto puro. Ver `plan-reader-v1.md`.
+- Medidas en metros.
+
+## Output schema
+
+`calculator.py:857-861`.
+
+```json
+{
+  "ok": true,
+  "pieces": [
+    { "label": "Mesada — 2.4 x 0.6", "m2": 1.44 },
+    { "label": "2.0ML X 0.05 ZOC", "m2": 0.1 },
+    { "label": "1.2 × 0.1 Alzada", "m2": 0.12, "qty": 2 }
+  ],
+  "total_m2": 1.66
+}
+```
+
+- `qty` solo aparece cuando > 1.
+- `m2` por entrada = `round_half_up(m2 × qty, 2)`.
+
+### Reglas de label (`calculator.py:837-849`)
+
+| `tipo` | Label |
+|---|---|
+| zocalo | `"{largo}ML X {dim2} ZOC"` (en ml) |
+| alzada | `"{largo} × {dim2} Alzada"` |
+| frentin | `"{largo}ML FALDON"` (m² = 0, solo cuenta para MO) |
+| mesada | `"{desc} — {largo} x {dim2}"`; agrega `" (SE REALIZA EN 2 TRAMOS)"` si `largo ≥ 3.0` y no es edificio |
+
+## Comportamientos importantes
+
+- **Gate de validación de plano:** si hay plano y NO es edificio, corre `_validate_plan_pieces(...)` (`agent.py:5526-5537`); si las piezas son inválidas retorna `{"ok": false, "error": "⛔ Piezas inválidas..."}`.
+- **Edificio:** se invoca como `list_pieces(pieces, is_edificio=True)` — relaja el requerimiento de `tipo`.
+- **Side effects del handler** (`agent.py:5546-5567`): persiste `paso1_pieces` + `paso1_total_m2` en `quote_breakdown`; adjunta `result["_paso1_rendered"]` (markdown vía `build_deterministic_paso1`).
+- **Auditoría m²:** el validador de superficie compara el total contra la planilla en `agent.py:5232`.
+
+## Código
+
+- Definición tool: `api/app/modules/agent/agent.py:1212`
+- Handler: `api/app/modules/agent/agent.py:5497-5567`
+- Motor: `calculator.py:809` (`list_pieces`) → `calculate_m2` (`calculator.py:817`)
+- Render: `build_deterministic_paso1` (`calculator.py:864-939`)

--- a/docs/handoff-context/tools/validate_quote.md
+++ b/docs/handoff-context/tools/validate_quote.md
@@ -1,0 +1,58 @@
+# Tool · `validate_quote` → `validate_despiece()`
+
+> **Fuente:** `api/app/modules/agent/tools/validation_tool.py`; invocación en `agent.py:7061` y `agent.py:5693`.
+> **Derivado de:** lectura en `sprint-3/extract-calc-contracts`.
+> **Última actualización:** 2026-05-13.
+
+## ⚠️ Aclaración importante
+
+**NO existe un tool Anthropic llamado `validate_quote`** en la lista de TOOLS del agente (`agent.py:1212-1221`). La validación es un **módulo interno** (`validate_despiece`) que el handler de `calculate_quote` y de `generate_documents` invocan automáticamente — Valentina no lo llama como tool explícito.
+
+> El router HTTP tiene un endpoint `POST /quotes/{id}/validate` (`router.py:803`), pero ese es OTRA cosa: regenera PDF/Excel/Drive desde el breakdown guardado y cambia el status a `validated`. NO corre `validate_despiece`. No confundir.
+
+Este doc documenta `validate_despiece` porque es el contrato que un sub-PR de Sprint 3 necesita para mockear la validación del paso 4.
+
+## Propósito
+
+Verifica que el output de `calculate_quote` sea consistente antes de generar documentos: IVA bien aplicado, totales que cierran, reglas de merma respetadas, PEGADOPILETA presente, m² coherentes. Función pura, sin I/O.
+
+## Input
+
+El dict resultado de `calculate_quote` (`qdata`).
+
+## Output
+
+`ValidationResult` dataclass (`validation_tool.py:19-23`):
+
+```json
+{ "ok": true, "errors": [], "warnings": [] }
+```
+
+`ok = (len(errors) == 0)` (`validation_tool.py:55`). Un check que crashea se degrada a warning (no rompe la validación, `:50-52`).
+
+## Sub-validadores (`validation_tool.py:34-45`)
+
+| Check | Línea | Severidad | Qué verifica |
+|---|---|---|---|
+| `_check_iva_material` | `:64` | **error** | `material_price_unit == floor(base×1.21)` (USD) / `round(base×1.21)` (ARS) |
+| `_check_iva_mo` | `:89` | **error** | cada MO `unit == round(base×1.21)`; edificio ÷1.05; `price_includes_vat` → `unit==base` |
+| `_check_material_total` | `:142` | **error** | `material_total == round(m2×price_unit) − discount` (skip en products-only) |
+| `_check_merma_rules` | `:173` | **error**/warn | Negro Brasil + `merma.aplica` → **error**; sintético sin merma (desperdicio≥1.0) → warn; natural con merma → warn |
+| `_check_pegadopileta` | `:201` | **error**/warn | empotrada necesita exactamente 1 MO pileta/pegado; 0 → error, >1 → warn |
+| `_check_piece_m2` | `:237` | **error** | por pieza `m2 == largo×dim2` (skip override/frentín); `material_m2 == sum(m2×qty)` |
+| `_check_mo_item_totals` | `:296` | warn | MO `total ≈ qty×unit` (tol. max($50, 0.1%)) |
+| `_check_colocacion_qty` | `:331` | warn | colocación qty `== max(material_m2, 1.0)` |
+| `_check_regrueso_consistency` | `:368` | **error** | suma m² piezas regrueso vs `regrueso_ml×0.05` (tol. 0.05) — anti doble-conteo/sub-conteo |
+| `_check_products_only_consistency` | `:453` | **error** | `_quote_mode=="products_only"`: material_m2=0, mo vacío, sinks no vacío, `total_ars==sum(sinks)−discount` (tol. 1 ARS) |
+
+## Invocación en el flow
+
+- **Post `calculate_quote`:** `validate_despiece(calc_result)` en `agent.py:7061`. Errores bloquean `generate_documents` (adjunta `_validation_note`).
+- **Pre `generate_documents` (doble gate):** shim `_validate_quote_data(qdata)` (`agent.py:31`, llamado `:5676`) + deep `validate_despiece(qdata)` (`agent.py:5693`). Los `.errors` bloquean con instrucción de recalcular-y-regenerar (`:5694-5706`).
+- Import: `agent.py:22` (`from ...validation_tool import validate_despiece`).
+
+## Código
+
+- Módulo: `api/app/modules/agent/tools/validation_tool.py`
+- Entry: `validate_despiece(qdata) -> ValidationResult` (`:29`)
+- Tests: `api/tests/test_validation.py`, `test_validator_includes_vat_flag.py`

--- a/docs/handoff-context/tools/validate_quote.md
+++ b/docs/handoff-context/tools/validate_quote.md
@@ -8,7 +8,7 @@
 
 **NO existe un tool Anthropic llamado `validate_quote`** en la lista de TOOLS del agente (`agent.py:1212-1221`). La validación es un **módulo interno** (`validate_despiece`) que el handler de `calculate_quote` y de `generate_documents` invocan automáticamente — Valentina no lo llama como tool explícito.
 
-> El router HTTP tiene un endpoint `POST /quotes/{id}/validate` (`router.py:803`), pero ese es OTRA cosa: regenera PDF/Excel/Drive desde el breakdown guardado y cambia el status a `validated`. NO corre `validate_despiece`. No confundir.
+> El router HTTP tiene un endpoint `POST /quotes/{id}/validate` (`agent/router.py:803`), pero ese es OTRA cosa: regenera PDF/Excel/Drive desde el breakdown guardado y cambia el status a `validated`. NO corre `validate_despiece`. No confundir.
 
 Este doc documenta `validate_despiece` porque es el contrato que un sub-PR de Sprint 3 necesita para mockear la validación del paso 4.
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -59,6 +59,54 @@ Detectado en audit independiente PR #457 NICE-TO-HAVE 5. Inline `style={{...}}` 
 
 **Plan:** revisar y alinear con spec del Master §13 en `sprint-3/paso-3-despiece` (cuando se toque el contexto reabierto) o en `sprint-5/cleanup-deuda`.
 
+### sprint-3/extract-calc-contracts (PR #461) · MINOR · Cifras canon Master §13 no reproducibles desde calculator.py
+
+**Detectado:** PR #461 audit de calculator.py 2258 LOC, 2026-05-13.
+
+**Descripción:** USD 2.184 (Cueto-Heredia) y ARS 660.890 (Pereyra) del Master §13 son design references, no reproducibles ejecutando `calculator.py` con catálogo vigente. Confirmado por audit independiente.
+
+**Decisión:** decisión D híbrida — mockups visuales mantienen las cifras, mocks-first y tests usan outputs reales del motor (`calculator-examples.md`). Master §13 actualizado para clarificar.
+
+---
+
+### sprint-3/extract-calc-contracts (PR #461) · MINOR · 2 reglas Master §16 no implementadas en calculator.py
+
+**Detectado:** PR #461 audit, 2026-05-13.
+
+**Descripción:** Master §16 declara 7 reglas; calculator.py implementa 12 reglas reales documentadas en `calculator-rules.md`. 2 reglas declaradas en Master NO están implementadas:
+
+1. Redondeo a múltiplos comerciales (ej: Negro Brasil debe ser entero)
+2. Conversión USD↔ARS automática
+
+**Impacto:** ninguno funcional hoy. El motor opera en monedas nativas (USD para material caro como Negro Brasil/Silestone; ARS para servicios locales) sin conversión cruzada.
+
+**Plan:** evaluar si implementar en Sprint 5 o si el approach actual (no conversión) es el correcto. Decidir con Javi al planear demo Marina.
+
+---
+
+### sprint-3/extract-calc-contracts (PR #461) · MINOR · validate_quote no es tool exportado de Valentina
+
+**Detectado:** PR #461 audit, 2026-05-13.
+
+**Descripción:** Master menciona `validate_quote` como tool de Valentina. En realidad:
+
+- Tools exportados de Valentina (`agent.py:1212-1221`): `list_pieces` + `calculate_quote` (entre otros), NO `validate_quote`.
+- `validate_quote` es función interna del módulo `validation_tool.py` (`validate_despiece`), no expuesta como Anthropic tool.
+
+**Impacto:** ninguno hoy. El doc `tools/validate_quote.md` aclara este punto explícitamente.
+
+**Plan:** si en el futuro se quiere exponer validación como tool a Valentina, registrar como feature nueva.
+
+---
+
+### sprint-3/extract-calc-contracts (PR #461) · MINOR · Motor calculator.py es 2258 LOC, no 360
+
+**Detectado:** PR #461 audit, 2026-05-13.
+
+**Descripción:** El spec del task mencionaba "calculator.py ~360 líneas". El motor real es 2258 líneas + spans multiple files del módulo `quote_engine/`. Cosmético, ya documentado en `calculator.md`.
+
+**Plan:** ninguno — solo registro para futuras estimaciones de scope.
+
 ## Resueltos
 
 _(vacío al inicio)_

--- a/docs/master.md
+++ b/docs/master.md
@@ -387,7 +387,36 @@ Suma de filas c/IVA = $597.971, subtotal claimed = $597.970. Cierre automático 
 
 ---
 
-## 13 · Datos canónicos de referencia
+## 13 · Datos canónicos de referencia · DESIGN REFERENCES vs EJEMPLOS REPRODUCIBLES
+
+> **Nota 2026-05-13 (decisión D post-PR #461):** las cifras de esta sección son **referencias visuales para mockups**, no fixtures reproducibles desde `calculator.py`. Para ejemplos worked reproducibles del motor real, ver `docs/handoff-context/calculator-examples.md`.
+
+### Design references (para mockups visuales)
+
+- **PRES-2026-018** · Cueto-Heredia · Granito Negro Brasil · 8,40 m² · USD 2.184
+- **PRES-2026-017** · Familia Pereyra · Silestone Blanco Norte · 6,50 m² · ARS 660.890 + USD 1.538
+
+Estas cifras son del handoff de diseño original. **No se asumen reproducibles** ejecutando el motor real con el catálogo vigente. El PR #461 (audit independiente de `calculator.py`, 2258 LOC) confirmó:
+
+- USD 2.184 no tiene derivación en código — número suelto en la línea "PRES-2026-018 = …" más abajo en esta misma sección.
+- ARS 660.890 + USD 1.538 solo se reproducen contra el breakdown mock de abajo, que usa Silestone a USD 249/m² (catálogo real USD 429/m² s/IVA → 519 c/IVA — bug P2 documentado en `docs/known-issues.md`).
+- Internamente §13 tenía líneas inconsistentes (Cueto/Negro Brasil vs Cueto/Silestone vs Pereyra/Silestone). Se aclara con esta nota; el breakdown histórico se preserva abajo para trazabilidad.
+
+### Ejemplos reproducibles del motor
+
+Para mocks-first del Sprint 3 (`paso-3-despiece`, `paso-4-calculo`), tests E2E que verifican cálculo, e integraciones reales contra backend → usar `docs/handoff-context/calculator-examples.md` (~16 ejemplos worked derivados de `api/tests/` reales del motor).
+
+### Decisión sobre el precio Silestone (bug P2)
+
+Diferido a Sprint 5 (demo Marina). Registrado en `docs/known-issues.md`. Hasta entonces:
+
+- Mockups visuales mantienen USD 249/m² implícito en ARS 660.890.
+- Backend real usa USD 519/m² c/IVA del catálogo.
+- Tests NO asiertan contra ARS 660.890 con catálogo real.
+
+---
+
+### [HISTÓRICO · breakdown del mockup, preservado para trazabilidad]
 
 ### Canon Cueto-Heredia · Silestone Blanco Norte (mockup 07 v4)
 


### PR DESCRIPTION
## Resumen del PR

PR previo de Sprint 3 (paralelo conceptual al #453 de Sprint 1.5). Deriva specs documentadas del motor de cálculo del backend para que los sub-PRs de paso 3 (despiece) y paso 4 (cálculo) tengan contratos claros contra los cuales mockear y luego conectar al backend real.

**100% documentación derivada. Cero código backend o frontend modificado.**

## Docs creados (6 + índice)

| Archivo | LOC | Contenido |
|---|---|---|
| `docs/handoff-context/calculator.md` | 118 | Overview: inputs/outputs, flujo de 10 pasos, regla de moneda (USD/ARS nativos sin conversión), edge cases |
| `docs/handoff-context/calculator-rules.md` | 154 | 12 reglas explícitas con line refs + 2 reglas del Master §16 NO implementadas (deuda) |
| `docs/handoff-context/calculator-examples.md` | 174 | ~16 ejemplos worked (de tests reales `[TEST]` + `api/examples` `[EJEMPLO]`) + sección discrepancia cifras canon |
| `docs/handoff-context/tools/list_pieces.md` | 75 | Tool spec paso 1 (extracción de piezas) |
| `docs/handoff-context/tools/calculate_quote.md` | 103 | Tool spec paso 4 (cálculo) |
| `docs/handoff-context/tools/validate_quote.md` | 58 | `validate_despiece` (validación interna) |
| `docs/handoff-context/README.md` | +cross-refs | Índice actualizado con sección Sprint 3 |
| **Total** | **682** | |

## Hallazgos importantes (requieren atención del audit)

### 🔴 Discrepancia · cifras canon Master §13 NO reproducibles

El motor real **no produce** las cifras "canon" del Master. Detalle completo en `calculator-examples.md` § "Discrepancia cifras canon". Resumen:

- **USD 2.184** (Cueto-Heredia / Negro Brasil): **sin derivación en ningún lado del repo** — número suelto en `master.md:432`, sin breakdown ni test.
- **ARS 660.890 + USD 1.538** (Pereyra / Silestone): solo reproducibles contra el breakdown **mock** de `master.md:392`, que usa Silestone a USD 249/m². El catálogo real (`materials-silestone.json`) tiene **USD 429/m² sin IVA → 519 con IVA** (el propio Master lo marca como bug P2, "−52% diff"). Con el precio real, no da 1.538.
- **Contradicción interna del Master §13:** línea 430 mapea PRES-2026-017→Pereyra/Silestone/660.890; línea 432 mapea PRES-2026-018→Cueto/Negro Brasil/2.184; pero el breakdown canónico (línea 392) y `endpoints-spec.md:69` etiquetan PRES-2026-018 como Silestone/660.890. El spec se contradice sobre qué ID/material/total van juntos.
- **No hay test Python que asierte 2184, 660890 ni 1538.** Solo los E2E del frontend verifican el texto contra mock data, no contra un cálculo real.

**Recomendación documentada:** mockear contra los ejemplos `[TEST]` reproducibles (del motor real); tratar las cifras canon del Master como placeholders de design, no como output esperado del motor.

### Reglas del Master §16 NO implementadas (deuda)

- **Redondeo a múltiplos comerciales** (ej. "Negro Brasil a entero"): mencionado en Master, NO existe en `calculator.py`. Único redondeo es half-up a 2 decimales.
- **Conversión USD↔ARS por exchange rate:** el motor NO convierte; los dos totales son nativos.

### Cantidad real de ejemplos worked

El Master menciona "34 examples". Los 34 archivos en `api/examples/` son **narrativas de razonamiento en prosa, NO fixtures ejecutables** (`CONTEXT.md:178` lo dice explícito). Los ejemplos **reproducibles** (asertados en tests Python) son los ~16 documentados en `calculator-examples.md`, marcados `[TEST]`/`[EJEMPLO]`/`[MOCK]`.

### Aclaración · no existe tool `validate_quote`

La lista de TOOLS del agente (`agent.py:1212-1221`) tiene `list_pieces` y `calculate_quote`, pero **NO** `validate_quote`. La validación es un módulo interno (`validate_despiece` en `validation_tool.py`) que los handlers invocan automáticamente. El endpoint HTTP `POST /quotes/{id}/validate` es otra cosa (regenera docs + flip status). Documentado así en `tools/validate_quote.md`.

## Verificación

- ✅ Cero archivos backend modificados — `git diff main..HEAD -- api/` vacío
- ✅ Cero archivos frontend modificados — `git diff main..HEAD -- web/` vacío (frontend provablemente intacto; este PR es 100% docs en `docs/handoff-context/`)
- ✅ El motor real fue leído completo (`calculator.py` 2258 líneas) + `validation_tool.py` + handlers en `agent.py` + tests en `api/tests/`
- ✅ Convención de naming/formato del PR #453 (`docs/handoff-context/`) mantenida

> **Nota:** smoke frontend (lint/typecheck/build) sustituido por la prueba más fuerte de que `git diff -- web/` está vacío — este PR no toca una sola línea de `web/`. No entra a Vercel preview (no toca frontend). La verificación es 100% review de los docs.

## Criterios de aceptación

- [x] 6 archivos nuevos en `docs/handoff-context/` (1 overview + 1 rules + 1 examples + 3 tools)
- [x] Cifras canon documentadas + discrepancia reportada (NO reproducibles)
- [x] Cero archivos backend modificados
- [x] Cero archivos frontend modificados
- [x] Reglas del Master §16 no implementadas, marcadas como deuda
- [x] Cantidad real de ejemplos aclarada (vs los 34 del Master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Cleanup pre-merge (commit 2865515)

- ✅ **Fix nice-to-have audit:** `validate_quote.md` ahora referencia `agent/router.py:803` (path completo, antes ambiguo `router.py:803`)
- ✅ **Master §13 actualizado con decisión D:** cifras canon clarificadas como *design references* (mockups visuales); ejemplos reproducibles del motor van en `calculator-examples.md`. Breakdown histórico preservado para trazabilidad.
- ✅ **`docs/known-issues.md`:** 4 entries de deuda nueva registradas (cifras canon no reproducibles · 2 reglas §16 no implementadas · validate_quote no es tool · motor 2258 LOC)

Sigue siendo 100% docs (`git diff main..HEAD` solo toca `docs/`).
