### PR TITLE
feat(despiece): paso 3 mocks-first — tabla editable + timeline + chat scoped

### DIFF
--- a/web/src/app/quotes/[id]/despiece/page.tsx
+++ b/web/src/app/quotes/[id]/despiece/page.tsx
@@ -1,18 +1,23 @@
 /**
- * Paso 3 · Despiece — placeholder.
+ * Paso 3 · Despiece (mockups 04/05/06/16).
  *
- * Implementación real (etable de piezas + cortes + edición inline)
- * en sub-PR `sprint-2/paso-3-despiece`.
+ * Reemplaza el placeholder del PR #456 chrome-refactor. Renderiza el
+ * container client `DespieceView`, que coordina la tabla de piezas
+ * editable + timeline de pasadas + chat scoped.
+ *
+ * Mock-first: el client de piezas vive en lib/api.ts (cubre el endpoint
+ * dedicado del paso 3 todavía inexistente). El switch a HTTP real es
+ * sprint-3/api-integration.
+ *
+ * NOTA: el quote (Topbar/Qhead) lo resuelve [id]/layout.tsx via
+ * getQuoteMetadata(params.id) — NO se duplica acá (fix-up #2 del PR #460).
  */
-export default function DespiecePage() {
-  return (
-    <div className="col placeholder-section">
-      <h2 className="font-serif italic" style={{ marginBottom: 8 }}>
-        Paso 3 · Despiece
-      </h2>
-      <p className="font-serif italic text-ink-soft">
-        Placeholder. Implementación viene en sprint-2/paso-3-despiece.
-      </p>
-    </div>
-  );
+import { DespieceView } from "@/components/despiece/DespieceView";
+
+interface Props {
+  params: { id: string };
+}
+
+export default function DespiecePage({ params }: Props) {
+  return <DespieceView quoteId={params.id} />;
 }

--- a/web/src/components/despiece/DespieceChatPanel.tsx
+++ b/web/src/components/despiece/DespieceChatPanel.tsx
@@ -1,0 +1,183 @@
+/**
+ * Chat scoped 480px del paso 3 (mockup 06).
+ *
+ * Dos modos:
+ *   - Paso completo: title "Ayuda con Despiece", ve las N piezas.
+ *   - Pieza puntual (focusedPiece): title "R2 · …", ve sólo esa pieza
+ *     (mockup 06 · chat sobre la bacha).
+ *
+ * Reusa los presentational `UserMessage` / `ValentinaMessage` del paso 2 +
+ * la estructura legacy `.chat` (head/scope/stream/sugs/composer). No reusa
+ * el `ChatPanel` del paso 2 porque ese tiene copy/scope hardcodeados del
+ * contexto; mantenerlos separados evita regresión del Sprint 2.
+ */
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { Piece } from "@/lib/api";
+import type { ChatMessage, ChatPanelState } from "@/lib/types";
+import { UserMessage } from "@/components/contexto/UserMessage";
+import { ValentinaMessage } from "@/components/contexto/ValentinaMessage";
+
+interface Props {
+  messages: ChatMessage[];
+  panelState: ChatPanelState;
+  pieceCount: number;
+  editedCount: number;
+  focusedPiece: Piece | null;
+  onSend: (text: string) => void;
+  onClose: () => void;
+}
+
+const STEP_SUGGESTIONS = [
+  "¿Por qué partiste la mesada en 3?",
+  "¿Qué es CORTE45?",
+  "¿El zócalo va por separado?",
+];
+
+const PIECE_SUGGESTIONS = ["¿La bacha entra en este ancho?", "¿Qué bacha asumiste?", "Ver corte"];
+
+export function DespieceChatPanel({
+  messages,
+  panelState,
+  pieceCount,
+  editedCount,
+  focusedPiece,
+  onSend,
+  onClose,
+}: Props) {
+  const [draft, setDraft] = useState("");
+  const streamRef = useRef<HTMLDivElement>(null);
+  const isStreaming = panelState === "streaming";
+  const focused = focusedPiece !== null;
+
+  useEffect(() => {
+    if (streamRef.current) {
+      streamRef.current.scrollTop = streamRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  function submit() {
+    const text = draft.trim();
+    if (!text || isStreaming) return;
+    onSend(text);
+    setDraft("");
+  }
+
+  const suggestions = focused ? PIECE_SUGGESTIONS : STEP_SUGGESTIONS;
+
+  return (
+    <aside
+      className="chat"
+      data-testid="chat-panel"
+      data-panel-state={panelState}
+      data-scope={focused ? "piece" : "step"}
+    >
+      <div className="head">
+        <div className="vbubble" />
+        <div>
+          <div className="title">
+            {focused ? `${focusedPiece.id} · ${focusedPiece.label}` : "Ayuda con Despiece"}
+          </div>
+          <div className="sub">
+            {focused ? "Scoped · enfocado en 1 pieza" : `Scoped · viendo ${pieceCount} piezas`}
+          </div>
+        </div>
+        <button
+          type="button"
+          className="x-btn"
+          onClick={onClose}
+          data-testid="chat-close"
+          aria-label="cerrar chat"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="scope">
+        <span className="lbl">Lo que veo</span>
+        {focused ? (
+          <span className="pill scope-pill-focus" data-testid="chat-scope-focus">
+            {focusedPiece.id} · {focusedPiece.width_mm / 10}×{focusedPiece.depth_mm / 10}
+          </span>
+        ) : (
+          <span className="pill">Despiece · {pieceCount} piezas</span>
+        )}
+        {editedCount > 0 && <span className="pill scope-pill-human">{editedCount} editadas</span>}
+        <span className="pill">Contexto confirmado</span>
+      </div>
+
+      <div className="stream" ref={streamRef} data-testid="chat-stream">
+        {messages.length === 0 && (
+          <div
+            className="font-mono"
+            style={{ color: "var(--ink-mute)", fontSize: 12, textAlign: "center" }}
+            data-testid="chat-empty"
+          >
+            {focused
+              ? `Preguntá lo que quieras sobre ${focusedPiece.id}.`
+              : "Hacé una pregunta o usá una sugerencia."}
+          </div>
+        )}
+        {messages.map((msg) =>
+          msg.role === "user" ? (
+            <UserMessage key={msg.id} message={msg} />
+          ) : (
+            <ValentinaMessage key={msg.id} message={msg} />
+          ),
+        )}
+      </div>
+
+      <div className="sugs">
+        {suggestions.map((s) => (
+          <span
+            key={s}
+            className="sug"
+            data-testid="chat-suggestion"
+            role="button"
+            tabIndex={0}
+            onClick={() => !isStreaming && onSend(s)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                if (!isStreaming) onSend(s);
+              }
+            }}
+          >
+            {s}
+          </span>
+        ))}
+      </div>
+
+      <div className="composer">
+        <div className="field">
+          <input
+            type="text"
+            placeholder={
+              focused ? `Preguntá sobre ${focusedPiece.id}…` : "Preguntá sobre el despiece…"
+            }
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") submit();
+            }}
+            disabled={isStreaming}
+            data-testid="chat-input"
+          />
+          <button
+            type="button"
+            className="send"
+            onClick={submit}
+            disabled={isStreaming || !draft.trim()}
+            data-testid="chat-send"
+          >
+            Enviar
+          </button>
+        </div>
+        <div className="hint">
+          Borra al cerrar · {focused ? "ve sólo esta pieza" : "ve las piezas del despiece"}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/web/src/components/despiece/DespieceEmptyState.tsx
+++ b/web/src/components/despiece/DespieceEmptyState.tsx
@@ -1,0 +1,75 @@
+/**
+ * Empty state del paso 3 (mockup 16 + variante 04-manual): Valentina no pudo
+ * proponer un despiece. Dos caminos: procesar con IA (vuelve al paso 1) o
+ * completar a mano (tabla editable vacía).
+ */
+"use client";
+
+interface Props {
+  onProcessWithAI: () => void;
+  onCompleteManual: () => void;
+}
+
+export function DespieceEmptyState({ onProcessWithAI, onCompleteManual }: Props) {
+  return (
+    <div className="empty-hero" data-testid="despiece-empty">
+      <div className="glyph">∅</div>
+      <h3>Acá todavía no hay piezas que despiezar</h3>
+      <p className="lead">
+        <em>Valentina</em> no pudo proponer un despiece — falta brief o contexto del ambiente. Elegí
+        cómo seguir:
+      </p>
+
+      <div className="empty-paths">
+        <div
+          className="path primary"
+          role="button"
+          tabIndex={0}
+          data-testid="empty-process-ai"
+          onClick={onProcessWithAI}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              onProcessWithAI();
+            }
+          }}
+        >
+          <div className="icon-wrap">
+            <div className="icon">↑</div>
+            <div className="ttl">Procesar con Valentina</div>
+            <div className="badge-rec">recomendado</div>
+          </div>
+          <div className="desc">
+            Subí el brief, el plano, o ambos. <em>Valentina</em> identifica las piezas y propone el
+            despiece completo. Después editás lo que quieras.
+          </div>
+          <div className="meta">→ vuelve al paso 1 · procesa con IA</div>
+        </div>
+
+        <div
+          className="path"
+          role="button"
+          tabIndex={0}
+          data-testid="empty-complete-manual"
+          onClick={onCompleteManual}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              onCompleteManual();
+            }
+          }}
+        >
+          <div className="icon-wrap">
+            <div className="icon">+</div>
+            <div className="ttl">Completar a mano</div>
+          </div>
+          <div className="desc">
+            Empezás con una tabla vacía y vas agregando piezas una por una con sus medidas. Sin
+            ayuda de Valentina hasta que confirmes contexto.
+          </div>
+          <div className="meta">→ tabla editable inline · sin cálculo automático</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/despiece/DespieceTable.tsx
+++ b/web/src/components/despiece/DespieceTable.tsx
@@ -1,0 +1,68 @@
+/**
+ * Tabla `.etable.cols-despiece` de piezas (mockups 04/05/06).
+ * Header fijo + una `PieceRow` por pieza + fila "agregar pieza manualmente".
+ */
+"use client";
+
+import type { Piece } from "@/lib/api";
+import { PieceRow } from "./PieceRow";
+
+interface Props {
+  pieces: Piece[];
+  focusedPieceId: string | null;
+  onUpdatePiece: (pieceId: string, partial: Partial<Piece>) => void;
+  onDeletePiece: (pieceId: string) => void;
+  onOpenPieceChat: (pieceId: string) => void;
+  onAddPiece: () => void;
+}
+
+export function DespieceTable({
+  pieces,
+  focusedPieceId,
+  onUpdatePiece,
+  onDeletePiece,
+  onOpenPieceChat,
+  onAddPiece,
+}: Props) {
+  return (
+    <div className="etable cols-despiece mb-16" data-testid="despiece-table">
+      <div className="colh">
+        <div>#</div>
+        <div>Pieza</div>
+        <div>Largo (cm)</div>
+        <div>Ancho (cm)</div>
+        <div>Cant.</div>
+        <div>m² unit.</div>
+        <div>m² total</div>
+        <div />
+      </div>
+
+      {pieces.map((piece) => (
+        <PieceRow
+          key={piece.id}
+          piece={piece}
+          focused={focusedPieceId === piece.id}
+          onUpdate={onUpdatePiece}
+          onDelete={onDeletePiece}
+          onOpenChat={onOpenPieceChat}
+        />
+      ))}
+
+      <div
+        className="add-row"
+        role="button"
+        tabIndex={0}
+        data-testid="despiece-add-row"
+        onClick={onAddPiece}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onAddPiece();
+          }
+        }}
+      >
+        + agregar pieza manualmente
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/despiece/DespieceTimeline.tsx
+++ b/web/src/components/despiece/DespieceTimeline.tsx
@@ -1,0 +1,55 @@
+/**
+ * Timeline de las 4 pasadas de Valentina leyendo el plano (mockup 04/05).
+ * `.pasadas-timeline` con header + 4 `.step` (done / active / pending / failed).
+ */
+"use client";
+
+import type { ReactNode } from "react";
+import type { TimelineStep } from "@/lib/api";
+
+interface Props {
+  steps: TimelineStep[];
+  /** Texto del meta a la derecha del header (ej. "4 pasadas · 3 símbolos"). */
+  meta?: string;
+  title?: ReactNode;
+}
+
+function stepClass(state: TimelineStep["state"]): string {
+  if (state === "done") return "step done";
+  if (state === "running") return "step active";
+  return "step";
+}
+
+export function DespieceTimeline({ steps, meta, title }: Props) {
+  return (
+    <div className="pasadas-timeline" data-testid="despiece-timeline">
+      <div className="pt-head">
+        <span className="vmini" />
+        <span className="ttl">
+          {title ?? (
+            <>
+              Cómo <em>Valentina</em> lee el plano
+            </>
+          )}
+        </span>
+        {meta && <span className="meta">{meta}</span>}
+      </div>
+      <div className="steps">
+        {steps.map((s) => (
+          <div
+            className={stepClass(s.state)}
+            key={s.step}
+            data-testid={`timeline-step-${s.step}`}
+            data-state={s.state}
+          >
+            <div className="num">
+              <span className="dot" /> Paso {s.step}
+            </div>
+            <div className="lbl">{s.label}</div>
+            {s.detail && <div className="out">{s.detail}</div>}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/despiece/DespieceView.tsx
+++ b/web/src/components/despiece/DespieceView.tsx
@@ -1,0 +1,417 @@
+/**
+ * Container del paso 3 — coordina el state machine del despiece + chat scoped.
+ *
+ * Estados (mockups 04/05/06/16):
+ *   - loading   → skeleton de filas + timeline corriendo (mockup 04-A en carga)
+ *   - empty     → IA no propuso piezas → empty-hero (mockup 16 / 04-manual)
+ *   - manual    → tabla vacía editable tras "Completar a mano"
+ *   - A propuso → tabla de piezas + timeline done (mockup 04-A)
+ *   - B editó   → ediciones en púrpura + banner recalculado (mockup 05)
+ *   - C chat    → panel 480px enfocado en el paso o en una pieza (mockup 06)
+ *
+ * Layout: el chrome [id]/layout.tsx ya renderea el children dentro de
+ * `.body.no-chat`. Acá montamos un grid interno que alterna 1col / 1fr 480px
+ * según el chat (mismo patrón validado en ContextView del paso 2). NO se
+ * toca el chrome ni el layout (reglas estrictas #2/#3).
+ */
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { piecesTotalM2, type Piece } from "@/lib/api";
+import { useDespiece } from "@/lib/hooks/useDespiece";
+import { useChatScoped } from "@/lib/hooks/useChatScoped";
+import { DESPIECE_LOADING_TIMELINE } from "@/lib/mocks/canonicalQuote";
+import { DespieceTable } from "./DespieceTable";
+import { DespieceTimeline } from "./DespieceTimeline";
+import { DespieceEmptyState } from "./DespieceEmptyState";
+import { DespieceChatPanel } from "./DespieceChatPanel";
+
+interface Props {
+  quoteId: string;
+}
+
+const SKELETON_COLS = ["sk-w-70", "sk-w-60", "sk-w-60", "sk-w-40", "sk-w-50", "sk-w-50"];
+
+function NewPieceDefaults(): Omit<Piece, "id" | "origin" | "confidence" | "extracted_from"> {
+  return {
+    type: "encimera",
+    label: "Pieza nueva",
+    sublabel: "describí la pieza",
+    width_mm: 1000,
+    depth_mm: 600,
+    quantity: 1,
+    options: {},
+  };
+}
+
+export function DespieceView({ quoteId }: Props) {
+  const router = useRouter();
+  const {
+    pieces,
+    timeline,
+    status,
+    state,
+    error,
+    updatePiece,
+    addPiece,
+    deletePiece,
+    regenerate,
+    isDirty,
+    editedCount,
+  } = useDespiece(quoteId);
+
+  const [focusedPieceId, setFocusedPieceId] = useState<string | null>(null);
+  const [manualMode, setManualMode] = useState(false);
+  const [confirmRegen, setConfirmRegen] = useState(false);
+  const [regenMenuOpen, setRegenMenuOpen] = useState(false);
+
+  const chat = useChatScoped(quoteId, "despiece", focusedPieceId ?? undefined);
+  const chatOpen = chat.panelState !== "closed";
+  const focusedPiece = useMemo(
+    () => pieces.find((p) => p.id === focusedPieceId) ?? null,
+    [pieces, focusedPieceId],
+  );
+
+  const totalM2 = piecesTotalM2(pieces);
+
+  function openStepChat() {
+    setFocusedPieceId(null);
+    chat.open();
+  }
+  function openPieceChat(pieceId: string) {
+    setFocusedPieceId(pieceId);
+    chat.open();
+  }
+  function closeChat() {
+    chat.close();
+    setFocusedPieceId(null);
+  }
+
+  /* ── Loading ─────────────────────────────────────────────────────── */
+  if (state === "loading") {
+    return (
+      <div className="col" data-testid="despiece-view" data-state="loading">
+        <div className="section-head">
+          <div>
+            <div className="meta">Paso 3 de 5 · Despiece</div>
+            <h2>Despiece de piezas</h2>
+          </div>
+        </div>
+        <div className="ia-banner">
+          <div className="vbubble" />
+          <div className="text">
+            <em>Valentina</em> está leyendo el plano para proponer las piezas.
+            <div className="sub">
+              Identifica el inventario en 4 pasadas · puede tardar unos segundos
+            </div>
+          </div>
+        </div>
+        <DespieceTimeline steps={DESPIECE_LOADING_TIMELINE} meta="4 pasadas" />
+        <div className="etable cols-despiece mb-16" data-testid="despiece-loading">
+          <div className="colh">
+            <div>#</div>
+            <div>Pieza</div>
+            <div>Largo (cm)</div>
+            <div>Ancho (cm)</div>
+            <div>Cant.</div>
+            <div>m² unit.</div>
+            <div>m² total</div>
+            <div />
+          </div>
+          {[0, 1, 2, 3, 4].map((i) => (
+            <div className="row" key={i}>
+              <div className="cell dim">R{i + 1}</div>
+              {SKELETON_COLS.map((w, j) => (
+                <div className="cell" key={j}>
+                  <span className={`skel ${w}`} />
+                </div>
+              ))}
+              <div className="cell action dim dim-40">⋯</div>
+            </div>
+          ))}
+        </div>
+        <div className="status-bar slow">
+          <span className="vbubble" />
+          <em>Valentina</em> está calculando las piezas…
+          <span className="elapsed">leyendo el plano</span>
+        </div>
+      </div>
+    );
+  }
+
+  /* ── Error ───────────────────────────────────────────────────────── */
+  if (state === "error") {
+    return (
+      <div className="col" data-testid="despiece-view" data-state="error">
+        <div className="section-head">
+          <h2>No pude cargar el despiece</h2>
+        </div>
+        <p className="font-mono" style={{ fontSize: 12, color: "var(--error)" }}>
+          {error ?? "Error desconocido"}
+        </p>
+      </div>
+    );
+  }
+
+  /* ── Empty (IA falló, sin piezas, sin modo manual activado) ────────── */
+  const isEmpty = pieces.length === 0 && status === "failed" && !manualMode;
+  if (isEmpty) {
+    return (
+      <div className="col" data-testid="despiece-view" data-state="idle" data-status="failed">
+        <div className="section-head">
+          <div>
+            <div className="meta">Paso 3 de 5 · Despiece</div>
+            <h2>Despiece de piezas</h2>
+          </div>
+        </div>
+        <DespieceEmptyState
+          onProcessWithAI={() => router.push(`/quotes/${quoteId}/brief`)}
+          onCompleteManual={() => setManualMode(true)}
+        />
+      </div>
+    );
+  }
+
+  /* ── A / B / C / manual ────────────────────────────────────────────── */
+  const showTimeline = timeline.length > 0 && status !== "failed";
+  const symbolsCount = pieces.reduce((n, p) => n + (p.detected_symbols?.length ?? 0), 0);
+  const canConfirm = pieces.length > 0 && state !== "regenerating";
+
+  return (
+    <div
+      data-testid="despiece-view"
+      data-state={state}
+      data-status={status}
+      data-dirty={isDirty ? "true" : "false"}
+      data-chat-open={chatOpen ? "true" : "false"}
+      style={{
+        display: "grid",
+        gridTemplateColumns: chatOpen ? "1fr 480px" : "1fr",
+        gap: 24,
+        minHeight: 0,
+      }}
+    >
+      <div className="col">
+        <div className="section-head">
+          <div>
+            <div className="meta">Paso 3 de 5 · Despiece</div>
+            <h2>Despiece de piezas</h2>
+          </div>
+          <div className="right">
+            {confirmRegen ? (
+              <div
+                className="status-bar slow"
+                style={{ margin: 0 }}
+                data-testid="despiece-regen-confirm-bar"
+              >
+                Re-generar descarta la propuesta actual.
+                <button
+                  type="button"
+                  className="btn ghost sm"
+                  data-testid="despiece-regen-cancel"
+                  onClick={() => setConfirmRegen(false)}
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="button"
+                  className="btn primary sm"
+                  data-testid="despiece-regen-confirm"
+                  onClick={() => {
+                    setConfirmRegen(false);
+                    setRegenMenuOpen(false);
+                    setFocusedPieceId(null);
+                    void regenerate("all");
+                  }}
+                >
+                  Re-generar todo
+                </button>
+              </div>
+            ) : isDirty ? (
+              <div className="regen-wrap">
+                <div className="regen-split">
+                  <button
+                    type="button"
+                    className="main"
+                    data-testid="despiece-regen-keep"
+                    onClick={() => void regenerate("keep-edits")}
+                  >
+                    ↻ Re-generar no-editadas
+                    <span className="count">{editedCount} quedan tuyas</span>
+                  </button>
+                  <button
+                    type="button"
+                    className="kebab"
+                    aria-label="más opciones de re-generar"
+                    onClick={() => setRegenMenuOpen((v) => !v)}
+                  >
+                    ⋮
+                  </button>
+                </div>
+                {regenMenuOpen && (
+                  <div className="regen-menu open">
+                    <div
+                      className="item danger"
+                      role="button"
+                      tabIndex={0}
+                      data-testid="despiece-regen"
+                      onClick={() => setConfirmRegen(true)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          setConfirmRegen(true);
+                        }
+                      }}
+                    >
+                      Re-generar TODO el despiece
+                      <span className="desc">
+                        descarta {editedCount} cambios · pide confirmación
+                      </span>
+                    </div>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <button
+                type="button"
+                className="btn ghost sm"
+                data-testid="despiece-regen"
+                onClick={() => setConfirmRegen(true)}
+              >
+                ↻ Re-generar despiece
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Banner Valentina · pristine / dirty / focused */}
+        <div
+          className={`ia-banner${manualMode && pieces.length === 0 ? " muted" : ""}`}
+          data-testid="despiece-banner"
+        >
+          <div className="vbubble" />
+          <div className="text">
+            {focusedPiece ? (
+              <>
+                Estoy enfocada en{" "}
+                <strong className="t-accent">
+                  {focusedPiece.id} · {focusedPiece.label}
+                </strong>
+                . Si querés validar otra pieza, abrí su chat desde la fila.
+                <div className="sub">
+                  El chat sólo ve esta pieza · al cerrar se borra el historial
+                </div>
+              </>
+            ) : manualMode && pieces.length === 0 ? (
+              <>
+                <em>Valentina</em> está pausada. Cargá las piezas a mano con{" "}
+                <strong>+ agregar pieza manualmente</strong>.
+                <div className="sub">
+                  Si querés que lo intente de nuevo, usá ↻ Re-generar arriba
+                </div>
+              </>
+            ) : isDirty ? (
+              <>
+                Recalculé m² con tus{" "}
+                <strong className="t-human">
+                  {editedCount} ajuste{editedCount === 1 ? "" : "s"}
+                </strong>
+                . <em>Valentina</em> mantiene los símbolos detectados del plano.
+                <div className="sub">
+                  Tus ediciones quedan en púrpura · podés deshacer cualquiera
+                </div>
+              </>
+            ) : (
+              <>
+                <em>Valentina</em> propuso <strong>{pieces.length} piezas</strong> leyendo el plano
+                en 4 pasadas.
+                <div className="sub">
+                  Valentina lee, no propone alternativas · click cualquier celda para editar
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+
+        {showTimeline && (
+          <DespieceTimeline
+            steps={timeline}
+            meta={`4 pasadas${symbolsCount > 0 ? ` · ${symbolsCount} símbolos detectados` : ""}`}
+            title={
+              isDirty ? (
+                <>
+                  Cómo <em>Valentina</em> leyó el plano
+                </>
+              ) : undefined
+            }
+          />
+        )}
+
+        <DespieceTable
+          pieces={pieces}
+          focusedPieceId={focusedPieceId}
+          onUpdatePiece={updatePiece}
+          onDeletePiece={deletePiece}
+          onOpenPieceChat={openPieceChat}
+          onAddPiece={() => void addPiece(NewPieceDefaults())}
+        />
+
+        {manualMode && (
+          <div className="status-bar manual" data-testid="despiece-status-manual">
+            <span className="vbubble" />
+            <strong>Modo manual</strong> · <em>Valentina</em> pausada
+            <span className="hint-end">
+              si querés que lo intente de nuevo, usá ↻ Re-generar arriba
+            </span>
+          </div>
+        )}
+
+        <div className="confirm-bar">
+          <div className="summary" data-testid="despiece-summary">
+            <strong>{pieces.length} piezas</strong> · {totalM2.toFixed(2)} m²
+            {isDirty && (
+              <>
+                {" "}
+                ·{" "}
+                <strong className="t-human">
+                  {editedCount} edición{editedCount === 1 ? "" : "es"}
+                </strong>{" "}
+                tuyas
+              </>
+            )}
+          </div>
+          <button
+            type="button"
+            className="btn ghost"
+            data-testid="despiece-open-chat"
+            onClick={openStepChat}
+          >
+            💬 Ayuda con esta sección
+          </button>
+          <button
+            type="button"
+            className="btn primary"
+            data-testid="confirm-despiece"
+            disabled={!canConfirm}
+            onClick={() => router.push(`/quotes/${quoteId}/calculo`)}
+          >
+            Confirmar y seguir →
+          </button>
+        </div>
+      </div>
+
+      {chatOpen && (
+        <DespieceChatPanel
+          messages={chat.messages}
+          panelState={chat.panelState}
+          pieceCount={pieces.length}
+          editedCount={editedCount}
+          focusedPiece={focusedPiece}
+          onSend={chat.send}
+          onClose={closeChat}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/components/despiece/PieceCell.tsx
+++ b/web/src/components/despiece/PieceCell.tsx
@@ -1,0 +1,101 @@
+/**
+ * Celda numérica editable inline de una pieza (Largo / Ancho / Cant.).
+ *
+ * Mismo patrón validado en el paso 2 (ContextField · Master §4 #3):
+ *   - Click en el value → edit mode (input con foco + select)
+ *   - Tab / Enter / blur → commit (guarda)
+ *   - Esc → cancela + revierte al value original
+ *
+ * Visual: `.cell.num`; si `edited` agrega `.edited` (borde púrpura + ✏);
+ * mientras se tipea agrega `.typing` (outline púrpura + cursor).
+ */
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+interface Props {
+  value: number;
+  edited?: boolean;
+  testId: string;
+  /** Sólo enteros (cantidades). Default false → admite decimales (cm). */
+  integer?: boolean;
+  onCommit: (value: number) => void;
+}
+
+export function PieceCell({ value, edited = false, testId, integer = false, onCommit }: Props) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(() => String(value));
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  useEffect(() => {
+    if (!editing) setDraft(String(value));
+  }, [value, editing]);
+
+  function commit() {
+    setEditing(false);
+    const parsed = integer ? parseInt(draft, 10) : parseFloat(draft);
+    if (Number.isNaN(parsed) || parsed < 0 || parsed === value) {
+      setDraft(String(value));
+      return;
+    }
+    onCommit(parsed);
+  }
+
+  function cancel() {
+    setDraft(String(value));
+    setEditing(false);
+  }
+
+  return (
+    <div
+      className={`cell num${edited ? " edited" : ""}${editing ? " typing" : ""}`}
+      data-testid={testId}
+      data-edited={edited}
+    >
+      {editing ? (
+        <input
+          ref={inputRef}
+          className="input num"
+          inputMode={integer ? "numeric" : "decimal"}
+          value={draft}
+          data-testid={`${testId}-input`}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === "Tab") {
+              if (e.key === "Enter") e.preventDefault();
+              commit();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              cancel();
+            }
+          }}
+        />
+      ) : (
+        <span
+          className="value-clickable"
+          data-testid={`${testId}-value`}
+          role="button"
+          tabIndex={0}
+          style={{ cursor: "pointer" }}
+          onClick={() => setEditing(true)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              setEditing(true);
+            }
+          }}
+        >
+          {value}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/despiece/PieceChatButton.tsx
+++ b/web/src/components/despiece/PieceChatButton.tsx
@@ -1,0 +1,32 @@
+/**
+ * Ítem de menú que abre el chat scoped enfocado en UNA pieza concreta
+ * (mockup 06 · chat sobre R2 = bacha). Reusa la clase `.item` del
+ * `.regen-menu` legacy para heredar el estilo del popover sin CSS nuevo.
+ */
+"use client";
+
+interface Props {
+  pieceId: string;
+  onOpen: () => void;
+}
+
+export function PieceChatButton({ pieceId, onOpen }: Props) {
+  return (
+    <div
+      className="item"
+      role="button"
+      tabIndex={0}
+      data-testid={`piece-chat-${pieceId}`}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+    >
+      💬 Preguntar a Valentina sobre {pieceId}
+      <span className="desc">chat enfocado en esta pieza</span>
+    </div>
+  );
+}

--- a/web/src/components/despiece/PieceRow.tsx
+++ b/web/src/components/despiece/PieceRow.tsx
@@ -1,0 +1,190 @@
+/**
+ * Fila de una pieza del despiece (mockups 04/05/06).
+ *
+ * Columnas (grid `.cols-despiece`): # · Pieza · Largo · Ancho · Cant. ·
+ * m² unit. · m² total · acciones.
+ *
+ * - Largo/Ancho/Cant. son `PieceCell` editables (Tab/Enter/Esc).
+ * - m² unit/total son derivados (read-only) de las dimensiones actuales.
+ * - Las dimensiones se guardan en mm; la tabla muestra cm (mm/10).
+ * - Highlight `.edited` por celda comparando contra el valor inicial de la
+ *   sesión; piezas `AGREGADO_MANUAL` muestran todas las celdas en púrpura.
+ */
+"use client";
+
+import { useRef, useState } from "react";
+import { pieceM2Total, pieceM2Unit, type Piece } from "@/lib/api";
+import { PieceCell } from "./PieceCell";
+import { PieceChatButton } from "./PieceChatButton";
+
+interface Props {
+  piece: Piece;
+  focused: boolean;
+  onUpdate: (pieceId: string, partial: Partial<Piece>) => void;
+  onDelete: (pieceId: string) => void;
+  onOpenChat: (pieceId: string) => void;
+}
+
+const RESET_BTN: React.CSSProperties = {
+  background: "transparent",
+  border: "none",
+  color: "inherit",
+  font: "inherit",
+  cursor: "pointer",
+  padding: 0,
+  lineHeight: 1,
+};
+
+export function PieceRow({ piece, focused, onUpdate, onDelete, onOpenChat }: Props) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  // Valores iniciales de la sesión para resaltar celdas tocadas.
+  const initial = useRef({
+    largo: piece.width_mm / 10,
+    ancho: piece.depth_mm / 10,
+    cant: piece.quantity,
+  });
+
+  const isManual = piece.origin === "AGREGADO_MANUAL";
+  const isEdited = piece.edited === true || piece.origin === "EDITADO" || isManual;
+
+  const largoCm = piece.width_mm / 10;
+  const anchoCm = piece.depth_mm / 10;
+
+  const rowCls = [
+    "row",
+    isEdited ? "row-edited" : "",
+    isManual ? "row-manual" : "",
+    focused ? "row-chat-ref" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  function closeMenu() {
+    setMenuOpen(false);
+    setConfirmDelete(false);
+  }
+
+  return (
+    <div
+      className={rowCls}
+      data-testid={`piece-row-${piece.id}`}
+      data-origin={piece.origin}
+      data-edited={isEdited}
+    >
+      <div className="cell">{piece.id}</div>
+
+      <div className="cell label-cell">
+        <span>{piece.label}</span>
+        {isEdited && (
+          <span className="k k-edited" data-testid={`piece-edited-chip-${piece.id}`}>
+            EDITADO
+          </span>
+        )}
+        {(piece.sublabel || (piece.detected_symbols && piece.detected_symbols.length > 0)) && (
+          <span className="sub">
+            {piece.sublabel}
+            {piece.detected_symbols?.map((s, i) => (
+              <span className="det-sym" key={`${s.src}-${i}`}>
+                <span className="src">{s.src}</span>
+                <span className="arrow">→</span>
+                <span className="out">{s.out}</span>
+              </span>
+            ))}
+          </span>
+        )}
+        {focused && <span className="sub sub-chat-ref">↳ chat enfocado aquí</span>}
+      </div>
+
+      <PieceCell
+        value={largoCm}
+        edited={isManual || largoCm !== initial.current.largo}
+        testId={`piece-largo-${piece.id}`}
+        onCommit={(cm) => onUpdate(piece.id, { width_mm: Math.round(cm * 10) })}
+      />
+      <PieceCell
+        value={anchoCm}
+        edited={isManual || anchoCm !== initial.current.ancho}
+        testId={`piece-ancho-${piece.id}`}
+        onCommit={(cm) => onUpdate(piece.id, { depth_mm: Math.round(cm * 10) })}
+      />
+      <PieceCell
+        value={piece.quantity}
+        edited={isManual || piece.quantity !== initial.current.cant}
+        testId={`piece-cant-${piece.id}`}
+        integer
+        onCommit={(qty) => onUpdate(piece.id, { quantity: qty })}
+      />
+
+      <div className="cell num" data-testid={`piece-m2unit-${piece.id}`}>
+        {pieceM2Unit(piece).toFixed(2)}
+      </div>
+      <div className="cell num" data-testid={`piece-m2total-${piece.id}`}>
+        {pieceM2Total(piece).toFixed(2)}
+      </div>
+
+      <div className="cell action regen-wrap">
+        <button
+          type="button"
+          style={RESET_BTN}
+          aria-label={`acciones de ${piece.id}`}
+          data-testid={`piece-menu-${piece.id}`}
+          onClick={() => (menuOpen ? closeMenu() : setMenuOpen(true))}
+        >
+          ⋯
+        </button>
+        {menuOpen && (
+          <div className="regen-menu open" role="menu">
+            <PieceChatButton
+              pieceId={piece.id}
+              onOpen={() => {
+                onOpenChat(piece.id);
+                closeMenu();
+              }}
+            />
+            {!confirmDelete ? (
+              <div
+                className="item danger"
+                role="button"
+                tabIndex={0}
+                data-testid={`piece-delete-${piece.id}`}
+                onClick={() => setConfirmDelete(true)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setConfirmDelete(true);
+                  }
+                }}
+              >
+                Eliminar pieza
+                <span className="desc">se quita del despiece</span>
+              </div>
+            ) : (
+              <div
+                className="item danger"
+                role="button"
+                tabIndex={0}
+                data-testid={`piece-delete-confirm-${piece.id}`}
+                onClick={() => {
+                  onDelete(piece.id);
+                  closeMenu();
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onDelete(piece.id);
+                    closeMenu();
+                  }
+                }}
+              >
+                ¿Confirmar? eliminar {piece.id}
+                <span className="desc">esta acción no se puede deshacer</span>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -232,9 +232,26 @@ export interface ChatStreamChunk {
   message?: string;
 }
 
-/** Frases canónicas rioplatenses para mock — varían según scope. */
-function pickResponse(scope: ChatScope, message: string): string {
+/** Frases canónicas rioplatenses para mock — varían según scope.
+ *  `targetPieceId` (opcional) enfoca la respuesta del scope `despiece`
+ *  en una pieza puntual (mockup 06 · chat sobre R2 = bacha). */
+function pickResponse(scope: ChatScope, message: string, targetPieceId?: string): string {
   const lower = message.toLowerCase();
+  if (scope === "despiece") {
+    if (targetPieceId === "R2" || lower.includes("bacha") || lower.includes("pileta")) {
+      return "Sí, da con margen pero ajustado. Una bacha doble entra en 65cm de ancho útil; si va undermount con rebaje 45° te recomiendo +2cm en R2 y recalculo el m².";
+    }
+    if (lower.includes("inglete") || lower.includes("corte") || lower.includes("45")) {
+      return "El INGLETE del plano lo traduje a CORTE45 donde se unen los brazos de la mesada. Es un corte a 45° — lo cargo como MO en el paso 4.";
+    }
+    if (lower.includes("zócalo") || lower.includes("zocalo") || lower.includes("alzada")) {
+      return "El zócalo y la alzada los calculo por ml real de cada lado. Si alguno no va, lo sacás de la tabla y recalculo el m² total.";
+    }
+    if (lower.includes("toma")) {
+      return "Detecté 2 TOMAS en la alzada (símbolo del plano). Cada toma suma una línea de MO en el paso 4. Si son más o menos, editás la pieza y se ajusta.";
+    }
+    return "Te ayudo con el despiece. Click en la fila de la pieza que quieras revisar y te explico de dónde saqué cada medida.";
+  }
   if (scope === "contexto") {
     if (lower.includes("anafe")) {
       return "Marqué anafe porque en el plano se ve el dibujo del símbolo en la mesada. Si no es así, lo desmarcás vos y se recalcula la MO en el paso 3.";
@@ -260,9 +277,9 @@ export function streamChat(
   _quoteId: string,
   message: string,
   scope: ChatScope,
-  options?: { signal?: AbortSignal },
+  options?: { signal?: AbortSignal; targetPieceId?: string },
 ): ReadableStream<ChatStreamChunk> {
-  const text = pickResponse(scope, message);
+  const text = pickResponse(scope, message, options?.targetPieceId);
   const tokens = text.split(/(\s+)/); // split conservando whitespace
 
   return new ReadableStream<ChatStreamChunk>({
@@ -416,4 +433,278 @@ export async function getValentinaBriefSummary(
   const { BRIEF_SUMMARY_BY_QUOTE_ID, BRIEF_SUMMARY_GENERIC } =
     await import("./mocks/canonicalQuote");
   return BRIEF_SUMMARY_BY_QUOTE_ID[quoteId] ?? BRIEF_SUMMARY_GENERIC;
+}
+
+/* ════════════════════════════════════════════════════════════════════════
+   Sprint 3 paso-3-despiece · mock client de piezas (despiece)
+   ════════════════════════════════════════════════════════════════════════
+   Espeja el tool backend `list_pieces` (api/.../quote_engine/calculator.py),
+   que recibe piezas con `largo`/`prof|alto` en METROS + `quantity` y devuelve
+   labels + m² determinísticos. Como el endpoint dedicado del paso 3 todavía
+   no existe (sprint-3/api-integration hace el switch a HTTP real), este mock
+   cubre la brecha sirviendo las cifras canon del despiece Cueto-Heredia
+   (mockup 04-despiece-A · Master §13).
+
+   Discrepancias mockup ↔ contract documentadas (gana el mockup · Master §14):
+   - El mockup muestra cm ("Largo (cm)" 285); el contract usa metros (largo
+     2.85). El tipo `Piece` usa `width_mm`/`depth_mm` (mm) como unidad canónica
+     interna → la UI divide /10 para mostrar cm. m² = width_mm·depth_mm / 1e6.
+   - El mockup tiene columna `Cant.` y labels descriptivos + símbolos del plano
+     (.det-sym) que NO están en el interface base del prompt. Se extienden
+     `Piece` con `quantity`, `label`, `sublabel`, `detected_symbols` (el backend
+     ya maneja `quantity` y `description`). */
+
+/** Símbolo detectado en el plano y su traducción a SKU/operación.
+ *  Mockup 04-despiece: INGLETE→CORTE45, DESAGUE→AGUJEROAPOYO, 2 TOMAS→TOMAS. */
+export interface DetectedSymbol {
+  src: string;
+  out: string;
+}
+
+export type PieceType = "encimera" | "frente" | "zocalo" | "alzada" | "isla" | (string & {});
+
+export interface PieceOptions {
+  pileta?: { tipo: "empotrada" | "sobre-mesada" | null; sku?: string };
+  anafe?: boolean;
+  tomas?: number;
+  alzada?: boolean;
+  regrueso_mm?: number;
+}
+
+export interface Piece {
+  id: string; // "R1", "R2", ...
+  type: PieceType;
+  /** Label descriptivo del mockup (ej. "Mesada perimetral · brazo izq"). */
+  label: string;
+  /** Sub-texto bajo el label (ej. "contra pared norte"). */
+  sublabel?: string;
+  width_mm: number; // columna "Largo" del mockup (cm × 10)
+  depth_mm: number; // columna "Ancho" del mockup (cm × 10)
+  quantity: number; // columna "Cant." del mockup
+  options: PieceOptions;
+  /** Símbolos del plano (.det-sym) — sólo presentes en piezas origin=IA. */
+  detected_symbols?: DetectedSymbol[];
+  origin: "IA" | "EDITADO" | "AGREGADO_MANUAL";
+  confidence?: number; // 0..1, sólo si origin=IA
+  extracted_from?: string; // referencia al plano (ej. "plan_p1_z2")
+  edited?: boolean; // true si Marina lo tocó
+}
+
+export interface TimelineStep {
+  step: 1 | 2 | 3 | 4;
+  label: string;
+  state: "pending" | "running" | "done" | "failed";
+  /** Texto de salida de la pasada (.out del mockup). */
+  detail?: string;
+  started_at?: string;
+  completed_at?: string;
+}
+
+export interface PieceList {
+  pieces: Piece[];
+  status: "pending" | "inferring" | "done" | "failed";
+  timeline: TimelineStep[];
+  warnings: string[];
+}
+
+/** m² unitario (half-up a 2 decimales, igual que calculator.py). */
+export function pieceM2Unit(piece: Pick<Piece, "width_mm" | "depth_mm">): number {
+  return Math.round(((piece.width_mm * piece.depth_mm) / 1_000_000) * 100) / 100;
+}
+
+/** m² total = m² unitario × cantidad (half-up a 2 decimales). */
+export function pieceM2Total(piece: Pick<Piece, "width_mm" | "depth_mm" | "quantity">): number {
+  return Math.round(pieceM2Unit(piece) * piece.quantity * 100) / 100;
+}
+
+/** Suma de m² total de un set de piezas. */
+export function piecesTotalM2(pieces: Piece[]): number {
+  return Math.round(pieces.reduce((sum, p) => sum + pieceM2Total(p), 0) * 100) / 100;
+}
+
+/** In-memory store para que edits/add/delete persistan en la sesión del browser. */
+const _piecesStore = new Map<string, PieceList>();
+
+/** Reset helper (tests / reset entre quotes en dev). */
+export function _resetPiecesStore() {
+  _piecesStore.clear();
+}
+
+function deepClonePieces(pieces: Piece[]): Piece[] {
+  return JSON.parse(JSON.stringify(pieces)) as Piece[];
+}
+
+/** Clona la lista devuelta para que el caller (hook) NUNCA comparta refs con
+ *  `_piecesStore` — si las compartiera, una mutación del store (push/replace)
+ *  se duplicaría con el append optimista del hook. */
+function clonePieceList(list: PieceList): PieceList {
+  return JSON.parse(JSON.stringify(list)) as PieceList;
+}
+
+function buildDoneTimeline(count: number, totalM2: number): TimelineStep[] {
+  return [
+    { step: 1, label: "Inventario", state: "done", detail: "piezas identificadas desde el plano" },
+    { step: 2, label: "Paredes y libres", state: "done", detail: "perímetro vs piezas libres" },
+    { step: 3, label: "Medidas", state: "done", detail: "cotas en mm convertidas a cm" },
+    {
+      step: 4,
+      label: "Verificación",
+      state: "done",
+      detail: `${count} piezas confirmadas · ${totalM2.toFixed(2)} m²`,
+    },
+  ];
+}
+
+function buildFailedTimeline(): TimelineStep[] {
+  return [
+    { step: 1, label: "Inventario", state: "failed", detail: "sin brief ni contexto" },
+    { step: 2, label: "Paredes y libres", state: "pending" },
+    { step: 3, label: "Medidas", state: "pending" },
+    { step: 4, label: "Verificación", state: "pending" },
+  ];
+}
+
+async function seedPieceList(quoteId: string): Promise<PieceList> {
+  const { PIECES_BY_QUOTE_ID, TIMELINE_BY_QUOTE_ID } = await import("./mocks/canonicalQuote");
+  const canon = PIECES_BY_QUOTE_ID[quoteId];
+  if (canon && canon.length > 0) {
+    const pieces = deepClonePieces(canon);
+    const total = piecesTotalM2(pieces);
+    return {
+      pieces,
+      status: "done",
+      timeline: TIMELINE_BY_QUOTE_ID[quoteId] ?? buildDoneTimeline(pieces.length, total),
+      warnings: [],
+    };
+  }
+  // Sin canon definido → Valentina no pudo inferir (empty state · mockup 16).
+  return {
+    pieces: [],
+    status: "failed",
+    timeline: buildFailedTimeline(),
+    warnings: ["Valentina no pudo proponer un despiece — cargá el brief o completá a mano."],
+  };
+}
+
+/**
+ * GET piezas del despiece para un quote. Indexa por quoteId via
+ * PIECES_BY_QUOTE_ID (PRES-2026-018 → Cueto-Heredia 5 piezas, PRES-2026-017 →
+ * Pereyra) con fallback a empty (`status: 'failed'`) para quotes sin canon.
+ *
+ * Lección Sprint 2.5 (fix-up #2 del PR #460): TODO lookup indexa por quoteId.
+ * NUNCA devolver siempre las piezas de PRES-018.
+ */
+export async function listPiecesForQuote(
+  quoteId: string,
+  options?: { signal?: AbortSignal },
+): Promise<PieceList> {
+  await delay(500 + Math.random() * 300, options?.signal);
+  const existing = _piecesStore.get(quoteId);
+  if (existing) return clonePieceList(existing);
+  const seeded = await seedPieceList(quoteId);
+  _piecesStore.set(quoteId, seeded);
+  return clonePieceList(seeded);
+}
+
+async function ensureList(quoteId: string): Promise<PieceList> {
+  const existing = _piecesStore.get(quoteId);
+  if (existing) return existing;
+  const seeded = await seedPieceList(quoteId);
+  _piecesStore.set(quoteId, seeded);
+  return seeded;
+}
+
+/**
+ * PATCH parcial de una pieza. Marca `edited: true` y, si era propuesta de la
+ * IA, `origin: 'EDITADO'` (regla Master §4 #1 — la edición humana no se pisa).
+ */
+export async function updatePieceForQuote(
+  quoteId: string,
+  pieceId: string,
+  partial: Partial<Piece>,
+  options?: { signal?: AbortSignal },
+): Promise<Piece> {
+  await delay(120 + Math.random() * 160, options?.signal);
+  const list = await ensureList(quoteId);
+  const idx = list.pieces.findIndex((p) => p.id === pieceId);
+  if (idx === -1) {
+    throw new ApiError("PIECE_NOT_FOUND", `Pieza ${pieceId} no existe en ${quoteId}`, 404);
+  }
+  const current = list.pieces[idx];
+  const nextOrigin = current.origin === "AGREGADO_MANUAL" ? current.origin : "EDITADO";
+  const updated: Piece = {
+    ...current,
+    ...partial,
+    id: current.id,
+    origin: nextOrigin,
+    edited: true,
+  };
+  list.pieces[idx] = updated;
+  _piecesStore.set(quoteId, list);
+  return { ...updated };
+}
+
+/** Próximo id "R{n}" libre dentro del set. */
+function nextPieceId(pieces: Piece[]): string {
+  let max = 0;
+  for (const p of pieces) {
+    const m = /^R(\d+)$/.exec(p.id);
+    if (m) max = Math.max(max, Number(m[1]));
+  }
+  return `R${max + 1}`;
+}
+
+/** Agrega una pieza manual (origin=AGREGADO_MANUAL, sin confidence/IA). */
+export async function addPieceForQuote(
+  quoteId: string,
+  piece: Omit<Piece, "id" | "origin" | "confidence" | "extracted_from">,
+  options?: { signal?: AbortSignal },
+): Promise<Piece> {
+  await delay(120 + Math.random() * 160, options?.signal);
+  const list = await ensureList(quoteId);
+  const created: Piece = {
+    ...piece,
+    id: nextPieceId(list.pieces),
+    origin: "AGREGADO_MANUAL",
+    edited: true,
+  };
+  list.pieces.push(created);
+  _piecesStore.set(quoteId, list);
+  return { ...created };
+}
+
+/** Elimina una pieza del set. */
+export async function deletePieceForQuote(
+  quoteId: string,
+  pieceId: string,
+  options?: { signal?: AbortSignal },
+): Promise<void> {
+  await delay(120 + Math.random() * 160, options?.signal);
+  const list = await ensureList(quoteId);
+  list.pieces = list.pieces.filter((p) => p.id !== pieceId);
+  _piecesStore.set(quoteId, list);
+}
+
+/**
+ * Re-corre la inferencia de Valentina.
+ * - `mode: 'all'` (default) → descarta TODO y re-siembra desde el canon.
+ * - `mode: 'keep-edits'` → re-siembra IA pero preserva las piezas editadas /
+ *   manuales por id (Master §10 #10 — las ediciones no se pisan al re-generar).
+ */
+export async function regenerateDespiece(
+  quoteId: string,
+  options?: { signal?: AbortSignal; mode?: "all" | "keep-edits" },
+): Promise<PieceList> {
+  await delay(700 + Math.random() * 500, options?.signal);
+  const fresh = await seedPieceList(quoteId);
+  if (options?.mode === "keep-edits") {
+    const previous = _piecesStore.get(quoteId);
+    const kept = (previous?.pieces ?? []).filter(
+      (p) => p.edited === true || p.origin === "AGREGADO_MANUAL",
+    );
+    const keptIds = new Set(kept.map((p) => p.id));
+    fresh.pieces = [...fresh.pieces.filter((p) => !keptIds.has(p.id)), ...kept];
+  }
+  _piecesStore.set(quoteId, fresh);
+  return clonePieceList(fresh);
 }

--- a/web/src/lib/hooks/useChatScoped.ts
+++ b/web/src/lib/hooks/useChatScoped.ts
@@ -23,7 +23,13 @@ function makeId(): string {
   return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-export function useChatScoped(quoteId: string, scope: ChatScope) {
+/**
+ * @param targetPieceId  (opcional, scope `despiece`) enfoca el chat en una
+ *   pieza puntual — el mock de Valentina responde sobre esa pieza (mockup 06,
+ *   chat sobre R2 = bacha). Cambiarlo NO borra el historial; eso sólo pasa al
+ *   cerrar (Master §10 #1).
+ */
+export function useChatScoped(quoteId: string, scope: ChatScope, targetPieceId?: string) {
   const [panelState, setPanelState] = useState<ChatPanelState>("closed");
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const abortRef = useRef<AbortController | null>(null);
@@ -60,7 +66,10 @@ export function useChatScoped(quoteId: string, scope: ChatScope) {
       const ctrl = new AbortController();
       abortRef.current = ctrl;
       try {
-        const stream = streamChat(quoteId, trimmed, scope, { signal: ctrl.signal });
+        const stream = streamChat(quoteId, trimmed, scope, {
+          signal: ctrl.signal,
+          targetPieceId,
+        });
         const reader = stream.getReader();
         while (true) {
           const { done, value } = await reader.read();
@@ -87,7 +96,7 @@ export function useChatScoped(quoteId: string, scope: ChatScope) {
         setPanelState((curr) => (curr === "streaming" ? "open" : curr));
       }
     },
-    [quoteId, scope],
+    [quoteId, scope, targetPieceId],
   );
 
   return { panelState, messages, open, close, send };

--- a/web/src/lib/hooks/useDespiece.ts
+++ b/web/src/lib/hooks/useDespiece.ts
@@ -1,0 +1,159 @@
+/**
+ * Hook que gestiona el despiece del paso 3:
+ *   - load inicial via listPiecesForQuote (skeleton + timeline)
+ *   - updatePiece / addPiece / deletePiece (edición humana en vivo)
+ *   - regenerate (Valentina re-corre la inferencia)
+ *   - dirty tracking: isDirty si ≥1 pieza fue editada o agregada a mano
+ *
+ * Cancela cualquier load pendiente al desmontar (AbortController). Los
+ * datasources indexan SIEMPRE por quoteId (lección Sprint 2.5 fix-up #2).
+ */
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  addPieceForQuote,
+  deletePieceForQuote,
+  listPiecesForQuote,
+  regenerateDespiece,
+  updatePieceForQuote,
+  type Piece,
+  type PieceList,
+  type TimelineStep,
+} from "../api";
+import type { DespieceFormState } from "../types";
+
+export function useDespiece(quoteId: string) {
+  const [data, setData] = useState<PieceList | null>(null);
+  const [state, setState] = useState<DespieceFormState>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const mutAbortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    let aborted = false;
+    const ctrl = new AbortController();
+    setState("loading");
+    setError(null);
+    setData(null);
+    listPiecesForQuote(quoteId, { signal: ctrl.signal })
+      .then((list) => {
+        if (aborted) return;
+        setData(list);
+        setState("idle");
+      })
+      .catch((err) => {
+        if (aborted || (err instanceof DOMException && err.name === "AbortError")) return;
+        setError(err instanceof Error ? err.message : "Error al cargar el despiece");
+        setState("error");
+      });
+    return () => {
+      aborted = true;
+      ctrl.abort();
+    };
+  }, [quoteId]);
+
+  const updatePiece = useCallback(
+    async (pieceId: string, partial: Partial<Piece>) => {
+      mutAbortRef.current?.abort();
+      const ctrl = new AbortController();
+      mutAbortRef.current = ctrl;
+      setState("saving");
+      setError(null);
+      try {
+        const updated = await updatePieceForQuote(quoteId, pieceId, partial, {
+          signal: ctrl.signal,
+        });
+        setData((prev) =>
+          prev
+            ? { ...prev, pieces: prev.pieces.map((p) => (p.id === pieceId ? updated : p)) }
+            : prev,
+        );
+        setState("idle");
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setError(err instanceof Error ? err.message : "Error al guardar la pieza");
+        setState("error");
+      }
+    },
+    [quoteId],
+  );
+
+  const addPiece = useCallback(
+    async (piece: Omit<Piece, "id" | "origin" | "confidence" | "extracted_from">) => {
+      setState("saving");
+      setError(null);
+      try {
+        const created = await addPieceForQuote(quoteId, piece);
+        setData((prev) => (prev ? { ...prev, pieces: [...prev.pieces, created] } : prev));
+        setState("idle");
+        return created;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Error al agregar la pieza");
+        setState("error");
+        return null;
+      }
+    },
+    [quoteId],
+  );
+
+  const deletePiece = useCallback(
+    async (pieceId: string) => {
+      setState("saving");
+      setError(null);
+      try {
+        await deletePieceForQuote(quoteId, pieceId);
+        setData((prev) =>
+          prev ? { ...prev, pieces: prev.pieces.filter((p) => p.id !== pieceId) } : prev,
+        );
+        setState("idle");
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Error al eliminar la pieza");
+        setState("error");
+      }
+    },
+    [quoteId],
+  );
+
+  const regenerate = useCallback(
+    async (mode: "all" | "keep-edits" = "all") => {
+      setState("regenerating");
+      setError(null);
+      try {
+        const fresh = await regenerateDespiece(quoteId, { mode });
+        setData(fresh);
+        setState("idle");
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setError(err instanceof Error ? err.message : "Error al regenerar el despiece");
+        setState("error");
+      }
+    },
+    [quoteId],
+  );
+
+  const pieces: Piece[] = data?.pieces ?? [];
+  const timeline: TimelineStep[] = data?.timeline ?? [];
+  const status = data?.status ?? "pending";
+  const warnings = data?.warnings ?? [];
+  const isDirty = pieces.some(
+    (p) => p.edited === true || p.origin === "EDITADO" || p.origin === "AGREGADO_MANUAL",
+  );
+  const editedCount = pieces.filter(
+    (p) => p.edited === true || p.origin === "AGREGADO_MANUAL",
+  ).length;
+
+  return {
+    pieces,
+    timeline,
+    status,
+    warnings,
+    state,
+    error,
+    updatePiece,
+    addPiece,
+    deletePiece,
+    regenerate,
+    isDirty,
+    editedCount,
+  };
+}

--- a/web/src/lib/mocks/canonicalQuote.ts
+++ b/web/src/lib/mocks/canonicalQuote.ts
@@ -74,7 +74,7 @@ export function getCurrentStep(pathname: string): StepId {
    path de extracción que Valentina usaría: BRIEF (texto/PDF directo) o
    INFERIDO (cruzando catálogos / reglas). */
 
-import type { ContextResponse } from "../api";
+import type { ContextResponse, Piece, TimelineStep } from "../api";
 
 export const CANONICAL_CONTEXT: ContextResponse = {
   cliente: { value: "Cueto-Heredia Arquitectura", origin: "BRIEF" },
@@ -153,3 +153,191 @@ export const BRIEF_SUMMARY_BY_QUOTE_ID: Record<string, string> = {
 
 export const BRIEF_SUMMARY_GENERIC =
   "extraje los datos del brief — revisalos y editá lo que haga falta";
+
+/* ════════════════════════════════════════════════════════════════════════
+   Sprint 3 paso-3-despiece · CANONICAL_PIECES por quoteId
+   ════════════════════════════════════════════════════════════════════════
+   Las 5 piezas que Valentina propone para PRES-2026-018 (mockup
+   04-despiece-A-ia-propuso). Confirm-bar canon: "5 piezas · 6.81 m²".
+   Dimensiones literales del mockup en cm → guardadas en mm (cm × 10).
+
+   m² unitario = width_mm · depth_mm / 1e6:
+     R1 285×62 = 1.77 · R2 240×62 = 1.49 · R3 180×62 = 1.12 ·
+     R4 285×8 = 0.23 · R5 220×100 = 2.20  → total 6.81 m² ✓
+
+   Indexado por quoteId desde el inicio (lección Sprint 2.5 fix-up #2 del
+   PR #460): NUNCA hardcodear PRES-018, todo lookup pasa por quoteId. */
+
+export const CANONICAL_PIECES_018: Piece[] = [
+  {
+    id: "R1",
+    type: "encimera",
+    label: "Mesada perimetral · brazo izq",
+    sublabel: "contra pared norte",
+    width_mm: 2850,
+    depth_mm: 620,
+    quantity: 1,
+    options: { regrueso_mm: 40 },
+    detected_symbols: [{ src: "INGLETE", out: "CORTE45" }],
+    origin: "IA",
+    confidence: 0.92,
+    extracted_from: "plan_p1_z1",
+  },
+  {
+    // R2 = bacha · pieza sobre la que va el chat scoped del mockup 06.
+    id: "R2",
+    type: "encimera",
+    label: "Mesada perimetral · brazo derecho",
+    sublabel: "con bacha empotrada",
+    width_mm: 2400,
+    depth_mm: 620,
+    quantity: 1,
+    options: { pileta: { tipo: "empotrada", sku: "JOHNSON-C37D" }, regrueso_mm: 40 },
+    detected_symbols: [
+      { src: "DESAGUE", out: "AGUJEROAPOYO" },
+      { src: "INGLETE", out: "CORTE45" },
+    ],
+    origin: "IA",
+    confidence: 0.88,
+    extracted_from: "plan_p1_z2",
+  },
+  {
+    id: "R3",
+    type: "encimera",
+    label: "Mesada perimetral · fondo",
+    sublabel: "une R1 y R2",
+    width_mm: 1800,
+    depth_mm: 620,
+    quantity: 1,
+    options: { regrueso_mm: 40 },
+    detected_symbols: [{ src: "INGLETE×2", out: "CORTE45" }],
+    origin: "IA",
+    confidence: 0.9,
+    extracted_from: "plan_p1_z3",
+  },
+  {
+    id: "R4",
+    type: "alzada",
+    label: "Alzada salpicadero",
+    sublabel: "contra pared · h=8cm corre 285cm",
+    width_mm: 2850,
+    depth_mm: 80,
+    quantity: 1,
+    options: { alzada: true, tomas: 2 },
+    detected_symbols: [{ src: "2 TOMAS", out: "TOMAS" }],
+    origin: "IA",
+    confidence: 0.85,
+    extracted_from: "plan_p1_z1",
+  },
+  {
+    id: "R5",
+    type: "isla",
+    label: "Isla central",
+    sublabel: "con voladizo 30cm lado comedor",
+    width_mm: 2200,
+    depth_mm: 1000,
+    quantity: 1,
+    options: {},
+    origin: "IA",
+    confidence: 0.83,
+    extracted_from: "plan_p1_z4",
+  },
+];
+
+/** PRES-2026-017 · Familia Pereyra · dataset reducido y DISTINTO al de 018
+ *  (el mockup desktop no cubre el despiece de Pereyra — Master §6: Pereyra
+ *  sólo aparece en mobile/dashboard). Sirve de regression check de que los
+ *  datasources indexan por quoteId (no contaminan con PRES-018). */
+export const CANONICAL_PIECES_017: Piece[] = [
+  {
+    id: "R1",
+    type: "encimera",
+    label: "Mesada en U · tramo A",
+    sublabel: "contra pared",
+    width_mm: 3000,
+    depth_mm: 600,
+    quantity: 1,
+    options: {},
+    origin: "IA",
+    confidence: 0.86,
+    extracted_from: "plan_p1_z1",
+  },
+  {
+    id: "R2",
+    type: "encimera",
+    label: "Mesada en U · tramo B",
+    sublabel: "con pileta empotrada",
+    width_mm: 1600,
+    depth_mm: 600,
+    quantity: 1,
+    options: { pileta: { tipo: "empotrada" } },
+    detected_symbols: [{ src: "DESAGUE", out: "AGUJEROAPOYO" }],
+    origin: "IA",
+    confidence: 0.84,
+    extracted_from: "plan_p1_z2",
+  },
+  {
+    id: "R3",
+    type: "isla",
+    label: "Isla",
+    sublabel: "libre 4 lados",
+    width_mm: 1800,
+    depth_mm: 900,
+    quantity: 1,
+    options: {},
+    origin: "IA",
+    confidence: 0.8,
+    extracted_from: "plan_p1_z3",
+  },
+];
+
+/** Fallback para los quotes restantes del dataset (sin canon de piezas).
+ *  Vacío a propósito → `listPiecesForQuote` devuelve status:'failed' y la UI
+ *  cae al empty state (mockup 16). */
+export const CANONICAL_PIECES_GENERIC: Piece[] = [];
+
+export const PIECES_BY_QUOTE_ID: Record<string, Piece[]> = {
+  "PRES-2026-018": CANONICAL_PIECES_018, // Cueto-Heredia (case desktop completo)
+  "PRES-2026-017": CANONICAL_PIECES_017, // Pereyra (regression datasources por quoteId)
+};
+
+/** Timeline canon de las 4 pasadas de Valentina sobre PRES-2026-018
+ *  (mockup 04-despiece-A · 4 pasadas + 3 símbolos detectados). */
+export const CANONICAL_TIMELINE_018: TimelineStep[] = [
+  {
+    step: 1,
+    label: "Inventario",
+    state: "done",
+    detail: "cocina U + isla · 1 pileta empotrada · 1 alzada · 1 zócalo",
+  },
+  {
+    step: 2,
+    label: "Paredes y libres",
+    state: "done",
+    detail: "3 brazos perimetrales (R1·R2·R3) · isla libre 4 lados (R5)",
+  },
+  {
+    step: 3,
+    label: "Medidas",
+    state: "done",
+    detail: "cotas en mm convertidas a cm · INGLETE/DESAGUE/TOMAS detectados",
+  },
+  {
+    step: 4,
+    label: "Verificación",
+    state: "done",
+    detail: "5 piezas confirmadas · 6.81 m²",
+  },
+];
+
+export const TIMELINE_BY_QUOTE_ID: Record<string, TimelineStep[]> = {
+  "PRES-2026-018": CANONICAL_TIMELINE_018,
+};
+
+/** Timeline mostrado durante la carga inicial (skeleton) — pasada 4 corriendo. */
+export const DESPIECE_LOADING_TIMELINE: TimelineStep[] = [
+  { step: 1, label: "Inventario", state: "done" },
+  { step: 2, label: "Paredes y libres", state: "done" },
+  { step: 3, label: "Medidas", state: "done" },
+  { step: 4, label: "Verificación", state: "running", detail: "cruzando con catálogo…" },
+];

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -30,3 +30,25 @@ export interface ChatMessage {
 }
 
 export type ChatPanelState = "closed" | "open" | "streaming";
+
+/* ─── Sprint 3 paso-3-despiece · state machine + chat scope ─────────── */
+
+/** Estado del container del paso 3 (DespieceView).
+ *  - loading: carga inicial de piezas (skeleton + timeline running)
+ *  - idle: piezas cargadas, sin operación en curso
+ *  - editing: una celda está en edit mode (Tab/Enter/Esc)
+ *  - saving: persistiendo un update/add/delete
+ *  - regenerating: Valentina re-corre la inferencia
+ *  - error: fallo de carga
+ */
+export type DespieceFormState =
+  | "loading"
+  | "idle"
+  | "editing"
+  | "saving"
+  | "regenerating"
+  | "error";
+
+/** Scope del chat del paso 3: sobre el paso completo, o enfocado en 1 pieza
+ *  (mockup 06 · chat sobre R2 = bacha). */
+export type DespieceStreamScope = "despiece" | { scope: "despiece"; target_piece_id: string };

--- a/web/tests/e2e/despiece.spec.ts
+++ b/web/tests/e2e/despiece.spec.ts
@@ -206,3 +206,56 @@ test("datasources por quoteId — PRES-017 muestra piezas de Pereyra, no de 018"
   await expect(page.locator('[data-testid="piece-largo-R1-value"]')).toHaveText("300");
   await expect(page.locator('[data-testid="piece-largo-R1-value"]')).not.toHaveText("285");
 });
+
+test("regenerate keep-edits — preserva la edición de R1, re-genera el resto (Master §10 #10)", async ({
+  page,
+}) => {
+  await gotoLoaded(page);
+  // Estado inicial: R3 es propuesta IA sin tocar (largo 180, no editada).
+  await expect(page.locator('[data-testid="piece-largo-R3-value"]')).toHaveText("180");
+  await expect(page.locator('[data-testid="piece-row-R3"]')).toHaveAttribute(
+    "data-edited",
+    "false",
+  );
+
+  // Marina edita R1 (285 → 250 cm).
+  await page.locator('[data-testid="piece-largo-R1-value"]').click();
+  await page.locator('[data-testid="piece-largo-R1-input"]').fill("250");
+  await page.keyboard.press("Tab");
+  await expect(page.locator('[data-testid="piece-row-R1"]')).toHaveAttribute(
+    "data-edited",
+    "true",
+    {
+      timeout: 3000,
+    },
+  );
+  // Estado dirty → aparece el split-button "Re-generar no-editadas".
+  const keepBtn = page.locator('[data-testid="despiece-regen-keep"]');
+  await expect(keepBtn).toBeVisible();
+
+  // Re-generar preservando ediciones (mode keep-edits, sin confirmación).
+  await keepBtn.click();
+  await expect(page.locator('[data-testid="despiece-view"]')).toHaveAttribute(
+    "data-state",
+    "regenerating",
+  );
+  await expect(page.locator('[data-testid="despiece-view"]')).toHaveAttribute(
+    "data-state",
+    "idle",
+    {
+      timeout: 6000,
+    },
+  );
+
+  // La edición de R1 SOBREVIVE (Master §10 #10: las ediciones no se pisan).
+  await expect(page.locator('[data-testid="piece-largo-R1-value"]')).toHaveText("250");
+  await expect(page.locator('[data-testid="piece-row-R1"]')).toHaveAttribute("data-edited", "true");
+  // R3 (no editada) se re-generó desde el canon: sigue siendo IA, sin púrpura.
+  await expect(page.locator('[data-testid="piece-row-R3"]')).toHaveAttribute(
+    "data-edited",
+    "false",
+  );
+  await expect(page.locator('[data-testid="piece-largo-R3-value"]')).toHaveText("180");
+  // Sigue habiendo 5 piezas.
+  await expect(page.locator('[data-testid^="piece-row-"]')).toHaveCount(5);
+});

--- a/web/tests/e2e/despiece.spec.ts
+++ b/web/tests/e2e/despiece.spec.ts
@@ -1,0 +1,208 @@
+/**
+ * E2E del paso 3 — despiece + chat scoped.
+ *
+ * Cubre los estados visuales (mockups 04-A / 04-manual / 05 / 06 / 16),
+ * edit mode inline (Tab/Enter/Esc), add/delete, chat scoped sobre el paso
+ * y sobre una pieza (R2 = bacha), persistencia borra-al-cerrar (Master §10
+ * #1), regenerate, empty state, routing al paso 4 y — crítico — que los
+ * datasources indexan por quoteId (lección Sprint 2.5 fix-up #2 del PR #460).
+ */
+import { expect, test, type Page } from "@playwright/test";
+
+const URL_018 = "/quotes/PRES-2026-018/despiece";
+const URL_017 = "/quotes/PRES-2026-017/despiece";
+
+/** Navega y espera a que termine la carga (5 piezas canon visibles). */
+async function gotoLoaded(page: Page, url = URL_018) {
+  await page.goto(url);
+  await expect(page.locator('[data-testid="piece-row-R1"]')).toBeVisible({ timeout: 8000 });
+}
+
+test("estado loading — skeleton + timeline corriendo", async ({ page }) => {
+  await page.goto(URL_018);
+  // El skeleton + la pasada 4 corriendo se renderean durante la carga inicial
+  // (DespieceView arranca en state=loading, incluso en el SSR).
+  await expect(page.locator('[data-testid="despiece-loading"]')).toBeVisible();
+  await expect(page.locator('[data-testid="timeline-step-4"]')).toHaveAttribute(
+    "data-state",
+    "running",
+  );
+});
+
+test("estado A — 5 piezas canon visibles + timeline done", async ({ page }) => {
+  await gotoLoaded(page);
+  await expect(page.locator('[data-testid^="piece-row-"]')).toHaveCount(5);
+  await expect(page.locator('[data-testid="despiece-view"]')).toHaveAttribute("data-state", "idle");
+  await expect(page.locator('[data-testid="timeline-step-4"]')).toHaveAttribute(
+    "data-state",
+    "done",
+  );
+  await expect(page.locator('[data-testid="despiece-banner"]')).toContainText("Valentina");
+});
+
+test("cifras canon — R1..R5 con dimensiones del mockup 04-A", async ({ page }) => {
+  await gotoLoaded(page);
+  // R1 285×62 = 1.77
+  await expect(page.locator('[data-testid="piece-largo-R1-value"]')).toHaveText("285");
+  await expect(page.locator('[data-testid="piece-ancho-R1-value"]')).toHaveText("62");
+  await expect(page.locator('[data-testid="piece-m2unit-R1"]')).toHaveText("1.77");
+  // R5 220×100 = 2.20 (isla)
+  await expect(page.locator('[data-testid="piece-largo-R5-value"]')).toHaveText("220");
+  await expect(page.locator('[data-testid="piece-ancho-R5-value"]')).toHaveText("100");
+  await expect(page.locator('[data-testid="piece-m2unit-R5"]')).toHaveText("2.20");
+  // total canon 6.81 m²
+  await expect(page.locator('[data-testid="despiece-summary"]')).toContainText("5 piezas");
+  await expect(page.locator('[data-testid="despiece-summary"]')).toContainText("6.81");
+});
+
+test("edit mode — click → input → Tab guarda → row púrpura + chip EDITADO", async ({ page }) => {
+  await gotoLoaded(page);
+  await page.locator('[data-testid="piece-largo-R2-value"]').click();
+  const input = page.locator('[data-testid="piece-largo-R2-input"]');
+  await expect(input).toBeVisible();
+  await expect(input).toBeFocused();
+  await input.fill("250");
+  await page.keyboard.press("Tab");
+  await expect(page.locator('[data-testid="piece-row-R2"]')).toHaveAttribute(
+    "data-edited",
+    "true",
+    {
+      timeout: 3000,
+    },
+  );
+  await expect(page.locator('[data-testid="piece-edited-chip-R2"]')).toBeVisible();
+  // m² recalculado: 250×62 = 1.55
+  await expect(page.locator('[data-testid="piece-m2unit-R2"]')).toHaveText("1.55");
+  // El form pasa a dirty
+  await expect(page.locator('[data-testid="despiece-view"]')).toHaveAttribute("data-dirty", "true");
+});
+
+test("Esc cancela edición — revierte y no guarda", async ({ page }) => {
+  await gotoLoaded(page);
+  await page.locator('[data-testid="piece-ancho-R3-value"]').click();
+  await page.locator('[data-testid="piece-ancho-R3-input"]').fill("99");
+  await page.keyboard.press("Escape");
+  await expect(page.locator('[data-testid="piece-ancho-R3-value"]')).toHaveText("62");
+  await expect(page.locator('[data-testid="piece-row-R3"]')).toHaveAttribute(
+    "data-edited",
+    "false",
+  );
+});
+
+test("add pieza — fila nueva con origin AGREGADO_MANUAL", async ({ page }) => {
+  await gotoLoaded(page);
+  await page.locator('[data-testid="despiece-add-row"]').click();
+  await expect(page.locator('[data-testid="piece-row-R6"]')).toBeVisible({ timeout: 3000 });
+  await expect(page.locator('[data-testid="piece-row-R6"]')).toHaveAttribute(
+    "data-origin",
+    "AGREGADO_MANUAL",
+  );
+  await expect(page.locator('[data-testid^="piece-row-"]')).toHaveCount(6);
+});
+
+test("delete pieza — kebab → confirmación → pieza eliminada", async ({ page }) => {
+  await gotoLoaded(page);
+  await page.locator('[data-testid="piece-menu-R5"]').click();
+  await page.locator('[data-testid="piece-delete-R5"]').click();
+  await page.locator('[data-testid="piece-delete-confirm-R5"]').click();
+  await expect(page.locator('[data-testid="piece-row-R5"]')).toHaveCount(0, { timeout: 3000 });
+  await expect(page.locator('[data-testid^="piece-row-"]')).toHaveCount(4);
+});
+
+test("chat scoped paso — abrir, enviar, streaming", async ({ page }) => {
+  await gotoLoaded(page);
+  await expect(page.locator('[data-testid="chat-panel"]')).not.toBeVisible();
+  await page.locator('[data-testid="despiece-open-chat"]').click();
+  await expect(page.locator('[data-testid="chat-panel"]')).toBeVisible();
+  await expect(page.locator('[data-testid="chat-panel"]')).toHaveAttribute("data-scope", "step");
+
+  await page.locator('[data-testid="chat-input"]').fill("¿Por qué partiste la mesada en 3?");
+  await page.locator('[data-testid="chat-send"]').click();
+  await expect(page.locator('[data-testid="chat-msg-user"]').first()).toContainText("mesada");
+  await expect(page.locator('[data-testid="chat-panel"]')).toHaveAttribute(
+    "data-panel-state",
+    "open",
+    { timeout: 10000 },
+  );
+  await expect(page.locator('[data-testid="chat-msg-valentina"]').first()).toContainText(
+    /despiece|pieza|medida|corte|plano/i,
+  );
+});
+
+test("chat scoped R2 — enfocado en la bacha", async ({ page }) => {
+  await gotoLoaded(page);
+  await page.locator('[data-testid="piece-menu-R2"]').click();
+  await page.locator('[data-testid="piece-chat-R2"]').click();
+  await expect(page.locator('[data-testid="chat-panel"]')).toBeVisible();
+  await expect(page.locator('[data-testid="chat-panel"]')).toHaveAttribute("data-scope", "piece");
+  await expect(page.locator('[data-testid="chat-scope-focus"]')).toContainText("R2");
+
+  await page.locator('[data-testid="chat-input"]').fill("¿La bacha entra en 65cm de ancho?");
+  await page.locator('[data-testid="chat-send"]').click();
+  await expect(page.locator('[data-testid="chat-msg-valentina"]').first()).toContainText(
+    /bacha|undermount|ancho/i,
+    { timeout: 10000 },
+  );
+});
+
+test("persistencia chat — cerrar borra mensajes (Master §10 #1)", async ({ page }) => {
+  await gotoLoaded(page);
+  await page.locator('[data-testid="despiece-open-chat"]').click();
+  await page.locator('[data-testid="chat-input"]').fill("hola Valentina");
+  await page.locator('[data-testid="chat-send"]').click();
+  await expect(page.locator('[data-testid="chat-msg-user"]').first()).toBeVisible();
+  await page.locator('[data-testid="chat-close"]').click();
+  await expect(page.locator('[data-testid="chat-panel"]')).not.toBeVisible();
+  // Reabrir → stream vacío
+  await page.locator('[data-testid="despiece-open-chat"]').click();
+  await expect(page.locator('[data-testid="chat-empty"]')).toBeVisible();
+  await expect(page.locator('[data-testid="chat-msg-user"]')).toHaveCount(0);
+});
+
+test("regenerate — confirmación → regenerating → idle con 5 piezas", async ({ page }) => {
+  await gotoLoaded(page);
+  await page.locator('[data-testid="despiece-regen"]').click();
+  await page.locator('[data-testid="despiece-regen-confirm"]').click();
+  // El estado se setea sincrónico al confirmar (antes del await del mock).
+  await expect(page.locator('[data-testid="despiece-view"]')).toHaveAttribute(
+    "data-state",
+    "regenerating",
+  );
+  await expect(page.locator('[data-testid="despiece-view"]')).toHaveAttribute(
+    "data-state",
+    "idle",
+    {
+      timeout: 6000,
+    },
+  );
+  await expect(page.locator('[data-testid^="piece-row-"]')).toHaveCount(5);
+});
+
+test("empty state — status failed → empty-hero + CTA completar a mano", async ({ page }) => {
+  await page.goto("/quotes/PRES-2099-000/despiece");
+  await expect(page.locator('[data-testid="despiece-empty"]')).toBeVisible({ timeout: 5000 });
+  const manual = page.locator('[data-testid="empty-complete-manual"]');
+  await expect(manual).toBeVisible();
+  await expect(manual).toContainText("Completar a mano");
+  // Click → modo manual con tabla vacía editable
+  await manual.click();
+  await expect(page.locator('[data-testid="despiece-table"]')).toBeVisible();
+  await expect(page.locator('[data-testid="despiece-status-manual"]')).toBeVisible();
+});
+
+test("routing post-confirm — navega a /calculo", async ({ page }) => {
+  await gotoLoaded(page);
+  await page.locator('[data-testid="confirm-despiece"]').click();
+  await page.waitForURL("**/quotes/PRES-2026-018/calculo");
+  await expect(page.locator(".stepper")).toHaveAttribute("data-current-step", "calculo");
+});
+
+test("datasources por quoteId — PRES-017 muestra piezas de Pereyra, no de 018", async ({
+  page,
+}) => {
+  await gotoLoaded(page, URL_017);
+  // Pereyra = 3 piezas con dims distintas (R1 300cm), NO las de 018 (R1 285cm).
+  await expect(page.locator('[data-testid^="piece-row-"]')).toHaveCount(3);
+  await expect(page.locator('[data-testid="piece-largo-R1-value"]')).toHaveText("300");
+  await expect(page.locator('[data-testid="piece-largo-R1-value"]')).not.toHaveText("285");
+});


### PR DESCRIPTION
## Resumen

Implementa el **paso 3 (Despiece)** del flujo, mocks-first (sin backend real — eso es `sprint-3/api-integration`). Marina ve las piezas que Valentina extrajo del plano, las edita inline (Tab/Enter/Esc), ve el timeline de las 4 pasadas IA, y abre un chat scoped sobre el paso completo o sobre una pieza puntual (R2 = bacha).

Mockups cubiertos: `04-despiece-A-ia-propuso`, `04-despiece-A-completar-a-mano`, `05-despiece-B-marina-edito`, `06-despiece-C-chat-abierto`, `16-empty-despiece-lateral`.

15 archivos · +2025 / −22.

## Componentes creados (LOC)

| Componente | LOC | Rol |
|---|---|---|
| `DespieceView.tsx` | 417 | container · coordina loading/empty/A/B/C/manual + grid del chat |
| `PieceRow.tsx` | 190 | fila de pieza · highlight por celda + kebab (chat/eliminar) |
| `DespieceChatPanel.tsx` | 183 | chat scoped 480px · modo paso vs pieza |
| `PieceCell.tsx` | 101 | celda numérica editable Tab/Enter/Esc |
| `DespieceEmptyState.tsx` | 75 | empty-hero (mockup 16) + CTA "Completar a mano" |
| `DespieceTable.tsx` | 68 | `.etable.cols-despiece` + add-row |
| `DespieceTimeline.tsx` | 55 | `.pasadas-timeline` 4 pasadas |
| `PieceChatButton.tsx` | 32 | abre chat enfocado en una pieza |
| `useDespiece.ts` | 159 | hook load/edit/add/delete/regenerate + dirty tracking |
| `despiece.spec.ts` | 208 | 14 tests E2E |

Extendidos (sin romper lo existente): `api.ts` (+299), `canonicalQuote.ts` (+190), `types.ts` (+22), `useChatScoped.ts` (+15), `page.tsx`.

## Decisiones técnicas

- **Split DespieceTable / PieceRow / PieceCell**: la tabla mapea piezas → filas; la fila arma las celdas y deriva m² (read-only) de las dimensiones actuales; la celda encapsula el edit-mode (mismo patrón validado en `ContextField` del paso 2). Las dimensiones se guardan en **mm** (unidad canónica del tipo `Piece`) y se muestran en **cm** (mm/10), igual que el mockup; `m² = width_mm·depth_mm / 1e6`.
- **useChatScoped extendido**: sólo se agregó un 3er parámetro opcional `targetPieceId` que viaja a `streamChat` vía options. La lógica de stream + persistencia borra-al-cerrar no cambió. `DespieceView` mantiene `focusedPieceId`: null → chat del paso, `"R2"` → chat de la pieza.
- **regenerate**: `regenerateDespiece(quoteId, { mode })`. `all` descarta y re-siembra (con confirmación inline); `keep-edits` preserva piezas editadas/manuales por id (Master §10 #10). El split-button "Re-generar no-editadas" aparece sólo en estado dirty.
- **Mock store**: `listPieces`/`regenerate`/`update`/`add` devuelven **clones** para que el estado del hook nunca comparta refs con `_piecesStore` (si no, el push del mock se duplicaba con el append optimista del hook).

## Discrepancias mockup ↔ contract (gana el mockup · Master §14)

- El contract backend `list_pieces` (`quote_engine/calculator.py`) usa **metros** + `quantity`; el mockup muestra **cm**; el tipo `Piece` del prompt usa `width_mm`/`depth_mm`. Resuelto: store en mm, display en cm.
- El mockup tiene columna `Cant.`, labels descriptivos y símbolos del plano (`.det-sym`) que no estaban en el interface base del prompt. Se extendió `Piece` con `quantity`, `label`, `sublabel`, `detected_symbols` (el backend ya maneja `quantity` y `description`).
- Estado canon = las **5 piezas R1-R5** que terminaron en el mockup 04-A (`6.81 m²`); el sub-estado "R6/R7 calculando" se representa como la fase de carga inicial (skeleton + timeline running).

## Datasources por quoteId (lección Sprint 2.5 fix-up #2 del PR #460)

Confirmado: **ningún lookup hardcodea PRES-018**. `PIECES_BY_QUOTE_ID` indexa por `params.id` con fallback a empty (`status: 'failed'`). Verificado en E2E + visual: `/quotes/PRES-2026-017/despiece` muestra las 3 piezas de Pereyra (R1 largo 300), NO las de PRES-018 (R1 285).

## Confirmación de las 13 reglas estrictas

1. ✅ `operator-shared.css` sin tocar (`diff -q` vs canónico = vacío).
2. ✅ Chrome shell sin tocar (Sidebar/Topbar/Qhead/Stepper).
3. ✅ `[id]/layout.tsx` sin tocar.
4. ✅ `canonicalQuote.ts` sólo extendido (CANONICAL_PIECES_*); lo existente intacto.
5. ✅ `api.ts` sólo extendido; funciones existentes intactas (streamChat sólo suma `targetPieceId` opcional).
6. ✅ `useChatScoped` sólo extendido con `targetPieceId` opcional.
7. ✅ Cero archivos `.py` modificados.
8. ✅ Sprint 2 + 2.5 sin regresión (47/47 E2E verdes, incluye los 33 previos + fonts).
9. ✅ Sin copiar `chrome.js`/`bug-report.js`/`frame-label`.
10. ✅ Sin state management global (useState/useRef).
11. ✅ Sin paquetes nuevos.
12. ✅ Sin hardcodear PRES-018 en componentes (todo por `params.id`).
13. ✅ No se pushea con tests/lint en rojo.

## Verificación local

- `npm run lint` ✅ (0 errores)
- `npm run typecheck` ✅
- `npm run test:unit` ✅
- `npm run test:e2e` ✅ **47/47** (33 previos + 14 nuevos del paso 3 + fonts)
- `npm run build` ✅ (sin warnings de código)
- `diff -q operator-shared.css` ✅ idéntico

## Visual check (local, dev server contra este worktree)

- `/quotes/PRES-2026-018/despiece`: 5 piezas canon, chips `.det-sym` (INGLETE→CORTE45, DESAGUE→AGUJEROAPOYO, 2 TOMAS→TOMAS), timeline done, summary `5 piezas · 6.81 m²`, chat scoped 480px abre OK. Sin errores de consola.
- `/quotes/PRES-2026-017/despiece`: 3 piezas Pereyra, sin contaminación de 018.

⚠️ El **visual check obligatorio vía Claude for Chrome** (regla operativa Sprint 2.5) queda para el review de Javi, sobre las rutas críticas 018 (5 piezas) y 017 (sin contaminación).

## Test plan

- [x] Estado loading (skeleton + timeline running)
- [x] Estado A (5 piezas + timeline done)
- [x] Cifras canon R1-R5
- [x] Edit Tab/Enter + Esc cancela
- [x] Add (origin AGREGADO_MANUAL) + Delete con confirmación
- [x] Chat scoped paso + chat scoped R2 (bacha)
- [x] Persistencia chat borra-al-cerrar
- [x] Regenerate (confirmación → regenerating → idle)
- [x] Empty state (status=failed) + CTA Completar a mano
- [x] Routing → /calculo
- [x] Datasources por quoteId (017 ≠ 018)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Fix-up post-audit (commit 2297db9)

✅ **C9 cerrado**: agregado test E2E de **regenerate keep-edits** (Master §10 #10) — el único nice-to-have de cobertura del audit. El test ejercita: editar R1 (285→250) → "Re-generar no-editadas" → la edición de R1 sobrevive (row-edited) y R3 (no editada) se re-genera desde el canon (sigue origin=IA, sin púrpura).
✅ **48/48 E2E verde** (47 previos + 1 nuevo).
✅ Sin cambios de componentes: usa los `data-testid` existentes (`despiece-regen-keep`, `piece-largo-R1-value/-input`, `piece-row-*`).