### PR TITLE
Sprint 3 · sub-PR · auth · login + client-side gate (Opción 1)

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -107,6 +107,29 @@ Detectado en audit independiente PR #457 NICE-TO-HAVE 5. Inline `style={{...}}` 
 
 **Plan:** ninguno — solo registro para futuras estimaciones de scope.
 
+---
+
+## Decisiones de arquitectura
+
+### sprint-3/auth · auth gate via `NEXT_PUBLIC_REQUIRE_AUTH` (no `NEXT_PUBLIC_API_URL`)
+
+**Fecha:** 2026-05-13.
+
+**Contexto:** el `auth_token` del backend es una cookie httpOnly scoped a `railway.app`. El frontend vive en `vercel.app` (cross-origin, PR #322). Ni el JS del cliente ni el middleware edge de Vercel pueden leer esa cookie → un middleware edge que gatee por `auth_token` produce loop infinito (documentado en `web/src/middleware.ts`).
+
+**Decisión route-protection:** client-side gate (`AuthGuard`) — la sesión se trackea en `localStorage`; el enforcement real lo hace el backend con 401. (Recomendado por PR #322.)
+
+**Decisión sobre el flag de activación:** se usa un flag **dedicado** `NEXT_PUBLIC_REQUIRE_AUTH`, NO `NEXT_PUBLIC_API_URL`. Razón: `NEXT_PUBLIC_API_URL` ya estaba seteada a `http://localhost:8000` (dummy) en `playwright.config.ts:42` desde Sprint 2 — reusarla para gatear auth rompía los 48 E2E previos (todos redirigían a `/login`).
+
+Dos flags ortogonales:
+
+| Var | Controla |
+|-----|----------|
+| `NEXT_PUBLIC_API_URL` | mock vs real backend (gestionado por `sprint-3/api-integration`) |
+| `NEXT_PUBLIC_REQUIRE_AUTH` | auth on/off (este PR) |
+
+Para activar auth en prod: setear `NEXT_PUBLIC_REQUIRE_AUTH=true` en las env vars del proyecto Vercel.
+
 ## Resueltos
 
 _(vacío al inicio)_

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -130,6 +130,38 @@ Dos flags ortogonales:
 
 Para activar auth en prod: setear `NEXT_PUBLIC_REQUIRE_AUTH=true` en las env vars del proyecto Vercel.
 
+### v2 NO compila Tailwind utilities · decisión + deuda
+
+**Detectado:** visual check PR #463, 2026-05-13.
+
+**Estado actual:** el proyecto tiene `web/tailwind.config.ts` pero **NO tiene directivas `@tailwind` en ningún archivo CSS**. Resultado: las utility classes (`flex`, `min-h-screen`, `items-center`, `font-serif`, `italic`, `rounded-md`, `bg-accent`, `text-ink`, `px-3`, etc.) **NO se generan en el CSS bundle — son dead no-ops**.
+
+**Patrón v2 que SÍ funciona** (verificado en `DashboardView`, `ContextView`, `Sidebar`):
+
+1. Clases legacy de `operator-shared.css` (`.btn primary`, `.input`, `.eyebrow`, `.nav-i`, `.kpi-card`, `.etable`, etc.)
+2. Inline `style={{}}` para layout (`display: flex`, `minHeight`, etc.)
+3. CSS vars del design system (`var(--bg)`, `var(--ink)`, `var(--accent)`, `var(--serif)`, `var(--mono)`, `var(--r-md)`, etc.)
+
+**Componentes que YA usan utility classes muertas** (deuda latente — no rompen hoy por respaldo inline o herencia de operator-shared.css):
+
+- `DashboardView` (algunas classes Tailwind ignoradas)
+- Root layout `<body className="bg-bg text-ink">` (no aplica — el bg real lo da operator-shared.css)
+- (otros TBD si se hace pasada de cleanup)
+
+**Opciones para Sprint 5:**
+
+- **A) Pasada de cleanup:** eliminar todas las utility classes muertas del v2, estandarizar inline styles + clases legacy.
+- **B) Agregar directivas `@tailwind` al pipeline:** activaría TODAS las utilities de golpe → requiere QA visual completo (clases hoy no-ops empezarían a aplicar, potencialmente rompiendo el diseño actual).
+- **C) Híbrido:** configurar Tailwind con cherry-pick de utilities específicas vía `corePlugins`.
+
+**Decisión pendiente:** Sprint 5 cleanup, o cuando se haga refactor del design system.
+
+**REGLA OPERATIVA para PRs en curso (Sprint 3+):**
+
+- ❌ NO usar Tailwind utility classes en componentes nuevos del v2.
+- ✅ USAR clases legacy de `operator-shared.css` + inline `style={{}}` con CSS vars.
+- ✅ Visual check vía Claude for Chrome **OBLIGATORIO** para todo PR con UI nueva (el audit de código + tests E2E NO detectan layout roto por utilities muertas).
+
 ## Resueltos
 
 _(vacío al inicio)_

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -162,6 +162,24 @@ Para activar auth en prod: setear `NEXT_PUBLIC_REQUIRE_AUTH=true` en las env var
 - ✅ USAR clases legacy de `operator-shared.css` + inline `style={{}}` con CSS vars.
 - ✅ Visual check vía Claude for Chrome **OBLIGATORIO** para todo PR con UI nueva (el audit de código + tests E2E NO detectan layout roto por utilities muertas).
 
+### sprint-3/auth (PR #463) · MINOR · `body { min-width: 1440px }` global descentra páginas standalone
+
+**Detectado:** screenshot verificado por Claude Code durante el refactor visual del PR #463, 2026-05-13.
+
+**Descripción:** `operator-shared.css` tiene `body { min-width: 1440px }` global. En viewports <1440 cualquier página standalone se renderiza **descentrada** — el body es 1440px wide aunque el viewport sea menor, el contenido se centra dentro del body y aparece off-center respecto al viewport real.
+
+**Impacto:** `/login` standalone lo sufría antes del fix. Otras páginas standalone potencialmente igual. El dashboard y rutas con chrome shell completo no lo notan porque el chrome ≥1440 ya define su layout.
+
+**Fix aplicado en /login (commit 64a8e04):** `.login-root` con `position: fixed; inset: 0` → fija al viewport real, no al body con min-width global. Sin tocar operator-shared.css.
+
+> Nota: este hallazgo **solo lo detecta un visual check / screenshot** — los E2E y el audit de código pasan igual con la card descentrada. Refuerza la regla operativa del ADR de Tailwind (visual check obligatorio para UI nueva).
+
+**Plan Sprint 5:** decidir entre:
+
+1. Eliminar el `min-width` global de operator-shared.css (requiere QA visual del chrome).
+2. Mover el `min-width` a un contenedor específico del chrome shell.
+3. Documentar como "operator es desktop-only intencional, mobile es excepción".
+
 ## Resueltos
 
 _(vacío al inicio)_

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -22,6 +22,7 @@
  */
 import type { Metadata } from "next";
 import { Fraunces, Inter_Tight, JetBrains_Mono } from "next/font/google";
+import { AuthGuard } from "@/components/auth/AuthGuard";
 import "./operator-shared.css";
 import "./globals.css";
 
@@ -58,7 +59,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       lang="es"
       className={`${fraunces.variable} ${interTight.variable} ${jetbrainsMono.variable}`}
     >
-      <body className="bg-bg text-ink">{children}</body>
+      <body className="bg-bg text-ink">
+        <AuthGuard>{children}</AuthGuard>
+      </body>
     </html>
   );
 }

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,15 +1,19 @@
 /**
  * `/login` · Sprint 3 sub-PR auth.
  *
- * Página standalone (sin chrome shell — no hay sidebar/topbar). Form de
- * usuario + contraseña → `POST /api/auth/login`. Usa tokens del design
- * system v2 (ink/accent/surface/line). NO usa operator-shared.css.
+ * Página standalone (sin chrome shell). Estilo via el patrón real del v2:
+ * clases legacy de operator-shared.css (`.btn.primary`, `.input`,
+ * `.eyebrow`) + inline `style={{}}` para layout. NO usa Tailwind utility
+ * classes porque el proyecto NO tiene directivas `@tailwind` → esas
+ * utilities no se compilan (fix del visual check del PR #463).
  */
 "use client";
 
 import { Suspense, useState, type FormEvent } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { login } from "@/lib/auth";
+
+const inputStyle: React.CSSProperties = { width: "100%", marginTop: 0 };
 
 function LoginForm() {
   const router = useRouter();
@@ -35,27 +39,70 @@ function LoginForm() {
     }
   }
 
-  const inputCls =
-    "w-full rounded-r-md border border-line bg-surface px-3 py-2 text-ink placeholder:text-ink-mute focus:border-line-strong focus:outline-none disabled:opacity-50";
-
   return (
-    <div className="flex min-h-screen items-center justify-center bg-bg px-4">
-      <div className="w-full max-w-sm">
-        <h1 className="font-serif text-2xl italic text-ink">D&apos;Angelo</h1>
-        <p className="mt-1 font-mono text-xs uppercase tracking-wide text-ink-mute">
+    <div
+      style={{
+        display: "flex",
+        minHeight: "100vh",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "var(--bg)",
+        padding: "0 16px",
+      }}
+    >
+      <div style={{ width: "100%", maxWidth: 360 }}>
+        <h1
+          style={{
+            fontFamily: "var(--serif)",
+            fontStyle: "italic",
+            fontWeight: 500,
+            fontSize: 26,
+            color: "var(--ink)",
+            margin: 0,
+            letterSpacing: "-0.3px",
+          }}
+        >
+          D&apos;Angelo
+        </h1>
+        <div
+          style={{
+            fontFamily: "var(--mono)",
+            fontSize: 11,
+            textTransform: "uppercase",
+            letterSpacing: "0.6px",
+            color: "var(--ink-mute)",
+            marginTop: 6,
+          }}
+        >
           Acceso operador
-        </p>
+        </div>
 
         {reason === "expired" && (
           <div
-            className="mt-4 rounded-r-md border border-line-strong bg-surface px-3 py-2 text-sm text-warn"
             data-testid="login-expired"
+            style={{
+              marginTop: 16,
+              padding: "10px 12px",
+              border: "1px solid var(--line-strong)",
+              borderRadius: "var(--r-md)",
+              background: "var(--surface)",
+              color: "var(--warn)",
+              fontSize: 13,
+            }}
           >
             Tu sesión expiró. Iniciá sesión de nuevo.
           </div>
         )}
 
-        <form onSubmit={handleSubmit} className="mt-6 space-y-3">
+        <form
+          onSubmit={handleSubmit}
+          style={{
+            marginTop: 24,
+            display: "flex",
+            flexDirection: "column",
+            gap: 12,
+          }}
+        >
           <input
             type="text"
             name="username"
@@ -65,7 +112,8 @@ function LoginForm() {
             required
             autoFocus
             disabled={loading}
-            className={inputCls}
+            className="input"
+            style={inputStyle}
           />
           <input
             type="password"
@@ -75,17 +123,19 @@ function LoginForm() {
             onChange={(e) => setPassword(e.target.value)}
             required
             disabled={loading}
-            className={inputCls}
+            className="input"
+            style={inputStyle}
           />
           {error && (
-            <div className="text-sm text-error" data-testid="login-error">
+            <div data-testid="login-error" style={{ color: "var(--error)", fontSize: 13 }}>
               {error}
             </div>
           )}
           <button
             type="submit"
+            className="btn primary"
             disabled={loading || !username || !password}
-            className="w-full rounded-r-md bg-accent px-4 py-2 text-bg disabled:opacity-50"
+            style={{ width: "100%", justifyContent: "center" }}
           >
             {loading ? "Entrando…" : "Entrar"}
           </button>

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,19 +1,22 @@
 /**
- * `/login` · Sprint 3 sub-PR auth.
+ * `/login` · Sprint 3 sub-PR auth · re-diseño visual editorial.
  *
- * Página standalone (sin chrome shell). Estilo via el patrón real del v2:
- * clases legacy de operator-shared.css (`.btn.primary`, `.input`,
- * `.eyebrow`) + inline `style={{}}` para layout. NO usa Tailwind utility
- * classes porque el proyecto NO tiene directivas `@tailwind` → esas
- * utilities no se compilan (fix del visual check del PR #463).
+ * Aesthetic: refined minimalism · dark editorial. "Un cuarto de marmolería
+ * oscuro con una sola pieza iluminada" — card al centro sobre un glow radial
+ * tenue, con una hairline de acento arriba (motivo veta de mármol).
+ *
+ * Styling sin Tailwind utilities (no compilan — ver docs/known-issues.md):
+ * inline `style={{}}` + CSS vars + un `<style>` scoped con clases `.login-*`
+ * para lo que inline no puede (focus, hover, ::placeholder, @keyframes
+ * stagger). NO toca operator-shared.css ni globals.css.
+ *
+ * Lógica del flow (submit, error, redirect, expired, loading) sin cambios.
  */
 "use client";
 
 import { Suspense, useState, type FormEvent } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { login } from "@/lib/auth";
-
-const inputStyle: React.CSSProperties = { width: "100%", marginTop: 0 };
 
 function LoginForm() {
   const router = useRouter();
@@ -40,110 +43,260 @@ function LoginForm() {
   }
 
   return (
-    <div
-      style={{
-        display: "flex",
-        minHeight: "100vh",
-        alignItems: "center",
-        justifyContent: "center",
-        background: "var(--bg)",
-        padding: "0 16px",
-      }}
-    >
-      <div style={{ width: "100%", maxWidth: 360 }}>
-        <h1
-          style={{
-            fontFamily: "var(--serif)",
-            fontStyle: "italic",
-            fontWeight: 500,
-            fontSize: 26,
-            color: "var(--ink)",
-            margin: 0,
-            letterSpacing: "-0.3px",
-          }}
-        >
-          D&apos;Angelo
-        </h1>
-        <div
-          style={{
-            fontFamily: "var(--mono)",
-            fontSize: 11,
-            textTransform: "uppercase",
-            letterSpacing: "0.6px",
-            color: "var(--ink-mute)",
-            marginTop: 6,
-          }}
-        >
-          Acceso operador
-        </div>
+    <main className="login-root">
+      <style>{LOGIN_CSS}</style>
 
-        {reason === "expired" && (
-          <div
-            data-testid="login-expired"
+      {/* Glow radial tenue detrás de la card · "pieza iluminada" */}
+      <div className="login-glow" aria-hidden="true" />
+
+      <section className="login-card" aria-labelledby="login-brand">
+        {/* Hairline de acento · motivo veta */}
+        <div className="login-vein" aria-hidden="true" />
+
+        <header className="login-reveal login-d0">
+          <h1
+            id="login-brand"
             style={{
-              marginTop: 16,
-              padding: "10px 12px",
-              border: "1px solid var(--line-strong)",
-              borderRadius: "var(--r-md)",
-              background: "var(--surface)",
-              color: "var(--warn)",
-              fontSize: 13,
+              fontFamily: "var(--serif)",
+              fontStyle: "italic",
+              fontWeight: 500,
+              fontSize: 38,
+              lineHeight: 1.05,
+              letterSpacing: "-0.5px",
+              color: "var(--ink)",
+              margin: 0,
             }}
           >
+            D&apos;Angelo
+          </h1>
+          <div
+            style={{
+              fontFamily: "var(--mono)",
+              fontSize: 10.5,
+              textTransform: "uppercase",
+              letterSpacing: "2.5px",
+              color: "var(--ink-mute)",
+              marginTop: 10,
+            }}
+          >
+            Acceso operador
+          </div>
+        </header>
+
+        {reason === "expired" && (
+          <div className="login-reveal login-d1 login-banner" role="status" data-testid="login-expired">
             Tu sesión expiró. Iniciá sesión de nuevo.
           </div>
         )}
 
-        <form
-          onSubmit={handleSubmit}
-          style={{
-            marginTop: 24,
-            display: "flex",
-            flexDirection: "column",
-            gap: 12,
-          }}
-        >
-          <input
-            type="text"
-            name="username"
-            placeholder="Usuario"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            required
-            autoFocus
-            disabled={loading}
-            className="input"
-            style={inputStyle}
-          />
-          <input
-            type="password"
-            name="password"
-            placeholder="Contraseña"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            disabled={loading}
-            className="input"
-            style={inputStyle}
-          />
+        <form onSubmit={handleSubmit} style={{ marginTop: 32 }}>
+          <div className="login-reveal login-d1" style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+            <label className="login-field">
+              <span className="login-label">Usuario</span>
+              <input
+                type="text"
+                name="username"
+                placeholder="tu usuario"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                required
+                autoFocus
+                disabled={loading}
+                className="login-input"
+                autoComplete="username"
+              />
+            </label>
+            <label className="login-field">
+              <span className="login-label">Contraseña</span>
+              <input
+                type="password"
+                name="password"
+                placeholder="••••••••"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                disabled={loading}
+                className="login-input"
+                autoComplete="current-password"
+              />
+            </label>
+          </div>
+
           {error && (
-            <div data-testid="login-error" style={{ color: "var(--error)", fontSize: 13 }}>
+            <div className="login-error" role="alert" data-testid="login-error">
               {error}
             </div>
           )}
-          <button
-            type="submit"
-            className="btn primary"
-            disabled={loading || !username || !password}
-            style={{ width: "100%", justifyContent: "center" }}
-          >
-            {loading ? "Entrando…" : "Entrar"}
-          </button>
+
+          <div className="login-reveal login-d2">
+            <button
+              type="submit"
+              className="login-submit"
+              disabled={loading || !username || !password}
+            >
+              {loading ? "Entrando…" : "Entrar"}
+            </button>
+          </div>
         </form>
-      </div>
-    </div>
+      </section>
+
+      <footer className="login-reveal login-d3 login-foot">
+        D&apos;Angelo Operator · sistema interno
+      </footer>
+    </main>
   );
 }
+
+const LOGIN_CSS = `
+.login-root {
+  /* fixed + inset:0 fija el overlay al viewport real e ignora el
+     body { min-width: 1440px } global de operator-shared.css — si no,
+     en viewports < 1440 la card se descentra a la derecha. */
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 16px;
+  background: var(--bg);
+  overflow-y: auto;
+}
+.login-glow {
+  position: absolute;
+  top: 38%;
+  left: 50%;
+  width: 620px;
+  height: 620px;
+  max-width: 140vw;
+  transform: translate(-50%, -50%);
+  background: radial-gradient(circle, rgba(169,193,214,0.10) 0%, rgba(169,193,214,0.03) 38%, transparent 68%);
+  pointer-events: none;
+  z-index: 0;
+}
+.login-card {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 400px;
+  padding: 46px 40px 40px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  box-shadow:
+    inset 0 1px 0 rgba(232,237,229,0.05),
+    0 1px 2px rgba(0,0,0,0.3),
+    0 28px 56px -20px rgba(0,0,0,0.55);
+  overflow: hidden;
+}
+.login-vein {
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent 0%, var(--accent) 50%, transparent 100%);
+  opacity: 0.5;
+}
+.login-banner {
+  margin-top: 22px;
+  padding: 10px 13px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--warn);
+  background: rgba(232,237,229,0.04);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-md);
+}
+.login-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.login-label {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+  color: var(--ink-mute);
+}
+.login-input {
+  width: 100%;
+  padding: 12px 14px;
+  font-family: var(--sans);
+  font-size: 14px;
+  color: var(--ink);
+  background: var(--surface-2);
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  outline: none;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+}
+.login-input::placeholder { color: var(--ink-mute); opacity: 0.6; }
+.login-input:hover:not(:disabled) { border-color: var(--line-strong); }
+.login-input:focus {
+  border-color: var(--accent);
+  background: var(--surface);
+  box-shadow: 0 0 0 3px rgba(169,193,214,0.12);
+}
+.login-input:disabled { opacity: 0.55; cursor: not-allowed; }
+.login-error {
+  margin-top: 14px;
+  font-size: 12.5px;
+  color: var(--error);
+  animation: loginFade 0.22s ease both;
+}
+.login-submit {
+  width: 100%;
+  margin-top: 24px;
+  padding: 12px 24px;
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  color: var(--bg);
+  background: var(--accent);
+  border: none;
+  border-radius: var(--r-md);
+  cursor: pointer;
+  transition: filter 0.18s ease, transform 0.05s ease, opacity 0.18s ease;
+}
+.login-submit:hover:not(:disabled) { filter: brightness(1.08); }
+.login-submit:active:not(:disabled) { transform: translateY(1px); }
+.login-submit:disabled { opacity: 0.45; cursor: not-allowed; }
+.login-foot {
+  position: relative;
+  z-index: 1;
+  margin-top: 22px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.5px;
+  color: var(--ink-mute);
+  opacity: 0.55;
+}
+.login-reveal {
+  opacity: 0;
+  animation: loginReveal 0.5s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+.login-d0 { animation-delay: 0.05s; }
+.login-d1 { animation-delay: 0.14s; }
+.login-d2 { animation-delay: 0.23s; }
+.login-d3 { animation-delay: 0.32s; }
+@keyframes loginReveal {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes loginFade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@media (max-width: 420px) {
+  .login-card { padding: 34px 24px 30px; }
+  #login-brand { font-size: 30px !important; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .login-reveal, .login-error { animation: none; opacity: 1; }
+}
+`;
 
 export default function LoginPage() {
   return (

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,0 +1,104 @@
+/**
+ * `/login` · Sprint 3 sub-PR auth.
+ *
+ * Página standalone (sin chrome shell — no hay sidebar/topbar). Form de
+ * usuario + contraseña → `POST /api/auth/login`. Usa tokens del design
+ * system v2 (ink/accent/surface/line). NO usa operator-shared.css.
+ */
+"use client";
+
+import { Suspense, useState, type FormEvent } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { login } from "@/lib/auth";
+
+function LoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const redirect = searchParams.get("redirect") || "/";
+  const reason = searchParams.get("reason");
+
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      await login({ username, password });
+      router.replace(redirect);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error desconocido");
+      setLoading(false);
+    }
+  }
+
+  const inputCls =
+    "w-full rounded-r-md border border-line bg-surface px-3 py-2 text-ink placeholder:text-ink-mute focus:border-line-strong focus:outline-none disabled:opacity-50";
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-bg px-4">
+      <div className="w-full max-w-sm">
+        <h1 className="font-serif text-2xl italic text-ink">D&apos;Angelo</h1>
+        <p className="mt-1 font-mono text-xs uppercase tracking-wide text-ink-mute">
+          Acceso operador
+        </p>
+
+        {reason === "expired" && (
+          <div
+            className="mt-4 rounded-r-md border border-line-strong bg-surface px-3 py-2 text-sm text-warn"
+            data-testid="login-expired"
+          >
+            Tu sesión expiró. Iniciá sesión de nuevo.
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="mt-6 space-y-3">
+          <input
+            type="text"
+            name="username"
+            placeholder="Usuario"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            required
+            autoFocus
+            disabled={loading}
+            className={inputCls}
+          />
+          <input
+            type="password"
+            name="password"
+            placeholder="Contraseña"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            disabled={loading}
+            className={inputCls}
+          />
+          {error && (
+            <div className="text-sm text-error" data-testid="login-error">
+              {error}
+            </div>
+          )}
+          <button
+            type="submit"
+            disabled={loading || !username || !password}
+            className="w-full rounded-r-md bg-accent px-4 py-2 text-bg disabled:opacity-50"
+          >
+            {loading ? "Entrando…" : "Entrar"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginForm />
+    </Suspense>
+  );
+}

--- a/web/src/components/auth/AuthGuard.tsx
+++ b/web/src/components/auth/AuthGuard.tsx
@@ -21,7 +21,13 @@ const PUBLIC_PATHS = ["/login"];
 export function AuthGuard({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
-  const [checked, setChecked] = useState(false);
+  // Init sincrónico: en modo default (sin NEXT_PUBLIC_REQUIRE_AUTH) arranca
+  // ya en `true` para eliminar el flash "Verificando sesión…" (fix UX del
+  // visual check del PR #463). SSR → false para no asumir estado.
+  const [checked, setChecked] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return process.env.NEXT_PUBLIC_REQUIRE_AUTH !== "true";
+  });
 
   useEffect(() => {
     // Auth off por default. Solo enforcea con NEXT_PUBLIC_REQUIRE_AUTH==='true'.
@@ -47,10 +53,20 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
   if (!checked) {
     return (
       <div
-        className="flex min-h-screen items-center justify-center bg-bg"
         data-testid="auth-checking"
+        style={{
+          display: "flex",
+          minHeight: "100vh",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "var(--bg)",
+        }}
       >
-        <div className="font-mono text-sm text-ink-mute">Verificando sesión…</div>
+        <div
+          style={{ fontFamily: "var(--mono)", fontSize: 13, color: "var(--ink-mute)" }}
+        >
+          Verificando sesión…
+        </div>
       </div>
     );
   }

--- a/web/src/components/auth/AuthGuard.tsx
+++ b/web/src/components/auth/AuthGuard.tsx
@@ -1,0 +1,59 @@
+/**
+ * Guard de auth client-side · Sprint 3 sub-PR auth (Opción 1).
+ *
+ * Reemplaza la protección de rutas via middleware edge (imposible en la
+ * arquitectura cross-origin — ver `web/src/middleware.ts`). Verifica
+ * `getSession()` al mount y redirige a /login si no hay sesión.
+ *
+ * Activación: solo enforcea cuando `NEXT_PUBLIC_REQUIRE_AUTH === 'true'`.
+ * Por default (CI, dev local) es no-op → los 48 E2E previos siguen verdes.
+ * Se usa un flag dedicado y NO `NEXT_PUBLIC_API_URL` porque esa var ya
+ * está seteada a localhost:8000 en playwright.config.ts desde Sprint 2.
+ */
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { getSession } from "@/lib/auth";
+
+const PUBLIC_PATHS = ["/login"];
+
+export function AuthGuard({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [checked, setChecked] = useState(false);
+
+  useEffect(() => {
+    // Auth off por default. Solo enforcea con NEXT_PUBLIC_REQUIRE_AUTH==='true'.
+    // (NEXT_PUBLIC_API_URL NO sirve como gate: ya está seteada a localhost:8000
+    // en playwright.config.ts desde Sprint 2 → rompería los 48 E2E previos.)
+    if (process.env.NEXT_PUBLIC_REQUIRE_AUTH !== "true") {
+      setChecked(true);
+      return;
+    }
+    // Rutas públicas → sin gate.
+    if (PUBLIC_PATHS.includes(pathname)) {
+      setChecked(true);
+      return;
+    }
+    // Verificar sesión local.
+    if (!getSession()) {
+      router.replace(`/login?redirect=${encodeURIComponent(pathname)}`);
+      return;
+    }
+    setChecked(true);
+  }, [pathname, router]);
+
+  if (!checked) {
+    return (
+      <div
+        className="flex min-h-screen items-center justify-center bg-bg"
+        data-testid="auth-checking"
+      >
+        <div className="font-mono text-sm text-ink-mute">Verificando sesión…</div>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/web/src/components/chrome/Sidebar.tsx
+++ b/web/src/components/chrome/Sidebar.tsx
@@ -9,8 +9,22 @@
  * (no hay routing real entre secciones todavía). El item actual
  * (Presupuestos) tiene la clase `.on` para el highlight. Click
  * handlers + Link real vienen en sub-PRs siguientes.
+ *
+ * Sprint 3 auth: agregado botón de logout al pie (Opción 1 · client-side).
  */
+"use client";
+
+import { useRouter } from "next/navigation";
+import { logout } from "@/lib/auth";
+
 export function Sidebar() {
+  const router = useRouter();
+
+  async function handleLogout() {
+    await logout();
+    router.replace("/login");
+  }
+
   return (
     <aside className="sidebar">
       {/* Brand · "D'Angelo Operator" en serif itálica */}
@@ -82,6 +96,24 @@ export function Sidebar() {
         </div>
         <div style={{ fontSize: 12, color: "var(--ink-soft)" }}>Marina · operadora</div>
       </div>
+
+      {/* Logout · Sprint 3 auth */}
+      <button
+        type="button"
+        onClick={handleLogout}
+        data-testid="logout-button"
+        className="nav-i"
+        style={{
+          width: "100%",
+          background: "transparent",
+          border: 0,
+          font: "inherit",
+          textAlign: "left",
+          color: "var(--ink-mute)",
+        }}
+      >
+        <span>Cerrar sesión</span>
+      </button>
     </aside>
   );
 }

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,0 +1,100 @@
+/**
+ * Cliente de auth · Sprint 3 sub-PR auth.
+ *
+ * Opción 1 (client-side gate · recomendada por PR #322): la sesión se
+ * trackea en localStorage. El `auth_token` real es una cookie httpOnly
+ * scoped a railway.app — NO accesible ni por el JS ni por el middleware
+ * edge de Vercel (por eso `middleware.ts` queda no-op).
+ *
+ * El enforcement de seguridad lo hace el backend: cualquier `/api/*` sin
+ * cookie válida devuelve 401. El gate client-side es solo UX (evitar
+ * mostrar el shell a alguien sin sesión).
+ */
+
+const SESSION_KEY = "op_session_v1"; // versionado por si cambia el shape
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+export interface Session {
+  username: string;
+  /** JWT que el backend devuelve en el BODY del login (no la cookie httpOnly). */
+  token: string;
+  loginAt: number;
+}
+
+export interface LoginCredentials {
+  username: string;
+  password: string;
+}
+
+export async function login(credentials: LoginCredentials): Promise<Session> {
+  if (!API_URL) {
+    throw new Error("NEXT_PUBLIC_API_URL no configurada — el modo mock no soporta login real");
+  }
+
+  const response = await fetch(`${API_URL}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    // CRÍTICO: el browser maneja la cookie httpOnly de railway.app cross-origin.
+    credentials: "include",
+    body: JSON.stringify(credentials),
+  });
+
+  if (!response.ok) {
+    if (response.status === 401) throw new Error("Credenciales inválidas");
+    throw new Error(`Error ${response.status}`);
+  }
+
+  const body = (await response.json()) as { ok: boolean; username: string; token: string };
+
+  const session: Session = {
+    username: body.username,
+    token: body.token,
+    loginAt: Date.now(),
+  };
+  localStorage.setItem(SESSION_KEY, JSON.stringify(session));
+  return session;
+}
+
+export async function logout(): Promise<void> {
+  if (API_URL) {
+    try {
+      await fetch(`${API_URL}/api/auth/logout`, {
+        method: "POST",
+        credentials: "include",
+      });
+    } catch {
+      // Best-effort — el logout client-side no depende del backend.
+    }
+  }
+  clearSession();
+}
+
+export function getSession(): Session | null {
+  if (typeof window === "undefined") return null; // SSR-safe
+  try {
+    const raw = localStorage.getItem(SESSION_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as Session;
+  } catch {
+    return null;
+  }
+}
+
+export function clearSession(): void {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(SESSION_KEY);
+}
+
+/**
+ * Helper para `lib/api/real.ts` (sub-PR api-integration): ante un 401
+ * del backend (sesión expirada), limpia la sesión local y manda a /login.
+ */
+export function handleApiError(response: Response): void {
+  if (response.status === 401) {
+    clearSession();
+    if (typeof window !== "undefined") {
+      window.location.href = "/login?reason=expired";
+    }
+  }
+}

--- a/web/tests/e2e/auth.spec.ts
+++ b/web/tests/e2e/auth.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * E2E del sub-PR auth (Opción 1 · client-side gate).
+ *
+ * Default (CI, sin NEXT_PUBLIC_REQUIRE_AUTH): el AuthGuard es no-op →
+ * los flujos siguen accesibles sin login. Estos 2 tests corren siempre.
+ *
+ * Modo auth (NEXT_PUBLIC_REQUIRE_AUTH==='true' + credentials): login real
+ * contra Railway. Skip por default hasta tener credentials de prod
+ * confirmadas (admin/admin da 401 en prod — users viven en DB).
+ */
+import { expect, test } from "@playwright/test";
+
+const REQUIRE_AUTH = process.env.NEXT_PUBLIC_REQUIRE_AUTH === "true";
+
+test("modo mock: no requiere login, acceso directo a /", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator(".kpi-card").first()).toBeVisible();
+});
+
+test("modo mock: /quotes/[id]/contexto sin login carga el canon", async ({ page }) => {
+  await page.goto("/quotes/PRES-2026-018/contexto");
+  await expect(page.locator('[data-testid="context-value-cliente"]')).toContainText(
+    "Cueto-Heredia",
+  );
+});
+
+test.describe("modo real (requiere NEXT_PUBLIC_REQUIRE_AUTH + credentials)", () => {
+  test.skip(!REQUIRE_AUTH, "NEXT_PUBLIC_REQUIRE_AUTH no configurada");
+
+  test("login con credenciales correctas redirect a /", async ({ page }) => {
+    test.skip(
+      !process.env.TEST_USERNAME || !process.env.TEST_PASSWORD,
+      "TEST_USERNAME/TEST_PASSWORD no configuradas",
+    );
+    await page.goto("/login");
+    await page.fill('[name="username"]', process.env.TEST_USERNAME!);
+    await page.fill('[name="password"]', process.env.TEST_PASSWORD!);
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL("/");
+  });
+
+  test("login con credenciales incorrectas muestra error", async ({ page }) => {
+    await page.goto("/login");
+    await page.fill('[name="username"]', "wrong-user-xyz");
+    await page.fill('[name="password"]', "wrong-password-xyz");
+    await page.click('button[type="submit"]');
+    await expect(page.locator('[data-testid="login-error"]')).toContainText(
+      /credenciales inválidas/i,
+    );
+  });
+
+  test("ruta protegida sin sesión redirect a /login", async ({ page, context }) => {
+    await context.clearCookies();
+    await page.goto("/login"); // asegura origin cargado antes de tocar localStorage
+    await page.evaluate(() => localStorage.clear());
+    await page.goto("/quotes/PRES-2026-018/contexto");
+    await expect(page).toHaveURL(/\/login/);
+  });
+});


### PR DESCRIPTION
## Resumen

Agrega login funcional al frontend v2 contra `POST /api/auth/login` del backend (eliminado en Sprint 2.5 con el legacy). Necesario para que `api-integration` (sub-PR siguiente) pueda consumir el backend real, que tiene `auth_middleware` global JWT.

**Route-protection: Opción 1 (client-side gate)** — recomendada por PR #322. El `auth_token` es cookie httpOnly scoped a `railway.app`; el middleware edge de Vercel (vercel.app) no puede leerla → un gate edge produce loop infinito. Por eso `middleware.ts` queda no-op y el gate vive en `AuthGuard` client-side. El enforcement real lo hace el backend con 401.

## FASE 1 · Investigación (hallazgos)

| Tema | Resultado |
|------|-----------|
| **URL Railway** | ✅ `https://ia-agent-quote-marble-operator-production.up.railway.app` (verificada: `/health` → 200, `db:connected`) |
| **Login schema** | `POST /api/auth/login` `{username, password}` → `{ok, username, token}` + `Set-Cookie auth_token` · 401 `{detail}` |
| **Cookie** | `auth_token` (no `access_token`) · httpOnly · SameSite=None (prod) · path=/ · backend acepta también `Authorization: Bearer` (fallback iOS ITP) |
| **`/me`** | ❌ no existe → gate solo por presencia de sesión, no validez (el 401 del backend maneja expiración) |
| **CORS** | ✅ regex acepta previews de Vercel del proyecto/team |
| **Logout** | `POST /api/auth/logout` |

## 🔴 2 hallazgos que ahorraron horas de debugging

1. **Middleware edge roto (PR #322):** `web/src/middleware.ts` documenta que un gate edge por `auth_token` produce loop infinito en arquitectura cross-origin. El plan original (middleware) era exactamente eso → se descartó por Opción 1.
2. **Gate por env var:** `NEXT_PUBLIC_API_URL` ya estaba seteada a `localhost:8000` en `playwright.config.ts:42` desde Sprint 2 → usarla para gatear auth rompía los 48 E2E previos (todos redirigían a `/login`). Se usa flag **dedicado** `NEXT_PUBLIC_REQUIRE_AUTH`.

## Variables de entorno

| Var | Default | Activa |
|-----|---------|--------|
| `NEXT_PUBLIC_API_URL` | (mock data) | Cuando definida, fetches van a esa URL (operativo post-`api-integration`) |
| `NEXT_PUBLIC_REQUIRE_AUTH` | `false` | Cuando `==='true'`, `AuthGuard` redirige a `/login` si no hay sesión en localStorage |

**Para activar auth en prod:** setear `NEXT_PUBLIC_REQUIRE_AUTH=true` en las env vars del proyecto Vercel.

## Archivos

| Archivo | Cambio |
|---------|--------|
| `lib/auth.ts` (nuevo) | login/logout/getSession/clearSession/handleApiError |
| `components/auth/AuthGuard.tsx` (nuevo) | gate client-side, activa con `NEXT_PUBLIC_REQUIRE_AUTH` |
| `app/login/page.tsx` (nuevo) | form standalone (tokens v2, sin chrome) |
| `app/layout.tsx` | envuelve children con `<AuthGuard>` |
| `components/chrome/Sidebar.tsx` | + botón "Cerrar sesión" (client component) |
| `tests/e2e/auth.spec.ts` (nuevo) | 2 mock + 3 reales (skip) |
| `docs/known-issues.md` | ADR de la decisión de gating |
| `middleware.ts` | **NO tocado** (no-op del PR #322) |

## Verificación

| Check | Status |
|-------|--------|
| `npm run lint` | ✅ |
| `npm run typecheck` | ✅ |
| `npm run test:unit` | ✅ 1/1 |
| `npm run test:e2e` | ✅ **50 passed + 3 skipped** (48 previos + 2 mock-auth; 3 reales skip por `NEXT_PUBLIC_REQUIRE_AUTH` no seteada) |
| `npm run build` | ✅ |
| `diff operator-shared.css handoff` | ✅ byte-identical |
| `git diff -- api/` | ✅ vacío (cero backend) |

## Pendiente · credentials de prod para smoke real

`admin/admin` da **401 en prod** (users viven en la tabla `users` de la DB, no en env vars). Para el smoke real / los 3 tests skipeados se necesita un user real en la DB de prod:
- **Opción a:** crear user via `POST /api/auth/create-user` (endpoint público) con un `curl`.
- **Opción b:** usar un user existente (si Javi tiene uno).
- **Opción c:** diferir el smoke real al sub-PR `api-integration`.

Registrado como pendiente; no bloquea este PR (los tests reales son skip-by-default).

## Cómo verificar manualmente contra Railway

```bash
cd web
NEXT_PUBLIC_API_URL=https://ia-agent-quote-marble-operator-production.up.railway.app \
NEXT_PUBLIC_REQUIRE_AUTH=true \
npm run dev
# http://localhost:3000 → redirect a /login → login con user real → redirect a /
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Fix-up post-Visual Check (commit 5b8bfee)

Visual check (Claude for Chrome) detectó **bug crítico de layout**: el proyecto **no tiene directivas `@tailwind`** en ningún CSS → las Tailwind utility classes (`flex`, `min-h-screen`, `items-center`, `font-serif`, `rounded-md`, `bg-accent`…) **nunca se compilan** al bundle. El patrón real del v2 es operator-shared.css + inline `style={{}}` (DashboardView tiene 26 inline styles).

- ✅ **FIX CRÍTICO:** `/login` refactor completo a inline `style={{}}` para layout + clases legacy `.input` / `.btn primary`. Fonts via `var(--serif)`/`var(--mono)` inline.
- ✅ **FIX nice-to-have:** `rounded-r-md` eliminado (era dead utility — convertido a `borderRadius: var(--r-md)` inline donde aplica).
- ✅ **FIX nice-to-have (UX):** `AuthGuard.checked` init sincrónico → sin flash "Verificando sesión…" en modo default (sin `NEXT_PUBLIC_REQUIRE_AUTH`).
- ✅ **AuthGuard loading state** también pasado a inline styles.

**50 passed + 3 skipped** E2E sin regresión · build OK · operator-shared.css byte-identical.

> Nota de deuda (fuera de scope): otros componentes v2 (DashboardView, root layout `body className="bg-bg text-ink"`) también usan utility classes dead. Hoy no rompen porque tienen inline styles de respaldo o heredan de operator-shared.css, pero conviene una pasada de cleanup en Sprint 5 o evaluar agregar las directivas `@tailwind` al pipeline. Registrar si se quiere.


---

## ADR registrado (commit a206001)

Deuda + decisión arquitectónica documentada en `docs/known-issues.md` § "v2 NO compila Tailwind utilities": el proyecto no tiene directivas `@tailwind` → todas las utility classes son dead no-ops. Incluye el patrón que funciona (legacy classes + inline styles + CSS vars), componentes con deuda latente, 3 opciones de cleanup para Sprint 5, y la **regla operativa para PRs Sprint 3+** (no usar utility classes · visual check obligatorio para UI nueva). Crítico para `paso-4-calculo`, `observability`, `error-states`.


---

## Fix-up #2 · re-diseño visual del /login (commit 64a8e04)

Visual review dio APPROVE técnico pero rechazo estético ("el form flotaba sin anchor visual"). Re-diseño **refined-minimalism dark editorial**.

- ✅ **Card** sobre `var(--surface)` con padding generoso, border + shadow dark sutil, hairline de acento arriba (motivo veta de mármol) y glow radial tenue de fondo.
- ✅ **Brand** `D'Angelo` en Fraunces italic 38px + eyebrow mono uppercase tracking.
- ✅ **Inputs** con label mono, focus state styled (border accent + ring), hover, `::placeholder` atenuado, transition.
- ✅ **Button** bg accent vivo + hover/active.
- ✅ **Microanimación** stagger reveal CSS-only (brand→form→button→footer) + `prefers-reduced-motion`.
- ✅ **Footer** sutil + mobile-friendly (375px verificado).
- ✅ **Fix de centrado:** `.login-root` usa `position:fixed + inset:0` para ignorar el `body{min-width:1440px}` global de operator-shared.css (descentraba la card en viewports <1440).

100% inline `style` + CSS vars + `<style>` scoped `.login-*` (sin Tailwind utilities, sin tocar operator-shared.css). **50 passed + 3 skipped** E2E sin regresión. Verificado visualmente con screenshots desktop 1280 + mobile 375 (ambos centrados).
