### PR TITLE
Sprint 3 · api-integration · switch mock→real (B3 incremental) + 4 SSE event types

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -54,9 +54,11 @@ jobs:
           cache-dependency-path: web/package-lock.json
       - run: cd web && npm ci
       - run: cd web && npx playwright install --with-deps chromium
+      # Sprint 3 api-integration: SIN NEXT_PUBLIC_API_URL → E2E corren modo
+      # MOCK (determinístico, sin backend). Con la var seteada, el feature
+      # flag de lib/api activaría el client real → fetch a localhost:8000
+      # (inexistente en CI) → dashboard vacío → tests rotos.
       - run: cd web && npm run test:e2e
-        env:
-          NEXT_PUBLIC_API_URL: http://localhost:8000
 
   build:
     runs-on: ubuntu-latest

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -109,6 +109,42 @@ Detectado en audit independiente PR #457 NICE-TO-HAVE 5. Inline `style={{...}}` 
 
 ---
 
+### sprint-3/api-integration (PR #464) · ARCHITECTURE · 6+1 funciones siguen en mock (B3 incremental)
+
+**Detectado:** FASE 1 PR #463 + confirmado en FASE 1 PR #464, 2026-05-14.
+
+**Descripción:** el backend es agent/chat-centric, no REST-CRUD. Solo 3 funciones mapean limpio a endpoints REST y se wirearon contra real: `streamChat` (`POST /api/quotes/{id}/chat`), `listQuotes` (`GET /api/quotes`), `getQuoteMetadata` (`GET /api/quotes/{id}`). Las siguientes **NO tienen endpoint REST equivalente** y quedan en mock con el feature flag activo:
+
+- `getContextForQuote` / `updateContextForQuote` — el contexto vive en `quote_breakdown` + el SSE `context_analysis`, no hay GET/PATCH dedicado.
+- `listPiecesForQuote` / `updatePieceForQuote` / `addPieceForQuote` / `deletePieceForQuote` — piezas embebidas en `quote_breakdown.dual_read_result`, side-effect del agent. (Editables vía `PATCH /api/quotes/{id}` con `pieces[]`, pero sin GET/POST/DELETE dedicados.)
+- `regenerateDespiece` — `POST /api/quotes/{id}/regenerate` existe pero regenera **PDF/Excel**, no piezas.
+- `getDashboardKpis` — no existe (los KPIs dependen de m²/actividad que el listado real no expone).
+- `getValentinaBriefSummary` — no existe.
+
+**Plan Sprint 4/5:** A) refactor frontend a chat-centric (derivar context+pieces del SSE + `quote_breakdown`); B) backend agrega endpoints REST (viola "no tocar backend"); C) híbrido.
+
+---
+
+### sprint-3/api-integration (PR #464) · MAJOR · createDraftQuote queda en mock SIN hide — paso-1 rompe en modo real
+
+**Detectado:** FASE 1 PR #464, 2026-05-14.
+
+**Descripción:** el real `POST /api/quotes` crea un **draft vacío** (`{id}` only, sin brief/archivos) — el procesamiento del brief ES el chat stream (multipart), no la creación. El mock `createDraftQuote({planFile, photos, briefText})` no mapea. Queda en mock. **Consecuencia con flag real activo:** el paso-1 (`/quotes/new` → BriefView) crea quotes mock cuyo `id` (PRES-2026-018) NO existe en el `listQuotes` real → navegar a `/quotes/PRES-2026-018/contexto` mostrará un 404 o quote distinto. Javi aceptó romper parcial (sistema no se usa todavía).
+
+**Plan Sprint 4:** `sprint-4/paso-1-real` — rebuild BriefView para el flow real 2-fases (`POST /quotes` shell + `POST /chat` multipart con `dual_read_result`).
+
+---
+
+### sprint-3/api-integration (PR #464) · MINOR · Schema gaps degradados con em dash
+
+**Detectado:** FASE 1 PR #464, 2026-05-14.
+
+**Descripción:** el listado/detalle real no expone `m2`, `lastActivityDays`, `daysToExpire`. El adapter en `real.ts` los degrada a `"—"` (em dash, no 0) — `toLocaleString` sobre un string devuelve el string, así que la tabla muestra "— m²" sin romper. `clientFull`←`client_name`, `currency/amount`← `total_usd>0 ? USD : ARS`. `getQuoteMetadata` intenta derivar `m2` de `quote_breakdown.dual_read_result.sectores[].m2_total`, fallback "—".
+
+**Plan Sprint 4:** `sprint-4/derive-fields` (mejorar adapters) + `sprint-4/dashboard-kpis` (calcular KPIs client-side derivando del listado real).
+
+---
+
 ## Decisiones de arquitectura
 
 ### sprint-3/auth · auth gate via `NEXT_PUBLIC_REQUIRE_AUTH` (no `NEXT_PUBLIC_API_URL`)

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -147,6 +147,20 @@ Detectado en audit independiente PR #457 NICE-TO-HAVE 5. Inline `style={{...}}` 
 
 ## Decisiones de arquitectura
 
+### sprint-3/api-integration · Auth client-held vs SSR fetch en Server Components
+
+**Detectado:** smoke real CFC 2026-05-14 — `/quotes/{id}/contexto` crasheaba en el 100% de las quotes reales.
+
+**Causa raíz:** tensión entre la auth del PR #463 (Opción 1 · client-side gate: localStorage + cookie httpOnly del browser) y los **async Server Components** que fetchean recursos protegidos (`/quotes/[id]/layout.tsx` hace `await getQuoteMetadata()`). La cookie httpOnly solo existe en el browser; el Server Component corre en Node SSR **sin** cookie jar → el fetch real devuelve 401 → `throw` → "Application error" con digest por-request. (El dashboard `/` NO crasheaba porque `DashboardView` es client component → su fetch corre en el browser con la cookie.)
+
+**Fix aplicado (PR #464 fix-up #1):** `getQuoteMetadata` real con try/catch. En SSR (`typeof window === "undefined"`) devuelve un header placeholder ("—") en vez de throw → el chrome rendea, la navegación funciona, el contenido client-side trae datos reales. Client-side los errores se propagan normalmente.
+
+**Plan Sprint 4 (`sprint-4/ssr-auth`):** traer la metadata real en SSR. Dos opciones:
+- A) Client-ify `/quotes/[id]/layout.tsx` (useEffect → browser tiene cookie). Simple, requiere loading skeleton.
+- B) Route handler proxy server-side que use `next/headers cookies()` para forwardear la cookie a Railway. Preserva SSR, pero acopla la capa real a API server-only.
+
+**Regla operativa (Sprint 3+):** cualquier función de `real.ts` que pueda llamarse desde un Server Component debe tener **fallback gracioso para SSR** (return placeholder, no throw). Verificar en code review. El audit de código y los E2E (mock) NO atrapan esto — solo el smoke real.
+
 ### sprint-3/auth · auth gate via `NEXT_PUBLIC_REQUIRE_AUTH` (no `NEXT_PUBLIC_API_URL`)
 
 **Fecha:** 2026-05-13.

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,1 +1,15 @@
-NEXT_PUBLIC_API_URL=http://localhost:8000
+# ─── Frontend v2 · variables de entorno ───────────────────────────────
+#
+# NEXT_PUBLIC_API_URL · controla mock vs backend real (Sprint 3 api-integration)
+#   - SIN definir (default)  → modo MOCK: el client usa lib/api/mocks.ts.
+#                              Tests E2E + dev local sin backend corren así.
+#   - Definida (Railway URL) → modo REAL: streamChat / listQuotes /
+#                              getQuoteMetadata pegan al backend. El resto
+#                              de las funciones siguen en mock (B3 incremental,
+#                              ver docs/known-issues.md).
+# NEXT_PUBLIC_API_URL=https://ia-agent-quote-marble-operator-production.up.railway.app
+
+# NEXT_PUBLIC_REQUIRE_AUTH · controla el gate de login client-side (Sprint 3 auth)
+#   - SIN definir / != "true" (default) → AuthGuard no-op (acceso sin login).
+#   - "true"                            → redirige a /login si no hay sesión.
+# NEXT_PUBLIC_REQUIRE_AUTH=true

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,54 @@
+# Marble Operator · Frontend v2
+
+Next.js 14 (App Router) · TypeScript. Panel del operador para el agente
+Valentina (presupuestos de marmolería D'Angelo).
+
+## Cómo correr local
+
+### Modo mock (default · sin backend)
+
+```bash
+npm install
+npm run dev          # http://localhost:3000
+```
+
+Sin `NEXT_PUBLIC_API_URL`, el client (`src/lib/api`) sirve **mocks**
+determinísticos (`src/lib/api/mocks.ts`). Es el modo de los tests E2E y de
+desarrollo sin backend.
+
+### Modo real (contra backend Railway)
+
+```bash
+NEXT_PUBLIC_API_URL=https://ia-agent-quote-marble-operator-production.up.railway.app \
+NEXT_PUBLIC_REQUIRE_AUTH=true \
+npm run dev
+```
+
+→ redirige a `/login`. Logueás con un user real de la DB (ej. `marmoleria`).
+En modo real, **3 funciones** pegan al backend (`streamChat`, `listQuotes`,
+`getQuoteMetadata`); el resto sigue en mock (B3 incremental · ver
+`docs/known-issues.md`).
+
+## Variables de entorno
+
+| Var | Default | Efecto |
+|-----|---------|--------|
+| `NEXT_PUBLIC_API_URL` | (mock) | Definida → client real contra esa URL. Sin definir → mocks. |
+| `NEXT_PUBLIC_REQUIRE_AUTH` | `false` | `"true"` → `AuthGuard` exige login (redirige a `/login` sin sesión). |
+
+Las dos son **ortogonales**: una controla mock/real, la otra auth on/off
+(ver `docs/known-issues.md` § "Decisiones de arquitectura").
+
+## Tests
+
+```bash
+npm run lint          # eslint
+npm run typecheck     # tsc --noEmit
+npm run test:unit     # vitest (lógica pura + SSE event types)
+npm run test:e2e      # playwright (modo mock por default)
+npm run build         # next build
+```
+
+Los E2E corren en **modo mock** (el `playwright.config.ts` NO setea
+`NEXT_PUBLIC_API_URL`). Para correrlos contra el backend real, exportá la var
+manualmente antes de `npm run test:e2e`.

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -31,15 +31,14 @@ export default defineConfig({
     },
   ],
   webServer: {
-    // Reutiliza el dev server del legacy (mismo Next.js — el routing v2
-    // convive). En CI no hay backend real, NEXT_PUBLIC_API_URL apunta
-    // a placeholder para que `next.config.mjs` no rompa.
+    // Sprint 3 api-integration: NO seteamos NEXT_PUBLIC_API_URL → modo MOCK
+    // por default. Antes apuntaba a localhost:8000 (dummy del Sprint 2); con
+    // el feature flag de `lib/api/index.ts` eso activaría el client real y
+    // los 50 E2E (determinísticos contra mocks) romperían. Para correr E2E
+    // contra el backend real: exportar NEXT_PUBLIC_API_URL manualmente.
     command: "npm run dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
-    env: {
-      NEXT_PUBLIC_API_URL: "http://localhost:8000",
-    },
   },
 });

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -84,13 +84,20 @@ function LoginForm() {
         </header>
 
         {reason === "expired" && (
-          <div className="login-reveal login-d1 login-banner" role="status" data-testid="login-expired">
+          <div
+            className="login-reveal login-d1 login-banner"
+            role="status"
+            data-testid="login-expired"
+          >
             Tu sesión expiró. Iniciá sesión de nuevo.
           </div>
         )}
 
         <form onSubmit={handleSubmit} style={{ marginTop: 32 }}>
-          <div className="login-reveal login-d1" style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          <div
+            className="login-reveal login-d1"
+            style={{ display: "flex", flexDirection: "column", gap: 14 }}
+          >
             <label className="login-field">
               <span className="login-label">Usuario</span>
               <input

--- a/web/src/components/auth/AuthGuard.tsx
+++ b/web/src/components/auth/AuthGuard.tsx
@@ -62,9 +62,7 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
           background: "var(--bg)",
         }}
       >
-        <div
-          style={{ fontFamily: "var(--mono)", fontSize: 13, color: "var(--ink-mute)" }}
-        >
+        <div style={{ fontFamily: "var(--mono)", fontSize: 13, color: "var(--ink-mute)" }}>
           Verificando sesión…
         </div>
       </div>

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Selector del client v2 · Sprint 3 api-integration · B3 incremental.
+ *
+ * Feature flag `NEXT_PUBLIC_API_URL`: si está definida → las 3 funciones
+ * wireadas usan el backend real; si no → mocks (default CI + dev local).
+ *
+ * B3 incremental: solo streamChat + listQuotes + getQuoteMetadata mapean
+ * limpio a endpoints REST. createDraftQuote + las 6 sin endpoint quedan
+ * SIEMPRE en mock (ver docs/known-issues.md · Sprint 4 las resuelve).
+ *
+ * El resto del frontend importa `from "@/lib/api"` sin enterarse del switch.
+ */
+import * as mocks from "./mocks";
+import * as real from "./real";
+
+const USE_REAL_API =
+  !!process.env.NEXT_PUBLIC_API_URL && process.env.NEXT_PUBLIC_API_URL.length > 0;
+
+/* ─── Wireadas contra real cuando el flag está activo ────────────── */
+export const streamChat = USE_REAL_API ? real.streamChat : mocks.streamChat;
+export const listQuotes = USE_REAL_API ? real.listQuotes : mocks.listQuotes;
+export const getQuoteMetadata = USE_REAL_API ? real.getQuoteMetadata : mocks.getQuoteMetadata;
+
+/* ─── Siempre en mock (B3 incremental · sin endpoint REST equivalente) ── */
+export const createDraftQuote = mocks.createDraftQuote;
+export const getContextForQuote = mocks.getContextForQuote;
+export const updateContextForQuote = mocks.updateContextForQuote;
+export const getDashboardKpis = mocks.getDashboardKpis;
+export const getValentinaBriefSummary = mocks.getValentinaBriefSummary;
+export const listPiecesForQuote = mocks.listPiecesForQuote;
+export const updatePieceForQuote = mocks.updatePieceForQuote;
+export const addPieceForQuote = mocks.addPieceForQuote;
+export const deletePieceForQuote = mocks.deletePieceForQuote;
+export const regenerateDespiece = mocks.regenerateDespiece;
+
+/* ─── Helpers de test (reset de stores in-memory del mock) ───────── */
+export const _resetContextStore = mocks._resetContextStore;
+export const _resetPiecesStore = mocks._resetPiecesStore;
+
+/* ─── Tipos + helpers puros + constantes ─────────────────────────── */
+export * from "./types";

--- a/web/src/lib/api/mocks.ts
+++ b/web/src/lib/api/mocks.ts
@@ -1,53 +1,34 @@
 /**
- * Mock client v2 — Sprint 2 paso 1 brief upload.
+ * Mock client v2 · Sprint 3 api-integration.
  *
- * Mock-first per Master §21.7 decisión 4 + endpoint dedicado del paso 1
- * marcado como "P2 · NO EXISTE" en docs/handoff-context/missing-endpoints.md
- * (`POST /api/quotes/{id}/brief`). Este client simula el response de
- * creación de draft con latencia 2-5s y soporte de AbortController.
- * Retorna las cifras canon Cueto-Heredia (Master §13).
+ * Movido desde `lib/api.ts` (split en módulos). Comportamiento idéntico —
+ * los 50 E2E corren contra estos mocks por default (sin NEXT_PUBLIC_API_URL).
+ * Tipos compartidos viven en `./types`.
  *
- * TODO sprint-3/api-integration: switch al cliente HTTP real cuando
- * el backend implemente el endpoint dedicado, o cuando se decida
- * pasarlo dentro del primer turno del chat (Opción A en
- * missing-endpoints.md).
+ * streamChat extendido (FASE 3.2): emite los 4 event types nuevos
+ * (action / context_analysis / dual_read_result / zone_selector) ante
+ * keywords de trigger, además del streaming de texto.
  */
-import { CANONICAL_QUOTE } from "./mocks/canonicalQuote";
-
-export const V2_API_BASE = "/api";
-
-export interface CreateDraftQuoteInput {
-  planFile: File;
-  photos?: File[];
-  briefText?: string;
-}
-
-export interface CreateDraftQuoteResponse {
-  id: string;
-  status: "draft";
-  createdAt: string;
-}
-
-export class ApiError extends Error {
-  constructor(
-    public code: string,
-    message: string,
-    public status?: number,
-  ) {
-    super(message);
-    this.name = "ApiError";
-  }
-}
-
-/** Validaciones declarativas (defensa en profundidad — la UI también valida). */
-export const VALIDATION = {
-  PLAN_MAX_BYTES: 20 * 1024 * 1024, // 20 MB
-  PLAN_MIME: ["application/pdf"] as const,
-  PHOTO_MAX_BYTES: 5 * 1024 * 1024, // 5 MB
-  PHOTO_MIME: ["image/jpeg", "image/png"] as const,
-  PHOTOS_MAX_COUNT: 5,
-  BRIEF_MAX_CHARS: 2000,
-} as const;
+import { CANONICAL_QUOTE } from "../mocks/canonicalQuote";
+import { DASHBOARD_QUOTES, DASHBOARD_COUNTS, type DashboardQuote } from "../mocks/dashboardDataset";
+import {
+  ApiError,
+  VALIDATION,
+  piecesTotalM2,
+  type ChatScope,
+  type ChatStreamChunk,
+  type ContextData,
+  type ContextField,
+  type ContextResponse,
+  type CreateDraftQuoteInput,
+  type CreateDraftQuoteResponse,
+  type DashboardKpis,
+  type ListQuotesFilters,
+  type Piece,
+  type PieceList,
+  type QuoteHeader,
+  type TimelineStep,
+} from "./types";
 
 function validateInput(input: CreateDraftQuoteInput): void {
   if (!VALIDATION.PLAN_MIME.includes(input.planFile.type as "application/pdf")) {
@@ -74,18 +55,11 @@ function validateInput(input: CreateDraftQuoteInput): void {
   }
 }
 
-/**
- * Crea un draft quote a partir de un PDF + fotos + brief.
- *
- * Mock: simula latencia 2-5s. Si llega `signal.aborted`, rechaza con
- * `AbortError` para que el UI pueda volver al estado B (form cargado).
- */
 export async function createDraftQuote(
   input: CreateDraftQuoteInput,
   options?: { signal?: AbortSignal },
 ): Promise<CreateDraftQuoteResponse> {
   validateInput(input);
-
   const latency = 2000 + Math.random() * 3000;
   await new Promise<void>((resolve, reject) => {
     if (options?.signal?.aborted) {
@@ -98,61 +72,13 @@ export async function createDraftQuote(
       reject(new DOMException("Aborted", "AbortError"));
     });
   });
-
-  return {
-    id: CANONICAL_QUOTE.id,
-    status: "draft",
-    createdAt: new Date().toISOString(),
-  };
+  return { id: CANONICAL_QUOTE.id, status: "draft", createdAt: new Date().toISOString() };
 }
 
-/* ════════════════════════════════════════════════════════════════════════
-   Sprint 2 paso-2-contexto · mock client de contexto + chat scoped
-   ════════════════════════════════════════════════════════════════════════
-   Endpoints `PATCH /api/v1/quotes/{id}/context` y `POST /api/v1/quotes/{id}/chat`
-   marcados como missing/parcial en docs/handoff-context/missing-endpoints.md.
-   El mock cubre la brecha temporal hasta sprint-3/api-integration. */
+/* ─── Contexto ───────────────────────────────────────────────────── */
 
-/** Origen del valor de cada campo del contexto (Master §10 data model). */
-export type ContextOrigin =
-  | "BRIEF" // extraído del brief original (PDF + textarea)
-  | "INFERIDO" // inferido por Valentina al cruzar catálogos / regla
-  | "DEFAULT" // valor por defecto (ej. zócalo 5cm)
-  | "EDITADO" // Marina lo tocó manualmente
-  | "FALTA"; // no extraído ni inferido — requiere input humano
-
-export interface ContextField<T = string | number | boolean | null> {
-  value: T;
-  origin: ContextOrigin;
-  edited?: boolean;
-}
-
-/** Los 11 campos del contexto (Master §6 mockup 01-A).
- *  Sprint 2.5 fix-up: campos string admiten `null` para representar
- *  `origin: 'FALTA'` (quotes sin canon definido en CONTEXT_BY_QUOTE_ID).
- */
-export interface ContextData {
-  cliente: string | null; // arquitecta / razón social
-  contacto: string | null; // teléfono / email
-  localidad: string | null; // obra · ciudad
-  plazo: string | null; // desde confirmación de medidas
-  tipologia: string | null; // cocina, baño, mesa
-  tipo_obra: "particular" | "edificio";
-  material: string | null; // piedra o engineered
-  pileta: string | null; // tipo + origen
-  zocalo: string | null; // contra pared · si/no + alto
-  regrueso: string | null; // borde frontal grueso
-  anafe: boolean; // define MO ANAFE en paso 3
-}
-
-export type ContextResponse = {
-  [K in keyof ContextData]: ContextField<ContextData[K]>;
-};
-
-/** In-memory store para que updates persistan dentro de la sesión del browser. */
 const _contextStore = new Map<string, ContextResponse>();
 
-/** Reset helper (útil para tests / reset entre quotes en dev). */
 export function _resetContextStore() {
   _contextStore.clear();
 }
@@ -171,14 +97,6 @@ async function delay(ms: number, signal?: AbortSignal): Promise<void> {
   });
 }
 
-/**
- * GET context para un quote. Mock indexa por quoteId via CONTEXT_BY_QUOTE_ID
- * (PRES-2026-018 → Cueto-Heredia, PRES-2026-017 → Pereyra) con fallback
- * a CANONICAL_CONTEXT_GENERIC para quotes del dataset sin canon definido.
- *
- * Fix BLOCKER del Visual Check del PR #460 — antes devolvía siempre
- * CANONICAL_CONTEXT (Cueto-Heredia) sin importar el quoteId.
- */
 export async function getContextForQuote(
   quoteId: string,
   options?: { signal?: AbortSignal },
@@ -186,18 +104,14 @@ export async function getContextForQuote(
   await delay(150 + Math.random() * 200, options?.signal);
   const existing = _contextStore.get(quoteId);
   if (existing) return existing;
-  // Lazy import para evitar circular en build (canonicalQuote re-importa types).
-  const { CONTEXT_BY_QUOTE_ID, CANONICAL_CONTEXT_GENERIC } = await import("./mocks/canonicalQuote");
+  const { CONTEXT_BY_QUOTE_ID, CANONICAL_CONTEXT_GENERIC } =
+    await import("../mocks/canonicalQuote");
   const base = CONTEXT_BY_QUOTE_ID[quoteId] ?? CANONICAL_CONTEXT_GENERIC;
   const seeded = JSON.parse(JSON.stringify(base)) as ContextResponse;
   _contextStore.set(quoteId, seeded);
   return seeded;
 }
 
-/**
- * PATCH parcial del contexto. Marca cada campo recibido como
- * `origin: 'EDITADO'` + `edited: true` (regla Master §4 #3).
- */
 export async function updateContextForQuote(
   quoteId: string,
   partial: Partial<ContextData>,
@@ -205,36 +119,19 @@ export async function updateContextForQuote(
 ): Promise<ContextResponse> {
   await delay(120 + Math.random() * 180, options?.signal);
   const current = await getContextForQuote(quoteId);
-  // Cast a Record para permitir asignación dinámica por key — la mapped
-  // type ContextResponse rechaza writes heterogéneos sin narrowing.
   const next = { ...current } as Record<keyof ContextData, ContextField>;
   for (const k of Object.keys(partial) as (keyof ContextData)[]) {
     const value = partial[k];
     if (value === undefined) continue;
-    next[k] = {
-      value: value as string | number | boolean | null,
-      origin: "EDITADO",
-      edited: true,
-    };
+    next[k] = { value: value as string | number | boolean | null, origin: "EDITADO", edited: true };
   }
   const result = next as ContextResponse;
   _contextStore.set(quoteId, result);
   return result;
 }
 
-/* ─── Chat scoped streaming (mock SSE via ReadableStream) ─────────── */
+/* ─── Chat scoped (mock SSE via ReadableStream) ──────────────────── */
 
-export type ChatScope = "contexto" | "despiece" | "calculo" | "pdf";
-
-export interface ChatStreamChunk {
-  type: "text" | "done" | "error";
-  content?: string;
-  message?: string;
-}
-
-/** Frases canónicas rioplatenses para mock — varían según scope.
- *  `targetPieceId` (opcional) enfoca la respuesta del scope `despiece`
- *  en una pieza puntual (mockup 06 · chat sobre R2 = bacha). */
 function pickResponse(scope: ChatScope, message: string, targetPieceId?: string): string {
   const lower = message.toLowerCase();
   if (scope === "despiece") {
@@ -269,10 +166,49 @@ function pickResponse(scope: ChatScope, message: string, targetPieceId?: string)
   return "Te puedo ayudar con eso. Decime qué campo querés revisar y te explico de dónde lo saqué.";
 }
 
-/**
- * Mock SSE del chat scoped — emite chunks de texto cada 50-100ms para
- * simular streaming token-por-token. Soporta abort via signal.
- */
+/** Card events plausibles según keywords del mensaje (matchean shapes reales). */
+function mockCardEvents(scope: ChatScope, message: string): ChatStreamChunk[] {
+  const lower = message.toLowerCase();
+  const events: ChatStreamChunk[] = [];
+  if (lower.includes("plano") || lower.includes("leé") || lower.includes("medidas")) {
+    events.push({ type: "action", content: "📐 Leyendo medidas del plano…" });
+    events.push({
+      type: "dual_read_result",
+      content: JSON.stringify({
+        sectores: [
+          { id: "S1", tipo: "cocina", tramos: [], m2_total: { valor: 6.5, status: "ok" } },
+        ],
+        requires_human_review: false,
+        source: "DUAL",
+        view_type: "planta",
+      }),
+    });
+  }
+  if (scope === "contexto" && (lower.includes("contexto") || lower.includes("analiz"))) {
+    events.push({
+      type: "context_analysis",
+      content: JSON.stringify({
+        data_known: ["cliente", "material"],
+        assumptions: ["pileta empotrada"],
+        tech_detections: [{ field: "anafe" }],
+        pending_questions: [],
+        sector_summary: "cocina U + isla",
+      }),
+    });
+  }
+  if (lower.includes("zona") || lower.includes("dónde") || lower.includes("donde")) {
+    events.push({
+      type: "zone_selector",
+      content: JSON.stringify({
+        image_url: "/files/mock/page_1.jpg",
+        page_num: 1,
+        instruction: "Dibujá un rectángulo sobre la zona a revisar.",
+      }),
+    });
+  }
+  return events;
+}
+
 export function streamChat(
   _quoteId: string,
   message: string,
@@ -280,11 +216,17 @@ export function streamChat(
   options?: { signal?: AbortSignal; targetPieceId?: string },
 ): ReadableStream<ChatStreamChunk> {
   const text = pickResponse(scope, message, options?.targetPieceId);
-  const tokens = text.split(/(\s+)/); // split conservando whitespace
+  const tokens = text.split(/(\s+)/);
+  const cards = mockCardEvents(scope, message);
 
   return new ReadableStream<ChatStreamChunk>({
     async start(controller) {
       try {
+        // Card events de tool-use ANTES del texto (igual que el backend real).
+        for (const card of cards) {
+          await delay(60 + Math.random() * 60, options?.signal);
+          controller.enqueue(card);
+        }
         for (const token of tokens) {
           await delay(50 + Math.random() * 50, options?.signal);
           controller.enqueue({ type: "text", content: token });
@@ -303,24 +245,7 @@ export function streamChat(
   });
 }
 
-/* ════════════════════════════════════════════════════════════════════════
-   Sprint 2.5 switch-to-main · mock dashboard
-   ════════════════════════════════════════════════════════════════════════
-   Endpoint `GET /api/v1/quotes` para listado del dashboard. Marcado como
-   missing en docs/handoff-context/missing-endpoints.md (P1 listing). El mock
-   sirve `DASHBOARD_QUOTES` con filtros por status + search. */
-
-import type { DashboardQuote, DashboardStatus, DashboardCounts } from "./mocks/dashboardDataset";
-import { DASHBOARD_QUOTES, DASHBOARD_COUNTS } from "./mocks/dashboardDataset";
-
-export interface ListQuotesFilters {
-  /** Si vacío o ausente, devuelve todos. */
-  statuses?: ReadonlyArray<DashboardStatus>;
-  /** Subcadena buscada en `client` (case-insensitive). */
-  search?: string;
-  /** Pre-filter aplicado por KPI cards del desktop. */
-  kpi?: "expire-soon" | "no-response";
-}
+/* ─── Dashboard ──────────────────────────────────────────────────── */
 
 function matchesFilters(quote: DashboardQuote, filters?: ListQuotesFilters): boolean {
   if (!filters) return true;
@@ -350,13 +275,6 @@ export async function listQuotes(
   return DASHBOARD_QUOTES.filter((q) => matchesFilters(q, filters));
 }
 
-export interface DashboardKpis {
-  expireSoon: number;
-  noResponse: number;
-  pendingAction: number;
-  counts: DashboardCounts;
-}
-
 export async function getDashboardKpis(options?: { signal?: AbortSignal }): Promise<DashboardKpis> {
   await delay(100 + Math.random() * 150, options?.signal);
   const expireSoonQuotes = DASHBOARD_QUOTES.filter(
@@ -377,25 +295,7 @@ export async function getDashboardKpis(options?: { signal?: AbortSignal }): Prom
   };
 }
 
-export type { DashboardQuote, DashboardStatus, DashboardCounts };
-
-/* ════════════════════════════════════════════════════════════════════════
-   Sprint 2.5 fix-up #2 · QuoteHeader metadata por quoteId
-   ════════════════════════════════════════════════════════════════════════
-   El Qhead + Topbar del chrome shell mostraban siempre datos de
-   CANONICAL_QUOTE (PRES-2026-018 · Cueto-Heredia) sin importar el
-   params.id de la URL. Fix arquitectónico: getQuoteMetadata deriva
-   de DASHBOARD_QUOTES (single source of truth del listado) + fallback
-   GENERIC para IDs no presentes en el dataset. */
-
-export interface QuoteHeader {
-  id: string;
-  client: string;
-  clientFull: string;
-  material: string;
-  m2: number;
-  status: "draft" | "sent" | "expired" | "lost";
-}
+/* ─── Quote header ───────────────────────────────────────────────── */
 
 const GENERIC_QUOTE_HEADER: Omit<QuoteHeader, "id"> = {
   client: "Cliente sin identificar",
@@ -424,108 +324,20 @@ export async function getQuoteMetadata(
   return { id: quoteId, ...GENERIC_QUOTE_HEADER };
 }
 
-/** Texto del banner Valentina del paso 2 — por quoteId. */
 export async function getValentinaBriefSummary(
   quoteId: string,
-  options?: { signal?: AbortSignal },
+  _options?: { signal?: AbortSignal },
 ): Promise<string> {
-  await delay(60 + Math.random() * 100, options?.signal);
+  await delay(60 + Math.random() * 100, _options?.signal);
   const { BRIEF_SUMMARY_BY_QUOTE_ID, BRIEF_SUMMARY_GENERIC } =
-    await import("./mocks/canonicalQuote");
+    await import("../mocks/canonicalQuote");
   return BRIEF_SUMMARY_BY_QUOTE_ID[quoteId] ?? BRIEF_SUMMARY_GENERIC;
 }
 
-/* ════════════════════════════════════════════════════════════════════════
-   Sprint 3 paso-3-despiece · mock client de piezas (despiece)
-   ════════════════════════════════════════════════════════════════════════
-   Espeja el tool backend `list_pieces` (api/.../quote_engine/calculator.py),
-   que recibe piezas con `largo`/`prof|alto` en METROS + `quantity` y devuelve
-   labels + m² determinísticos. Como el endpoint dedicado del paso 3 todavía
-   no existe (sprint-3/api-integration hace el switch a HTTP real), este mock
-   cubre la brecha sirviendo las cifras canon del despiece Cueto-Heredia
-   (mockup 04-despiece-A · Master §13).
+/* ─── Piezas / despiece ──────────────────────────────────────────── */
 
-   Discrepancias mockup ↔ contract documentadas (gana el mockup · Master §14):
-   - El mockup muestra cm ("Largo (cm)" 285); el contract usa metros (largo
-     2.85). El tipo `Piece` usa `width_mm`/`depth_mm` (mm) como unidad canónica
-     interna → la UI divide /10 para mostrar cm. m² = width_mm·depth_mm / 1e6.
-   - El mockup tiene columna `Cant.` y labels descriptivos + símbolos del plano
-     (.det-sym) que NO están en el interface base del prompt. Se extienden
-     `Piece` con `quantity`, `label`, `sublabel`, `detected_symbols` (el backend
-     ya maneja `quantity` y `description`). */
-
-/** Símbolo detectado en el plano y su traducción a SKU/operación.
- *  Mockup 04-despiece: INGLETE→CORTE45, DESAGUE→AGUJEROAPOYO, 2 TOMAS→TOMAS. */
-export interface DetectedSymbol {
-  src: string;
-  out: string;
-}
-
-export type PieceType = "encimera" | "frente" | "zocalo" | "alzada" | "isla" | (string & {});
-
-export interface PieceOptions {
-  pileta?: { tipo: "empotrada" | "sobre-mesada" | null; sku?: string };
-  anafe?: boolean;
-  tomas?: number;
-  alzada?: boolean;
-  regrueso_mm?: number;
-}
-
-export interface Piece {
-  id: string; // "R1", "R2", ...
-  type: PieceType;
-  /** Label descriptivo del mockup (ej. "Mesada perimetral · brazo izq"). */
-  label: string;
-  /** Sub-texto bajo el label (ej. "contra pared norte"). */
-  sublabel?: string;
-  width_mm: number; // columna "Largo" del mockup (cm × 10)
-  depth_mm: number; // columna "Ancho" del mockup (cm × 10)
-  quantity: number; // columna "Cant." del mockup
-  options: PieceOptions;
-  /** Símbolos del plano (.det-sym) — sólo presentes en piezas origin=IA. */
-  detected_symbols?: DetectedSymbol[];
-  origin: "IA" | "EDITADO" | "AGREGADO_MANUAL";
-  confidence?: number; // 0..1, sólo si origin=IA
-  extracted_from?: string; // referencia al plano (ej. "plan_p1_z2")
-  edited?: boolean; // true si Marina lo tocó
-}
-
-export interface TimelineStep {
-  step: 1 | 2 | 3 | 4;
-  label: string;
-  state: "pending" | "running" | "done" | "failed";
-  /** Texto de salida de la pasada (.out del mockup). */
-  detail?: string;
-  started_at?: string;
-  completed_at?: string;
-}
-
-export interface PieceList {
-  pieces: Piece[];
-  status: "pending" | "inferring" | "done" | "failed";
-  timeline: TimelineStep[];
-  warnings: string[];
-}
-
-/** m² unitario (half-up a 2 decimales, igual que calculator.py). */
-export function pieceM2Unit(piece: Pick<Piece, "width_mm" | "depth_mm">): number {
-  return Math.round(((piece.width_mm * piece.depth_mm) / 1_000_000) * 100) / 100;
-}
-
-/** m² total = m² unitario × cantidad (half-up a 2 decimales). */
-export function pieceM2Total(piece: Pick<Piece, "width_mm" | "depth_mm" | "quantity">): number {
-  return Math.round(pieceM2Unit(piece) * piece.quantity * 100) / 100;
-}
-
-/** Suma de m² total de un set de piezas. */
-export function piecesTotalM2(pieces: Piece[]): number {
-  return Math.round(pieces.reduce((sum, p) => sum + pieceM2Total(p), 0) * 100) / 100;
-}
-
-/** In-memory store para que edits/add/delete persistan en la sesión del browser. */
 const _piecesStore = new Map<string, PieceList>();
 
-/** Reset helper (tests / reset entre quotes en dev). */
 export function _resetPiecesStore() {
   _piecesStore.clear();
 }
@@ -534,9 +346,6 @@ function deepClonePieces(pieces: Piece[]): Piece[] {
   return JSON.parse(JSON.stringify(pieces)) as Piece[];
 }
 
-/** Clona la lista devuelta para que el caller (hook) NUNCA comparta refs con
- *  `_piecesStore` — si las compartiera, una mutación del store (push/replace)
- *  se duplicaría con el append optimista del hook. */
 function clonePieceList(list: PieceList): PieceList {
   return JSON.parse(JSON.stringify(list)) as PieceList;
 }
@@ -565,7 +374,7 @@ function buildFailedTimeline(): TimelineStep[] {
 }
 
 async function seedPieceList(quoteId: string): Promise<PieceList> {
-  const { PIECES_BY_QUOTE_ID, TIMELINE_BY_QUOTE_ID } = await import("./mocks/canonicalQuote");
+  const { PIECES_BY_QUOTE_ID, TIMELINE_BY_QUOTE_ID } = await import("../mocks/canonicalQuote");
   const canon = PIECES_BY_QUOTE_ID[quoteId];
   if (canon && canon.length > 0) {
     const pieces = deepClonePieces(canon);
@@ -577,7 +386,6 @@ async function seedPieceList(quoteId: string): Promise<PieceList> {
       warnings: [],
     };
   }
-  // Sin canon definido → Valentina no pudo inferir (empty state · mockup 16).
   return {
     pieces: [],
     status: "failed",
@@ -586,14 +394,6 @@ async function seedPieceList(quoteId: string): Promise<PieceList> {
   };
 }
 
-/**
- * GET piezas del despiece para un quote. Indexa por quoteId via
- * PIECES_BY_QUOTE_ID (PRES-2026-018 → Cueto-Heredia 5 piezas, PRES-2026-017 →
- * Pereyra) con fallback a empty (`status: 'failed'`) para quotes sin canon.
- *
- * Lección Sprint 2.5 (fix-up #2 del PR #460): TODO lookup indexa por quoteId.
- * NUNCA devolver siempre las piezas de PRES-018.
- */
 export async function listPiecesForQuote(
   quoteId: string,
   options?: { signal?: AbortSignal },
@@ -614,10 +414,6 @@ async function ensureList(quoteId: string): Promise<PieceList> {
   return seeded;
 }
 
-/**
- * PATCH parcial de una pieza. Marca `edited: true` y, si era propuesta de la
- * IA, `origin: 'EDITADO'` (regla Master §4 #1 — la edición humana no se pisa).
- */
 export async function updatePieceForQuote(
   quoteId: string,
   pieceId: string,
@@ -644,7 +440,6 @@ export async function updatePieceForQuote(
   return { ...updated };
 }
 
-/** Próximo id "R{n}" libre dentro del set. */
 function nextPieceId(pieces: Piece[]): string {
   let max = 0;
   for (const p of pieces) {
@@ -654,7 +449,6 @@ function nextPieceId(pieces: Piece[]): string {
   return `R${max + 1}`;
 }
 
-/** Agrega una pieza manual (origin=AGREGADO_MANUAL, sin confidence/IA). */
 export async function addPieceForQuote(
   quoteId: string,
   piece: Omit<Piece, "id" | "origin" | "confidence" | "extracted_from">,
@@ -673,7 +467,6 @@ export async function addPieceForQuote(
   return { ...created };
 }
 
-/** Elimina una pieza del set. */
 export async function deletePieceForQuote(
   quoteId: string,
   pieceId: string,
@@ -685,12 +478,6 @@ export async function deletePieceForQuote(
   _piecesStore.set(quoteId, list);
 }
 
-/**
- * Re-corre la inferencia de Valentina.
- * - `mode: 'all'` (default) → descarta TODO y re-siembra desde el canon.
- * - `mode: 'keep-edits'` → re-siembra IA pero preserva las piezas editadas /
- *   manuales por id (Master §10 #10 — las ediciones no se pisan al re-generar).
- */
 export async function regenerateDespiece(
   quoteId: string,
   options?: { signal?: AbortSignal; mode?: "all" | "keep-edits" },

--- a/web/src/lib/api/real.ts
+++ b/web/src/lib/api/real.ts
@@ -146,32 +146,69 @@ function deriveM2(detail: RealQuoteDetail): number {
   return "—" as unknown as number;
 }
 
+/** Placeholder con em dash para SSR sin cookie (ver bloque de doc arriba). */
+function ssrFallbackHeader(quoteId: string): QuoteHeader {
+  return {
+    id: quoteId,
+    client: "—",
+    clientFull: "—",
+    material: "—",
+    m2: "—" as unknown as number,
+    status: "draft",
+  };
+}
+
+/**
+ * GET /api/quotes/{id} · resiliente para SSR.
+ *
+ * `/quotes/[id]/layout.tsx` es un async Server Component que hace
+ * `await getQuoteMetadata`. En SSR (Node) el fetch NO lleva la cookie
+ * httpOnly del browser (auth client-held · PR #463 Opción 1) → 401. Si
+ * tiráramos, el Server Component crashea con "Application error" en el
+ * 100% de las quotes reales (bug detectado por smoke CFC).
+ *
+ * Fix: en SSR (`typeof window === "undefined"`) devolvemos un header
+ * placeholder ("—") en vez de throw — el chrome shell rendea, la
+ * navegación funciona, y el contenido client-side (contexto/despiece)
+ * trae sus datos. Client-side los errores SÍ se propagan (el chrome ya
+ * está montado y el browser tiene cookie). Sprint 4 (sprint-4/ssr-auth)
+ * trae la metadata real en SSR. Ver docs/known-issues.md.
+ */
 export async function getQuoteMetadata(
   quoteId: string,
   options?: { signal?: AbortSignal },
 ): Promise<QuoteHeader> {
-  const response = await apiFetch(`/api/quotes/${encodeURIComponent(quoteId)}`, {
-    signal: options?.signal,
-  });
-  if (response.status === 404) {
-    throw new ApiError("QUOTE_NOT_FOUND", `Quote ${quoteId} no encontrado`, 404);
+  try {
+    const response = await apiFetch(`/api/quotes/${encodeURIComponent(quoteId)}`, {
+      signal: options?.signal,
+    });
+    if (response.status === 404) {
+      throw new ApiError("QUOTE_NOT_FOUND", `Quote ${quoteId} no encontrado`, 404);
+    }
+    if (!response.ok) {
+      throw new ApiError(
+        "GET_QUOTE_FAILED",
+        `GET /api/quotes/${quoteId} ${response.status}`,
+        response.status,
+      );
+    }
+    const detail = (await response.json()) as RealQuoteDetail;
+    return {
+      id: detail.id,
+      client: detail.client_name || "Cliente sin identificar",
+      clientFull: detail.client_name || detail.project || "—",
+      material: detail.material || "—",
+      m2: deriveM2(detail),
+      status: adaptStatus(detail.status) as QuoteHeader["status"],
+    };
+  } catch (error) {
+    // SSR sin cookie → degradación graceful (no crashea el Server Component).
+    if (typeof window === "undefined") {
+      return ssrFallbackHeader(quoteId);
+    }
+    // Client-side: error real, propagar (el chrome ya montado lo maneja).
+    throw error;
   }
-  if (!response.ok) {
-    throw new ApiError(
-      "GET_QUOTE_FAILED",
-      `GET /api/quotes/${quoteId} ${response.status}`,
-      response.status,
-    );
-  }
-  const detail = (await response.json()) as RealQuoteDetail;
-  return {
-    id: detail.id,
-    client: detail.client_name || "Cliente sin identificar",
-    clientFull: detail.client_name || detail.project || "—",
-    material: detail.material || "—",
-    m2: deriveM2(detail),
-    status: adaptStatus(detail.status) as QuoteHeader["status"],
-  };
 }
 
 /* ─── streamChat ─────────────────────────────────────────────────────

--- a/web/src/lib/api/real.ts
+++ b/web/src/lib/api/real.ts
@@ -1,0 +1,253 @@
+/**
+ * Client real (HTTP) · Sprint 3 api-integration · B3 incremental.
+ *
+ * Wirea SOLO las 3 funciones que mapean limpio a endpoints REST del backend
+ * Railway: streamChat, listQuotes, getQuoteMetadata. El resto (createDraftQuote
+ * + 6 sin endpoint) se queda en mocks.ts (ver index.ts + docs/known-issues.md).
+ *
+ * Reglas críticas:
+ * - `credentials: "include"` en TODOS los fetch (cookie httpOnly cross-origin
+ *   railway.app ↔ vercel.app no viaja sin esto).
+ * - `handleApiError(response)` ante 401 → clearSession + redirect /login.
+ * - Adapters de shape: el backend devuelve schemas distintos a los mocks; el
+ *   adapter preserva la signature/tipo que el frontend ya consume. Campos que
+ *   el backend no expone se degradan a "—" (em dash), NO a 0/null.
+ */
+import { handleApiError } from "@/lib/auth";
+import {
+  ApiError,
+  type ChatScope,
+  type ChatStreamChunk,
+  type DashboardQuote,
+  type DashboardStatus,
+  type ListQuotesFilters,
+  type QuoteHeader,
+} from "./types";
+
+// Garantizado no-vacío por el gate USE_REAL_API de index.ts.
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** fetch con credentials:include + timeout + 401 handling + merge de signal externo. */
+async function apiFetch(
+  path: string,
+  init: RequestInit & { signal?: AbortSignal } = {},
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<Response> {
+  const ctrl = new AbortController();
+  const timeout = setTimeout(() => ctrl.abort(), timeoutMs);
+  if (init.signal) {
+    if (init.signal.aborted) ctrl.abort();
+    else init.signal.addEventListener("abort", () => ctrl.abort(), { once: true });
+  }
+  try {
+    const response = await fetch(`${API_URL}${path}`, {
+      ...init,
+      credentials: "include",
+      signal: ctrl.signal,
+    });
+    handleApiError(response); // 401 → clearSession + redirect /login?reason=expired
+    return response;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/* ─── listQuotes ─────────────────────────────────────────────────────
+   GET /api/quotes → array plano de QuoteListResponse.
+   Adapter: client_name→client, total_*→amount/currency. Campos que el
+   backend NO expone (m2, lastActivityDays, daysToExpire) → "—". */
+
+interface RealQuoteListItem {
+  id: string;
+  client_name: string;
+  project: string;
+  material: string | null;
+  total_ars: number | null;
+  total_usd: number | null;
+  status: string;
+  created_at: string;
+}
+
+function adaptStatus(s: string): DashboardStatus {
+  return (["draft", "sent", "expired", "lost"].includes(s) ? s : "draft") as DashboardStatus;
+}
+
+/** El backend no expone m2/actividad/vigencia → degradación a em dash. */
+const EM_DASH = "—" as unknown as number; // el componente lo renderiza como string; ver known-issues
+
+function adaptListItem(item: RealQuoteListItem): DashboardQuote {
+  const currency: "ARS" | "USD" = (item.total_usd ?? 0) > 0 ? "USD" : "ARS";
+  const amount = currency === "USD" ? (item.total_usd ?? 0) : (item.total_ars ?? 0);
+  return {
+    id: item.id,
+    client: item.client_name || "Cliente sin identificar",
+    clientFull: item.client_name || item.project || "—",
+    material: item.material || "—",
+    m2: EM_DASH, // backend no expone m² en el listado (Sprint 4: derive-fields)
+    currency,
+    amount,
+    amountSecondary: null,
+    status: adaptStatus(item.status),
+    lastActivityDays: EM_DASH, // backend no expone updated_at en el listado
+    daysToExpire: EM_DASH, // sin policy de vigencia en backend
+    sentDate: null,
+  } as unknown as DashboardQuote;
+}
+
+export async function listQuotes(
+  filters?: ListQuotesFilters,
+  options?: { signal?: AbortSignal },
+): Promise<DashboardQuote[]> {
+  const response = await apiFetch("/api/quotes?limit=200", { signal: options?.signal });
+  if (!response.ok)
+    throw new ApiError("LIST_QUOTES_FAILED", `GET /api/quotes ${response.status}`, response.status);
+  const data = (await response.json()) as RealQuoteListItem[];
+  let quotes = data.map(adaptListItem);
+  // Filtros client-side (el backend solo pagina, no filtra por status/search).
+  if (filters?.statuses && filters.statuses.length > 0) {
+    quotes = quotes.filter((q) => filters.statuses!.includes(q.status));
+  }
+  if (filters?.search) {
+    const needle = filters.search.toLowerCase();
+    quotes = quotes.filter((q) => q.client.toLowerCase().includes(needle));
+  }
+  // kpi pre-filters dependen de m2/actividad que el real no expone → no se aplican
+  // (la tabla muestra todo; los KPI cards quedan en mock · ver known-issues).
+  return quotes;
+}
+
+/* ─── getQuoteMetadata ───────────────────────────────────────────────
+   GET /api/quotes/{id} → QuoteDetailResponse. m² no está como campo: se
+   intenta derivar de quote_breakdown.dual_read_result.sectores[].m2_total. */
+
+interface RealQuoteDetail {
+  id: string;
+  client_name: string;
+  project: string;
+  material: string | null;
+  status: string;
+  quote_breakdown?: {
+    dual_read_result?: {
+      sectores?: Array<{ m2_total?: { valor?: number } }>;
+    };
+  } | null;
+}
+
+function deriveM2(detail: RealQuoteDetail): number {
+  const sectores = detail.quote_breakdown?.dual_read_result?.sectores;
+  if (Array.isArray(sectores) && sectores.length > 0) {
+    const total = sectores.reduce((sum, s) => sum + (s.m2_total?.valor ?? 0), 0);
+    if (total > 0) return Math.round(total * 100) / 100;
+  }
+  // No derivable → "—" degradado. Cast: el tipo es number pero toLocaleString
+  // sobre un string devuelve el string ("— m²"). Ver known-issues + Sprint 4.
+  return "—" as unknown as number;
+}
+
+export async function getQuoteMetadata(
+  quoteId: string,
+  options?: { signal?: AbortSignal },
+): Promise<QuoteHeader> {
+  const response = await apiFetch(`/api/quotes/${encodeURIComponent(quoteId)}`, {
+    signal: options?.signal,
+  });
+  if (response.status === 404) {
+    throw new ApiError("QUOTE_NOT_FOUND", `Quote ${quoteId} no encontrado`, 404);
+  }
+  if (!response.ok) {
+    throw new ApiError(
+      "GET_QUOTE_FAILED",
+      `GET /api/quotes/${quoteId} ${response.status}`,
+      response.status,
+    );
+  }
+  const detail = (await response.json()) as RealQuoteDetail;
+  return {
+    id: detail.id,
+    client: detail.client_name || "Cliente sin identificar",
+    clientFull: detail.client_name || detail.project || "—",
+    material: detail.material || "—",
+    m2: deriveM2(detail),
+    status: adaptStatus(detail.status) as QuoteHeader["status"],
+  };
+}
+
+/* ─── streamChat ─────────────────────────────────────────────────────
+   POST /api/quotes/{id}/chat · multipart/form-data (message + plan_files).
+   Response text/event-stream `data: {json}\n\n` + `: keepalive\n\n` comments.
+   Mantiene la signature del mock (ReadableStream<ChatStreamChunk>) para que
+   useChatScoped y los 50 E2E no cambien. El `scope` no existe en el backend
+   (rutea por contenido del message) → se ignora en el body. */
+
+export function streamChat(
+  quoteId: string,
+  message: string,
+  _scope: ChatScope,
+  options?: { signal?: AbortSignal; targetPieceId?: string; planFiles?: File[] },
+): ReadableStream<ChatStreamChunk> {
+  return new ReadableStream<ChatStreamChunk>({
+    async start(controller) {
+      try {
+        const form = new FormData();
+        form.append("message", message);
+        for (const f of options?.planFiles ?? []) form.append("plan_files", f);
+
+        const response = await apiFetch(
+          `/api/quotes/${encodeURIComponent(quoteId)}/chat`,
+          { method: "POST", body: form, signal: options?.signal },
+          120_000, // SSE long-lived
+        );
+        if (!response.ok || !response.body) {
+          controller.enqueue({
+            type: "error",
+            content: `Chat falló: ${response.status}`,
+          });
+          controller.enqueue({ type: "done", error: true });
+          controller.close();
+          return;
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+
+          // SSE: eventos separados por blank line. Tolera `: keepalive` comments.
+          const blocks = buffer.split("\n\n");
+          buffer = blocks.pop() ?? "";
+          for (const block of blocks) {
+            const dataLine = block.split("\n").find((l) => l.startsWith("data: "));
+            if (!dataLine) continue; // comment / keepalive → skip
+            const json = dataLine.slice(6);
+            try {
+              const chunk = JSON.parse(json) as ChatStreamChunk;
+              controller.enqueue(chunk);
+              if (chunk.type === "done") {
+                controller.close();
+                return;
+              }
+            } catch {
+              console.warn("[streamChat] SSE parse failed:", json.slice(0, 120));
+            }
+          }
+        }
+        controller.enqueue({ type: "done" });
+        controller.close();
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          controller.close();
+          return;
+        }
+        controller.enqueue({ type: "error", content: "Error de conexión con el chat" });
+        controller.enqueue({ type: "done", error: true });
+        controller.close();
+      }
+    },
+  });
+}

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -1,0 +1,205 @@
+/**
+ * Tipos compartidos del client v2 · Sprint 3 api-integration.
+ *
+ * Hogar único de los tipos que consumen mocks.ts + real.ts + el resto del
+ * frontend. Si el backend real devuelve un shape distinto, el adapter vive
+ * en real.ts — estos tipos NO cambian (el frontend no se entera del switch).
+ */
+import type { DashboardQuote, DashboardStatus, DashboardCounts } from "../mocks/dashboardDataset";
+
+export type { DashboardQuote, DashboardStatus, DashboardCounts };
+
+export const V2_API_BASE = "/api";
+
+/* ─── Brief / draft (paso 1) ─────────────────────────────────────── */
+
+export interface CreateDraftQuoteInput {
+  planFile: File;
+  photos?: File[];
+  briefText?: string;
+}
+
+export interface CreateDraftQuoteResponse {
+  id: string;
+  status: "draft";
+  createdAt: string;
+}
+
+export class ApiError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public status?: number,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+/** Validaciones declarativas (defensa en profundidad — la UI también valida). */
+export const VALIDATION = {
+  PLAN_MAX_BYTES: 20 * 1024 * 1024, // 20 MB
+  PLAN_MIME: ["application/pdf"] as const,
+  PHOTO_MAX_BYTES: 5 * 1024 * 1024, // 5 MB
+  PHOTO_MIME: ["image/jpeg", "image/png"] as const,
+  PHOTOS_MAX_COUNT: 5,
+  BRIEF_MAX_CHARS: 2000,
+} as const;
+
+/* ─── Contexto (paso 2) ──────────────────────────────────────────── */
+
+export type ContextOrigin = "BRIEF" | "INFERIDO" | "DEFAULT" | "EDITADO" | "FALTA";
+
+export interface ContextField<T = string | number | boolean | null> {
+  value: T;
+  origin: ContextOrigin;
+  edited?: boolean;
+}
+
+export interface ContextData {
+  cliente: string | null;
+  contacto: string | null;
+  localidad: string | null;
+  plazo: string | null;
+  tipologia: string | null;
+  tipo_obra: "particular" | "edificio";
+  material: string | null;
+  pileta: string | null;
+  zocalo: string | null;
+  regrueso: string | null;
+  anafe: boolean;
+}
+
+export type ContextResponse = {
+  [K in keyof ContextData]: ContextField<ContextData[K]>;
+};
+
+/* ─── Chat scoped (SSE) ──────────────────────────────────────────── */
+
+export type ChatScope = "contexto" | "despiece" | "calculo" | "pdf";
+
+/**
+ * Chunk del stream del chat. El backend real (router.py:2355-2380) emite 7
+ * tipos. `text` se concatena; `action` es status transitorio; los 3 tipos de
+ * card (`context_analysis`, `dual_read_result`, `zone_selector`) traen su
+ * payload como **JSON string dentro de `content`** (doble parse → parseSSEContent).
+ * `done` cierra el stream; `error` reporta.
+ */
+export interface ChatStreamChunk {
+  type:
+    | "text"
+    | "action"
+    | "context_analysis"
+    | "dual_read_result"
+    | "zone_selector"
+    | "done"
+    | "error";
+  content?: string;
+  /** sólo en `error` del mock legacy. */
+  message?: string;
+  /** `done` con `error: true` en el error-path del backend. */
+  error?: boolean;
+}
+
+/** Parsea `content` cuando el event type lo trae como JSON string (card events). */
+export function parseSSEContent<T = unknown>(chunk: ChatStreamChunk): T | string {
+  if (!chunk.content) return "";
+  try {
+    return JSON.parse(chunk.content) as T;
+  } catch {
+    return chunk.content;
+  }
+}
+
+/* ─── Dashboard ──────────────────────────────────────────────────── */
+
+export interface ListQuotesFilters {
+  statuses?: ReadonlyArray<DashboardStatus>;
+  search?: string;
+  kpi?: "expire-soon" | "no-response";
+}
+
+export interface DashboardKpis {
+  expireSoon: number;
+  noResponse: number;
+  pendingAction: number;
+  counts: DashboardCounts;
+}
+
+/* ─── Quote header (chrome shell) ────────────────────────────────── */
+
+export interface QuoteHeader {
+  id: string;
+  client: string;
+  clientFull: string;
+  material: string;
+  /** Número (mock) o "—" degradado en modo real (cast en real.ts cuando el
+   *  backend no expone m². El componente lo renderiza vía toLocaleString que
+   *  en un string devuelve el string tal cual → "— m²"). */
+  m2: number;
+  status: "draft" | "sent" | "expired" | "lost";
+}
+
+/* ─── Piezas / despiece (paso 3) ─────────────────────────────────── */
+
+export interface DetectedSymbol {
+  src: string;
+  out: string;
+}
+
+export type PieceType = "encimera" | "frente" | "zocalo" | "alzada" | "isla" | (string & {});
+
+export interface PieceOptions {
+  pileta?: { tipo: "empotrada" | "sobre-mesada" | null; sku?: string };
+  anafe?: boolean;
+  tomas?: number;
+  alzada?: boolean;
+  regrueso_mm?: number;
+}
+
+export interface Piece {
+  id: string;
+  type: PieceType;
+  label: string;
+  sublabel?: string;
+  width_mm: number;
+  depth_mm: number;
+  quantity: number;
+  options: PieceOptions;
+  detected_symbols?: DetectedSymbol[];
+  origin: "IA" | "EDITADO" | "AGREGADO_MANUAL";
+  confidence?: number;
+  extracted_from?: string;
+  edited?: boolean;
+}
+
+export interface TimelineStep {
+  step: 1 | 2 | 3 | 4;
+  label: string;
+  state: "pending" | "running" | "done" | "failed";
+  detail?: string;
+  started_at?: string;
+  completed_at?: string;
+}
+
+export interface PieceList {
+  pieces: Piece[];
+  status: "pending" | "inferring" | "done" | "failed";
+  timeline: TimelineStep[];
+  warnings: string[];
+}
+
+/** m² unitario (half-up a 2 decimales, igual que calculator.py). */
+export function pieceM2Unit(piece: Pick<Piece, "width_mm" | "depth_mm">): number {
+  return Math.round(((piece.width_mm * piece.depth_mm) / 1_000_000) * 100) / 100;
+}
+
+/** m² total = m² unitario × cantidad (half-up a 2 decimales). */
+export function pieceM2Total(piece: Pick<Piece, "width_mm" | "depth_mm" | "quantity">): number {
+  return Math.round(pieceM2Unit(piece) * piece.quantity * 100) / 100;
+}
+
+/** Suma de m² total de un set de piezas. */
+export function piecesTotalM2(pieces: Piece[]): number {
+  return Math.round(pieces.reduce((sum, p) => sum + pieceM2Total(p), 0) * 100) / 100;
+}

--- a/web/src/lib/hooks/useChatScoped.ts
+++ b/web/src/lib/hooks/useChatScoped.ts
@@ -13,8 +13,16 @@
 "use client";
 
 import { useCallback, useRef, useState } from "react";
-import { streamChat, type ChatScope } from "../api";
+import { streamChat, parseSSEContent, type ChatScope } from "../api";
 import type { ChatMessage, ChatPanelState } from "../types";
+
+/** Card events del backend real (context_analysis / dual_read_result / zone_selector),
+ *  con el `content` ya parseado de su JSON string. Estado preparado para que el
+ *  paso 2/3 lo consuma; la UI de cada card llega en sub-PRs siguientes. */
+export interface ChatCardEvent {
+  type: "context_analysis" | "dual_read_result" | "zone_selector";
+  payload: unknown;
+}
 
 function makeId(): string {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
@@ -32,6 +40,9 @@ function makeId(): string {
 export function useChatScoped(quoteId: string, scope: ChatScope, targetPieceId?: string) {
   const [panelState, setPanelState] = useState<ChatPanelState>("closed");
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  // FASE 3.4: status transitorio (`action`) + último card event parseado.
+  const [lastAction, setLastAction] = useState<string | null>(null);
+  const [lastCard, setLastCard] = useState<ChatCardEvent | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
   const open = useCallback(() => setPanelState("open"), []);
@@ -40,6 +51,8 @@ export function useChatScoped(quoteId: string, scope: ChatScope, targetPieceId?:
     abortRef.current?.abort();
     setPanelState("closed");
     setMessages([]); // borra al cerrar (Master §10 #1)
+    setLastAction(null);
+    setLastCard(null);
   }, []);
 
   const send = useCallback(
@@ -62,6 +75,7 @@ export function useChatScoped(quoteId: string, scope: ChatScope, targetPieceId?:
       };
       setMessages((prev) => [...prev, userMsg, valentinaMsg]);
       setPanelState("streaming");
+      setLastAction(null);
       abortRef.current?.abort();
       const ctrl = new AbortController();
       abortRef.current = ctrl;
@@ -79,6 +93,21 @@ export function useChatScoped(quoteId: string, scope: ChatScope, targetPieceId?:
             setMessages((prev) =>
               prev.map((m) => (m.id === valentinaId ? { ...m, content: m.content + chunk } : m)),
             );
+          } else if (value.type === "action") {
+            // Status transitorio del tool-use ("📐 Leyendo medidas…").
+            setLastAction(value.content ?? null);
+          } else if (
+            value.type === "context_analysis" ||
+            value.type === "dual_read_result" ||
+            value.type === "zone_selector"
+          ) {
+            // Card event: payload viene como JSON string en content → parse.
+            // El state queda listo; el refetch de contexto/piezas y la UI de
+            // zone_selector llegan en sub-PRs (Sprint 4). Por ahora se expone.
+            setLastCard({ type: value.type, payload: parseSSEContent(value) });
+            if (value.type === "zone_selector") {
+              console.warn("[useChatScoped] zone_selector recibido — UI pendiente (Sprint 4)");
+            }
           } else if (value.type === "done") {
             setMessages((prev) =>
               prev.map((m) => (m.id === valentinaId ? { ...m, partial: false } : m)),
@@ -99,5 +128,5 @@ export function useChatScoped(quoteId: string, scope: ChatScope, targetPieceId?:
     [quoteId, scope, targetPieceId],
   );
 
-  return { panelState, messages, open, close, send };
+  return { panelState, messages, lastAction, lastCard, open, close, send };
 }

--- a/web/tests/e2e/api-integration.spec.ts
+++ b/web/tests/e2e/api-integration.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * E2E · Sprint 3 api-integration.
+ *
+ * Modo mock (default · sin NEXT_PUBLIC_API_URL). Verifica que:
+ *  1. El feature flag default sigue sirviendo mocks (dashboard carga canon).
+ *  2. El mock streamChat extendido (con card events action/context_analysis/
+ *     dual_read_result/zone_selector intercalados) NO rompe el streaming de
+ *     texto del chat — Valentina sigue respondiendo end-to-end.
+ *  3. zone_selector dispara el console.warn del hook (único event con efecto
+ *     observable hoy; las cards restantes son state sin UI · Sprint 4).
+ *
+ * La cobertura unitaria de los 4 event types está en tests/unit/sse-events.test.ts.
+ */
+import { expect, test } from "@playwright/test";
+
+test("modo mock default · dashboard carga datos canon (sin NEXT_PUBLIC_API_URL)", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.locator('[data-testid="quote-row-PRES-2026-018"]')).toContainText(
+    "Cueto-Heredia",
+  );
+});
+
+test("chat sigue streameando texto con card events intercalados en el stream", async ({ page }) => {
+  await page.goto("/quotes/PRES-2026-018/contexto");
+  await expect(page.locator('[data-testid="context-form"]')).toBeVisible();
+  await page.locator('[data-testid="open-chat"]').click();
+  // Mensaje que dispara dual_read_result + action en el mock
+  await page.locator('[data-testid="chat-input"]').fill("leé el plano y las medidas");
+  await page.locator('[data-testid="chat-send"]').click();
+  // El texto de Valentina llega igual (las cards no rompen el stream)
+  const valentina = page.locator('[data-testid="chat-msg-valentina"]').first();
+  await expect(valentina).toBeVisible();
+  await expect(page.locator('[data-testid="chat-panel"]')).toHaveAttribute(
+    "data-panel-state",
+    "open",
+    { timeout: 10000 },
+  );
+  await expect(valentina).not.toHaveText("");
+});
+
+test("zone_selector dispara console.warn del hook (efecto observable)", async ({ page }) => {
+  const warnings: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "warning") warnings.push(msg.text());
+  });
+  await page.goto("/quotes/PRES-2026-018/contexto");
+  await expect(page.locator('[data-testid="context-form"]')).toBeVisible();
+  await page.locator('[data-testid="open-chat"]').click();
+  await page.locator('[data-testid="chat-input"]').fill("¿en qué zona está la bacha?");
+  await page.locator('[data-testid="chat-send"]').click();
+  await expect(page.locator('[data-testid="chat-panel"]')).toHaveAttribute(
+    "data-panel-state",
+    "open",
+    { timeout: 10000 },
+  );
+  expect(warnings.some((w) => w.includes("zone_selector"))).toBe(true);
+});

--- a/web/tests/unit/sse-events.test.ts
+++ b/web/tests/unit/sse-events.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests · Sprint 3 api-integration · FASE 3.
+ *
+ * Verifican los 4 event types SSE nuevos (action / context_analysis /
+ * dual_read_result / zone_selector) emitidos por el mock `streamChat` +
+ * el helper `parseSSEContent` (doble parse del JSON-string-en-content que
+ * usa el backend real para los card events).
+ *
+ * Por qué unit y no E2E: estos events actualizan STATE del hook
+ * (lastAction / lastCard) sin UI que los renderee todavía — la UI de las
+ * cards llega en Sprint 4. Un E2E no puede asertar DOM inexistente sin
+ * modificar componentes (prohibido). El unit test cubre la lógica real.
+ */
+import { describe, expect, test } from "vitest";
+import { streamChat, parseSSEContent, type ChatStreamChunk } from "@/lib/api";
+
+async function collect(stream: ReadableStream<ChatStreamChunk>): Promise<ChatStreamChunk[]> {
+  const reader = stream.getReader();
+  const out: ChatStreamChunk[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out.push(value);
+  }
+  return out;
+}
+
+describe("streamChat mock · event types SSE", () => {
+  test("action + dual_read_result al pedir lectura del plano", async () => {
+    const events = await collect(
+      streamChat("PRES-2026-018", "leé el plano y las medidas", "contexto"),
+    );
+    const types = events.map((e) => e.type);
+    expect(types).toContain("action");
+    expect(types).toContain("dual_read_result");
+    // siempre termina con texto + done
+    expect(types).toContain("text");
+    expect(types.at(-1)).toBe("done");
+  });
+
+  test("context_analysis en scope contexto al pedir análisis", async () => {
+    const events = await collect(streamChat("PRES-2026-018", "analizá el contexto", "contexto"));
+    const card = events.find((e) => e.type === "context_analysis");
+    expect(card).toBeDefined();
+    // content es JSON string → parseSSEContent lo expande a objeto
+    const payload = parseSSEContent<{ data_known: string[] }>(card!);
+    expect(typeof payload).toBe("object");
+    expect((payload as { data_known: string[] }).data_known).toContain("cliente");
+  });
+
+  test("zone_selector al preguntar por una zona del plano", async () => {
+    const events = await collect(
+      streamChat("PRES-2026-018", "¿en qué zona está la bacha?", "despiece"),
+    );
+    const card = events.find((e) => e.type === "zone_selector");
+    expect(card).toBeDefined();
+    const payload = parseSSEContent<{ page_num: number; instruction: string }>(card!);
+    expect((payload as { page_num: number }).page_num).toBe(1);
+  });
+
+  test("done siempre cierra el stream (sin card triggers)", async () => {
+    const events = await collect(streamChat("PRES-2026-018", "hola", "contexto"));
+    expect(events.at(-1)?.type).toBe("done");
+    expect(events.some((e) => e.type === "text")).toBe(true);
+  });
+
+  test("parseSSEContent devuelve string crudo si no es JSON", () => {
+    const chunk: ChatStreamChunk = { type: "action", content: "📐 Leyendo medidas…" };
+    expect(parseSSEContent(chunk)).toBe("📐 Leyendo medidas…");
+  });
+});


### PR DESCRIPTION
## Resumen

Conecta el frontend al backend Railway real para las funciones que mapean limpio a endpoints REST, vía split modular con feature flag. Sin UI nueva. **B3 incremental** confirmado en FASE 1: solo 3 funciones se wirean contra real; el resto queda en mock con deuda documentada.

## FASE 1 · mapping endpoints (verificado contra código fuente)

| Función | Endpoint real | Estado |
|---------|---------------|--------|
| `streamChat` | `POST /api/quotes/{id}/chat` (multipart + SSE) | ✅ **real** |
| `listQuotes` | `GET /api/quotes` (array plano) | ✅ **real** (adapter) |
| `getQuoteMetadata` | `GET /api/quotes/{id}` | ✅ **real** (adapter + derive m²) |
| `createDraftQuote` | `POST /api/quotes` devuelve `{id}` vacío, sin brief/archivos | 🟡 **mock** (no mapea — Sprint 4) |
| `getContextForQuote` / `updateContextForQuote` | no existe (vive en `quote_breakdown` + SSE) | 🟡 mock |
| `listPieces` / `update/add/delete Piece` | no existe (en `quote_breakdown.dual_read_result`) | 🟡 mock |
| `regenerateDespiece` | `POST /api/quotes/{id}/regenerate` regenera **docs**, no piezas | 🟡 mock |
| `getDashboardKpis` / `getValentinaBriefSummary` | no existen | 🟡 mock |

### SSE protocol (chat)
`text/event-stream`, formato `data: {json}\n\n` + líneas `: keepalive\n\n` (toleradas). 7 event types. Los 3 card events (`context_analysis`, `dual_read_result`, `zone_selector`) traen su payload como **JSON-string dentro de `content`** → doble parse (`parseSSEContent`).

## FASE 2 · split modular

```
web/src/lib/api/
├── index.ts   ← selector feature flag (NEXT_PUBLIC_API_URL → mocks | real, por función)
├── types.ts   ← tipos compartidos + helpers puros (pieceM2*, parseSSEContent, ApiError, VALIDATION)
├── mocks.ts   ← impl mock (verbatim del lib/api.ts previo + streamChat extendido)
└── real.ts    ← streamChat/listQuotes/getQuoteMetadata reales + adapters
```
`lib/api.ts` viejo eliminado. Resto del frontend importa `from "@/lib/api"` sin cambios.

## FASE 3 · 4 SSE event types nuevos
- `ChatStreamChunk` extendido con `action`/`context_analysis`/`dual_read_result`/`zone_selector`.
- `real.ts streamChat` parsea el SSE real (mantiene la signature `ReadableStream<ChatStreamChunk>` para no tocar `useChatScoped` ni los E2E).
- `mocks.ts streamChat` emite los 4 types ante keywords de trigger.
- `useChatScoped` los maneja: `action`→`lastAction`, cards→`lastCard` (parseado), `zone_selector`→console.warn. State expuesto; UI de cards = Sprint 4.

## FASE 4-5 · tests
- **unit (`sse-events.test.ts`):** 5 tests de los 4 event types + `parseSSEContent`. (Unit y no E2E porque actualizan state sin UI todavía — un E2E no puede asertar DOM inexistente sin tocar componentes.)
- **E2E (`api-integration.spec.ts`):** 3 tests — dashboard mock default + chat sigue streameando con cards intercaladas + `zone_selector` console.warn observable.
- `playwright.config.ts`: quitado `NEXT_PUBLIC_API_URL` del webServer.env → E2E modo mock por default.

## FASE 6 · smoke
- Reachability vs Railway: `GET /health` → **200** (`db: connected`); `GET /api/quotes` sin cookie → **401** (`No autenticado`) = wiring + auth correctos.
- Smoke autenticado end-to-end (login `marmoleria` → quotes reales): **pendiente de Javi en el Vercel preview** (env vars `NEXT_PUBLIC_API_URL` + `NEXT_PUBLIC_REQUIRE_AUTH` ya configuradas en Preview).

## Verificación local

| Check | Status |
|-------|--------|
| `npm run lint` | ✅ |
| `npm run typecheck` | ✅ |
| `npm run test:unit` | ✅ **6** (1 smoke + 5 sse-events) |
| `npm run test:e2e` | ✅ **53 passed + 3 skipped** (50 prev + 3 nuevos; 3 skip = auth real) |
| `npm run build` | ✅ |
| `diff operator-shared.css handoff` | ✅ byte-identical |
| `git diff -- api/` | ✅ vacío (cero backend) |
| `middleware.ts` | ✅ intacto (no-op PR #322) |

## ⚠️ Deuda registrada (docs/known-issues.md) + Plan Sprint 4

- **createDraftQuote en mock SIN hide (MAJOR):** con flag real activo, paso-1 crea quotes mock que `listQuotes` real no tiene → `/quotes/PRES-2026-018/contexto` rompe. Javi aceptó (sistema no se usa). → `sprint-4/paso-1-real` (flow 2-fases real).
- **6 funciones en mock (ARCHITECTURE):** backend chat-centric, no REST-CRUD. → `sprint-4/derive-fields` + chat-centric refactor.
- **Schema gaps con em dash (MINOR):** m2/lastActivityDays/daysToExpire no expuestos → "—". → `sprint-4/dashboard-kpis`.

## Cómo verificar en el Vercel preview
Las env vars `NEXT_PUBLIC_API_URL` + `NEXT_PUBLIC_REQUIRE_AUTH=true` ya están en Preview. Abrí el preview → `/login` → user `marmoleria` → el dashboard carga quotes reales (con m²/actividad en "—"). El chat scoped pega al backend real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Fix-up #1 post-smoke real (commit eb65622)

Smoke real (CFC) detectó `/quotes/{id}/contexto` crasheando en 100% de las quotes reales.

**Causa raíz (distinta del diagnóstico inicial):** NO era mock-ID-mismatch — los mocks de context/pieces/brief-summary ya tenían fallback gracioso. La causa real: `/quotes/[id]/layout.tsx` es un **async Server Component** que hace `await getQuoteMetadata` (wireada real); en SSR el fetch no lleva la cookie httpOnly del browser (auth client-held · PR #463) → 401 → `throw` → Application error. Auditoría confirmó que `getQuoteMetadata` es la **única** función real llamada desde un Server Component.

- ✅ **FIX:** `getQuoteMetadata` real con try/catch → en SSR (`typeof window === "undefined"`) devuelve placeholder "—" en vez de throw. Chrome rendea, navegación OK, contenido client-side trae datos reales.
- ✅ **/quotes/{id}/contexto ya no crashea en modo real.**
- ✅ Tensión arquitectónica auth-client-held vs SSR-fetch + regla operativa documentadas en `known-issues.md`. Plan `sprint-4/ssr-auth`.
- ✅ **53 passed + 3 skipped** E2E sin regresión. `real.ts` único archivo de código tocado.
