### PR TITLE
feat(sprint-3/paso-4-calculo): Cálculo screen mocks-first · 4 estados + 13 componentes + 12 E2E

### DIFF
--- a/docs/handoff-design/design_files/operator-shared.css
+++ b/docs/handoff-design/design_files/operator-shared.css
@@ -71,11 +71,18 @@ a { color: inherit; text-decoration: none; }
   display: grid;
   grid-template-columns: 240px 1fr;
   min-height: 100vh;
-  min-width: 1440px;
-  width: 1440px;
+  /* Sprint 3 paso-4 fix-up #2 · target real refinado: solo desktop hasta 14".
+     Antes: min-width 1440 + width 1440 (rompía notebooks 14" con overflow horizontal).
+     Ahora: min 1200 · max 1440 · width 100% para fluir entre ambos.
+     - ≥1440: cap a 1440 centrada (preserva audit CFC 1920px con margin c/lado).
+     - 1366 y 1200: fluye sin overflow.
+     - <1200: overflow horizontal esperado (target OUT de scope). */
+  min-width: 1200px;
+  max-width: 1440px;
+  width: 100%;
   margin: 0 auto;
 }
-body { min-width: 1440px; }
+body { min-width: 1200px; }
 
 /* ─── Sprint 1.5 · Layout fijo a viewport ───
    El .page se fija a la altura de viewport y NO scrollea como página entera.
@@ -340,7 +347,12 @@ body { min-width: 1440px; }
   border: 1px solid var(--line-strong);
   border-radius: var(--r-md);
   background: var(--surface);
-  overflow: hidden;
+  /* Sprint 3 paso-4 fix-up #2 · scroll horizontal interno cuando el grid
+     de columnas excede el viewport (notebooks 14"). Antes: overflow:hidden
+     (contenido se cortaba). Ahora: overflow-x:auto, overflow-y:hidden
+     (scroll horizontal interno · página entera nunca scrollea horizontal). */
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 .etable .colh {
   display: grid;
@@ -582,16 +594,22 @@ body { min-width: 1440px; }
 
 /* ─── Mini chat panel (right side, 480px) ─── */
 .chat {
+  /* Sprint 3 paso-4 fix-up #2 · drawer overlay (no comprime main content).
+     Antes: sticky dentro de grid `1fr 480px` → estrangulaba el main 1200→720.
+     Ahora: fixed overlay sobre el contenido. Grid del container vuelve a `1fr`
+     siempre. Aplica a calculo Y despiece (ambos comparten esta clase). */
   background: var(--surface);
   border: 1px solid var(--line-strong);
   border-radius: var(--r-md);
   display: flex; flex-direction: column;
   overflow: hidden;
-  align-self: stretch;
-  height: fit-content;
-  position: sticky;
+  position: fixed;
+  right: 24px;
   top: 24px;
-  max-height: calc(100vh - 100px);
+  bottom: 24px;
+  width: 480px;
+  z-index: 100;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
 }
 .chat .head {
   padding: 14px 16px;

--- a/docs/handoff-design/design_files/operator-shared.css
+++ b/docs/handoff-design/design_files/operator-shared.css
@@ -281,12 +281,13 @@ body { min-width: 1200px; }
 
 /* Section body layout */
 .body {
-  /* Sprint 3 paso-4 fix-up #3 · padding-bottom 80→120 (múltiplo de 8).
-     Antes: 80px daba sensación de ConfirmBar pegada al borde inferior
-     (último child sin elemento visible debajo). Aplica a paso-2/3/4 (todos
-     usan ConfirmBar en el mismo patrón). Sticky bar evaluada como decisión
-     arquitectónica futura (Sprint 4 si Marina lo pide en uso real). */
-  padding: 28px 24px 120px;
+  /* Sprint 3 paso-4 fix-up #3/#4 · padding-bottom 80→160 (múltiplo de 8 · 8×20).
+     Iteración #3 a 120 fue insuficiente (Javi confirmó ConfirmBar todavía
+     pegada). Más margin-bottom propio del .confirm-bar (24px) abajo. Combo
+     total: bar tiene 24px propios + body tiene 160px → respiro generoso al
+     fondo de paso-2/3/4 cuando el scroll llega al end. Sticky bar evaluada
+     como decisión arquitectónica futura (Sprint 4 si Marina lo pide). */
+  padding: 28px 24px 160px;
   flex: 1;
   display: grid;
   grid-template-columns: 1fr 480px;
@@ -510,8 +511,12 @@ body { min-width: 1200px; }
 
 /* Confirm bar */
 .confirm-bar {
+  /* Sprint 3 paso-4 fix-up #4 · margin-bottom propio (24px) además del
+     padding-bottom del .body. Garantiza respiro propio del bar al fondo
+     del scroll, independiente del .body padding. */
   display: flex; align-items: center; gap: 14px;
   margin-top: 18px;
+  margin-bottom: 24px;
   padding: 16px 18px;
   background: var(--surface);
   border: 1px solid var(--line-strong);

--- a/docs/handoff-design/design_files/operator-shared.css
+++ b/docs/handoff-design/design_files/operator-shared.css
@@ -66,6 +66,14 @@ html, body {
 
 a { color: inherit; text-decoration: none; }
 
+/* ─── Sprint 3 paso-4 fix-up #5b · scrollbar invisible global ─────────────
+   Universal scope · scroll por wheel/keyboard/trackpad preservado.
+   Cubre html, body, .body chrome y cualquier container con overflow interno.
+   Iteración #5 (solo .body) fue insuficiente: scrollbars seguían apareciendo
+   en otros containers (probablemente html/body raíz o cards internos).  */
+* { scrollbar-width: none; -ms-overflow-style: none; }
+*::-webkit-scrollbar { width: 0; height: 0; display: none; }
+
 /* ─── Page chrome (sidebar + header reusados, NO redesign) ─── */
 .page {
   display: grid;
@@ -291,13 +299,7 @@ body { min-width: 1200px; }
   grid-template-columns: 1fr 480px;
   gap: 24px;
   min-height: 0;
-  /* Sprint 3 paso-4 fix-up #5 · scrollbar oculta cross-browser ·
-     scroll por wheel/keyboard/trackpad preservado. Aplica solo al
-     .body (único container scrolleable del chrome · Sprint 1.5). */
-  scrollbar-width: none;        /* Firefox */
-  -ms-overflow-style: none;     /* IE/Edge legacy */
 }
-.body::-webkit-scrollbar { display: none; }  /* Chrome/Safari/Edge */
 .body.no-chat { grid-template-columns: 1fr; }
 .body .col { min-width: 0; }
 

--- a/docs/handoff-design/design_files/operator-shared.css
+++ b/docs/handoff-design/design_files/operator-shared.css
@@ -71,14 +71,12 @@ a { color: inherit; text-decoration: none; }
   display: grid;
   grid-template-columns: 240px 1fr;
   min-height: 100vh;
-  /* Sprint 3 paso-4 fix-up #2 · target real refinado: solo desktop hasta 14".
-     Antes: min-width 1440 + width 1440 (rompía notebooks 14" con overflow horizontal).
-     Ahora: min 1200 · max 1440 · width 100% para fluir entre ambos.
-     - ≥1440: cap a 1440 centrada (preserva audit CFC 1920px con margin c/lado).
-     - 1366 y 1200: fluye sin overflow.
-     - <1200: overflow horizontal esperado (target OUT de scope). */
+  /* Sprint 3 paso-4 fix-up #2/#5 · target desktop hasta 14" sin cap superior.
+     Iteración #2 puso max-width 1440 (preservaba audit CFC 1920 con margen),
+     pero Javi en uso real pidió full width. Iteración #5: quitamos el cap,
+     la app fluye a 100% del viewport en cualquier ≥1200. Trade-off conocido:
+     en ultra-wide (>1920) la grid se estira más, pero es lo que Javi quiere. */
   min-width: 1200px;
-  max-width: 1440px;
   width: 100%;
   margin: 0 auto;
 }
@@ -293,7 +291,13 @@ body { min-width: 1200px; }
   grid-template-columns: 1fr 480px;
   gap: 24px;
   min-height: 0;
+  /* Sprint 3 paso-4 fix-up #5 · scrollbar oculta cross-browser ·
+     scroll por wheel/keyboard/trackpad preservado. Aplica solo al
+     .body (único container scrolleable del chrome · Sprint 1.5). */
+  scrollbar-width: none;        /* Firefox */
+  -ms-overflow-style: none;     /* IE/Edge legacy */
 }
+.body::-webkit-scrollbar { display: none; }  /* Chrome/Safari/Edge */
 .body.no-chat { grid-template-columns: 1fr; }
 .body .col { min-width: 0; }
 

--- a/docs/handoff-design/design_files/operator-shared.css
+++ b/docs/handoff-design/design_files/operator-shared.css
@@ -281,7 +281,12 @@ body { min-width: 1200px; }
 
 /* Section body layout */
 .body {
-  padding: 28px 24px 80px;
+  /* Sprint 3 paso-4 fix-up #3 · padding-bottom 80→120 (múltiplo de 8).
+     Antes: 80px daba sensación de ConfirmBar pegada al borde inferior
+     (último child sin elemento visible debajo). Aplica a paso-2/3/4 (todos
+     usan ConfirmBar en el mismo patrón). Sticky bar evaluada como decisión
+     arquitectónica futura (Sprint 4 si Marina lo pide en uso real). */
+  padding: 28px 24px 120px;
   flex: 1;
   display: grid;
   grid-template-columns: 1fr 480px;
@@ -719,9 +724,19 @@ body { min-width: 1200px; }
 .chat .composer input::placeholder,
 .chat .composer textarea::placeholder { color: var(--ink-mute); }
 .chat .composer .send {
-  width: 28px; height: 28px; border-radius: 7px;
+  /* Sprint 3 paso-4 fix-up #3 · pill rectangular con padding lateral.
+     Antes: width 28px (icon button) · pero JSX renderea texto "Enviar" → corte.
+     Bug heredado desde Sprint 2, nunca detectado por audits funcionales.
+     Mantiene accent color y border-radius. */
+  min-width: 28px;
+  height: 32px;
+  padding: 0 14px;
+  border-radius: 7px;
   background: var(--accent); color: #0f1318; border: none;
   display: grid; place-items: center; cursor: pointer;
+  font-size: 12.5px;
+  font-weight: 500;
+  letter-spacing: 0.3px;
 }
 .chat .composer .hint {
   font-family: var(--mono); font-size: 10.5px; color: var(--ink-mute);

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -230,6 +230,47 @@ Para activar auth en prod: setear `NEXT_PUBLIC_REQUIRE_AUTH=true` en las env var
 2. Mover el `min-width` a un contenedor específico del chrome shell.
 3. Documentar como "operator es desktop-only intencional, mobile es excepción".
 
+---
+
+## sprint-3/paso-4-calculo (PR #465 fix-up #2) · ARCHITECTURE · Target del producto refinado · 14" notebooks
+
+**Detectado:** Audit visual de designer CFC sobre paso-4 + aclaración Javi 11.05.2026.
+
+**Decisión arquitectónica:**
+
+- Target real del producto: solo desktop, hasta pantallas 14" (MacBook Pro 14" y notebooks Windows 14").
+- Mobile (375-768): OUT del scope.
+- Tablet/iPad: OUT del scope.
+- Viewport mínimo soportado: 1200px.
+- Notebooks 14" Windows con viewport ~1366: tabla puede tener scroll horizontal **interno**, pero la página entera no.
+- Monitores ≥1440: cap a 1440 centrada (preserva comportamiento auditado en 1920 con margen lateral).
+
+**Cambios técnicos (commit fix-up #2):**
+
+- `operator-shared.css §.page`: `min-width: 1200px; max-width: 1440px; width: 100%` (antes: `min-width: 1440; width: 1440`).
+- `operator-shared.css §body`: `min-width: 1200px` (antes 1440).
+- `operator-shared.css §.chat`: `position: fixed; right: 24px; top: 24px; bottom: 24px; width: 480px; z-index: 100` (antes: `position: sticky` dentro de grid 2-columnas). Drawer ahora es overlay puro, NO comprime el main content. Aplica a calculo Y despiece (CSS compartido).
+- `operator-shared.css §.etable`: `overflow-x: auto; overflow-y: hidden` (antes: `overflow: hidden`). Scroll horizontal interno cuando el grid de columnas excede viewport, sin scrollear la página entera.
+- `CalculoView.tsx` y `DespieceView.tsx`: `gridTemplateColumns: "1fr"` siempre (antes: `chatOpen ? "1fr 480px" : "1fr"`). El chat ya no ocupa columna en el grid.
+- `docs/handoff-design/design_files/operator-shared.css`: sync byte-identical con frontend.
+
+**Evolución de regla operativa:**
+
+- **ANTES:** `operator-shared.css` byte-identical vs handoff = regla absoluta inmutable.
+- **AHORA:** `operator-shared.css` se modifica con decisión arquitectónica documentada (handoff queda como referencia histórica del Sprint 1; ambos se mantienen byte-identical entre sí, pero pueden evolucionar juntos).
+
+**Lección operativa nueva — bugs de CSS compartido:**
+
+El bug del chat drawer existía en paso-3-despiece desde el Sprint 3 día anterior pero nadie lo había detectado (audit CFC focalizó solo paso-4). Lección: bugs de CSS compartido se atrapan en CSS compartido, no en wrappers por componente. Fix correlativo (1 cambio en CSS + N containers) es más limpio que N fixes scoped por componente. Este es el 11° hallazgo del Sprint 3 atrapado por gates específicos — patrón FASE 1 antes de implementar paga dividendos incluso en fix-ups de fix-ups.
+
+**Razón:**
+
+El handoff fue diseñado asumiendo desktop ≥1440. El target real (operador usando MacBook 14") cambia ese supuesto. Las reglas se revisan cuando los supuestos subyacentes cambian.
+
+---
+
 ## Resueltos
 
-_(vacío al inicio)_
+- **(parcial)** El issue Sprint 2 "operator-shared.css con min-width: 1440px global rompe layouts <1440" queda **mitigado** por el fix-up #2 del PR #465 (min global ahora 1200, no 1440). El plan Sprint 5 (eliminar `min-width` global) sigue pendiente como mejora futura si target se expande a tablet/mobile.
+
+

--- a/web/src/app/operator-shared.css
+++ b/web/src/app/operator-shared.css
@@ -71,11 +71,18 @@ a { color: inherit; text-decoration: none; }
   display: grid;
   grid-template-columns: 240px 1fr;
   min-height: 100vh;
-  min-width: 1440px;
-  width: 1440px;
+  /* Sprint 3 paso-4 fix-up #2 · target real refinado: solo desktop hasta 14".
+     Antes: min-width 1440 + width 1440 (rompía notebooks 14" con overflow horizontal).
+     Ahora: min 1200 · max 1440 · width 100% para fluir entre ambos.
+     - ≥1440: cap a 1440 centrada (preserva audit CFC 1920px con margin c/lado).
+     - 1366 y 1200: fluye sin overflow.
+     - <1200: overflow horizontal esperado (target OUT de scope). */
+  min-width: 1200px;
+  max-width: 1440px;
+  width: 100%;
   margin: 0 auto;
 }
-body { min-width: 1440px; }
+body { min-width: 1200px; }
 
 /* ─── Sprint 1.5 · Layout fijo a viewport ───
    El .page se fija a la altura de viewport y NO scrollea como página entera.
@@ -340,7 +347,12 @@ body { min-width: 1440px; }
   border: 1px solid var(--line-strong);
   border-radius: var(--r-md);
   background: var(--surface);
-  overflow: hidden;
+  /* Sprint 3 paso-4 fix-up #2 · scroll horizontal interno cuando el grid
+     de columnas excede el viewport (notebooks 14"). Antes: overflow:hidden
+     (contenido se cortaba). Ahora: overflow-x:auto, overflow-y:hidden
+     (scroll horizontal interno · página entera nunca scrollea horizontal). */
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 .etable .colh {
   display: grid;
@@ -582,16 +594,22 @@ body { min-width: 1440px; }
 
 /* ─── Mini chat panel (right side, 480px) ─── */
 .chat {
+  /* Sprint 3 paso-4 fix-up #2 · drawer overlay (no comprime main content).
+     Antes: sticky dentro de grid `1fr 480px` → estrangulaba el main 1200→720.
+     Ahora: fixed overlay sobre el contenido. Grid del container vuelve a `1fr`
+     siempre. Aplica a calculo Y despiece (ambos comparten esta clase). */
   background: var(--surface);
   border: 1px solid var(--line-strong);
   border-radius: var(--r-md);
   display: flex; flex-direction: column;
   overflow: hidden;
-  align-self: stretch;
-  height: fit-content;
-  position: sticky;
+  position: fixed;
+  right: 24px;
   top: 24px;
-  max-height: calc(100vh - 100px);
+  bottom: 24px;
+  width: 480px;
+  z-index: 100;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
 }
 .chat .head {
   padding: 14px 16px;

--- a/web/src/app/operator-shared.css
+++ b/web/src/app/operator-shared.css
@@ -281,12 +281,13 @@ body { min-width: 1200px; }
 
 /* Section body layout */
 .body {
-  /* Sprint 3 paso-4 fix-up #3 · padding-bottom 80→120 (múltiplo de 8).
-     Antes: 80px daba sensación de ConfirmBar pegada al borde inferior
-     (último child sin elemento visible debajo). Aplica a paso-2/3/4 (todos
-     usan ConfirmBar en el mismo patrón). Sticky bar evaluada como decisión
-     arquitectónica futura (Sprint 4 si Marina lo pide en uso real). */
-  padding: 28px 24px 120px;
+  /* Sprint 3 paso-4 fix-up #3/#4 · padding-bottom 80→160 (múltiplo de 8 · 8×20).
+     Iteración #3 a 120 fue insuficiente (Javi confirmó ConfirmBar todavía
+     pegada). Más margin-bottom propio del .confirm-bar (24px) abajo. Combo
+     total: bar tiene 24px propios + body tiene 160px → respiro generoso al
+     fondo de paso-2/3/4 cuando el scroll llega al end. Sticky bar evaluada
+     como decisión arquitectónica futura (Sprint 4 si Marina lo pide). */
+  padding: 28px 24px 160px;
   flex: 1;
   display: grid;
   grid-template-columns: 1fr 480px;
@@ -510,8 +511,12 @@ body { min-width: 1200px; }
 
 /* Confirm bar */
 .confirm-bar {
+  /* Sprint 3 paso-4 fix-up #4 · margin-bottom propio (24px) además del
+     padding-bottom del .body. Garantiza respiro propio del bar al fondo
+     del scroll, independiente del .body padding. */
   display: flex; align-items: center; gap: 14px;
   margin-top: 18px;
+  margin-bottom: 24px;
   padding: 16px 18px;
   background: var(--surface);
   border: 1px solid var(--line-strong);

--- a/web/src/app/operator-shared.css
+++ b/web/src/app/operator-shared.css
@@ -66,6 +66,14 @@ html, body {
 
 a { color: inherit; text-decoration: none; }
 
+/* ─── Sprint 3 paso-4 fix-up #5b · scrollbar invisible global ─────────────
+   Universal scope · scroll por wheel/keyboard/trackpad preservado.
+   Cubre html, body, .body chrome y cualquier container con overflow interno.
+   Iteración #5 (solo .body) fue insuficiente: scrollbars seguían apareciendo
+   en otros containers (probablemente html/body raíz o cards internos).  */
+* { scrollbar-width: none; -ms-overflow-style: none; }
+*::-webkit-scrollbar { width: 0; height: 0; display: none; }
+
 /* ─── Page chrome (sidebar + header reusados, NO redesign) ─── */
 .page {
   display: grid;
@@ -291,13 +299,7 @@ body { min-width: 1200px; }
   grid-template-columns: 1fr 480px;
   gap: 24px;
   min-height: 0;
-  /* Sprint 3 paso-4 fix-up #5 · scrollbar oculta cross-browser ·
-     scroll por wheel/keyboard/trackpad preservado. Aplica solo al
-     .body (único container scrolleable del chrome · Sprint 1.5). */
-  scrollbar-width: none;        /* Firefox */
-  -ms-overflow-style: none;     /* IE/Edge legacy */
 }
-.body::-webkit-scrollbar { display: none; }  /* Chrome/Safari/Edge */
 .body.no-chat { grid-template-columns: 1fr; }
 .body .col { min-width: 0; }
 

--- a/web/src/app/operator-shared.css
+++ b/web/src/app/operator-shared.css
@@ -71,14 +71,12 @@ a { color: inherit; text-decoration: none; }
   display: grid;
   grid-template-columns: 240px 1fr;
   min-height: 100vh;
-  /* Sprint 3 paso-4 fix-up #2 · target real refinado: solo desktop hasta 14".
-     Antes: min-width 1440 + width 1440 (rompía notebooks 14" con overflow horizontal).
-     Ahora: min 1200 · max 1440 · width 100% para fluir entre ambos.
-     - ≥1440: cap a 1440 centrada (preserva audit CFC 1920px con margin c/lado).
-     - 1366 y 1200: fluye sin overflow.
-     - <1200: overflow horizontal esperado (target OUT de scope). */
+  /* Sprint 3 paso-4 fix-up #2/#5 · target desktop hasta 14" sin cap superior.
+     Iteración #2 puso max-width 1440 (preservaba audit CFC 1920 con margen),
+     pero Javi en uso real pidió full width. Iteración #5: quitamos el cap,
+     la app fluye a 100% del viewport en cualquier ≥1200. Trade-off conocido:
+     en ultra-wide (>1920) la grid se estira más, pero es lo que Javi quiere. */
   min-width: 1200px;
-  max-width: 1440px;
   width: 100%;
   margin: 0 auto;
 }
@@ -293,7 +291,13 @@ body { min-width: 1200px; }
   grid-template-columns: 1fr 480px;
   gap: 24px;
   min-height: 0;
+  /* Sprint 3 paso-4 fix-up #5 · scrollbar oculta cross-browser ·
+     scroll por wheel/keyboard/trackpad preservado. Aplica solo al
+     .body (único container scrolleable del chrome · Sprint 1.5). */
+  scrollbar-width: none;        /* Firefox */
+  -ms-overflow-style: none;     /* IE/Edge legacy */
 }
+.body::-webkit-scrollbar { display: none; }  /* Chrome/Safari/Edge */
 .body.no-chat { grid-template-columns: 1fr; }
 .body .col { min-width: 0; }
 

--- a/web/src/app/operator-shared.css
+++ b/web/src/app/operator-shared.css
@@ -281,7 +281,12 @@ body { min-width: 1200px; }
 
 /* Section body layout */
 .body {
-  padding: 28px 24px 80px;
+  /* Sprint 3 paso-4 fix-up #3 · padding-bottom 80→120 (múltiplo de 8).
+     Antes: 80px daba sensación de ConfirmBar pegada al borde inferior
+     (último child sin elemento visible debajo). Aplica a paso-2/3/4 (todos
+     usan ConfirmBar en el mismo patrón). Sticky bar evaluada como decisión
+     arquitectónica futura (Sprint 4 si Marina lo pide en uso real). */
+  padding: 28px 24px 120px;
   flex: 1;
   display: grid;
   grid-template-columns: 1fr 480px;
@@ -719,9 +724,19 @@ body { min-width: 1200px; }
 .chat .composer input::placeholder,
 .chat .composer textarea::placeholder { color: var(--ink-mute); }
 .chat .composer .send {
-  width: 28px; height: 28px; border-radius: 7px;
+  /* Sprint 3 paso-4 fix-up #3 · pill rectangular con padding lateral.
+     Antes: width 28px (icon button) · pero JSX renderea texto "Enviar" → corte.
+     Bug heredado desde Sprint 2, nunca detectado por audits funcionales.
+     Mantiene accent color y border-radius. */
+  min-width: 28px;
+  height: 32px;
+  padding: 0 14px;
+  border-radius: 7px;
   background: var(--accent); color: #0f1318; border: none;
   display: grid; place-items: center; cursor: pointer;
+  font-size: 12.5px;
+  font-weight: 500;
+  letter-spacing: 0.3px;
 }
 .chat .composer .hint {
   font-family: var(--mono); font-size: 10.5px; color: var(--ink-mute);

--- a/web/src/app/quotes/[id]/calculo/page.tsx
+++ b/web/src/app/quotes/[id]/calculo/page.tsx
@@ -1,18 +1,17 @@
 /**
- * Paso 4 · Cálculo — placeholder.
+ * Paso 4 · Cálculo · Sprint 3 paso-4-calculo.
  *
- * Implementación real (calc-section con material/MO/flete + descuentos
- * + IVA + edición humana) en sub-PR `sprint-2/paso-4-calculo`.
+ * Reemplaza el placeholder del PR #456. Renderiza el container client
+ * `CalculoView` con los 4 estados (loading/A/B/C). Server Component que
+ * SOLO pasa quoteId — sin fetch SSR (lección Sprint 3 día 3, getQuoteMetadata
+ * real ya tiene fallback; no agregamos más fetches server-side).
  */
-export default function CalculoPage() {
-  return (
-    <div className="col placeholder-section">
-      <h2 className="font-serif italic" style={{ marginBottom: 8 }}>
-        Paso 4 · Cálculo
-      </h2>
-      <p className="font-serif italic text-ink-soft">
-        Placeholder. Implementación viene en sprint-2/paso-4-calculo.
-      </p>
-    </div>
-  );
+import { CalculoView } from "@/components/calculo/CalculoView";
+
+interface Props {
+  params: { id: string };
+}
+
+export default function CalculoPage({ params }: Props) {
+  return <CalculoView quoteId={params.id} />;
 }

--- a/web/src/components/calculo/AuditChip.tsx
+++ b/web/src/components/calculo/AuditChip.tsx
@@ -1,0 +1,10 @@
+/**
+ * Chip `.aud-i` con tooltip nativo (title) · Sprint 3 paso-4.
+ */
+export function AuditChip({ title }: { title: string }) {
+  return (
+    <span className="aud-i" title={title} aria-label={title}>
+      ⓘ
+    </span>
+  );
+}

--- a/web/src/components/calculo/AuditTrail.tsx
+++ b/web/src/components/calculo/AuditTrail.tsx
@@ -1,0 +1,29 @@
+/**
+ * Bloque `.aud-trail` per-row · SOURCE / REGLA / CALC / IVA / SUMA.
+ * Solo renderea cuando `auditOn` está activo (toggle global del toolbar).
+ */
+import type { AuditEntry } from "@/lib/api";
+
+interface Props {
+  entries: AuditEntry[];
+}
+
+export function AuditTrail({ entries }: Props) {
+  if (!entries.length) return null;
+  return (
+    <div className="aud-trail" data-testid="aud-trail">
+      {entries.map((e, i) => (
+        <span key={`${e.kind}-${i}`} className="at-row">
+          <span className="at-k">{e.kind}</span>
+          <span className="at-v">
+            {e.kind === "CALC" || e.kind === "IVA" || e.kind === "SUMA" ? (
+              <span className="calc">{e.text}</span>
+            ) : (
+              e.text
+            )}
+          </span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/calculo/CalcBanner.tsx
+++ b/web/src/components/calculo/CalcBanner.tsx
@@ -1,0 +1,33 @@
+/**
+ * Banner `.calc-banner` · línea 1 resumen sistema + línea 2 ajustes Valentina.
+ * Estado A/C. (Estado B usa PatchErrorBanner.)
+ */
+import type { ValentinaAdjustment } from "@/lib/api";
+
+interface Props {
+  summary: string;
+  adjustments: ValentinaAdjustment[];
+}
+
+export function CalcBanner({ summary, adjustments }: Props) {
+  return (
+    <div className="calc-banner" data-testid="calc-banner">
+      <div className="l1">
+        <span>{summary}</span>
+      </div>
+      {adjustments.length > 0 && (
+        <div className="l2">
+          <em>Valentina</em> aplicó:
+          <span className="adj-list">
+            {adjustments.map((a, i) => (
+              <span key={i}>
+                {a.text}
+                {i < adjustments.length - 1 && <span className="pt"> · </span>}
+              </span>
+            ))}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/calculo/CalcChatPanel.tsx
+++ b/web/src/components/calculo/CalcChatPanel.tsx
@@ -1,0 +1,144 @@
+/**
+ * Chat scoped 480px del paso 4 (mockup 09).
+ *
+ * Reusa `useChatScoped` ya wireado real del PR #464. Scope label
+ * "📌 paso 4 · cálculo". El chat es scope full o por sección (no
+ * per-item, decisión paso-4). Sin sim-table ni "Aplicar al breakdown"
+ * en este PR (decisión Javi #6 · Sprint 4).
+ */
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useChatScoped } from "@/lib/hooks/useChatScoped";
+
+interface Props {
+  quoteId: string;
+  onClose: () => void;
+}
+
+const SUGGESTIONS = [
+  "¿Qué pasa si saco el zócalo?",
+  "¿Cuánto sale con Negro Brasil?",
+  "Explicame el descuento arquitecta",
+];
+
+export function CalcChatPanel({ quoteId, onClose }: Props) {
+  const { messages, lastAction, send, panelState } = useChatScoped(quoteId, "calculo");
+  const [draft, setDraft] = useState("");
+  const streamRef = useRef<HTMLDivElement>(null);
+  const isStreaming = panelState === "streaming";
+
+  useEffect(() => {
+    if (streamRef.current) streamRef.current.scrollTop = streamRef.current.scrollHeight;
+  }, [messages]);
+
+  function submit() {
+    const text = draft.trim();
+    if (!text || isStreaming) return;
+    send(text);
+    setDraft("");
+  }
+
+  return (
+    <aside className="chat" data-testid="calc-chat-panel" data-panel-state={panelState}>
+      <div className="head">
+        <div className="vbubble" />
+        <div>
+          <div className="title">Ayuda con Cálculo</div>
+          <div className="sub">📌 paso 4 · cálculo · scope full</div>
+        </div>
+        <button
+          type="button"
+          className="x-btn"
+          onClick={onClose}
+          data-testid="chat-close"
+          aria-label="cerrar"
+        >
+          ✕
+        </button>
+      </div>
+      <div className="scope">
+        <span className="lbl">Lo que veo</span>
+        <span className="pill">5 secciones del cálculo</span>
+        <span className="pill">Totales ARS + USD</span>
+      </div>
+      {lastAction && (
+        <div
+          data-testid="chat-action"
+          style={{
+            padding: "8px 16px",
+            background: "var(--surface-2)",
+            color: "var(--ink-soft)",
+            fontFamily: "var(--mono)",
+            fontSize: 11,
+            borderBottom: "1px solid var(--line)",
+          }}
+        >
+          {lastAction}
+        </div>
+      )}
+      <div className="stream" ref={streamRef} data-testid="chat-stream">
+        {messages.length === 0 && (
+          <div
+            style={{ color: "var(--ink-mute)", fontSize: 12, textAlign: "center", padding: 20 }}
+            data-testid="chat-empty"
+          >
+            Hacé una pregunta o usá una sugerencia.
+          </div>
+        )}
+        {messages.map((m) =>
+          m.role === "user" ? (
+            <div key={m.id} className="msg user" data-testid="chat-msg-user">
+              {m.content}
+            </div>
+          ) : (
+            <div key={m.id} className="msg v" data-testid="chat-msg-valentina">
+              <div className="name">Valentina</div>
+              <div className="body">{m.content}</div>
+            </div>
+          ),
+        )}
+      </div>
+      <div className="sugs">
+        {SUGGESTIONS.map((s) => (
+          <span
+            key={s}
+            className="sug"
+            data-testid="chat-suggestion"
+            role="button"
+            tabIndex={0}
+            onClick={() => !isStreaming && send(s)}
+            onKeyDown={(e) => {
+              if ((e.key === "Enter" || e.key === " ") && !isStreaming) send(s);
+            }}
+          >
+            {s}
+          </span>
+        ))}
+      </div>
+      <div className="composer">
+        <div className="field">
+          <input
+            type="text"
+            placeholder="Preguntá sobre el cálculo…"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && submit()}
+            disabled={isStreaming}
+            data-testid="chat-input"
+          />
+          <button
+            type="button"
+            className="send"
+            onClick={submit}
+            disabled={isStreaming || !draft.trim()}
+            data-testid="chat-send"
+          >
+            Enviar
+          </button>
+        </div>
+        <div className="hint">Borra al cerrar · respuestas usan el breakdown completo</div>
+      </div>
+    </aside>
+  );
+}

--- a/web/src/components/calculo/CalcConfirmBar.tsx
+++ b/web/src/components/calculo/CalcConfirmBar.tsx
@@ -1,0 +1,79 @@
+/**
+ * Confirm bar inferior. Variante `.warn-bar` en estado B con confirm disabled.
+ * Confirm → router.push a /quotes/[id]/pdf (placeholder en este PR).
+ */
+"use client";
+
+import { useState } from "react";
+
+interface Props {
+  quoteId: string;
+  blocked: boolean;
+  blockedReason?: string;
+  onOpenChat: () => void;
+  onConfirm: () => void;
+}
+
+export function CalcConfirmBar({
+  quoteId: _quoteId,
+  blocked,
+  blockedReason,
+  onOpenChat,
+  onConfirm,
+}: Props) {
+  const [vigencia, setVigencia] = useState("15");
+  return (
+    <div className={`confirm-bar${blocked ? " warn-bar" : ""}`} data-testid="confirm-bar">
+      <div className="summary">
+        {blocked ? (
+          <span className="warn-tone">
+            ⚠ <strong>No se puede confirmar</strong>
+            {blockedReason && ` · ${blockedReason}`}
+          </span>
+        ) : (
+          <>
+            Vigencia
+            <input
+              className="vig-input"
+              type="text"
+              value={vigencia}
+              onChange={(e) => setVigencia(e.target.value)}
+              data-testid="vig-input"
+              style={{
+                margin: "0 6px",
+                padding: "3px 8px",
+                width: 50,
+                background: "var(--surface-2)",
+                border: "1px solid var(--line)",
+                borderRadius: "var(--r-sm)",
+                color: "var(--ink)",
+                fontFamily: "var(--mono)",
+                fontSize: 13,
+                textAlign: "center",
+              }}
+            />
+            días · listo para generar PDF
+          </>
+        )}
+      </div>
+      <button
+        type="button"
+        className="btn ghost"
+        onClick={onOpenChat}
+        data-testid="open-chat"
+        style={{ marginRight: 8 }}
+      >
+        💬 Ayuda con esta sección
+      </button>
+      <button
+        type="button"
+        className={`btn primary${blocked ? " disabled" : ""}`}
+        disabled={blocked}
+        onClick={onConfirm}
+        data-testid="confirm-calculo"
+      >
+        Confirmar y generar PDF →
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/calculo/CalcSectionFlete.tsx
+++ b/web/src/components/calculo/CalcSectionFlete.tsx
@@ -1,0 +1,40 @@
+/**
+ * Sección 05 · Flete · una sola `.row-line` con zona + viajes.
+ */
+import type { FleteRow } from "@/lib/api";
+import { AuditChip } from "./AuditChip";
+import { AuditTrail } from "./AuditTrail";
+
+interface Props {
+  flete: FleteRow;
+  auditOn: boolean;
+}
+
+export function CalcSectionFlete({ flete, auditOn }: Props) {
+  return (
+    <section className="calc-section" data-testid="calc-section-flete">
+      <div className="sh">
+        <span className="num">05</span>
+        <span className="ttl">Flete</span>
+      </div>
+      <div className="sb">
+        <div className="row-line">
+          <div className="label-cell">
+            Flete + toma medidas {flete.zona}
+            {auditOn && flete.audit && flete.audit.length > 0 && (
+              <AuditChip title={flete.audit.map((a) => a.text).join(" · ")} />
+            )}
+          </div>
+          <div className="num">{flete.qty}</div>
+          <div className="num">{flete.basePrice}</div>
+          <div className="total">{flete.total}</div>
+        </div>
+        {auditOn && flete.audit && flete.audit.length > 0 && (
+          <div style={{ padding: "4px 0 8px 16px" }}>
+            <AuditTrail entries={flete.audit} />
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/calculo/CalcSectionLabor.tsx
+++ b/web/src/components/calculo/CalcSectionLabor.tsx
@@ -1,0 +1,58 @@
+/**
+ * Sección 03 · Mano de obra · Sprint 3 paso-4.
+ * `.etable.cols-mo` con cols SKU/desc/cant/base/iva/total + subtotal.
+ * `ivaVisible` controla columnas `base` + `iva` (decisión Javi #3).
+ */
+import type { LaborRowData } from "@/lib/api";
+import { LaborRow } from "./LaborRow";
+import { AuditChip } from "./AuditChip";
+
+interface Props {
+  rows: LaborRowData[];
+  subtotal: string;
+  auditOn: boolean;
+  ivaVisible: boolean;
+}
+
+export function CalcSectionLabor({ rows, subtotal, auditOn, ivaVisible }: Props) {
+  return (
+    <>
+      <section className="calc-section" data-testid="calc-section-labor">
+        <div className="sh">
+          <span className="num">03</span>
+          <span className="ttl">Mano de obra</span>
+        </div>
+      </section>
+      <div className={`etable cols-mo${ivaVisible ? "" : " no-iva"}`} data-testid="labor-table">
+        <div className="colh">
+          <div>SKU</div>
+          <div>Descripción</div>
+          <div>Cant</div>
+          {ivaVisible && <div>Base s/IVA</div>}
+          {ivaVisible && <div>×1,21</div>}
+          <div>Total c/IVA</div>
+          <div />
+        </div>
+        {rows.map((r) => (
+          <LaborRow key={r.sku} row={r} ivaVisible={ivaVisible} auditOn={auditOn} />
+        ))}
+        <div className="row subtotal-mo">
+          <div className="cell" />
+          <div className="cell label-cell subtotal-lbl">
+            Subtotal mano de obra · {rows.length} ítems
+            {auditOn && (
+              <AuditChip
+                title={`Suma de ${rows.length} SKUs MO base s/IVA · luego ×1,21 = ${subtotal}`}
+              />
+            )}
+          </div>
+          <div className="cell" />
+          {ivaVisible && <div className="cell" />}
+          {ivaVisible && <div className="cell" />}
+          <div className="cell num bold">{subtotal}</div>
+          <div className="cell" />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/web/src/components/calculo/CalcSectionMaterial.tsx
+++ b/web/src/components/calculo/CalcSectionMaterial.tsx
@@ -1,0 +1,62 @@
+/**
+ * Sección 01 · Material · Sprint 3 paso-4.
+ * Filas `.row-line` (incluye descuento arquitecta) + `.subtotal`.
+ */
+import type { MaterialRow } from "@/lib/api";
+import { AuditChip } from "./AuditChip";
+import { AuditTrail } from "./AuditTrail";
+
+interface Props {
+  rows: MaterialRow[];
+  subtotal: string;
+  auditOn: boolean;
+}
+
+export function CalcSectionMaterial({ rows, subtotal, auditOn }: Props) {
+  return (
+    <section className="calc-section" data-testid="calc-section-material">
+      <div className="sh">
+        <span className="num">01</span>
+        <span className="ttl">Material</span>
+      </div>
+      <div className="sb">
+        {rows.map((r, i) => (
+          <div key={`${r.label}-${i}`}>
+            <div className={`row-line${r.variant === "discount" ? " discount" : ""}`}>
+              <div className="label-cell">
+                {r.variant === "discount" ? (
+                  <>
+                    <em>Valentina</em> aplicó: {r.label}
+                  </>
+                ) : (
+                  r.label
+                )}
+                {auditOn && r.audit && r.audit.length > 0 && (
+                  <AuditChip
+                    title={r.audit
+                      .filter((a) => a.kind === "CALC" || a.kind === "REGLA")
+                      .map((a) => a.text)
+                      .join(" · ")}
+                  />
+                )}
+                {r.sub && <span className="sub">{r.sub}</span>}
+              </div>
+              <div className="num">{r.qty}</div>
+              <div className="num">{r.unit}</div>
+              <div className="total">{r.total}</div>
+            </div>
+            {auditOn && r.audit && r.audit.length > 0 && (
+              <div style={{ padding: "4px 0 8px 16px" }}>
+                <AuditTrail entries={r.audit} />
+              </div>
+            )}
+          </div>
+        ))}
+        <div className="subtotal">
+          <span className="lbl">Subtotal material</span>
+          <span className="val">{subtotal}</span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/calculo/CalcSectionMerma.tsx
+++ b/web/src/components/calculo/CalcSectionMerma.tsx
@@ -1,0 +1,104 @@
+/**
+ * Sección 02 · Merma / Sobrante · Sprint 3 paso-4.
+ * 3 modos: na · aplica (con sobrante/stock toggles) · error (estado B).
+ */
+"use client";
+
+import { useState } from "react";
+import type { MermaSection } from "@/lib/api";
+import { AuditChip } from "./AuditChip";
+import { AuditTrail } from "./AuditTrail";
+
+interface Props {
+  merma: MermaSection;
+  auditOn: boolean;
+  onFix?: () => void;
+}
+
+export function CalcSectionMerma({ merma, auditOn, onFix }: Props) {
+  const [sobrante, setSobrante] = useState(merma.sobranteToggle?.defaultChecked ?? false);
+  const [stock, setStock] = useState(merma.stockToggle?.defaultChecked ?? false);
+
+  return (
+    <section
+      className={`calc-section${merma.status === "error" ? " has-error" : ""}`}
+      data-testid="calc-section-merma"
+      data-merma-status={merma.status}
+    >
+      <div className="sh">
+        <span className="num">02</span>
+        <span className="ttl">Merma / Sobrante</span>
+        {merma.status === "aplica" && <span className="chip-info">{merma.chipLabel}</span>}
+        {merma.status === "na" && <span className="chip-na">{merma.chipLabel}</span>}
+        {merma.status === "error" && <span className="chip-error">{merma.chipLabel}</span>}
+      </div>
+      <div className="sb">
+        {merma.sub && (
+          <p className="sub" style={{ marginBottom: 10 }}>
+            {merma.sub}
+          </p>
+        )}
+        {merma.rows?.map((r, i) => (
+          <div key={`${r.label}-${i}`}>
+            <div className="row-line">
+              <div className="label-cell">
+                {r.label}
+                {auditOn && r.audit && r.audit.length > 0 && (
+                  <AuditChip title={r.audit.map((a) => a.text).join(" · ")} />
+                )}
+                {r.sub && <span className="sub">{r.sub}</span>}
+              </div>
+              <div className="num">{r.qty}</div>
+              <div className="num">{r.unit}</div>
+              <div className="total">{r.total}</div>
+            </div>
+            {auditOn && r.audit && r.audit.length > 0 && (
+              <div style={{ padding: "4px 0 8px 16px" }}>
+                <AuditTrail entries={r.audit} />
+              </div>
+            )}
+          </div>
+        ))}
+        {merma.errorRow && (
+          <div className="merma-row-error" data-testid="merma-row-error">
+            <div className="label-cell">
+              {merma.errorRow.label}
+              <span className="sub">{merma.errorRow.detail}</span>
+            </div>
+            <button type="button" className="fix-btn" onClick={onFix} data-testid="merma-fix">
+              {merma.errorRow.fixLabel}
+            </button>
+          </div>
+        )}
+        {merma.sobranteToggle && (
+          <label
+            className="sobrante-opt"
+            style={{ display: "flex", gap: 10, alignItems: "center", marginTop: 12 }}
+          >
+            <input
+              type="checkbox"
+              checked={sobrante}
+              onChange={(e) => setSobrante(e.target.checked)}
+              data-testid="sobrante-toggle"
+            />
+            <span className="sobrante-lbl">{merma.sobranteToggle.label}</span>
+          </label>
+        )}
+        {merma.stockToggle && (
+          <label
+            className="merma-stock"
+            style={{ display: "flex", gap: 10, alignItems: "center", marginTop: 8 }}
+          >
+            <input
+              type="checkbox"
+              checked={stock}
+              onChange={(e) => setStock(e.target.checked)}
+              data-testid="stock-toggle"
+            />
+            <span>{merma.stockToggle.label}</span>
+          </label>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/calculo/CalcSectionPiletas.tsx
+++ b/web/src/components/calculo/CalcSectionPiletas.tsx
@@ -1,0 +1,21 @@
+/**
+ * Sección 04 · Piletas · formato `.piletas-inline` compacto.
+ */
+import type { PiletaSection } from "@/lib/api";
+
+export function CalcSectionPiletas({ piletas }: { piletas: PiletaSection }) {
+  return (
+    <section className="calc-section piletas-inline" data-testid="calc-section-piletas">
+      <div className="sh">
+        <span className="num">04</span>
+        <span className="ttl">Piletas</span>
+        {piletas.variant === "na" ? (
+          <span className="chip-na">{piletas.chipLabel}</span>
+        ) : (
+          <span className="chip-info">{piletas.chipLabel}</span>
+        )}
+        {piletas.sub && <span className="sub">{piletas.sub}</span>}
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/calculo/CalcToolbar.tsx
+++ b/web/src/components/calculo/CalcToolbar.tsx
@@ -1,0 +1,102 @@
+/**
+ * Toolbar del header · AUDIT toggle · Tipo cliente · IVA toggle · ↻ Re-calcular.
+ *
+ * - AUDIT toggle controla `.aud-trail` per-row + chips `.aud-i` (decisión #1)
+ * - Tipo cliente Particular/Edificio es VISUAL-only (decisión #2)
+ * - IVA toggle muestra/oculta cols (decisión #3)
+ * - ↻ Re-calcular dispara `triggerCalculation` mock
+ */
+"use client";
+
+import type { CalcToggles } from "@/lib/api";
+
+interface Props {
+  toggles: CalcToggles;
+  onChange: <K extends keyof CalcToggles>(key: K, value: CalcToggles[K]) => void;
+  onRecalculate: () => void;
+  busy: boolean;
+}
+
+export function CalcToolbar({ toggles, onChange, onRecalculate, busy }: Props) {
+  return (
+    <div className="right" style={{ display: "flex", gap: 12, alignItems: "center" }}>
+      <button
+        type="button"
+        className={`audit-toggle${toggles.auditOn ? " on" : ""}`}
+        onClick={() => onChange("auditOn", !toggles.auditOn)}
+        data-testid="audit-toggle"
+        data-on={toggles.auditOn}
+        style={{
+          padding: "6px 10px",
+          border: "1px solid var(--line-strong)",
+          borderRadius: "var(--r-sm)",
+          background: toggles.auditOn ? "var(--surface-2)" : "transparent",
+          color: toggles.auditOn ? "var(--ink)" : "var(--ink-mute)",
+          fontFamily: "var(--mono)",
+          fontSize: 10.5,
+          textTransform: "uppercase",
+          letterSpacing: "0.5px",
+          cursor: "pointer",
+        }}
+      >
+        AUDIT {toggles.auditOn ? "ON" : "OFF"}
+      </button>
+
+      <div
+        className="tipo-toggle"
+        data-testid="tipo-toggle"
+        data-tipo={toggles.tipoCliente}
+        style={{
+          display: "flex",
+          border: "1px solid var(--line-strong)",
+          borderRadius: "var(--r-sm)",
+          overflow: "hidden",
+        }}
+      >
+        {(["particular", "edificio"] as const).map((t) => (
+          <button
+            key={t}
+            type="button"
+            className={`tt-btn${toggles.tipoCliente === t ? " on" : ""}`}
+            onClick={() => onChange("tipoCliente", t)}
+            data-testid={`tipo-${t}`}
+            style={{
+              padding: "6px 12px",
+              background: toggles.tipoCliente === t ? "var(--accent)" : "transparent",
+              color: toggles.tipoCliente === t ? "var(--bg)" : "var(--ink-soft)",
+              border: "none",
+              fontSize: 12,
+              cursor: "pointer",
+              textTransform: "capitalize",
+            }}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      <label
+        className="iva-toggle"
+        data-testid="iva-toggle"
+        style={{ display: "flex", gap: 6, alignItems: "center", fontSize: 12 }}
+      >
+        <input
+          type="checkbox"
+          checked={toggles.ivaVisible}
+          onChange={(e) => onChange("ivaVisible", e.target.checked)}
+        />
+        <span>Desglose IVA</span>
+      </label>
+
+      <button
+        type="button"
+        className="btn ghost sm"
+        onClick={onRecalculate}
+        disabled={busy}
+        data-testid="recalculate"
+      >
+        ↻ Re-calcular
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/calculo/CalculoView.tsx
+++ b/web/src/components/calculo/CalculoView.tsx
@@ -1,0 +1,161 @@
+/**
+ * Container del paso 4 · Cálculo. Coordina los 4 estados visuales
+ * (loading / A / B / C) + toggles + chat drawer.
+ *
+ * Mocks-first per decisión Javi: cifras canon del mockup 07-paso4-A-v4.
+ * Toggles tipo cliente / sobrante / stock son visual-only en este PR
+ * (Sprint 4 los conecta al recompute).
+ *
+ * Mismo patrón de grid interno que ContextView (1fr o 1fr/480px cuando
+ * el chat scoped está abierto). NO modifica el chrome layout del PR #456.
+ */
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useCalculo } from "@/lib/hooks/useCalculo";
+import { CalcBanner } from "./CalcBanner";
+import { CalcChatPanel } from "./CalcChatPanel";
+import { CalcConfirmBar } from "./CalcConfirmBar";
+import { CalcSectionFlete } from "./CalcSectionFlete";
+import { CalcSectionLabor } from "./CalcSectionLabor";
+import { CalcSectionMaterial } from "./CalcSectionMaterial";
+import { CalcSectionMerma } from "./CalcSectionMerma";
+import { CalcSectionPiletas } from "./CalcSectionPiletas";
+import { CalcToolbar } from "./CalcToolbar";
+import { DatosPdfDetails } from "./DatosPdfDetails";
+import { GrandTotal } from "./GrandTotal";
+import { PatchErrorBanner } from "./PatchErrorBanner";
+
+interface Props {
+  quoteId: string;
+}
+
+export function CalculoView({ quoteId }: Props) {
+  const { data, state, error, toggles, recalculate, applyFix, setToggle } = useCalculo(quoteId);
+  const [chatOpen, setChatOpen] = useState(false);
+  const router = useRouter();
+
+  // operator-shared.css §E3 gatea `.aud-trail` por `body[data-audit="on"]`
+  // (no por una clase del componente). Sincronizamos al toggle del toolbar
+  // y limpiamos al desmontar para que otras rutas no hereden el estado.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    document.body.dataset.audit = toggles.auditOn ? "on" : "off";
+    return () => {
+      delete document.body.dataset.audit;
+    };
+  }, [toggles.auditOn]);
+
+  if (state === "loading" && !data) {
+    return (
+      <div className="col" data-testid="calculo-loading">
+        <div className="section-head">
+          <div>
+            <div className="meta">Paso 4 de 5 · Cálculo</div>
+            <h2>Generando presupuesto…</h2>
+          </div>
+        </div>
+        <div className="ph-rows">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="skel long" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || (state === "error" && !data?.patchError)) {
+    return (
+      <div className="col" data-testid="calculo-error">
+        <div className="section-head">
+          <h2>No pude cargar el cálculo</h2>
+        </div>
+        <p className="font-mono" style={{ fontSize: 12, color: "var(--error)" }}>
+          {error ?? "Error desconocido"}
+        </p>
+      </div>
+    );
+  }
+
+  const isPatchError = state === "error" && !!data.patchError;
+  const hasChat = chatOpen;
+
+  return (
+    <div
+      data-testid="calculo-view"
+      data-state={isPatchError ? "B" : chatOpen ? "C" : "A"}
+      data-chat-open={chatOpen}
+      style={{
+        display: "grid",
+        gridTemplateColumns: hasChat ? "1fr 480px" : "1fr",
+        gap: 24,
+        minHeight: 0,
+      }}
+    >
+      <div className="col">
+        <div className="section-head">
+          <div>
+            <div className="meta">Paso 4 de 5 · Cálculo</div>
+            <h2>
+              Presupuesto calculado
+              {isPatchError && (
+                <span className="warn-inline" style={{ marginLeft: 8 }}>
+                  ⚠ presupuesto modificado
+                </span>
+              )}
+            </h2>
+          </div>
+          <CalcToolbar
+            toggles={toggles}
+            onChange={setToggle}
+            onRecalculate={recalculate}
+            busy={state === "loading"}
+          />
+        </div>
+
+        {isPatchError && data.patchError ? (
+          <PatchErrorBanner
+            traceId={data.patchError.traceId}
+            msg={data.patchError.msg}
+            onFix={applyFix}
+            onRecalcFromScratch={recalculate}
+          />
+        ) : (
+          <CalcBanner summary={data.bannerSummary} adjustments={data.bannerAdjustments} />
+        )}
+
+        <CalcSectionMaterial
+          rows={data.material.rows}
+          subtotal={data.material.subtotal}
+          auditOn={toggles.auditOn}
+        />
+        <CalcSectionMerma merma={data.merma} auditOn={toggles.auditOn} onFix={applyFix} />
+        <CalcSectionLabor
+          rows={data.labor.rows}
+          subtotal={data.labor.subtotal}
+          auditOn={toggles.auditOn}
+          ivaVisible={toggles.ivaVisible}
+        />
+        <CalcSectionPiletas piletas={data.piletas} />
+        <CalcSectionFlete flete={data.flete} auditOn={toggles.auditOn} />
+
+        <GrandTotal totals={data.totals} />
+
+        {!isPatchError && <DatosPdfDetails defaults={data.datosPdf} />}
+
+        <CalcConfirmBar
+          quoteId={quoteId}
+          blocked={isPatchError}
+          blockedReason={
+            isPatchError ? "resolvé la merma fantasma antes de generar PDF" : undefined
+          }
+          onOpenChat={() => setChatOpen(true)}
+          onConfirm={() => router.push(`/quotes/${quoteId}/pdf`)}
+        />
+      </div>
+
+      {chatOpen && <CalcChatPanel quoteId={quoteId} onClose={() => setChatOpen(false)} />}
+    </div>
+  );
+}

--- a/web/src/components/calculo/CalculoView.tsx
+++ b/web/src/components/calculo/CalculoView.tsx
@@ -79,7 +79,6 @@ export function CalculoView({ quoteId }: Props) {
   }
 
   const isPatchError = state === "error" && !!data.patchError;
-  const hasChat = chatOpen;
 
   return (
     <div
@@ -87,8 +86,10 @@ export function CalculoView({ quoteId }: Props) {
       data-state={isPatchError ? "B" : chatOpen ? "C" : "A"}
       data-chat-open={chatOpen}
       style={{
+        // Sprint 3 paso-4 fix-up #2 · grid SIEMPRE 1fr. El chat es overlay
+        // fixed (ver operator-shared.css §.chat) y NO ocupa columna en el grid.
         display: "grid",
-        gridTemplateColumns: hasChat ? "1fr 480px" : "1fr",
+        gridTemplateColumns: "1fr",
         gap: 24,
         minHeight: 0,
       }}

--- a/web/src/components/calculo/DatosPdfDetails.tsx
+++ b/web/src/components/calculo/DatosPdfDetails.tsx
@@ -1,0 +1,89 @@
+/**
+ * `<details class="datos-pdf">` plegable · form 5 inputs.
+ * UI editable SIN persist (decisión Javi #4 · persist Sprint 4).
+ */
+"use client";
+
+import { useState } from "react";
+import type { DatosPdfDefaults } from "@/lib/api";
+
+interface Props {
+  defaults: DatosPdfDefaults;
+}
+
+export function DatosPdfDetails({ defaults }: Props) {
+  const [form, setForm] = useState<DatosPdfDefaults>(defaults);
+  const update = <K extends keyof DatosPdfDefaults>(key: K, v: DatosPdfDefaults[K]) =>
+    setForm((p) => ({ ...p, [key]: v }));
+
+  return (
+    <details className="datos-pdf" data-testid="datos-pdf">
+      <summary>
+        <span className="dp-tag">PDF</span>
+        <span className="dp-ttl">Datos para el documento del cliente</span>
+        <span className="dp-meta">plazo · anticipo · saldo · envío · notas</span>
+        <span className="dp-chev" aria-hidden="true">
+          ▾
+        </span>
+      </summary>
+      <div className="dp-body">
+        <div className="dp-row">
+          <label className="dp-lbl">Plazo</label>
+          <input
+            className="dp-inp"
+            type="text"
+            value={form.plazo}
+            onChange={(e) => update("plazo", e.target.value)}
+            data-testid="dp-plazo"
+          />
+        </div>
+        <div className="dp-row">
+          <label className="dp-lbl">Anticipo</label>
+          <div className="dp-inline">
+            <input
+              className="dp-inp-sm"
+              type="text"
+              value={form.anticipoPct}
+              onChange={(e) => update("anticipoPct", e.target.value)}
+              data-testid="dp-anticipo"
+            />
+            <span className="dp-unit">%</span>
+          </div>
+        </div>
+        <div className="dp-row">
+          <label className="dp-lbl">Saldo</label>
+          <input
+            className="dp-inp"
+            type="text"
+            value={form.saldo}
+            onChange={(e) => update("saldo", e.target.value)}
+            data-testid="dp-saldo"
+          />
+        </div>
+        <div className="dp-row">
+          <label className="dp-lbl">Datos envío</label>
+          <input
+            className="dp-inp"
+            type="text"
+            value={form.envio}
+            onChange={(e) => update("envio", e.target.value)}
+            data-testid="dp-envio"
+          />
+        </div>
+        <div className="dp-row">
+          <label className="dp-lbl">Notas internas</label>
+          <textarea
+            className="dp-ta"
+            rows={3}
+            value={form.notas}
+            onChange={(e) => update("notas", e.target.value)}
+            data-testid="dp-notas"
+          />
+        </div>
+        <div className="dp-hint">
+          Estos campos se incluyen en el PDF del paso 5. (Sprint 4: persistencia)
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/web/src/components/calculo/GrandTotal.tsx
+++ b/web/src/components/calculo/GrandTotal.tsx
@@ -1,0 +1,38 @@
+/**
+ * Grand total bi-currency (ARS = MO + flete; USD = material importado).
+ * Variantes `.has-warn` (estado B) y `.has-sim` (chat con simulación).
+ */
+import type { GrandTotals } from "@/lib/api";
+
+interface Props {
+  totals: GrandTotals;
+  hasSim?: boolean;
+}
+
+export function GrandTotal({ totals, hasSim }: Props) {
+  const variant = totals.warnDetail ? " has-warn" : hasSim ? " has-sim" : "";
+  return (
+    <section className={`grand-total${variant}`} data-testid="grand-total">
+      <div className="col" data-testid="grand-total-ars">
+        <div className="lbl">
+          ARS <span className="sub">MO + flete</span>
+        </div>
+        <div className="val">{totals.ars.value}</div>
+        <div className="meta">{totals.ars.meta}</div>
+        {totals.warnDetail && (
+          <div className="error-tone" style={{ marginTop: 6, fontSize: 12 }}>
+            {totals.warnDetail}
+          </div>
+        )}
+      </div>
+      <div className="div" aria-hidden="true" />
+      <div className="col" data-testid="grand-total-usd">
+        <div className="lbl">
+          USD <span className="sub">material (importado)</span>
+        </div>
+        <div className="val">{totals.usd.value}</div>
+        <div className="meta">{totals.usd.meta}</div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/calculo/LaborRow.tsx
+++ b/web/src/components/calculo/LaborRow.tsx
@@ -1,0 +1,50 @@
+/**
+ * Fila `.row` de la tabla `.etable.cols-mo` · SKU/desc/cant/base/iva/total.
+ * Read-only (paso 4 no tiene edit per-row · decisión Javi). Acción "⋯" es
+ * placeholder de menú futuro.
+ */
+import type { LaborRowData } from "@/lib/api";
+import { AuditChip } from "./AuditChip";
+import { AuditTrail } from "./AuditTrail";
+
+interface Props {
+  row: LaborRowData;
+  ivaVisible: boolean;
+  auditOn: boolean;
+}
+
+export function LaborRow({ row, ivaVisible, auditOn }: Props) {
+  return (
+    <>
+      <div className="row" data-testid={`labor-row-${row.sku}`}>
+        <div className="cell sku">
+          {row.sku}
+          {auditOn && row.audit && row.audit.length > 0 && (
+            <AuditChip
+              title={row.audit
+                .filter((a) => a.kind === "CALC" || a.kind === "REGLA")
+                .map((a) => a.text)
+                .join(" · ")}
+            />
+          )}
+        </div>
+        <div className="cell label-cell">
+          {row.label}
+          {row.sub && <span className="sub">{row.sub}</span>}
+        </div>
+        <div className="cell num">{row.qty}</div>
+        {ivaVisible && <div className="cell num base">{row.basePrice}</div>}
+        {ivaVisible && <div className="cell iva">{row.iva}</div>}
+        <div className="cell num">{row.total}</div>
+        <div className="cell action">⋯</div>
+      </div>
+      {auditOn && row.audit && row.audit.length > 0 && (
+        <div className="row" style={{ background: "transparent" }}>
+          <div className="cell" style={{ gridColumn: "1 / -1", padding: "4px 16px 10px" }}>
+            <AuditTrail entries={row.audit} />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/components/calculo/PatchErrorBanner.tsx
+++ b/web/src/components/calculo/PatchErrorBanner.tsx
@@ -1,0 +1,61 @@
+/**
+ * Banner `.patch-banner` del estado B (merma fantasma post-PATCH).
+ * - Botón `.btn-warn` "✕ Eliminar merma" → auto-fix
+ * - Botón `.btn-warn.ghost` "Ver diff con v1" → DISABLED (TODO Sprint 4 #5)
+ * - Link "Recalcular todo desde cero" → recalculate (descarta patch)
+ */
+"use client";
+
+interface Props {
+  traceId: string;
+  msg: string;
+  onFix: () => void;
+  onRecalcFromScratch: () => void;
+}
+
+export function PatchErrorBanner({ traceId, msg, onFix, onRecalcFromScratch }: Props) {
+  return (
+    <div className="patch-banner" data-testid="patch-banner">
+      <div className="icon" aria-hidden="true">
+        !
+      </div>
+      <div className="pb-body">
+        <div className="head">
+          <strong>Validación post-PATCH</strong>
+          <span className="sub" style={{ marginLeft: 8, opacity: 0.7 }}>
+            trace {traceId}
+          </span>
+        </div>
+        <div className="msg">{msg}</div>
+        <div
+          className="actions"
+          style={{ display: "flex", gap: 8, marginTop: 12, alignItems: "center" }}
+        >
+          <button type="button" className="btn-warn" onClick={onFix} data-testid="patch-fix">
+            ✕ Eliminar merma
+          </button>
+          <button
+            type="button"
+            className="btn-warn ghost"
+            disabled
+            title="Ver diff con v1 — Sprint 4 (versioning + drawer)"
+            data-testid="patch-diff-disabled"
+          >
+            Ver diff con v1
+          </button>
+          <a
+            href="#"
+            className="recalc-link"
+            onClick={(e) => {
+              e.preventDefault();
+              onRecalcFromScratch();
+            }}
+            data-testid="patch-recalc-link"
+          >
+            Recalcular todo desde cero
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/despiece/DespieceView.tsx
+++ b/web/src/components/despiece/DespieceView.tsx
@@ -186,8 +186,10 @@ export function DespieceView({ quoteId }: Props) {
       data-dirty={isDirty ? "true" : "false"}
       data-chat-open={chatOpen ? "true" : "false"}
       style={{
+        // Sprint 3 paso-4 fix-up #2 · grid SIEMPRE 1fr. Chat es overlay fixed
+        // (ver operator-shared.css §.chat). Aplica fix correlativo a despiece.
         display: "grid",
-        gridTemplateColumns: chatOpen ? "1fr 480px" : "1fr",
+        gridTemplateColumns: "1fr",
         gap: 24,
         minHeight: 0,
       }}

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -33,9 +33,15 @@ export const addPieceForQuote = mocks.addPieceForQuote;
 export const deletePieceForQuote = mocks.deletePieceForQuote;
 export const regenerateDespiece = mocks.regenerateDespiece;
 
+/* ─── Cálculo (paso 4 · siempre mock · Sprint 4 wire chat-driven) ── */
+export const getCalculationForQuote = mocks.getCalculationForQuote;
+export const triggerCalculation = mocks.triggerCalculation;
+export const applyAutoFix = mocks.applyAutoFix;
+
 /* ─── Helpers de test (reset de stores in-memory del mock) ───────── */
 export const _resetContextStore = mocks._resetContextStore;
 export const _resetPiecesStore = mocks._resetPiecesStore;
+export const _resetCalcStore = mocks._resetCalcStore;
 
 /* ─── Tipos + helpers puros + constantes ─────────────────────────── */
 export * from "./types";

--- a/web/src/lib/api/mocks.ts
+++ b/web/src/lib/api/mocks.ts
@@ -495,3 +495,74 @@ export async function regenerateDespiece(
   _piecesStore.set(quoteId, fresh);
   return clonePieceList(fresh);
 }
+
+/* ─── Cálculo (paso 4) ───────────────────────────────────────────── */
+
+const _calcStore = new Map<string, import("./types").CalculationResult>();
+
+export function _resetCalcStore() {
+  _calcStore.clear();
+}
+
+/**
+ * GET calculation para un quote. Fallback gracioso desde el inicio
+ * (lección Sprint 3 día 3): IDs desconocidos (UUIDs del backend real,
+ * web-XXX, etc.) → `CANONICAL_CALCULATION_GENERIC` en lugar de undefined.
+ *
+ * Sprint 4 wire chat-driven: el backend produce `dual_read_result` +
+ * `context_analysis` durante el chat; el cálculo se deriva. Por ahora
+ * mock con cifras del mockup 07-paso4-A-v4.
+ */
+export async function getCalculationForQuote(
+  quoteId: string,
+  options?: { signal?: AbortSignal },
+): Promise<import("./types").CalculationResult> {
+  await delay(180 + Math.random() * 220, options?.signal);
+  const cached = _calcStore.get(quoteId);
+  if (cached) return cached;
+  const {
+    CALCULATIONS_BY_QUOTE_ID,
+    CANONICAL_CALCULATION_GENERIC,
+    CANONICAL_CALCULATION_018_PATCH_ERROR,
+  } = await import("../mocks/canonicalQuote");
+  // Trigger E2E del estado B (mockup 08 · validation error post-PATCH).
+  // En backend real lo dispara el server con un patch inconsistente; acá
+  // un sufijo `-ERROR` en el quoteId lo alcanza desde tests.
+  if (quoteId.endsWith("-ERROR")) {
+    const seeded = JSON.parse(
+      JSON.stringify(CANONICAL_CALCULATION_018_PATCH_ERROR),
+    ) as import("./types").CalculationResult;
+    seeded.quoteId = quoteId;
+    _calcStore.set(quoteId, seeded);
+    return seeded;
+  }
+  const base = CALCULATIONS_BY_QUOTE_ID[quoteId] ?? CANONICAL_CALCULATION_GENERIC;
+  const seeded = JSON.parse(JSON.stringify(base)) as import("./types").CalculationResult;
+  _calcStore.set(quoteId, seeded);
+  return seeded;
+}
+
+/** Simula re-cálculo (toolbar "↻ Re-calcular"). */
+export async function triggerCalculation(
+  quoteId: string,
+  options?: { signal?: AbortSignal },
+): Promise<import("./types").CalculationResult> {
+  await delay(800 + Math.random() * 400, options?.signal);
+  _calcStore.delete(quoteId);
+  return getCalculationForQuote(quoteId, options);
+}
+
+/** Auto-fix del estado B (botón "✕ Eliminar merma"). */
+export async function applyAutoFix(
+  quoteId: string,
+  options?: { signal?: AbortSignal },
+): Promise<import("./types").CalculationResult> {
+  await delay(300 + Math.random() * 200, options?.signal);
+  const { CANONICAL_CALCULATION_018 } = await import("../mocks/canonicalQuote");
+  const fresh = JSON.parse(
+    JSON.stringify(CANONICAL_CALCULATION_018),
+  ) as import("./types").CalculationResult;
+  fresh.quoteId = quoteId;
+  _calcStore.set(quoteId, fresh);
+  return fresh;
+}

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -203,3 +203,130 @@ export function pieceM2Total(piece: Pick<Piece, "width_mm" | "depth_mm" | "quant
 export function piecesTotalM2(pieces: Piece[]): number {
   return Math.round(pieces.reduce((sum, p) => sum + pieceM2Total(p), 0) * 100) / 100;
 }
+
+/* ─── Paso 4 · Cálculo ──────────────────────────────────────────── */
+
+export type CalcStatus = "pending" | "ok" | "error";
+
+export type CalcCurrency = "ARS" | "USD";
+
+export type AuditKind = "SOURCE" | "REGLA" | "CALC" | "IVA" | "SUMA";
+
+/** Una entrada del bloque `.aud-trail` per-row (SOURCE/REGLA/CALC). */
+export interface AuditEntry {
+  kind: AuditKind;
+  text: string;
+}
+
+/** Fila genérica de tabla MO (cols: SKU / desc / cant / base / iva / total). */
+export interface LaborRowData {
+  sku: string;
+  label: string;
+  sub?: string;
+  qty: string; // ej "6,50 m²" o "1" o "4,98 ml"
+  basePrice: string; // ej "$49.698"
+  iva: string; // ej "×1,21"
+  total: string; // ej "$390.875"
+  audit?: AuditEntry[];
+}
+
+/** Una fila de la sección "material" (sin tabla MO, formato `.row-line`). */
+export interface MaterialRow {
+  label: string;
+  sub?: string;
+  qty: string; // ej "6,50 m²"
+  unit: string; // ej "USD 249"
+  total: string; // ej "USD 1.619" o "−USD 81"
+  variant?: "default" | "discount" | "subtotal";
+  audit?: AuditEntry[];
+}
+
+/** Estado de la sección merma. */
+export type MermaStatus = "na" | "aplica" | "error";
+
+export interface MermaSection {
+  status: MermaStatus;
+  chipLabel: string; // ej "APLICA" / "N/A — Negro Brasil nunca mermea"
+  sub?: string;
+  /** Cuando aplica: filas de cálculo (placas + sobrante). */
+  rows?: MaterialRow[];
+  /** Cuando hay sobrante opcional al cliente. */
+  sobranteToggle?: { label: string; defaultChecked: boolean };
+  /** Cuando hay stock confirmado en taller. */
+  stockToggle?: { label: string; defaultChecked: boolean };
+  /** Cuando error (estado B): nombre de la fila huérfana + auto-fix CTA. */
+  errorRow?: { label: string; detail: string; fixLabel: string };
+}
+
+export interface PiletaSection {
+  /** Chip de estado: "N/A — pileta empotrada (la trae el cliente)" o "APLICA". */
+  chipLabel: string;
+  variant: "na" | "info";
+  sub?: string;
+}
+
+export interface FleteRow {
+  zona: string; // ej "Rosario"
+  qty: string; // ej "1 viaje"
+  basePrice: string;
+  total: string;
+  audit?: AuditEntry[];
+}
+
+/** Totales bi-currency (ARS = MO + flete; USD = material importado). */
+export interface GrandTotals {
+  ars: { value: string; meta: string };
+  usd: { value: string; meta: string };
+  /** En estado B (`has-warn`): ARS muestra error-tone con detalle de la merma fantasma. */
+  warnDetail?: string;
+}
+
+/** Inputs del operador que se persisten al confirmar (mocks-first → sin persist). */
+export interface DatosPdfDefaults {
+  plazo: string;
+  anticipoPct: string;
+  saldo: string;
+  envio: string;
+  notas: string;
+  vigenciaDias: string;
+}
+
+/** Ajustes de Valentina mostrados en `.calc-banner > .l2 > .adj-list`. */
+export interface ValentinaAdjustment {
+  text: string;
+}
+
+export interface CalculationResult {
+  quoteId: string;
+  status: CalcStatus;
+  /** Resumen línea 1 del calc-banner: "✓ Calculado · {material} · {m²} · Total ARS $… + USD …". */
+  bannerSummary: string;
+  /** Ajustes que aplicó Valentina (.adj-list). */
+  bannerAdjustments: ValentinaAdjustment[];
+  /** Sección 01 · Material — filas (incluye descuento arquitecta) + subtotal. */
+  material: { rows: MaterialRow[]; subtotal: string };
+  /** Sección 02 · Merma / Sobrante. */
+  merma: MermaSection;
+  /** Sección 03 · Mano de obra (tabla `.etable.cols-mo`). */
+  labor: { rows: LaborRowData[]; subtotal: string };
+  /** Sección 04 · Piletas (formato compacto). */
+  piletas: PiletaSection;
+  /** Sección 05 · Flete. */
+  flete: FleteRow;
+  /** Totales bi-currency. */
+  totals: GrandTotals;
+  /** Si estado B: detalle del patch-banner (trace + mensaje de Valentina). */
+  patchError?: {
+    traceId: string;
+    msg: string;
+  };
+  /** Defaults del form datos-pdf. */
+  datosPdf: DatosPdfDefaults;
+}
+
+/** Toggles UI controlados por CalcToolbar (no afectan el cálculo en este PR). */
+export interface CalcToggles {
+  auditOn: boolean;
+  ivaVisible: boolean;
+  tipoCliente: "particular" | "edificio";
+}

--- a/web/src/lib/hooks/useCalculo.ts
+++ b/web/src/lib/hooks/useCalculo.ts
@@ -1,0 +1,94 @@
+/**
+ * Hook del paso 4 · Cálculo. Mocks-first (Sprint 4 wire chat-driven).
+ *
+ * Carga `getCalculationForQuote` al mount + expone recalc + auto-fix
+ * (estado B) + toggles UI (audit/iva/tipoCliente). Fallback gracioso
+ * para IDs desconocidos en mocks.ts (sin crash).
+ *
+ * Toggles SON visual-only en este PR (no afectan cifras — decisión Javi
+ * #2/#3). Sprint 4 los conecta al recompute.
+ */
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  applyAutoFix,
+  getCalculationForQuote,
+  triggerCalculation,
+  type CalcToggles,
+  type CalculationResult,
+} from "../api";
+
+type State = "loading" | "ok" | "error";
+
+export function useCalculo(quoteId: string) {
+  const [data, setData] = useState<CalculationResult | null>(null);
+  const [state, setState] = useState<State>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [toggles, setToggles] = useState<CalcToggles>({
+    auditOn: false,
+    ivaVisible: true,
+    tipoCliente: "particular",
+  });
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    let aborted = false;
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    setState("loading");
+    getCalculationForQuote(quoteId, { signal: ctrl.signal })
+      .then((r) => {
+        if (aborted) return;
+        setData(r);
+        setState(r.status === "error" ? "error" : "ok");
+      })
+      .catch((err) => {
+        if (aborted || (err instanceof DOMException && err.name === "AbortError")) return;
+        setError(err instanceof Error ? err.message : "Error al cargar el cálculo");
+        setState("error");
+      });
+    return () => {
+      aborted = true;
+      ctrl.abort();
+    };
+  }, [quoteId]);
+
+  const recalculate = useCallback(async () => {
+    abortRef.current?.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    setState("loading");
+    try {
+      const r = await triggerCalculation(quoteId, { signal: ctrl.signal });
+      setData(r);
+      setState(r.status === "error" ? "error" : "ok");
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      setError(err instanceof Error ? err.message : "Error al recalcular");
+      setState("error");
+    }
+  }, [quoteId]);
+
+  const applyFix = useCallback(async () => {
+    abortRef.current?.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    setState("loading");
+    try {
+      const r = await applyAutoFix(quoteId, { signal: ctrl.signal });
+      setData(r);
+      setState("ok");
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      setError(err instanceof Error ? err.message : "Error al aplicar fix");
+      setState("error");
+    }
+  }, [quoteId]);
+
+  const setToggle = useCallback(<K extends keyof CalcToggles>(key: K, value: CalcToggles[K]) => {
+    setToggles((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  return { data, state, error, toggles, recalculate, applyFix, setToggle };
+}

--- a/web/src/lib/mocks/canonicalQuote.ts
+++ b/web/src/lib/mocks/canonicalQuote.ts
@@ -341,3 +341,260 @@ export const DESPIECE_LOADING_TIMELINE: TimelineStep[] = [
   { step: 3, label: "Medidas", state: "done" },
   { step: 4, label: "Verificación", state: "running", detail: "cruzando con catálogo…" },
 ];
+
+/* ════════════════════════════════════════════════════════════════════════
+   Sprint 3 paso-4-calculo · CANONICAL_CALCULATION_*
+   ════════════════════════════════════════════════════════════════════════
+   Cifras LITERALES del mockup 07-paso4-A-v4.html (Master §13 + decisión D
+   PR #461: las cifras canon son design references; mocks usan estos
+   valores fijos del mockup, NO los del motor real). */
+
+import type { CalculationResult, MaterialRow, LaborRowData } from "../api/types";
+
+/** PRES-2026-018 · Cueto-Heredia · Silestone Blanco Norte (mockup 07-paso4-A-v4). */
+const MATERIAL_018: MaterialRow[] = [
+  {
+    label: "Silestone Blanco Norte 20mm",
+    sub: "6,50 m² reales del trabajo · USD 249 c/IVA · piezas en paso 3",
+    qty: "6,50 m²",
+    unit: "USD 249",
+    total: "USD 1.619",
+    variant: "default",
+    audit: [
+      { kind: "SOURCE", text: "Brief (texto) + catalog/silestone.json sku SILESTONENORTE" },
+      { kind: "REGLA", text: "Material importado en USD; IVA ya incluido en lista" },
+      { kind: "CALC", text: "6,50 m² × USD 249 = USD 1.619" },
+    ],
+  },
+  {
+    label: "Descuento arquitecta",
+    sub: "Cueto-Heredia · architects.json · 5% sobre material importado",
+    qty: "−5%",
+    unit: "—",
+    total: "−USD 81",
+    variant: "discount",
+    audit: [
+      {
+        kind: "SOURCE",
+        text: "catalog/architects.json · firm Cueto-Heredia · discount imported 5%",
+      },
+      { kind: "REGLA", text: "Sólo aplica sobre material importado, nunca sobre MO ni flete" },
+      { kind: "CALC", text: "USD 1.619 × −5% = −USD 81" },
+    ],
+  },
+];
+
+const LABOR_018: LaborRowData[] = [
+  {
+    sku: "COLOCACION",
+    label: "Colocación",
+    sub: "6,50 m² · cuarzo 20mm usa SKU estándar (no DEKTON)",
+    qty: "6,50",
+    basePrice: "$49.698",
+    iva: "×1,21",
+    total: "$390.875",
+    audit: [
+      { kind: "SOURCE", text: "labor.json sku COLOCACION · $49.698 s/IVA / m²" },
+      { kind: "CALC", text: "6,50 m² × $49.698 × 1,21 = $390.875" },
+    ],
+  },
+  {
+    sku: "PEGADOPILETA",
+    label: "Pegado pileta empotrada",
+    sub: "1 unid · cliente trae la pileta",
+    qty: "1",
+    basePrice: "$53.840",
+    iva: "×1,21",
+    total: "$65.146",
+    audit: [
+      { kind: "SOURCE", text: "labor.json sku PEGADOPILETA" },
+      { kind: "CALC", text: "$53.840 × 1,21 = $65.146" },
+    ],
+  },
+  {
+    sku: "ANAFE",
+    label: "Anafe (corte y cargas)",
+    sub: "1 unid · detectado en plano (símbolo)",
+    qty: "1",
+    basePrice: "$35.617",
+    iva: "×1,21",
+    total: "$43.097",
+    audit: [
+      { kind: "SOURCE", text: "labor.json sku ANAFE" },
+      { kind: "CALC", text: "$35.617 × 1,21 = $43.097" },
+    ],
+  },
+  {
+    sku: "REGRUESO",
+    label: "Regrueso frontal",
+    sub: "4,98 ml · cuarzo 20mm usa REGRUESO (no FALDON+CORTE45)",
+    qty: "4,98 ml",
+    basePrice: "$13.810",
+    iva: "×1,21",
+    total: "$83.216",
+    audit: [
+      { kind: "SOURCE", text: "labor.json sku REGRUESO" },
+      {
+        kind: "REGLA",
+        text: "Para cuarzo 20mm cuenta REGRUESO; FALDON+CORTE45 sólo en otros espesores",
+      },
+      { kind: "CALC", text: "4,98 ml × $13.810 × 1,21 = $83.216" },
+    ],
+  },
+  {
+    sku: "TOMAS",
+    label: "Tomas (perforación)",
+    sub: "2 unid · auto: alzada + zócalo >10cm",
+    qty: "2",
+    basePrice: "$6.461",
+    iva: "×1,21",
+    total: "$15.636",
+    audit: [
+      { kind: "SOURCE", text: "labor.json sku TOMAS" },
+      {
+        kind: "REGLA",
+        text: "+1 por alzada (auto) · +1 por zócalo >10cm (auto, regla altura) = 2 unid",
+      },
+      { kind: "CALC", text: "$6.461 × 2 × 1,21 = $15.636" },
+    ],
+  },
+];
+
+export const CANONICAL_CALCULATION_018: CalculationResult = {
+  quoteId: "PRES-2026-018",
+  status: "ok",
+  bannerSummary:
+    "✓ Calculado · Silestone Blanco Norte 20mm · 6,50 m² · Total $660.890 ARS + USD 1.538",
+  bannerAdjustments: [
+    { text: "−5% descuento arquitecta Cueto-Heredia sobre material importado" },
+    { text: "+TOMAS automático: 1 por alzada + 1 por zócalo >10cm" },
+    { text: "REGRUESO en lugar de FALDON+CORTE45 (cuarzo 20mm)" },
+  ],
+  material: { rows: MATERIAL_018, subtotal: "USD 1.538" },
+  merma: {
+    status: "aplica",
+    chipLabel: "APLICA",
+    sub: "ceil(6,50 / 2,10) = 4 medias placas → 8,40 m² · desperdicio 1,90 m² ≥ 1 m² → aplica sobrante",
+    rows: [
+      {
+        label: "Sobrante facturado",
+        sub: "0,95 m² (mitad del desperdicio) · valor proporcional al m²",
+        qty: "0,95 m²",
+        unit: "USD 249",
+        total: "USD 237",
+        audit: [
+          {
+            kind: "REGLA",
+            text: "Sobrante = desperdicio/2 cuando desperdicio ≥ 1 m² (sintéticos)",
+          },
+          { kind: "CALC", text: "(8,40 − 6,50)/2 × USD 249 = USD 237" },
+        ],
+      },
+    ],
+    sobranteToggle: {
+      label: "Ofrecer sobrante al cliente como pieza adicional",
+      defaultChecked: false,
+    },
+    stockToggle: {
+      label: "Stock confirmado en taller (descuenta de stock.json)",
+      defaultChecked: true,
+    },
+  },
+  labor: { rows: LABOR_018, subtotal: "$597.970" },
+  piletas: {
+    chipLabel: "N/A — pileta empotrada (la trae el cliente)",
+    variant: "na",
+    sub: "MO de pegado ya contabilizada en sección 03 (PEGADOPILETA)",
+  },
+  flete: {
+    zona: "Rosario",
+    qty: "1 viaje",
+    basePrice: "$ 52.000",
+    total: "$ 62.920",
+    audit: [
+      { kind: "SOURCE", text: "delivery-zones.json zona Rosario · ENVIOROS $52.000 s/IVA" },
+      { kind: "REGLA", text: "Particular · 1 viaje (no edificio)" },
+      { kind: "CALC", text: "$52.000 × 1,21 = $62.920" },
+    ],
+  },
+  totals: {
+    ars: { value: "$660.890", meta: "MO + flete · IVA 21% incluido" },
+    usd: { value: "USD 1.538", meta: "6,50 m² × USD 249 − 5% arq." },
+  },
+  datosPdf: {
+    plazo: "3 semanas desde confirmación de medidas",
+    anticipoPct: "50",
+    saldo: "contra entrega · transferencia / efectivo",
+    envio: "Belgrano · CABA · coordinar día con Marina",
+    notas: "Cueto-Heredia · arquitecta · 5% importado aplicado",
+    vigenciaDias: "15",
+  },
+};
+
+/** PRES-2026-017 · Pereyra (mismo shape, datos distintos para verificar params.id). */
+export const CANONICAL_CALCULATION_017: CalculationResult = {
+  ...CANONICAL_CALCULATION_018,
+  quoteId: "PRES-2026-017",
+  bannerSummary:
+    "✓ Calculado · Silestone Blanco Norte 20mm · 6,50 m² · Total $660.890 ARS + USD 1.538",
+  bannerAdjustments: [
+    { text: "Sin descuento arquitecta (Pereyra es particular)" },
+    { text: "+TOMAS automático: 1 por alzada" },
+  ],
+  datosPdf: {
+    plazo: "4 semanas",
+    anticipoPct: "40",
+    saldo: "contra entrega",
+    envio: "Rosario · zona sur",
+    notas: "Familia Pereyra · particular",
+    vigenciaDias: "15",
+  },
+};
+
+/** Fallback gracioso para IDs desconocidos (lección Sprint 3 día 3: SIN crash). */
+export const CANONICAL_CALCULATION_GENERIC: CalculationResult = {
+  quoteId: "—",
+  status: "pending",
+  bannerSummary: "Cálculo pendiente · vení desde el paso 3 para generar el desglose",
+  bannerAdjustments: [],
+  material: { rows: [], subtotal: "—" },
+  merma: { status: "na", chipLabel: "—", sub: "sin datos" },
+  labor: { rows: [], subtotal: "—" },
+  piletas: { chipLabel: "—", variant: "na" },
+  flete: { zona: "—", qty: "—", basePrice: "—", total: "—" },
+  totals: {
+    ars: { value: "—", meta: "sin datos" },
+    usd: { value: "—", meta: "sin datos" },
+  },
+  datosPdf: { plazo: "—", anticipoPct: "—", saldo: "—", envio: "—", notas: "—", vigenciaDias: "—" },
+};
+
+/** Variante estado B · post-PATCH (cambio de material upstream → merma fantasma). */
+export const CANONICAL_CALCULATION_018_PATCH_ERROR: CalculationResult = {
+  ...CANONICAL_CALCULATION_018,
+  status: "error",
+  merma: {
+    status: "error",
+    chipLabel: "ERROR",
+    sub: "merma del cálculo anterior quedó huérfana tras cambio de material",
+    errorRow: {
+      label: "Merma Silestone (huérfana)",
+      detail: "0,95 m² × USD 249 = USD 237 · proviene del cálculo previo, no debería estar acá",
+      fixLabel: "✕ Eliminar merma",
+    },
+  },
+  totals: {
+    ars: { value: "$660.890", meta: "MO + flete" },
+    usd: { value: "USD 1.538", meta: "material importado" },
+    warnDetail: "+ merma fantasma USD 237 (eliminar antes de confirmar)",
+  },
+  patchError: {
+    traceId: "q-2026-0287",
+    msg: "Detecté una merma fantasma del cálculo anterior. Cambiaste el material y la línea de sobrante quedó huérfana. Puedo eliminarla con un click, o querés ver el diff con la versión 1 primero.",
+  },
+};
+
+export const CALCULATIONS_BY_QUOTE_ID: Record<string, CalculationResult> = {
+  "PRES-2026-018": CANONICAL_CALCULATION_018,
+  "PRES-2026-017": CANONICAL_CALCULATION_017,
+};

--- a/web/tests/e2e/calculo.spec.ts
+++ b/web/tests/e2e/calculo.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * E2E del paso 4 · Cálculo · Sprint 3 paso-4-calculo.
+ *
+ * Cubre los 4 estados visuales (loading / A / B / C), toggles (audit/iva/
+ * tipo cliente), checkboxes sobrante+stock, form datos-pdf editable sin
+ * persist, chat scoped, datasource por params.id, fallback gracioso para
+ * ID desconocido (lección Sprint 3 día 3), routing post-confirm a /pdf,
+ * estado B con botón "Ver diff" disabled (decisión Javi #5).
+ */
+import { expect, test, type Page } from "@playwright/test";
+
+async function goCalc(page: Page, id = "PRES-2026-018") {
+  await page.goto(`/quotes/${id}/calculo`);
+  await expect(page.locator('[data-testid="calculo-view"]')).toBeVisible();
+}
+
+test("estado A · banner + 5 secciones + totales bi-currency Cueto-Heredia", async ({ page }) => {
+  await goCalc(page);
+  await expect(page.locator('[data-testid="calculo-view"]')).toHaveAttribute("data-state", "A");
+  await expect(page.locator('[data-testid="calc-banner"]')).toContainText("$660.890");
+  await expect(page.locator('[data-testid="calc-banner"]')).toContainText("USD 1.538");
+  for (const s of ["material", "merma", "labor", "piletas", "flete"]) {
+    await expect(page.locator(`[data-testid="calc-section-${s}"]`)).toBeVisible();
+  }
+  await expect(page.locator('[data-testid="grand-total-ars"]')).toContainText("$660.890");
+  await expect(page.locator('[data-testid="grand-total-usd"]')).toContainText("USD 1.538");
+});
+
+test("IVA toggle muestra/oculta cols Base + ×1,21 en la tabla MO", async ({ page }) => {
+  await goCalc(page);
+  const table = page.locator('[data-testid="labor-table"]');
+  await expect(table).toContainText("Base s/IVA");
+  await page.locator('[data-testid="iva-toggle"] input').click();
+  await expect(table).not.toContainText("Base s/IVA");
+  await page.locator('[data-testid="iva-toggle"] input').click();
+  await expect(table).toContainText("Base s/IVA");
+});
+
+test("AUDIT toggle activa aud-trail + chips per-row", async ({ page }) => {
+  await goCalc(page);
+  await expect(page.locator('[data-testid="aud-trail"]').first()).not.toBeVisible();
+  await page.locator('[data-testid="audit-toggle"]').click();
+  await expect(page.locator('[data-testid="audit-toggle"]')).toHaveAttribute("data-on", "true");
+  await expect(page.locator('[data-testid="aud-trail"]').first()).toBeVisible();
+});
+
+test("tipo cliente Particular/Edificio toggle (visual-only)", async ({ page }) => {
+  await goCalc(page);
+  await expect(page.locator('[data-testid="tipo-toggle"]')).toHaveAttribute(
+    "data-tipo",
+    "particular",
+  );
+  await page.locator('[data-testid="tipo-edificio"]').click();
+  await expect(page.locator('[data-testid="tipo-toggle"]')).toHaveAttribute(
+    "data-tipo",
+    "edificio",
+  );
+});
+
+test("sobrante + stock checkboxes en sección merma (visual-only)", async ({ page }) => {
+  await goCalc(page);
+  const sobrante = page.locator('[data-testid="sobrante-toggle"]');
+  const stock = page.locator('[data-testid="stock-toggle"]');
+  await expect(sobrante).not.toBeChecked();
+  await expect(stock).toBeChecked();
+  await sobrante.click();
+  await expect(sobrante).toBeChecked();
+});
+
+test("datos-pdf form editable sin persist (decisión Javi #4)", async ({ page }) => {
+  await goCalc(page);
+  await page.locator('[data-testid="datos-pdf"] summary').click();
+  const plazo = page.locator('[data-testid="dp-plazo"]');
+  await expect(plazo).toHaveValue(/3 semanas/);
+  await plazo.fill("5 semanas");
+  await expect(plazo).toHaveValue("5 semanas");
+});
+
+test("chat scoped (estado C) · abrir/enviar/cerrar", async ({ page }) => {
+  await goCalc(page);
+  await page.locator('[data-testid="open-chat"]').click();
+  await expect(page.locator('[data-testid="calculo-view"]')).toHaveAttribute("data-state", "C");
+  await expect(page.locator('[data-testid="calc-chat-panel"]')).toBeVisible();
+  await page.locator('[data-testid="chat-input"]').fill("Explicame el descuento arquitecta");
+  await page.locator('[data-testid="chat-send"]').click();
+  await expect(page.locator('[data-testid="chat-msg-user"]').first()).toContainText("descuento");
+  await page.locator('[data-testid="chat-close"]').click();
+  await expect(page.locator('[data-testid="calc-chat-panel"]')).not.toBeVisible();
+});
+
+test("datasource por params.id · PRES-017 vs PRES-018", async ({ page }) => {
+  await goCalc(page, "PRES-2026-017");
+  await expect(page.locator('[data-testid="calc-banner"]')).toContainText("Pereyra");
+  await goCalc(page, "PRES-2026-018");
+  await expect(page.locator('[data-testid="calc-banner"]')).toContainText("arquitecta");
+});
+
+test("ID desconocido (UUID) renderea CANONICAL_GENERIC sin crash", async ({ page }) => {
+  await page.goto("/quotes/web-9543be47-deadbeef/calculo");
+  await expect(page.locator('[data-testid="calculo-view"]')).toBeVisible();
+  await expect(page.locator('[data-testid="calc-banner"]')).toContainText("pendiente");
+});
+
+test("confirm navega a /quotes/[id]/pdf", async ({ page }) => {
+  await goCalc(page);
+  await page.locator('[data-testid="confirm-calculo"]').click();
+  await page.waitForURL("**/quotes/PRES-2026-018/pdf");
+});
+
+test("recalcular ↻ dispara loading + recarga datos", async ({ page }) => {
+  await goCalc(page);
+  await page.locator('[data-testid="recalculate"]').click();
+  // El loading state aparece brevemente; verificamos que vuelve a estado A
+  await expect(page.locator('[data-testid="calculo-view"]')).toHaveAttribute("data-state", "A", {
+    timeout: 5000,
+  });
+  await expect(page.locator('[data-testid="calc-banner"]')).toContainText("$660.890");
+});
+
+test("estado B · patch-banner + auto-fix + diff button disabled (decisión Javi #5)", async ({
+  page,
+}) => {
+  await page.goto("/quotes/PRES-2026-018-ERROR/calculo");
+  await expect(page.locator('[data-testid="calculo-view"]')).toHaveAttribute("data-state", "B");
+  await expect(page.locator('[data-testid="patch-banner"]')).toBeVisible();
+  await expect(page.locator('[data-testid="patch-banner"]')).toContainText("merma fantasma");
+  // confirm bloqueado en estado B
+  await expect(page.locator('[data-testid="confirm-calculo"]')).toBeDisabled();
+  // botón "Ver diff con v1" disabled (decisión Javi: TODO Sprint 4)
+  await expect(page.locator('[data-testid="patch-diff-disabled"]')).toBeDisabled();
+  // Auto-fix vuelve a estado A
+  await page.locator('[data-testid="patch-fix"]').click();
+  await expect(page.locator('[data-testid="calculo-view"]')).toHaveAttribute("data-state", "A", {
+    timeout: 5000,
+  });
+  await expect(page.locator('[data-testid="confirm-calculo"]')).toBeEnabled();
+});


### PR DESCRIPTION
## Resumen

Paso 4 · **Cálculo** completo, mocks-first, siguiendo patrón de `paso-3-despiece`.
**4 estados** (Loading / A OK / B PatchError / C Chat) · **13 componentes** · **12 E2E nuevos** · cifras canon mockup 07-paso4-A-v4 ($660.890 ARS + USD 1.538).

## Fix-up #2 post-audit visual CFC (commit `99580ed`)

Audit visual designer CFC sobre paso-4 + aclaración Javi (11.05.2026) sobre target real (solo desktop, hasta 14" notebooks) detectó 2 BLOCKERs reales:

✅ **BLOCKER #1** · Chat drawer ya no comprime el main (1200→720). `.chat` ahora es `position: fixed` overlay; grid del container siempre `1fr`. Aplica a CalculoView Y DespieceView — fix correlativo en paso-3 también (bug compartido nunca detectado en audit anterior).
✅ **BLOCKER #2** · `body` y `.page` min-width 1440 → 1200 · `.page` también `max-width: 1440; width: 100%` (preserva cap centrado en monitores grandes, fluye limpio en notebooks 14"/1366/1200).
✅ **Tabla** · `.etable { overflow-x: auto }` — scroll horizontal **interno** cuando excede viewport, página entera nunca scrollea horizontal en target.
✅ **MAJORs** · resueltos por #2 (stock label completo, banner sin truncar, error banner texto completo).
✅ **Sync handoff** byte-identical con frontend.
✅ **ADR registrado** en `docs/known-issues.md`: evolución de regla operativa — `operator-shared.css` se modifica con decisión arquitectónica documentada (antes inmutable). Lección operativa nueva: bugs de CSS compartido se atrapan en CSS compartido, no en wrappers por componente.

### Verificación visual local (Chrome MCP)

| Viewport | Estado | Resultado |
|---|---|---|
| 1440 paso-4 estado A | banner + 5 secciones + bi-currency | ✅ sin scroll-X |
| Chat overlay | `position:fixed`, `width:480`, `mainCol=1141`, `gridCols=1141px` | ✅ NO estrangulado |
| 1440 paso-3 despiece | 5 piezas R1-R5 + tabla `.etable cols-despiece` | ✅ sin regresión |
| Chat overlay paso-3 | mismas métricas (mainCol=1141) | ✅ fix correlativo |

### Computed styles confirmados via JS eval
```
body min-width: 1200px ✓
.page min-width: 1200px ✓
.page max-width: 1440px ✓
.chat position: fixed ✓
.chat right: 24px / width: 480px ✓
```

## Decisiones Javi originales (8 features) — todas implementadas

| # | Feature | Disposición |
|---|---|---|
| 1 | AUDIT toggle | ✅ visual-only (sync `body[data-audit]`) |
| 2 | Tipo cliente Particular/Edificio | ✅ visual-only |
| 3 | IVA toggle | ✅ muestra/oculta cols Base + ×1,21 |
| 4 | Datos-pdf form (5 inputs) | ✅ UI sin persist |
| 5 | Diff drawer "Ver diff con v1" | ⏭ DISABLED + TODO Sprint 4 |
| 6 | Chat sim-apply al breakdown | ⏭ chat scoped sin sim-table |
| 7 | Sobrante + Stock checkboxes | ✅ visual-only en merma |
| 8 | Mobile responsive | ⏭ desktop-first (target confirmado 14"+) |

## Verificación final

| Check | Resultado |
|---|---|
| lint | ✅ |
| typecheck | ✅ |
| test:unit | ✅ 6 passed |
| test:e2e | ✅ **65 passed** + 3 skipped |
| build | ✅ |
| `operator-shared.css` ↔ handoff byte-identical | ✅ (ambos modificados juntos) |
| `.py` modificados | 0 |
| Middleware / Chrome / `[id]/layout` intactos | ✅ |

## Test plan

- [ ] /quotes/PRES-2026-018/calculo · estado A en 1440 / 1366 / 1200 sin scroll-X
- [ ] /quotes/PRES-2026-017/calculo · datasource 017 (Pereyra particular)
- [ ] /quotes/\<UUID\>/calculo · CANONICAL_GENERIC sin crash
- [ ] /quotes/PRES-2026-018-ERROR/calculo · estado B con patch-banner
- [ ] AUDIT / IVA / Tipo cliente / Sobrante / Stock toggles
- [ ] Datos-pdf form editable in-memory
- [ ] Chat overlay 480px **no comprime** main content
- [ ] Confirmar → navega a /quotes/[id]/pdf
- [ ] Regression paso-3-despiece: 5 piezas + chat overlay correlativo

## Diferido a Sprint 4

- Wire chat-driven recompute (toggles → backend params)
- Diff drawer v1↔v2 con versioning
- Sim-table "Aplicar al breakdown" desde chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Fix-up #3 post-validación-estética Javi (commit `e400ebe`)

✅ FIX cosmético `.chat .composer .send` · 28×28 (icon button) → pill rectangular con `padding: 0 14px; height: 32px`. Texto "Enviar" ya no se corta. Aplica paso-3 + paso-4 (CSS compartido).
✅ FIX cosmético `.body { padding-bottom: 80px → 120px }` · ConfirmBar ya no se siente pegada al borde inferior. Aplica global paso-2/3/4.
✅ Sync handoff byte-identical.
✅ 65/3 E2E sin regresión.

**Verificación visual (Chrome MCP):** sendW=63.5px en ambos chats, "Enviar" completo dentro del drawer; bodyPaddingBottom 120px confirmado via getComputedStyle.

**Lección operativa documentada:** bugs cosméticos heredados desde Sprint 2 sobreviven a audit code, tests E2E, visual técnico y audit designer focused-on-blockers. Solo los atrapa validación estética humana sobre screenshots.