### PR TITLE
feat(sprint-3/observability-per-row): mockup 13 · audit-tray global + refactor toggle a TopBar

### DIFF
--- a/docs/handoff-design/design_files/operator-shared.css
+++ b/docs/handoff-design/design_files/operator-shared.css
@@ -4802,3 +4802,17 @@ body[data-audit="on"] .audit-tray { display: grid; }
   text-decoration: underline;
   color: oklch(0.92 0.06 25);
 }
+/* Fix-up #1 H2 · Col 3 (EVENTOS EN SESIÓN) truncada sin ellipsis a 1440.
+   `.v` ya tiene overflow:hidden + text-overflow:ellipsis pero faltaba
+   white-space:nowrap (sin él el text wraps en vez de truncarse). Aplica
+   SOLO a Col 3 para preservar Col 1 + Col 2 que estaban OK. */
+.audit-tray .col:nth-child(3) .kv .v {
+  white-space: nowrap;
+}
+/* Fix-up #1 H4 · link "ver tree" disabled debe verse muted (era azul
+   indistinguible de un link activo). Spec: aria-disabled="true" → no link UX. */
+.audit-tray a[aria-disabled="true"] {
+  color: var(--ink-mute);
+  cursor: not-allowed;
+  text-decoration: none;
+}

--- a/docs/handoff-design/design_files/operator-shared.css
+++ b/docs/handoff-design/design_files/operator-shared.css
@@ -4752,3 +4752,53 @@ body[data-audit="on"] .audit-toggle {
   font-size: 10px;
   padding: 5px 8px;
 }
+
+/* ─── Sprint 3 observability-per-row · mockup 13 ─────────────────────────
+   Audit tray global · 3 columnas mono-font con metadata IA + trazabilidad
+   + eventos. Visible solo cuando body[data-audit="on"] (gateado via
+   useAuditMode global). Mockup 13-audit-banner-on.html LITERAL.
+   `.ia-banner` y `.audit-note` ya existen del Sprint 1 — solo agregamos
+   `.audit-tray` aquí. */
+.audit-tray {
+  display: none;
+  background: oklch(0.30 0.10 25 / 0.55);
+  border-bottom: 1px solid oklch(0.55 0.18 25 / 0.40);
+  padding: 16px 24px;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 24px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: oklch(0.92 0.06 25);
+}
+body[data-audit="on"] .audit-tray { display: grid; }
+.audit-tray .col {
+  min-width: 0;
+}
+.audit-tray .col h4 {
+  margin: 0 0 8px;
+  font-size: 10.5px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: oklch(0.78 0.10 25);
+  font-weight: 600;
+}
+.audit-tray .kv {
+  display: flex;
+  gap: 8px;
+  padding: 3px 0;
+}
+.audit-tray .kv .k {
+  color: oklch(0.78 0.10 25);
+  width: 80px;
+  flex-shrink: 0;
+}
+.audit-tray .kv .v {
+  color: var(--ink);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.audit-tray a {
+  text-decoration: underline;
+  color: oklch(0.92 0.06 25);
+}

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -269,6 +269,28 @@ El handoff fue diseñado asumiendo desktop ≥1440. El target real (operador usa
 
 ---
 
+## sprint-3/observability-per-row (PR #466 fix-up #1) · DEUDA · AuditTray responsive <1440px
+
+**Detectado:** Visual check CFC post fix-up #1.
+
+**Situación:**
+
+- AuditTray funciona perfecto en target del producto (MacBook 14" para arriba · 1440+).
+- A 1366×768 (notebooks Windows 14"): Col 3 (EVENTOS EN SESIÓN) muy truncada incluso con ellipsis + tooltip aplicado en el fix-up.
+- A 1200×800: overflow horizontal del documento (las 3 columnas `1fr 1fr 1fr` no entran).
+
+**Decisión:** OUT del scope Sprint 3. Target del producto es MacBook 14" para arriba; viewports <1440 están fuera del target oficial.
+
+**Si en uso real se amplía target a Windows 14"/1366:**
+
+- Opción A: breakpoint @ ≤1440px que colapse Col 3 en accordion ("ver eventos →").
+- Opción B: stack vertical en viewports <1440 (1 columna apilada).
+- Opción C: ellipsis + tooltip más agresivo en todas las columnas.
+
+**Estimación si se aborda:** 3-5h Claude Code (sub-PR Sprint 4 `sprint-4/audit-tray-responsive`).
+
+---
+
 ## Resueltos
 
 - **(parcial)** El issue Sprint 2 "operator-shared.css con min-width: 1440px global rompe layouts <1440" queda **mitigado** por el fix-up #2 del PR #465 (min global ahora 1200, no 1440). El plan Sprint 5 (eliminar `min-width` global) sigue pendiente como mejora futura si target se expande a tablet/mobile.

--- a/web/src/app/operator-shared.css
+++ b/web/src/app/operator-shared.css
@@ -4802,3 +4802,17 @@ body[data-audit="on"] .audit-tray { display: grid; }
   text-decoration: underline;
   color: oklch(0.92 0.06 25);
 }
+/* Fix-up #1 H2 · Col 3 (EVENTOS EN SESIÓN) truncada sin ellipsis a 1440.
+   `.v` ya tiene overflow:hidden + text-overflow:ellipsis pero faltaba
+   white-space:nowrap (sin él el text wraps en vez de truncarse). Aplica
+   SOLO a Col 3 para preservar Col 1 + Col 2 que estaban OK. */
+.audit-tray .col:nth-child(3) .kv .v {
+  white-space: nowrap;
+}
+/* Fix-up #1 H4 · link "ver tree" disabled debe verse muted (era azul
+   indistinguible de un link activo). Spec: aria-disabled="true" → no link UX. */
+.audit-tray a[aria-disabled="true"] {
+  color: var(--ink-mute);
+  cursor: not-allowed;
+  text-decoration: none;
+}

--- a/web/src/app/operator-shared.css
+++ b/web/src/app/operator-shared.css
@@ -4752,3 +4752,53 @@ body[data-audit="on"] .audit-toggle {
   font-size: 10px;
   padding: 5px 8px;
 }
+
+/* ─── Sprint 3 observability-per-row · mockup 13 ─────────────────────────
+   Audit tray global · 3 columnas mono-font con metadata IA + trazabilidad
+   + eventos. Visible solo cuando body[data-audit="on"] (gateado via
+   useAuditMode global). Mockup 13-audit-banner-on.html LITERAL.
+   `.ia-banner` y `.audit-note` ya existen del Sprint 1 — solo agregamos
+   `.audit-tray` aquí. */
+.audit-tray {
+  display: none;
+  background: oklch(0.30 0.10 25 / 0.55);
+  border-bottom: 1px solid oklch(0.55 0.18 25 / 0.40);
+  padding: 16px 24px;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 24px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: oklch(0.92 0.06 25);
+}
+body[data-audit="on"] .audit-tray { display: grid; }
+.audit-tray .col {
+  min-width: 0;
+}
+.audit-tray .col h4 {
+  margin: 0 0 8px;
+  font-size: 10.5px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: oklch(0.78 0.10 25);
+  font-weight: 600;
+}
+.audit-tray .kv {
+  display: flex;
+  gap: 8px;
+  padding: 3px 0;
+}
+.audit-tray .kv .k {
+  color: oklch(0.78 0.10 25);
+  width: 80px;
+  flex-shrink: 0;
+}
+.audit-tray .kv .v {
+  color: var(--ink);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.audit-tray a {
+  text-decoration: underline;
+  color: oklch(0.92 0.06 25);
+}

--- a/web/src/app/quotes/[id]/layout.tsx
+++ b/web/src/app/quotes/[id]/layout.tsx
@@ -13,6 +13,7 @@ import { Sidebar } from "@/components/chrome/Sidebar";
 import { Topbar } from "@/components/chrome/Topbar";
 import { Qhead } from "@/components/chrome/Qhead";
 import { Stepper } from "@/components/chrome/Stepper";
+import { AuditTray } from "@/components/observability/AuditTray";
 import { getQuoteMetadata } from "@/lib/api";
 
 export default async function QuoteLayout({
@@ -29,6 +30,9 @@ export default async function QuoteLayout({
       <Sidebar />
       <main className="main">
         <Topbar quote={quote} />
+        {/* Sprint 3 observability · banner top global gateado por
+            body[data-audit="on"] (CSS · useAuditMode). */}
+        <AuditTray quoteId={params.id} />
         <Qhead quote={quote} />
         <Stepper />
         <div className="body no-chat">{children}</div>

--- a/web/src/components/calculo/CalcChatPanel.tsx
+++ b/web/src/components/calculo/CalcChatPanel.tsx
@@ -63,7 +63,7 @@ export function CalcChatPanel({ quoteId, onClose }: Props) {
         <span className="pill">5 secciones del cálculo</span>
         <span className="pill">Totales ARS + USD</span>
       </div>
-      <ChatAuditNote />
+      <ChatAuditNote quoteId={quoteId} />
       {lastAction && (
         <div
           data-testid="chat-action"

--- a/web/src/components/calculo/CalcChatPanel.tsx
+++ b/web/src/components/calculo/CalcChatPanel.tsx
@@ -10,6 +10,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useChatScoped } from "@/lib/hooks/useChatScoped";
+import { ChatAuditNote } from "@/components/observability/ChatAuditNote";
 
 interface Props {
   quoteId: string;
@@ -62,6 +63,7 @@ export function CalcChatPanel({ quoteId, onClose }: Props) {
         <span className="pill">5 secciones del cálculo</span>
         <span className="pill">Totales ARS + USD</span>
       </div>
+      <ChatAuditNote />
       {lastAction && (
         <div
           data-testid="chat-action"

--- a/web/src/components/calculo/CalcToolbar.tsx
+++ b/web/src/components/calculo/CalcToolbar.tsx
@@ -1,9 +1,13 @@
 /**
- * Toolbar del header · AUDIT toggle · Tipo cliente · IVA toggle · ↻ Re-calcular.
+ * Toolbar del header · Tipo cliente · IVA toggle · ↻ Re-calcular.
  *
- * - AUDIT toggle controla `.aud-trail` per-row + chips `.aud-i` (decisión #1)
- * - Tipo cliente Particular/Edificio es VISUAL-only (decisión #2)
- * - IVA toggle muestra/oculta cols (decisión #3)
+ * Sprint 3 observability-per-row · refactor decisión Javi C:
+ * el AUDIT toggle se removió de acá · ahora es global desde TopBar
+ * (AuditToggle component + useAuditMode hook). Eso evita 2 controles
+ * que hacen lo mismo en distintos lugares.
+ *
+ * - Tipo cliente Particular/Edificio es VISUAL-only (decisión #2 paso-4)
+ * - IVA toggle muestra/oculta cols (decisión #3 paso-4)
  * - ↻ Re-calcular dispara `triggerCalculation` mock
  */
 "use client";
@@ -20,28 +24,6 @@ interface Props {
 export function CalcToolbar({ toggles, onChange, onRecalculate, busy }: Props) {
   return (
     <div className="right" style={{ display: "flex", gap: 12, alignItems: "center" }}>
-      <button
-        type="button"
-        className={`audit-toggle${toggles.auditOn ? " on" : ""}`}
-        onClick={() => onChange("auditOn", !toggles.auditOn)}
-        data-testid="audit-toggle"
-        data-on={toggles.auditOn}
-        style={{
-          padding: "6px 10px",
-          border: "1px solid var(--line-strong)",
-          borderRadius: "var(--r-sm)",
-          background: toggles.auditOn ? "var(--surface-2)" : "transparent",
-          color: toggles.auditOn ? "var(--ink)" : "var(--ink-mute)",
-          fontFamily: "var(--mono)",
-          fontSize: 10.5,
-          textTransform: "uppercase",
-          letterSpacing: "0.5px",
-          cursor: "pointer",
-        }}
-      >
-        AUDIT {toggles.auditOn ? "ON" : "OFF"}
-      </button>
-
       <div
         className="tipo-toggle"
         data-testid="tipo-toggle"

--- a/web/src/components/calculo/CalculoView.tsx
+++ b/web/src/components/calculo/CalculoView.tsx
@@ -11,9 +11,11 @@
  */
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useCalculo } from "@/lib/hooks/useCalculo";
+import { useAuditMode } from "@/lib/hooks/useAuditMode";
+import { IaAuditBanner } from "@/components/observability/IaAuditBanner";
 import { CalcBanner } from "./CalcBanner";
 import { CalcChatPanel } from "./CalcChatPanel";
 import { CalcConfirmBar } from "./CalcConfirmBar";
@@ -36,16 +38,11 @@ export function CalculoView({ quoteId }: Props) {
   const [chatOpen, setChatOpen] = useState(false);
   const router = useRouter();
 
-  // operator-shared.css §E3 gatea `.aud-trail` por `body[data-audit="on"]`
-  // (no por una clase del componente). Sincronizamos al toggle del toolbar
-  // y limpiamos al desmontar para que otras rutas no hereden el estado.
-  useEffect(() => {
-    if (typeof document === "undefined") return;
-    document.body.dataset.audit = toggles.auditOn ? "on" : "off";
-    return () => {
-      delete document.body.dataset.audit;
-    };
-  }, [toggles.auditOn]);
+  // Sprint 3 observability-per-row · audit ahora es global (TopBar).
+  // Antes (PR #465 paso-4): useEffect local + toggle en CalcToolbar.
+  // Ahora: useAuditMode encapsula el body[data-audit] sync + persistencia.
+  // `auditOn` se usa para gatear AuditChip + AuditTrail per-row.
+  const { auditOn } = useAuditMode();
 
   if (state === "loading" && !data) {
     return (
@@ -115,6 +112,8 @@ export function CalculoView({ quoteId }: Props) {
           />
         </div>
 
+        <IaAuditBanner />
+
         {isPatchError && data.patchError ? (
           <PatchErrorBanner
             traceId={data.patchError.traceId}
@@ -129,17 +128,17 @@ export function CalculoView({ quoteId }: Props) {
         <CalcSectionMaterial
           rows={data.material.rows}
           subtotal={data.material.subtotal}
-          auditOn={toggles.auditOn}
+          auditOn={auditOn}
         />
-        <CalcSectionMerma merma={data.merma} auditOn={toggles.auditOn} onFix={applyFix} />
+        <CalcSectionMerma merma={data.merma} auditOn={auditOn} onFix={applyFix} />
         <CalcSectionLabor
           rows={data.labor.rows}
           subtotal={data.labor.subtotal}
-          auditOn={toggles.auditOn}
+          auditOn={auditOn}
           ivaVisible={toggles.ivaVisible}
         />
         <CalcSectionPiletas piletas={data.piletas} />
-        <CalcSectionFlete flete={data.flete} auditOn={toggles.auditOn} />
+        <CalcSectionFlete flete={data.flete} auditOn={auditOn} />
 
         <GrandTotal totals={data.totals} />
 

--- a/web/src/components/calculo/CalculoView.tsx
+++ b/web/src/components/calculo/CalculoView.tsx
@@ -112,7 +112,7 @@ export function CalculoView({ quoteId }: Props) {
           />
         </div>
 
-        <IaAuditBanner />
+        <IaAuditBanner quoteId={quoteId} />
 
         {isPatchError && data.patchError ? (
           <PatchErrorBanner

--- a/web/src/components/chrome/Topbar.tsx
+++ b/web/src/components/chrome/Topbar.tsx
@@ -10,6 +10,7 @@
  * cambio de status) en sub-PRs siguientes.
  */
 import type { QuoteHeader } from "@/lib/api";
+import { AuditToggle } from "@/components/observability/AuditToggle";
 
 interface TopbarProps {
   quote: QuoteHeader;
@@ -27,6 +28,9 @@ export function Topbar({ quote }: TopbarProps) {
       </div>
 
       <div className="right">
+        {/* Sprint 3 observability · audit toggle global (refactor decisión Javi C). */}
+        <AuditToggle />
+
         {/* Status chip — `.status-chip.draft` (color amarillento muted) */}
         <span className={`status-chip ${quote.status}`}>
           <span className="dot" />

--- a/web/src/components/despiece/DespieceChatPanel.tsx
+++ b/web/src/components/despiece/DespieceChatPanel.tsx
@@ -21,6 +21,9 @@ import { ValentinaMessage } from "@/components/contexto/ValentinaMessage";
 import { ChatAuditNote } from "@/components/observability/ChatAuditNote";
 
 interface Props {
+  /** Sprint 3 obs-per-row fix-up #2 · necesario para `useAuditEmpty` del
+   * `ChatAuditNote` (esconde cuando snapshot vacío para quotes desconocidos). */
+  quoteId: string;
   messages: ChatMessage[];
   panelState: ChatPanelState;
   pieceCount: number;
@@ -39,6 +42,7 @@ const STEP_SUGGESTIONS = [
 const PIECE_SUGGESTIONS = ["¿La bacha entra en este ancho?", "¿Qué bacha asumiste?", "Ver corte"];
 
 export function DespieceChatPanel({
+  quoteId,
   messages,
   panelState,
   pieceCount,
@@ -107,7 +111,7 @@ export function DespieceChatPanel({
         {editedCount > 0 && <span className="pill scope-pill-human">{editedCount} editadas</span>}
         <span className="pill">Contexto confirmado</span>
       </div>
-      <ChatAuditNote />
+      <ChatAuditNote quoteId={quoteId} />
 
       <div className="stream" ref={streamRef} data-testid="chat-stream">
         {messages.length === 0 && (

--- a/web/src/components/despiece/DespieceChatPanel.tsx
+++ b/web/src/components/despiece/DespieceChatPanel.tsx
@@ -18,6 +18,7 @@ import type { Piece } from "@/lib/api";
 import type { ChatMessage, ChatPanelState } from "@/lib/types";
 import { UserMessage } from "@/components/contexto/UserMessage";
 import { ValentinaMessage } from "@/components/contexto/ValentinaMessage";
+import { ChatAuditNote } from "@/components/observability/ChatAuditNote";
 
 interface Props {
   messages: ChatMessage[];
@@ -106,6 +107,7 @@ export function DespieceChatPanel({
         {editedCount > 0 && <span className="pill scope-pill-human">{editedCount} editadas</span>}
         <span className="pill">Contexto confirmado</span>
       </div>
+      <ChatAuditNote />
 
       <div className="stream" ref={streamRef} data-testid="chat-stream">
         {messages.length === 0 && (

--- a/web/src/components/despiece/DespieceView.tsx
+++ b/web/src/components/despiece/DespieceView.tsx
@@ -26,6 +26,7 @@ import { DespieceTable } from "./DespieceTable";
 import { DespieceTimeline } from "./DespieceTimeline";
 import { DespieceEmptyState } from "./DespieceEmptyState";
 import { DespieceChatPanel } from "./DespieceChatPanel";
+import { IaAuditBanner } from "@/components/observability/IaAuditBanner";
 
 interface Props {
   quoteId: string;
@@ -286,6 +287,9 @@ export function DespieceView({ quoteId }: Props) {
             )}
           </div>
         </div>
+
+        {/* Sprint 3 observability · banner explicativo cuando audit on. */}
+        <IaAuditBanner />
 
         {/* Banner Valentina · pristine / dirty / focused */}
         <div

--- a/web/src/components/despiece/DespieceView.tsx
+++ b/web/src/components/despiece/DespieceView.tsx
@@ -289,7 +289,7 @@ export function DespieceView({ quoteId }: Props) {
         </div>
 
         {/* Sprint 3 observability · banner explicativo cuando audit on. */}
-        <IaAuditBanner />
+        <IaAuditBanner quoteId={quoteId} />
 
         {/* Banner Valentina · pristine / dirty / focused */}
         <div
@@ -409,6 +409,7 @@ export function DespieceView({ quoteId }: Props) {
 
       {chatOpen && (
         <DespieceChatPanel
+          quoteId={quoteId}
           messages={chat.messages}
           panelState={chat.panelState}
           pieceCount={pieces.length}

--- a/web/src/components/observability/AuditToggle.tsx
+++ b/web/src/components/observability/AuditToggle.tsx
@@ -1,0 +1,40 @@
+/**
+ * Chip "AUDIT ON/OFF" mono · TopBar right side.
+ *
+ * Refactor decisión Javi C: el toggle local del paso-4 (CalcToolbar) se
+ * remueve · ahora hay un único toggle global que setea body[data-audit]
+ * via useAuditMode hook. Persiste en localStorage.
+ *
+ * Sub-PR Sprint 4 puede moverlo a /config cuando esa ruta exista.
+ */
+"use client";
+
+import { useAuditMode } from "@/lib/hooks/useAuditMode";
+
+export function AuditToggle() {
+  const { auditOn, toggle } = useAuditMode();
+  return (
+    <button
+      type="button"
+      className={`audit-toggle${auditOn ? " on" : ""}`}
+      onClick={toggle}
+      data-testid="audit-toggle"
+      data-on={auditOn}
+      title={auditOn ? "Audit ON · debug visible" : "Activar audit · debug visible"}
+      style={{
+        padding: "5px 10px",
+        border: "1px solid var(--line-strong)",
+        borderRadius: "var(--r-sm)",
+        background: auditOn ? "var(--surface-2)" : "transparent",
+        color: auditOn ? "var(--ink)" : "var(--ink-mute)",
+        fontFamily: "var(--mono)",
+        fontSize: 10.5,
+        textTransform: "uppercase",
+        letterSpacing: "0.5px",
+        cursor: "pointer",
+      }}
+    >
+      AUDIT {auditOn ? "ON" : "OFF"}
+    </button>
+  );
+}

--- a/web/src/components/observability/AuditTray.tsx
+++ b/web/src/components/observability/AuditTray.tsx
@@ -41,7 +41,9 @@ export function AuditTray({ quoteId }: Props) {
     };
   }, [auditOn, quoteId]);
 
-  if (!auditOn || !snapshot) return null;
+  // Fix-up #2 · esconder cuando snapshot vacío (fallback genérico para
+  // quotes desconocidos · UX rota mostrar tray gigante con em-dashes).
+  if (!auditOn || !snapshot || snapshot.isEmpty) return null;
 
   return (
     <div className="audit-tray" data-testid="audit-tray">

--- a/web/src/components/observability/AuditTray.tsx
+++ b/web/src/components/observability/AuditTray.tsx
@@ -106,15 +106,19 @@ export function AuditTray({ quoteId }: Props) {
             <span className="v">sin eventos</span>
           </div>
         ) : (
-          snapshot.events.map((ev, i) => (
-            <div className="kv" key={`${ev.timestamp}-${i}`}>
-              <span className="k">{ev.timestamp}</span>
-              <span className="v">
-                {ev.name}
-                {ev.detail ? ` (${ev.detail})` : ""}
-              </span>
-            </div>
-          ))
+          snapshot.events.map((ev, i) => {
+            // Fix-up #1 H2: full text como title para tooltip nativo en hover
+            // cuando la celda se trunca con ellipsis (a 1440 los detalles largos).
+            const full = `${ev.name}${ev.detail ? ` (${ev.detail})` : ""}`;
+            return (
+              <div className="kv" key={`${ev.timestamp}-${i}`}>
+                <span className="k">{ev.timestamp}</span>
+                <span className="v" title={full}>
+                  {full}
+                </span>
+              </div>
+            );
+          })
         )}
       </div>
     </div>

--- a/web/src/components/observability/AuditTray.tsx
+++ b/web/src/components/observability/AuditTray.tsx
@@ -1,0 +1,122 @@
+/**
+ * Audit-tray banner top global · mockup 13.
+ *
+ * Visible solo cuando `body[data-audit="on"]`. 3 columnas mono-font con
+ * metadata IA (model/tokens/latency), trazabilidad (trace_id/prompt_v/temp/
+ * cache) y eventos en sesión (timestamp+name+detail).
+ *
+ * Mock-only · datos via getAuditSnapshot con fallback gracioso a em-dash
+ * para IDs desconocidos (decisión Javi D). Tree view del trace_id queda
+ * disabled con TODO Sprint 4 (decisión Javi G).
+ */
+"use client";
+
+import { useEffect, useState } from "react";
+import type { AuditSnapshot } from "@/lib/api";
+import { getAuditSnapshot } from "@/lib/api";
+import { useAuditMode } from "@/lib/hooks/useAuditMode";
+
+interface Props {
+  quoteId: string;
+}
+
+export function AuditTray({ quoteId }: Props) {
+  const { auditOn } = useAuditMode();
+  const [snapshot, setSnapshot] = useState<AuditSnapshot | null>(null);
+
+  useEffect(() => {
+    if (!auditOn) return;
+    let aborted = false;
+    const ctrl = new AbortController();
+    getAuditSnapshot(quoteId, { signal: ctrl.signal })
+      .then((s) => {
+        if (!aborted) setSnapshot(s);
+      })
+      .catch(() => {
+        // Fallback gracioso ya está en el mock · si igual rompe, no mostrar tray.
+      });
+    return () => {
+      aborted = true;
+      ctrl.abort();
+    };
+  }, [auditOn, quoteId]);
+
+  if (!auditOn || !snapshot) return null;
+
+  return (
+    <div className="audit-tray" data-testid="audit-tray">
+      <div className="col">
+        <h4>· Última llamada IA</h4>
+        <div className="kv">
+          <span className="k">model</span>
+          <span className="v">{snapshot.lastCall.model}</span>
+        </div>
+        <div className="kv">
+          <span className="k">scope</span>
+          <span className="v">{snapshot.lastCall.scope}</span>
+        </div>
+        <div className="kv">
+          <span className="k">tokens</span>
+          <span className="v">
+            in {snapshot.lastCall.tokensIn.toLocaleString("es-AR")} · out{" "}
+            {snapshot.lastCall.tokensOut.toLocaleString("es-AR")}
+          </span>
+        </div>
+        <div className="kv">
+          <span className="k">latency</span>
+          <span className="v">{(snapshot.lastCall.latencyMs / 1000).toFixed(1)}s</span>
+        </div>
+      </div>
+      <div className="col">
+        <h4>· Trazabilidad</h4>
+        <div className="kv">
+          <span className="k">trace_id</span>
+          <span className="v">
+            {snapshot.trace.traceId} ·{" "}
+            <a
+              href="#"
+              aria-disabled="true"
+              title="ver tree — Sprint 4 (versioning + drawer)"
+              onClick={(e) => e.preventDefault()}
+              data-testid="trace-tree-disabled"
+              style={{ opacity: 0.55, cursor: "not-allowed" }}
+            >
+              ver tree
+            </a>
+          </span>
+        </div>
+        <div className="kv">
+          <span className="k">prompt_v</span>
+          <span className="v">{snapshot.trace.promptVersion}</span>
+        </div>
+        <div className="kv">
+          <span className="k">temp</span>
+          <span className="v">{snapshot.trace.temperature}</span>
+        </div>
+        <div className="kv">
+          <span className="k">cache</span>
+          <span className="v">prompt cache hit ({snapshot.trace.cacheHitPct}%)</span>
+        </div>
+      </div>
+      <div className="col">
+        <h4>· Eventos en sesión</h4>
+        {snapshot.events.length === 0 ? (
+          <div className="kv">
+            <span className="k">—</span>
+            <span className="v">sin eventos</span>
+          </div>
+        ) : (
+          snapshot.events.map((ev, i) => (
+            <div className="kv" key={`${ev.timestamp}-${i}`}>
+              <span className="k">{ev.timestamp}</span>
+              <span className="v">
+                {ev.name}
+                {ev.detail ? ` (${ev.detail})` : ""}
+              </span>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/observability/ChatAuditNote.tsx
+++ b/web/src/components/observability/ChatAuditNote.tsx
@@ -3,14 +3,21 @@
  * activo. Copy LITERAL del mockup 13.
  *
  * Reusable en CalcChatPanel + DespieceChatPanel.
+ * Fix-up #2: oculto cuando snapshot del quote es vacío (fallback genérico).
  */
 "use client";
 
 import { useAuditMode } from "@/lib/hooks/useAuditMode";
+import { useAuditEmpty } from "@/lib/hooks/useAuditEmpty";
 
-export function ChatAuditNote() {
+interface Props {
+  quoteId: string;
+}
+
+export function ChatAuditNote({ quoteId }: Props) {
   const { auditOn } = useAuditMode();
-  if (!auditOn) return null;
+  const isEmpty = useAuditEmpty(quoteId);
+  if (!auditOn || isEmpty !== false) return null;
   return (
     <div className="audit-note" data-testid="chat-audit-note">
       Audit ON: cada turno se loguea con trace_id.

--- a/web/src/components/observability/ChatAuditNote.tsx
+++ b/web/src/components/observability/ChatAuditNote.tsx
@@ -1,0 +1,19 @@
+/**
+ * Note `.audit-note` dentro del chat panel cuando audit mode global está
+ * activo. Copy LITERAL del mockup 13.
+ *
+ * Reusable en CalcChatPanel + DespieceChatPanel.
+ */
+"use client";
+
+import { useAuditMode } from "@/lib/hooks/useAuditMode";
+
+export function ChatAuditNote() {
+  const { auditOn } = useAuditMode();
+  if (!auditOn) return null;
+  return (
+    <div className="audit-note" data-testid="chat-audit-note">
+      Audit ON: cada turno se loguea con trace_id.
+    </div>
+  );
+}

--- a/web/src/components/observability/IaAuditBanner.tsx
+++ b/web/src/components/observability/IaAuditBanner.tsx
@@ -3,14 +3,22 @@
  * `body[data-audit="on"]`. Copy LITERAL del mockup 13.
  *
  * Decisión Javi F: IN (cost bajo, valor alto · parte del mockup literal).
+ * Fix-up #2: oculto cuando snapshot del quote es vacío (fallback genérico).
  */
 "use client";
 
 import { useAuditMode } from "@/lib/hooks/useAuditMode";
+import { useAuditEmpty } from "@/lib/hooks/useAuditEmpty";
 
-export function IaAuditBanner() {
+interface Props {
+  quoteId: string;
+}
+
+export function IaAuditBanner({ quoteId }: Props) {
   const { auditOn } = useAuditMode();
-  if (!auditOn) return null;
+  const isEmpty = useAuditEmpty(quoteId);
+  // Esconder en loading (null) y cuando isEmpty=true (sin datos reales).
+  if (!auditOn || isEmpty !== false) return null;
   return (
     <div className="ia-banner" data-testid="ia-audit-banner">
       <div className="vbubble" aria-hidden="true" />

--- a/web/src/components/observability/IaAuditBanner.tsx
+++ b/web/src/components/observability/IaAuditBanner.tsx
@@ -1,0 +1,26 @@
+/**
+ * Banner explicativo `.ia-banner` que aparece en paso-3/paso-4 cuando
+ * `body[data-audit="on"]`. Copy LITERAL del mockup 13.
+ *
+ * Decisión Javi F: IN (cost bajo, valor alto · parte del mockup literal).
+ */
+"use client";
+
+import { useAuditMode } from "@/lib/hooks/useAuditMode";
+
+export function IaAuditBanner() {
+  const { auditOn } = useAuditMode();
+  if (!auditOn) return null;
+  return (
+    <div className="ia-banner" data-testid="ia-audit-banner">
+      <div className="vbubble" aria-hidden="true" />
+      <div className="text">
+        Audit ON: cada respuesta de Valentina te muestra contexto, modelo, tokens y trace_id
+        arriba.
+        <div className="sub">
+          Sólo visible para usuarios con rol dev / QA · togglable desde Configuración
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -38,6 +38,9 @@ export const getCalculationForQuote = mocks.getCalculationForQuote;
 export const triggerCalculation = mocks.triggerCalculation;
 export const applyAutoFix = mocks.applyAutoFix;
 
+/* ─── Observability · Sprint 3 observability-per-row · mockup 13 ── */
+export const getAuditSnapshot = mocks.getAuditSnapshot;
+
 /* ─── Helpers de test (reset de stores in-memory del mock) ───────── */
 export const _resetContextStore = mocks._resetContextStore;
 export const _resetPiecesStore = mocks._resetPiecesStore;

--- a/web/src/lib/api/mocks.ts
+++ b/web/src/lib/api/mocks.ts
@@ -633,12 +633,16 @@ const _auditGeneric: import("./types").AuditSnapshot = {
     cacheHitPct: 0,
   },
   events: [],
+  // Fix-up #2 · marca snapshot como vacío · esconde tray/banner/note (UX
+  // rota mostrar 3 cols de em-dash + 0 tokens + 0 eventos). El AUDIT toggle
+  // y el aud-trail per-row del paso-4 NO dependen de este flag.
+  isEmpty: true,
 };
 
 /**
  * Snapshot del audit-tray para un quote. Mock-only · fallback gracioso para
- * IDs desconocidos (UUID/web-XXX) que devuelve el snapshot generic en em-dash.
- * Sprint 4: wire al backend cuando exponga la metadata real.
+ * IDs desconocidos (UUID/web-XXX) que devuelve el snapshot generic en em-dash
+ * con `isEmpty: true`. Sprint 4: wire al backend cuando exponga la metadata.
  */
 export async function getAuditSnapshot(
   quoteId: string,

--- a/web/src/lib/api/mocks.ts
+++ b/web/src/lib/api/mocks.ts
@@ -566,3 +566,84 @@ export async function applyAutoFix(
   _calcStore.set(quoteId, fresh);
   return fresh;
 }
+
+// ─── Sprint 3 observability-per-row · mockup 13 ───
+// Audit snapshot mock con fallback gracioso desde el inicio.
+// Datos LITERALES del mockup 13-audit-banner-on.html (model claude-sonnet-4,
+// tokens 1842/612, latency 4.2s, trace q_8f2a, prompt despiece.v3.2,
+// temp 0.2 seed fixed, cache 84%, 4 eventos del despiece flow).
+
+const _auditByQuote: Record<string, import("./types").AuditSnapshot> = {
+  "PRES-2026-018": {
+    lastCall: {
+      model: "claude-sonnet-4",
+      scope: "despiece · 5 piezas + contexto confirmado",
+      tokensIn: 1842,
+      tokensOut: 612,
+      latencyMs: 4200,
+    },
+    trace: {
+      traceId: "q_8f2a",
+      promptVersion: "despiece.v3.2",
+      temperature: "0.2 · seed fixed",
+      cacheHitPct: 84,
+    },
+    events: [
+      { timestamp: "10:04:12", name: "contexto.confirm" },
+      { timestamp: "10:04:14", name: "despiece.draft.start" },
+      { timestamp: "10:04:18", name: "despiece.draft.partial", detail: "5/7" },
+      { timestamp: "10:04:22", name: "despiece.draft.calc", detail: "R6, R7" },
+    ],
+  },
+  "PRES-2026-017": {
+    lastCall: {
+      model: "claude-sonnet-4",
+      scope: "calculo · particular · IVA on",
+      tokensIn: 1124,
+      tokensOut: 389,
+      latencyMs: 2800,
+    },
+    trace: {
+      traceId: "q_4c1e",
+      promptVersion: "calculo.v2.4",
+      temperature: "0.2 · seed fixed",
+      cacheHitPct: 72,
+    },
+    events: [
+      { timestamp: "09:51:08", name: "contexto.confirm" },
+      { timestamp: "09:51:09", name: "despiece.confirm" },
+      { timestamp: "09:51:11", name: "calculo.draft.start" },
+      { timestamp: "09:51:13", name: "calculo.draft.done", detail: "OK" },
+    ],
+  },
+};
+
+const _auditGeneric: import("./types").AuditSnapshot = {
+  lastCall: {
+    model: "—",
+    scope: "—",
+    tokensIn: 0,
+    tokensOut: 0,
+    latencyMs: 0,
+  },
+  trace: {
+    traceId: "—",
+    promptVersion: "—",
+    temperature: "—",
+    cacheHitPct: 0,
+  },
+  events: [],
+};
+
+/**
+ * Snapshot del audit-tray para un quote. Mock-only · fallback gracioso para
+ * IDs desconocidos (UUID/web-XXX) que devuelve el snapshot generic en em-dash.
+ * Sprint 4: wire al backend cuando exponga la metadata real.
+ */
+export async function getAuditSnapshot(
+  quoteId: string,
+  options?: { signal?: AbortSignal },
+): Promise<import("./types").AuditSnapshot> {
+  await delay(120 + Math.random() * 120, options?.signal);
+  return _auditByQuote[quoteId] ?? _auditGeneric;
+}

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -326,7 +326,48 @@ export interface CalculationResult {
 
 /** Toggles UI controlados por CalcToolbar (no afectan el cálculo en este PR). */
 export interface CalcToggles {
+  /** @deprecated Sprint 3 observability-per-row · audit ahora es global via
+   * `useAuditMode` (TopBar). Se mantiene en la interfaz solo por compatibilidad
+   * de tests · no se renderiza desde CalcToolbar. */
   auditOn: boolean;
   ivaVisible: boolean;
   tipoCliente: "particular" | "edificio";
+}
+
+// ─── Sprint 3 observability-per-row · mockup 13 ───
+// Banner top global de auditoría · visible cuando body[data-audit="on"].
+// Mock-only · backend no expone esta metadata (decisión Javi D).
+
+/** Última llamada al modelo IA — primera columna del audit-tray. */
+export interface AuditLastCall {
+  model: string;
+  scope: string;
+  tokensIn: number;
+  tokensOut: number;
+  latencyMs: number;
+}
+
+/** Trazabilidad de la corrida — segunda columna del audit-tray. */
+export interface AuditTrace {
+  traceId: string;
+  promptVersion: string;
+  temperature: string;
+  cacheHitPct: number;
+}
+
+/** Evento en sesión — tercera columna del audit-tray. */
+export interface AuditEvent {
+  /** Formato HH:MM:SS. */
+  timestamp: string;
+  /** Dot-notation del evento (ej. "despiece.draft.partial"). */
+  name: string;
+  /** Detalle opcional. */
+  detail?: string;
+}
+
+/** Snapshot completo del audit-tray. */
+export interface AuditSnapshot {
+  lastCall: AuditLastCall;
+  trace: AuditTrace;
+  events: AuditEvent[];
 }

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -324,12 +324,13 @@ export interface CalculationResult {
   datosPdf: DatosPdfDefaults;
 }
 
-/** Toggles UI controlados por CalcToolbar (no afectan el cálculo en este PR). */
+/** Toggles UI controlados por CalcToolbar (no afectan el cálculo en este PR).
+ * Sprint 3 obs-per-row fix-up #1: `auditOn` removido del state local de useCalculo
+ * — ahora vive en `useAuditMode` (TopBar global). El field también se eliminó
+ * de esta interfaz porque CalcSection (Material/Merma/Labor/Flete) y LaborRow
+ * reciben `auditOn` directo del hook global en CalculoView, no del state de
+ * toggles. */
 export interface CalcToggles {
-  /** @deprecated Sprint 3 observability-per-row · audit ahora es global via
-   * `useAuditMode` (TopBar). Se mantiene en la interfaz solo por compatibilidad
-   * de tests · no se renderiza desde CalcToolbar. */
-  auditOn: boolean;
   ivaVisible: boolean;
   tipoCliente: "particular" | "edificio";
 }

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -371,4 +371,10 @@ export interface AuditSnapshot {
   lastCall: AuditLastCall;
   trace: AuditTrace;
   events: AuditEvent[];
+  /** Fix-up #2: marca el snapshot como sin datos reales (fallback genérico).
+   * Cuando es true, AuditTray + IaAuditBanner + ChatAuditNote se ocultan
+   * (tray gigante con em-dashes = UX rota). El AUDIT toggle en TopBar y el
+   * aud-trail per-row del paso-4 siguen visibles porque tienen datos propios
+   * independientes del snapshot. */
+  isEmpty?: boolean;
 }

--- a/web/src/lib/hooks/useAuditEmpty.ts
+++ b/web/src/lib/hooks/useAuditEmpty.ts
@@ -1,0 +1,68 @@
+/**
+ * `useAuditEmpty(quoteId)` · Sprint 3 obs-per-row fix-up #2.
+ *
+ * Hook compartido que devuelve `true` cuando el snapshot del quote es vacío
+ * (fallback genérico para quotes desconocidos del backend real). Usado por
+ * AuditTray, IaAuditBanner y ChatAuditNote para esconder cuando no hay datos.
+ *
+ * Cache module-level evita N fetches paralelos cuando 3 componentes montan
+ * para el mismo quoteId. El cache se rellena con la respuesta del mock —
+ * Sprint 4 invalidará cuando el backend cambie el snapshot en runtime.
+ *
+ * Estado inicial: `null` (loading) · esconde por safety mientras carga.
+ * Cuando llega el snapshot: `true`/`false` según el flag isEmpty.
+ */
+"use client";
+
+import { useEffect, useState } from "react";
+import { getAuditSnapshot } from "@/lib/api";
+
+const _cache = new Map<string, boolean>();
+const _inflight = new Map<string, Promise<boolean>>();
+
+async function loadIsEmpty(quoteId: string): Promise<boolean> {
+  if (_cache.has(quoteId)) return _cache.get(quoteId) as boolean;
+  const existing = _inflight.get(quoteId);
+  if (existing) return existing;
+  const p = getAuditSnapshot(quoteId).then((snap) => {
+    const isEmpty = !!snap.isEmpty;
+    _cache.set(quoteId, isEmpty);
+    _inflight.delete(quoteId);
+    return isEmpty;
+  });
+  _inflight.set(quoteId, p);
+  return p;
+}
+
+/** Helper para tests que quieran reset del cache entre runs. */
+export function _resetAuditEmptyCache() {
+  _cache.clear();
+  _inflight.clear();
+}
+
+export function useAuditEmpty(quoteId: string): boolean | null {
+  const [isEmpty, setIsEmpty] = useState<boolean | null>(() => {
+    return _cache.has(quoteId) ? (_cache.get(quoteId) as boolean) : null;
+  });
+
+  useEffect(() => {
+    if (_cache.has(quoteId)) {
+      setIsEmpty(_cache.get(quoteId) as boolean);
+      return;
+    }
+    let aborted = false;
+    loadIsEmpty(quoteId)
+      .then((v) => {
+        if (!aborted) setIsEmpty(v);
+      })
+      .catch(() => {
+        // En caso de error tratamos como empty (esconder por safety).
+        if (!aborted) setIsEmpty(true);
+      });
+    return () => {
+      aborted = true;
+    };
+  }, [quoteId]);
+
+  return isEmpty;
+}

--- a/web/src/lib/hooks/useAuditMode.ts
+++ b/web/src/lib/hooks/useAuditMode.ts
@@ -1,0 +1,66 @@
+/**
+ * Audit mode global · Sprint 3 observability-per-row.
+ *
+ * Hook global con localStorage persist + sync `body[data-audit]`.
+ * Reemplaza el toggle local del paso-4 (CalcToolbar) por un flag único
+ * controlado desde TopBar. Visible para cualquier ruta del quote layout.
+ *
+ * Mock-only (decisión Javi H): role-gate dev/QA diferido — toggle
+ * discreto es proxy razonable mientras no exista role system.
+ */
+"use client";
+
+import { useCallback, useEffect, useSyncExternalStore } from "react";
+
+const STORAGE_KEY = "marble.audit-mode";
+
+type AuditMode = "on" | "off";
+
+// External store · simple pub/sub para que múltiples componentes
+// se sincronicen sin React Context ni state global.
+const listeners = new Set<() => void>();
+
+function subscribe(cb: () => void) {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+}
+
+function getSnapshot(): AuditMode {
+  if (typeof window === "undefined") return "off";
+  return (window.localStorage.getItem(STORAGE_KEY) as AuditMode) || "off";
+}
+
+function getServerSnapshot(): AuditMode {
+  return "off";
+}
+
+function setMode(value: AuditMode) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, value);
+  document.body.dataset.audit = value;
+  listeners.forEach((cb) => cb());
+}
+
+export function useAuditMode() {
+  const mode = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  const auditOn = mode === "on";
+
+  // Sync body[data-audit] al mount + cada vez que cambia.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    document.body.dataset.audit = mode;
+    return () => {
+      // No limpiamos al desmontar · el flag es global por sesión.
+    };
+  }, [mode]);
+
+  const toggle = useCallback(() => {
+    setMode(getSnapshot() === "on" ? "off" : "on");
+  }, []);
+
+  const setOn = useCallback((on: boolean) => {
+    setMode(on ? "on" : "off");
+  }, []);
+
+  return { auditOn, toggle, setOn };
+}

--- a/web/src/lib/hooks/useAuditMode.ts
+++ b/web/src/lib/hooks/useAuditMode.ts
@@ -34,10 +34,22 @@ function getServerSnapshot(): AuditMode {
   return "off";
 }
 
+function applyBody(value: AuditMode) {
+  if (typeof document === "undefined") return;
+  // Fix-up #1 H3: spec original dice attribute AUSENTE en OFF.
+  // Functionally equivalente para `body[data-audit="on"]` CSS selectors,
+  // pero coherente con la expectativa (DevTools muestra atributo solo cuando on).
+  if (value === "on") {
+    document.body.dataset.audit = "on";
+  } else {
+    delete document.body.dataset.audit;
+  }
+}
+
 function setMode(value: AuditMode) {
   if (typeof window === "undefined") return;
   window.localStorage.setItem(STORAGE_KEY, value);
-  document.body.dataset.audit = value;
+  applyBody(value);
   listeners.forEach((cb) => cb());
 }
 
@@ -47,11 +59,8 @@ export function useAuditMode() {
 
   // Sync body[data-audit] al mount + cada vez que cambia.
   useEffect(() => {
-    if (typeof document === "undefined") return;
-    document.body.dataset.audit = mode;
-    return () => {
-      // No limpiamos al desmontar · el flag es global por sesión.
-    };
+    applyBody(mode);
+    // No limpiamos al desmontar · el flag es global por sesión.
   }, [mode]);
 
   const toggle = useCallback(() => {

--- a/web/src/lib/hooks/useCalculo.ts
+++ b/web/src/lib/hooks/useCalculo.ts
@@ -26,7 +26,8 @@ export function useCalculo(quoteId: string) {
   const [state, setState] = useState<State>("loading");
   const [error, setError] = useState<string | null>(null);
   const [toggles, setToggles] = useState<CalcToggles>({
-    auditOn: false,
+    // Sprint 3 obs-per-row fix-up #1: `auditOn` removido del state local
+    // (ahora vive en useAuditMode global · TopBar).
     ivaVisible: true,
     tipoCliente: "particular",
   });

--- a/web/tests/e2e/observability.spec.ts
+++ b/web/tests/e2e/observability.spec.ts
@@ -25,11 +25,14 @@ test("toggle AUDIT global en TopBar sincroniza body[data-audit]", async ({ page 
   await go(page, "/quotes/PRES-2026-018/calculo");
   await expect(page.locator('[data-testid="audit-toggle"]')).toBeVisible();
   await expect(page.locator('[data-testid="audit-toggle"]')).toHaveAttribute("data-on", "false");
+  // Fix-up #1 H3: en OFF el atributo data-audit NO existe (delete en useAuditMode).
+  // Functionally equivalente para CSS [data-audit="on"] pero coherente con spec.
+  await expect(page.locator("body")).not.toHaveAttribute("data-audit", /.+/);
   await page.locator('[data-testid="audit-toggle"]').click();
   await expect(page.locator('[data-testid="audit-toggle"]')).toHaveAttribute("data-on", "true");
   await expect(page.locator("body")).toHaveAttribute("data-audit", "on");
   await page.locator('[data-testid="audit-toggle"]').click();
-  await expect(page.locator("body")).toHaveAttribute("data-audit", "off");
+  await expect(page.locator("body")).not.toHaveAttribute("data-audit", /.+/);
 });
 
 test("AuditTray banner muestra 3 columnas con datos canon PRES-018", async ({ page }) => {
@@ -94,7 +97,9 @@ test("IaAuditBanner visible en paso-4 calculo cuando audit on", async ({ page })
   await expect(page.locator('[data-testid="ia-audit-banner"]')).toBeVisible();
 });
 
-test("ChatAuditNote visible dentro del chat scoped del paso-4 cuando audit on", async ({ page }) => {
+test("ChatAuditNote visible dentro del chat scoped del paso-4 cuando audit on", async ({
+  page,
+}) => {
   await go(page, "/quotes/PRES-2026-018/calculo");
   await page.locator('[data-testid="audit-toggle"]').click();
   await page.locator('[data-testid="open-chat"]').click();
@@ -125,10 +130,7 @@ test("CalcToolbar ya no tiene AUDIT toggle local (solo Tipo + IVA + Recalcular)"
   page,
 }) => {
   await go(page, "/quotes/PRES-2026-018/calculo");
-  const toolbar = page.locator('[data-testid="tipo-toggle"]').locator("..");
-  // El AUDIT toggle ahora está en TopBar (1 sola instancia)
+  // El AUDIT toggle ahora está en TopBar (1 sola instancia · refactor decisión Javi C).
   await expect(page.locator('[data-testid="audit-toggle"]')).toHaveCount(1);
-  // El que queda está dentro de la TopBar, no del section-head del CalcToolbar
-  const inTopbar = page.locator('.topbar [data-testid="audit-toggle"]');
-  await expect(inTopbar).toBeVisible();
+  await expect(page.locator('.topbar [data-testid="audit-toggle"]')).toBeVisible();
 });

--- a/web/tests/e2e/observability.spec.ts
+++ b/web/tests/e2e/observability.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * E2E del observability mode global · Sprint 3 observability-per-row.
+ *
+ * Cubre mockup 13 LITERAL:
+ * - Toggle AUDIT en TopBar global (refactor decisión Javi C).
+ * - AuditTray banner top: 3 columnas con metadata IA + traza + eventos.
+ * - body[data-audit="on"] cuando toggle ON, "off" cuando OFF.
+ * - useAuditMode persiste en localStorage entre nav.
+ * - IaAuditBanner visible en paso-3/paso-4 cuando audit on.
+ * - ChatAuditNote visible dentro del chat scoped cuando audit on.
+ * - Tree view del trace_id disabled con TODO Sprint 4 (decisión Javi G).
+ * - Datasource isolation PRES-018 vs PRES-017.
+ * - Fallback gracioso para ID desconocido (UUID/web-XXX).
+ * - Audit per-row del paso-4 (aud-trail) sigue funcionando con el nuevo
+ *   toggle global (regression check post-refactor).
+ */
+import { expect, test, type Page } from "@playwright/test";
+
+async function go(page: Page, route: string) {
+  await page.goto(route);
+  await expect(page.locator(".topbar")).toBeVisible();
+}
+
+test("toggle AUDIT global en TopBar sincroniza body[data-audit]", async ({ page }) => {
+  await go(page, "/quotes/PRES-2026-018/calculo");
+  await expect(page.locator('[data-testid="audit-toggle"]')).toBeVisible();
+  await expect(page.locator('[data-testid="audit-toggle"]')).toHaveAttribute("data-on", "false");
+  await page.locator('[data-testid="audit-toggle"]').click();
+  await expect(page.locator('[data-testid="audit-toggle"]')).toHaveAttribute("data-on", "true");
+  await expect(page.locator("body")).toHaveAttribute("data-audit", "on");
+  await page.locator('[data-testid="audit-toggle"]').click();
+  await expect(page.locator("body")).toHaveAttribute("data-audit", "off");
+});
+
+test("AuditTray banner muestra 3 columnas con datos canon PRES-018", async ({ page }) => {
+  await go(page, "/quotes/PRES-2026-018/calculo");
+  await expect(page.locator('[data-testid="audit-tray"]')).not.toBeVisible();
+  await page.locator('[data-testid="audit-toggle"]').click();
+  const tray = page.locator('[data-testid="audit-tray"]');
+  await expect(tray).toBeVisible();
+  await expect(tray).toContainText("Última llamada IA");
+  await expect(tray).toContainText("claude-sonnet-4");
+  await expect(tray).toContainText("in 1.842");
+  await expect(tray).toContainText("4.2s");
+  await expect(tray).toContainText("Trazabilidad");
+  await expect(tray).toContainText("q_8f2a");
+  await expect(tray).toContainText("despiece.v3.2");
+  await expect(tray).toContainText("84%");
+  await expect(tray).toContainText("Eventos en sesión");
+  await expect(tray).toContainText("contexto.confirm");
+  await expect(tray).toContainText("despiece.draft.partial");
+});
+
+test("AuditTray datasource correcto PRES-017 vs PRES-018", async ({ page }) => {
+  await go(page, "/quotes/PRES-2026-017/calculo");
+  await page.locator('[data-testid="audit-toggle"]').click();
+  const tray = page.locator('[data-testid="audit-tray"]');
+  await expect(tray).toContainText("q_4c1e");
+  await expect(tray).toContainText("calculo.v2.4");
+  await expect(tray).not.toContainText("q_8f2a");
+});
+
+test("AuditTray ID desconocido renderea fallback em-dash sin crash", async ({ page }) => {
+  await go(page, "/quotes/web-deadbeef-cafe/contexto");
+  await page.locator('[data-testid="audit-toggle"]').click();
+  const tray = page.locator('[data-testid="audit-tray"]');
+  await expect(tray).toBeVisible();
+  await expect(tray.locator(".col").first()).toContainText("—");
+  await expect(tray).toContainText("sin eventos");
+});
+
+test("tree view del trace_id está disabled con TODO Sprint 4", async ({ page }) => {
+  await go(page, "/quotes/PRES-2026-018/calculo");
+  await page.locator('[data-testid="audit-toggle"]').click();
+  const treeLink = page.locator('[data-testid="trace-tree-disabled"]');
+  await expect(treeLink).toBeVisible();
+  await expect(treeLink).toHaveAttribute("aria-disabled", "true");
+  await expect(treeLink).toHaveAttribute("title", /Sprint 4/);
+});
+
+test("IaAuditBanner visible en paso-3 despiece cuando audit on", async ({ page }) => {
+  await go(page, "/quotes/PRES-2026-018/despiece");
+  await expect(page.locator('[data-testid="ia-audit-banner"]')).not.toBeVisible();
+  await page.locator('[data-testid="audit-toggle"]').click();
+  const banner = page.locator('[data-testid="ia-audit-banner"]');
+  await expect(banner).toBeVisible();
+  await expect(banner).toContainText("Audit ON");
+  await expect(banner).toContainText("trace_id");
+});
+
+test("IaAuditBanner visible en paso-4 calculo cuando audit on", async ({ page }) => {
+  await go(page, "/quotes/PRES-2026-018/calculo");
+  await page.locator('[data-testid="audit-toggle"]').click();
+  await expect(page.locator('[data-testid="ia-audit-banner"]')).toBeVisible();
+});
+
+test("ChatAuditNote visible dentro del chat scoped del paso-4 cuando audit on", async ({ page }) => {
+  await go(page, "/quotes/PRES-2026-018/calculo");
+  await page.locator('[data-testid="audit-toggle"]').click();
+  await page.locator('[data-testid="open-chat"]').click();
+  const note = page.locator('[data-testid="chat-audit-note"]');
+  await expect(note).toBeVisible();
+  await expect(note).toContainText("trace_id");
+});
+
+test("audit mode persiste en localStorage al navegar entre rutas", async ({ page }) => {
+  await go(page, "/quotes/PRES-2026-018/calculo");
+  await page.locator('[data-testid="audit-toggle"]').click();
+  await expect(page.locator("body")).toHaveAttribute("data-audit", "on");
+  await go(page, "/quotes/PRES-2026-018/despiece");
+  await expect(page.locator("body")).toHaveAttribute("data-audit", "on");
+  await expect(page.locator('[data-testid="audit-tray"]')).toBeVisible();
+});
+
+test("paso-4 audit per-row aud-trail sigue funcionando con toggle global (regression)", async ({
+  page,
+}) => {
+  await go(page, "/quotes/PRES-2026-018/calculo");
+  await expect(page.locator('[data-testid="aud-trail"]').first()).not.toBeVisible();
+  await page.locator('[data-testid="audit-toggle"]').click();
+  await expect(page.locator('[data-testid="aud-trail"]').first()).toBeVisible();
+});
+
+test("CalcToolbar ya no tiene AUDIT toggle local (solo Tipo + IVA + Recalcular)", async ({
+  page,
+}) => {
+  await go(page, "/quotes/PRES-2026-018/calculo");
+  const toolbar = page.locator('[data-testid="tipo-toggle"]').locator("..");
+  // El AUDIT toggle ahora está en TopBar (1 sola instancia)
+  await expect(page.locator('[data-testid="audit-toggle"]')).toHaveCount(1);
+  // El que queda está dentro de la TopBar, no del section-head del CalcToolbar
+  const inTopbar = page.locator('.topbar [data-testid="audit-toggle"]');
+  await expect(inTopbar).toBeVisible();
+});

--- a/web/tests/e2e/observability.spec.ts
+++ b/web/tests/e2e/observability.spec.ts
@@ -63,13 +63,27 @@ test("AuditTray datasource correcto PRES-017 vs PRES-018", async ({ page }) => {
   await expect(tray).not.toContainText("q_8f2a");
 });
 
-test("AuditTray ID desconocido renderea fallback em-dash sin crash", async ({ page }) => {
+test("AuditTray + banner + note SE OCULTAN cuando snapshot es empty (quote desconocida)", async ({
+  page,
+}) => {
+  // Fix-up #2: para quotes con fallback genérico (isEmpty=true), tray/banner/note
+  // NO deben renderearse · solo el chip TopBar queda visible (UX limpia).
   await go(page, "/quotes/web-deadbeef-cafe/contexto");
   await page.locator('[data-testid="audit-toggle"]').click();
-  const tray = page.locator('[data-testid="audit-tray"]');
-  await expect(tray).toBeVisible();
-  await expect(tray.locator(".col").first()).toContainText("—");
-  await expect(tray).toContainText("sin eventos");
+  // El chip del TopBar SÍ sigue visible y ON.
+  await expect(page.locator("body")).toHaveAttribute("data-audit", "on");
+  await expect(page.locator('[data-testid="audit-toggle"]')).toHaveAttribute("data-on", "true");
+  // Pero tray + banner explicativo NO renderean.
+  await expect(page.locator('[data-testid="audit-tray"]')).toHaveCount(0);
+  await expect(page.locator('[data-testid="ia-audit-banner"]')).toHaveCount(0);
+});
+
+test("AuditTray SÍ renderea cuando snapshot tiene datos canon (no empty)", async ({ page }) => {
+  await go(page, "/quotes/PRES-2026-018/calculo");
+  await page.locator('[data-testid="audit-toggle"]').click();
+  // Esperar a que el snapshot canónico cargue antes de asertar.
+  await expect(page.locator('[data-testid="audit-tray"]')).toBeVisible();
+  await expect(page.locator('[data-testid="ia-audit-banner"]')).toBeVisible();
 });
 
 test("tree view del trace_id está disabled con TODO Sprint 4", async ({ page }) => {


### PR DESCRIPTION
## Resumen

Implementa el **mockup 13** (audit banner ON) — banner top global de auditoría con metadata IA + trazabilidad + eventos en sesión. Refactor del audit toggle del paso-4 (PR #465) para que sea **único** y **global** desde TopBar.

**6/7 sub-PRs Sprint 3.**

## Decisión clave de FASE 1 (sorpresa atrapada)

El nombre del sub-PR sugería "per-row" pero el mockup 13 es **banner global**. FASE 1 detectó la divergencia en 20 min antes de implementar 2-3h de fix incorrecto.

**Lección operativa nueva consolidada**: los nombres de sub-PRs son lossy (vienen de planes hechos antes de leer mockups literales). FASE 1 no-negociable.

## Decisiones Javi (8 features) — todas implementadas

| # | Decisión | Disposición |
|---|---|---|
| A | Scope global (cualquier `/quotes/[id]/*`) | ✅ AuditTray en quote layout |
| B | Toggle en TopBar (no /config porque no existe) | ✅ chip "AUDIT ON/OFF" |
| C | Refactor toggle local paso-4 → global TopBar | ✅ removido del CalcToolbar |
| D | Mock-only con fallback gracioso | ✅ `getAuditSnapshot` + em-dash para IDs UUID |
| E | CSS `.audit-tray` a operator-shared.css + sync handoff | ✅ precedente fix-up #2 PR #465 |
| F | IaAuditBanner + ChatAuditNote IN | ✅ copy LITERAL del mockup |
| G | Tree view del trace_id OUT | ✅ link DISABLED con TODO Sprint 4 |
| H | Role-gate dev/QA OUT | ✅ diferido |

## Componentes creados

- `web/src/lib/hooks/useAuditMode.ts` — hook global · localStorage persist · `useSyncExternalStore` para coordinar componentes sin context
- `web/src/components/observability/AuditToggle.tsx` — chip mono en TopBar
- `web/src/components/observability/AuditTray.tsx` — banner top 3 columnas
- `web/src/components/observability/IaAuditBanner.tsx` — copy explicativo paso-3/4
- `web/src/components/observability/ChatAuditNote.tsx` — note en chat scoped

## Modificados

- `Topbar.tsx` (mount AuditToggle), `[id]/layout.tsx` (mount AuditTray)
- `CalcToolbar.tsx` (remove AUDIT toggle local), `CalculoView.tsx` (consume useAuditMode + remove useEffect), `CalcChatPanel.tsx` (mount ChatAuditNote)
- `DespieceView.tsx` (mount IaAuditBanner), `DespieceChatPanel.tsx` (mount ChatAuditNote)
- `types.ts` (AuditSnapshot interfaces + CalcToggles.auditOn @deprecated)
- `mocks.ts` (getAuditSnapshot con datos canon mockup 13 + fallback)
- `index.ts` (export)
- `operator-shared.css` (+ `.audit-tray`)

## Verificación

| Check | Resultado |
|---|---|
| lint / typecheck / unit / build | ✅ |
| E2E | **76 passed** + 3 skipped (65 prev + 11 nuevos) |
| `operator-shared.css` ↔ handoff byte-identical | ✅ |
| Visual local 1440 paso-4 audit OFF/ON | ✅ tray + IaBanner + aud-trail renderean |
| `.py` modificados | 0 |
| Middleware / Sidebar / chrome shell estructura | ✅ intactos |

## E2E nuevos (11 tests)

- toggle AUDIT global en TopBar sincroniza body[data-audit]
- AuditTray 3-col con datos canon PRES-018 (claude-sonnet-4 / q_8f2a / 4 eventos del despiece flow)
- AuditTray datasource isolation PRES-017 vs PRES-018
- AuditTray ID desconocido (web-XXX) → fallback em-dash sin crash
- Tree view disabled con TODO Sprint 4
- IaAuditBanner visible en paso-3 + paso-4 cuando on
- ChatAuditNote dentro del chat scoped paso-4 cuando on
- audit mode persiste en localStorage entre rutas
- aud-trail per-row sigue funcionando con toggle global (**regression check PR #465**)
- CalcToolbar ya no tiene AUDIT toggle local (1 sola instancia en TopBar)

## Test plan

- [ ] /quotes/PRES-2026-018/calculo · toggle AUDIT ON → tray + IaBanner + aud-trail
- [ ] /quotes/PRES-2026-017/calculo · datasource 017 (Pereyra · q_4c1e)
- [ ] /quotes/web-XXX/contexto · fallback em-dash sin crash
- [ ] Persist en localStorage entre rutas (toggle on → navegar → sigue on)
- [ ] Click "ver tree" no hace nada (disabled)
- [ ] Chat overlay paso-4 con audit ON → note visible
- [ ] Chat overlay paso-3 con audit ON → note visible
- [ ] Regression paso-4 estados A/B/C sin audit
- [ ] Regression toggle audit-on muestra aud-trail per-row del PR #465

## Diferido a Sprint 4

- Toggle migrar a /config cuando esa ruta exista
- Wire backend real para getAuditSnapshot
- Tree view del trace_id (drawer expandible)
- Role-gate dev/QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)