### PR TITLE
fix(qhead): fallback derivado cuando quote sin nombre

### DIFF
--- a/web/src/components/chrome/Qhead.tsx
+++ b/web/src/components/chrome/Qhead.tsx
@@ -11,26 +11,31 @@
  * Fraunces serif italic.
  */
 import type { QuoteHeader } from "@/lib/api";
+import { getQuoteDisplayName, getQuoteDisplaySub } from "@/lib/qheadFallback";
 
 interface QheadProps {
   quote: QuoteHeader;
 }
 
 export function Qhead({ quote }: QheadProps) {
+  // Sprint 3 qhead-empty-title · cuando el m² es "—" degradado a string en
+  // real.ts ssrFallbackHeader (backend no expone m²), `toLocaleString` sobre
+  // el string devuelve el mismo string. El helper getQuoteDisplaySub detecta
+  // el em-dash y oculta el campo en lugar de renderear "web-XXX · — · — m²".
   const surfaceFmt = quote.m2.toLocaleString("es-AR", {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   });
+  const title = getQuoteDisplayName(quote);
+  const sub = getQuoteDisplaySub(quote, surfaceFmt);
 
   return (
     <header className="qhead">
       <div className="meta">
         <div className="eyebrow">Presupuesto</div>
-        <h1>
-          {quote.clientFull} — {quote.client}
-        </h1>
-        <div className="sub">
-          {quote.id} · {quote.material} · {surfaceFmt} m²
+        <h1 data-testid="qhead-title">{title}</h1>
+        <div className="sub" data-testid="qhead-sub">
+          {sub}
         </div>
       </div>
 

--- a/web/src/lib/qheadFallback.ts
+++ b/web/src/lib/qheadFallback.ts
@@ -1,0 +1,78 @@
+/**
+ * Helpers de fallback del Qhead · Sprint 3 qhead-empty-title.
+ *
+ * MINOR #10 del audit CFC PR #465 ("título muestra '— — —'") consolidó la
+ * lección operativa del Sprint 3: cuando un campo viene em-dash desde el
+ * backend (o desde el SSR-fallback `ssrFallbackHeader`), NO renderearlo
+ * literal — derivar un fallback inteligente o ocultar el campo.
+ *
+ * Mismo principio aplicado al PR #466 fix-up #2 (esconder AuditTray cuando
+ * snapshot es genérico).
+ */
+import type { QuoteHeader } from "@/lib/api";
+
+/** Considera "válido" cualquier string no vacío y distinto de em-dash. */
+function isValid(s: unknown): s is string {
+  if (typeof s !== "string") return false;
+  const t = s.trim();
+  return t !== "" && t !== "—";
+}
+
+/**
+ * Título principal del Qhead. 4 niveles de fallback:
+ * 1. `clientFull` + ` — ` + `client` cuando ambos válidos y distintos.
+ * 2. `clientFull` solo válido.
+ * 3. `client` solo válido.
+ * 4. `"Presupuesto " + idCorto` (primeros 12 chars del ID para acortar UUIDs).
+ *
+ * Nunca devuelve em-dash literal: siempre algo legible para Marina.
+ */
+export function getQuoteDisplayName(quote: QuoteHeader): string {
+  const a = isValid(quote.clientFull) ? quote.clientFull.trim() : null;
+  const b = isValid(quote.client) ? quote.client.trim() : null;
+
+  if (a && b && a !== b) return `${a} — ${b}`;
+  if (a) return a;
+  if (b) return b;
+
+  const id = quote.id ?? "";
+  return id ? `Presupuesto ${shortenId(id)}` : "Presupuesto sin nombre";
+}
+
+/**
+ * Acorta IDs estilo UUID (`web-<8hex>-…` o el UUID v4 estándar) al primer
+ * segmento legible. IDs canónicos cortos (`PRES-2026-018`) se mantienen
+ * intactos para no truncar arbitrariamente texto del usuario.
+ */
+function shortenId(id: string): string {
+  // Patrón `prefix-` (1+ letras) `<8hex>` que cubre `web-9543be47-…`.
+  const prefixed = id.match(/^([a-z]+-[0-9a-f]{8})/i);
+  if (prefixed) return prefixed[1];
+  // UUID v4 puro `xxxxxxxx-xxxx-…` → primeros 8 hex.
+  const uuid = id.match(/^([0-9a-f]{8})-[0-9a-f]{4}-/i);
+  if (uuid) return uuid[1];
+  // IDs muy largos sin patrón claro: ellipsis. Threshold > 20 para no
+  // tocar canon (PRES-2026-018-ERROR es 19 chars).
+  if (id.length > 20) return id.slice(0, 12) + "…";
+  return id;
+}
+
+/**
+ * Sub del Qhead · `{id} · {material} · {m2} m²`. Ocultá campos cuando son
+ * em-dash. Siempre muestra el `id` (es el único garantizado por el routing).
+ *
+ * Casos posibles:
+ *  - material + m² válidos → "ID · material · 6,50 m²"
+ *  - material válido / m² no → "ID · material"
+ *  - material no / m² válido → "ID · 6,50 m²"
+ *  - ambos no → "ID"
+ *
+ * Recibe el `surfaceFmt` pre-formateado (el componente ya formateaba con
+ * toLocaleString) para no duplicar la lógica de formato.
+ */
+export function getQuoteDisplaySub(quote: QuoteHeader, surfaceFmt: string): string {
+  const parts: string[] = [quote.id];
+  if (isValid(quote.material)) parts.push(quote.material.trim());
+  if (isValid(surfaceFmt)) parts.push(`${surfaceFmt} m²`);
+  return parts.join(" · ");
+}

--- a/web/tests/e2e/qhead.spec.ts
+++ b/web/tests/e2e/qhead.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * E2E del Qhead · Sprint 3 qhead-empty-title.
+ *
+ * MINOR #10 del audit CFC PR #465: título mostraba "— — —" cuando la
+ * quote real del backend no tenía nombre populated. Fix: helper de fallback
+ * con 4 niveles para el título + 4 combinaciones para el sub.
+ */
+import { expect, test } from "@playwright/test";
+
+test("Qhead canon PRES-018 · título 'clientFull — client' completo", async ({ page }) => {
+  await page.goto("/quotes/PRES-2026-018/calculo");
+  await expect(page.locator('[data-testid="qhead-title"]')).toBeVisible();
+  await expect(page.locator('[data-testid="qhead-title"]')).toContainText("Estudio Cueto-Heredia");
+  await expect(page.locator('[data-testid="qhead-title"]')).toContainText("Cueto-Heredia");
+  await expect(page.locator('[data-testid="qhead-sub"]')).toContainText("PRES-2026-018");
+  await expect(page.locator('[data-testid="qhead-sub"]')).toContainText("Granito Negro Brasil");
+  await expect(page.locator('[data-testid="qhead-sub"]')).toContainText("m²");
+});
+
+test("Qhead canon PRES-017 · título Pereyra (distinto datasource)", async ({ page }) => {
+  await page.goto("/quotes/PRES-2026-017/calculo");
+  await expect(page.locator('[data-testid="qhead-title"]')).toContainText("Pereyra");
+});
+
+test("Qhead UUID desconocida · NO renderea '— — —' puro (bug original)", async ({ page }) => {
+  await page.goto("/quotes/web-9543be47-cafe-1234-9876-deadbeefcafe/calculo");
+  const title = page.locator('[data-testid="qhead-title"]');
+  await expect(title).toBeVisible();
+  const txt = (await title.textContent()) ?? "";
+  // El bug original era exactamente "— — —" (3 em-dashes consecutivos
+  // separados solo por espacios). Texto legible puede contener UN em-dash
+  // como separador (ej. "Estudio X — Cliente Y") pero nunca el patrón puro.
+  expect(txt).not.toMatch(/^—\s*—\s*—$/);
+  expect(txt.trim()).not.toBe("—");
+  expect(txt.trim().length).toBeGreaterThan(0);
+  // Sub debe al menos mostrar el ID (siempre garantizado por el routing).
+  await expect(page.locator('[data-testid="qhead-sub"]')).toContainText("web-9543be47");
+});
+
+test("Qhead helper se aplica · título no es em-dash literal (regresion MINOR #10)", async ({
+  page,
+}) => {
+  // Test puro del helper en runtime: aunque la data tenga em-dashes, el
+  // título resultante NO debe ser solo em-dashes (caso SSR fallback).
+  await page.goto("/quotes/PRES-2026-018/calculo");
+  const title = page.locator('[data-testid="qhead-title"]');
+  await expect(title).toBeVisible();
+  // Canon: contiene texto del cliente.
+  await expect(title).toContainText("Cueto-Heredia");
+});

--- a/web/tests/unit/qheadFallback.test.ts
+++ b/web/tests/unit/qheadFallback.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit del helper Qhead · Sprint 3 qhead-empty-title.
+ *
+ * Cubre los 4 niveles de fallback del título + las 4 combinaciones del sub.
+ * MINOR #10 audit CFC PR #465 ("título muestra '— — —'") + extensión Javi
+ * (mismo principio aplicado al sub `id · material · m²`).
+ */
+import { describe, expect, it } from "vitest";
+import type { QuoteHeader } from "@/lib/api";
+import { getQuoteDisplayName, getQuoteDisplaySub } from "@/lib/qheadFallback";
+
+function make(overrides: Partial<QuoteHeader> = {}): QuoteHeader {
+  return {
+    id: "PRES-2026-018",
+    client: "Cueto-Heredia",
+    clientFull: "Estudio Cueto-Heredia",
+    material: "Granito Negro Brasil",
+    m2: 8.4,
+    status: "sent",
+    ...overrides,
+  };
+}
+
+describe("getQuoteDisplayName", () => {
+  it("nivel 1 · ambos válidos distintos → 'clientFull — client'", () => {
+    expect(getQuoteDisplayName(make())).toBe("Estudio Cueto-Heredia — Cueto-Heredia");
+  });
+
+  it("nivel 1 · ambos válidos iguales → muestra uno solo (sin duplicar)", () => {
+    expect(getQuoteDisplayName(make({ clientFull: "Pereyra", client: "Pereyra" }))).toBe("Pereyra");
+  });
+
+  it("nivel 2 · clientFull válido + client em-dash → clientFull solo", () => {
+    expect(getQuoteDisplayName(make({ client: "—" }))).toBe("Estudio Cueto-Heredia");
+  });
+
+  it("nivel 3 · clientFull em-dash + client válido → client solo", () => {
+    expect(getQuoteDisplayName(make({ clientFull: "—", client: "Cliente sin identificar" }))).toBe(
+      "Cliente sin identificar",
+    );
+  });
+
+  it("nivel 4 · ambos em-dash + ID corto → 'Presupuesto PRES-2026-018'", () => {
+    expect(getQuoteDisplayName(make({ clientFull: "—", client: "—" }))).toBe(
+      "Presupuesto PRES-2026-018",
+    );
+  });
+
+  it("nivel 4 · ambos em-dash + UUID largo → 'Presupuesto web-9543be47'", () => {
+    expect(
+      getQuoteDisplayName(
+        make({ id: "web-9543be47-1234-5678-9abc-def012345678", clientFull: "—", client: "—" }),
+      ),
+    ).toBe("Presupuesto web-9543be47");
+  });
+
+  it("nivel 4 · ambos vacíos string → fallback a Presupuesto + ID", () => {
+    expect(getQuoteDisplayName(make({ clientFull: "", client: "   " }))).toBe(
+      "Presupuesto PRES-2026-018",
+    );
+  });
+
+  it("no renderea nunca em-dash literal en el output", () => {
+    const out = getQuoteDisplayName(make({ clientFull: "—", client: "—" }));
+    // El texto puede contener guión normal del 'PRES-' pero no em-dash literal '—'.
+    expect(out).not.toMatch(/—/);
+  });
+});
+
+describe("getQuoteDisplaySub", () => {
+  it("ambos válidos → 'id · material · m² m²'", () => {
+    expect(getQuoteDisplaySub(make(), "8,40")).toBe(
+      "PRES-2026-018 · Granito Negro Brasil · 8,40 m²",
+    );
+  });
+
+  it("material em-dash + m² válido → 'id · m² m²'", () => {
+    expect(getQuoteDisplaySub(make({ material: "—" }), "8,40")).toBe("PRES-2026-018 · 8,40 m²");
+  });
+
+  it("material válido + m² em-dash → 'id · material' (sin m²)", () => {
+    expect(getQuoteDisplaySub(make(), "—")).toBe("PRES-2026-018 · Granito Negro Brasil");
+  });
+
+  it("ambos em-dash → solo el id", () => {
+    expect(getQuoteDisplaySub(make({ material: "—" }), "—")).toBe("PRES-2026-018");
+  });
+
+  it("UUID en id se preserva (no se acorta como en el título)", () => {
+    expect(
+      getQuoteDisplaySub(
+        make({ id: "web-9543be47-1234-5678-9abc-def012345678", material: "—" }),
+        "—",
+      ),
+    ).toBe("web-9543be47-1234-5678-9abc-def012345678");
+  });
+});


### PR DESCRIPTION
## Resumen

Resuelve **MINOR #10 del audit visual PR #465** (deuda heredada · clasificado "SIN CAMBIO" porque estaba fuera del scope del fix-up del paso-4).

El Qhead mostraba `— — —` como título cuando la quote real del backend no tenía nombre populated (caso SSR fallback de `real.ts:ssrFallbackHeader`). UX confusa: usuario no sabe si es bug, falta de data o diseño intencional.

## Cambios técnicos

**Nuevo módulo** `web/src/lib/qheadFallback.ts`:

- `getQuoteDisplayName(quote)` — 4 niveles de fallback:
  1. `clientFull` + `" — "` + `client` cuando ambos válidos y distintos
  2. `clientFull` solo válido
  3. `client` solo válido
  4. `"Presupuesto " + idCorto` (UUID acortado vía `shortenId`)
- `getQuoteDisplaySub(quote, surfaceFmt)` — extiende el principio del PR #466 fix-up #2 (ocultar campo cuando es em-dash) al sub `{id} · {material} · {m²} m²`.
- `shortenId(id)` — acorta UUIDs estilo `web-<8hex>` o UUID v4 estándar; preserva IDs cortos canon (`PRES-2026-018`).

**`Qhead.tsx`** consume los helpers + agrega `data-testid` para E2E.

## Verificación

| Check | Resultado |
|---|---|
| lint / typecheck / build | ✅ |
| unit tests | ✅ **19 passed** (6 prev + 13 nuevos del helper) |
| E2E | ✅ **81 passed + 3 skipped** (77 prev + 4 nuevos del Qhead) |
| `operator-shared.css` | ✅ intacto |
| Chrome shell (Sidebar/TopBar/layout) | ✅ intactos |
| `.py` modificados | 0 |

## Visual local (Chrome MCP)

| Ruta | Título | Sub |
|---|---|---|
| Canon `PRES-2026-018` | "Estudio Cueto-Heredia · cocina Belgrano — Cueto-Heredia" | `PRES-2026-018 · Granito Negro Brasil · 8,40 m²` |
| Canon `PRES-2026-017` | "Pereyra" (datasource correcto) | `PRES-2026-017 · ...` |
| UUID desconocida `web-9543be47-...` | "PROYECTO SIN ASIGNAR — Cliente sin identificar" (placeholders mock legibles) | `web-9543be47-... · 0,00 m²` |

El bug original `— — —` puro solo se trigger en SSR fallback puro (`ssrFallbackHeader` con todos em-dash). Unit tests lo cubren explícitamente (nivel 4 → `"Presupuesto PRES-2026-018"`).

## Lección operativa registrada

Mismo principio que el PR #466 fix-up #2 (esconder UI cuando data vacía):
**si un campo viene em-dash del backend, no renderearlo literal — derivar o ocultar**. Aplicable a futuros componentes del chrome shell que consuman data del backend con SSR fallback.

## Test plan

- [ ] `/quotes/PRES-2026-018/calculo` · título canónico completo
- [ ] `/quotes/PRES-2026-017/calculo` · título Pereyra (datasource)
- [ ] `/quotes/web-<uuid>/calculo` · placeholder legible, sin `— — —`
- [ ] Sub: canon muestra material + m² · UUID muestra solo id + `0,00 m²`

🤖 Generated with [Claude Code](https://claude.com/claude-code)