### PR TITLE
feat(sprint-3/error-states): mockups 15 + 17 · cierra Sprint 3 a 7/7

### DIFF
--- a/web/src/components/despiece/DespieceChatPanel.tsx
+++ b/web/src/components/despiece/DespieceChatPanel.tsx
@@ -13,12 +13,14 @@
  */
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import type { Piece } from "@/lib/api";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { ChatFlaggedPreset, Piece } from "@/lib/api";
 import type { ChatMessage, ChatPanelState } from "@/lib/types";
 import { UserMessage } from "@/components/contexto/UserMessage";
 import { ValentinaMessage } from "@/components/contexto/ValentinaMessage";
 import { ChatAuditNote } from "@/components/observability/ChatAuditNote";
+import { FlaggedMessage } from "./FlaggedMessage";
+import { FeedbackBanner } from "./FeedbackBanner";
 
 interface Props {
   /** Sprint 3 obs-per-row fix-up #2 · necesario para `useAuditEmpty` del
@@ -31,6 +33,11 @@ interface Props {
   focusedPiece: Piece | null;
   onSend: (text: string) => void;
   onClose: () => void;
+  /** Sprint 3 error-states (mockup 17) · preset del chat flagged ·
+   * cuando presente, el chat carga el stream con 4 mensajes mock + último
+   * de Valentina flagged. Click en btn-feedback → FeedbackBanner +
+   * composer prefill. */
+  flaggedPreset?: ChatFlaggedPreset | null;
 }
 
 const STEP_SUGGESTIONS = [
@@ -50,11 +57,29 @@ export function DespieceChatPanel({
   focusedPiece,
   onSend,
   onClose,
+  flaggedPreset = null,
 }: Props) {
-  const [draft, setDraft] = useState("");
+  const [draft, setDraft] = useState(() => flaggedPreset?.composerPrefill ?? "");
   const streamRef = useRef<HTMLDivElement>(null);
   const isStreaming = panelState === "streaming";
   const focused = focusedPiece !== null;
+
+  // Sprint 3 error-states (mockup 17) · flag → feedback flow.
+  // alreadyFlagged: el btn-feedback ya fue clickeado → mostrar FeedbackBanner.
+  // El mockup arranca con btn DISABLED (post-click); replicamos arrancando
+  // en true cuando hay preset (Marina ya clickeó hace 30s en el mockup).
+  const [alreadyFlagged, setAlreadyFlagged] = useState(flaggedPreset !== null);
+  const handleFlag = () => setAlreadyFlagged(true);
+  const handleReformulate = () => {
+    setAlreadyFlagged(false);
+    setDraft(flaggedPreset?.composerPrefill ?? "");
+  };
+
+  // Stream a mostrar: preset (4 mock) o messages reales del useChatScoped.
+  const streamMessages = useMemo(
+    () => (flaggedPreset ? flaggedPreset.messages : messages),
+    [flaggedPreset, messages],
+  );
 
   useEffect(() => {
     if (streamRef.current) {
@@ -85,7 +110,18 @@ export function DespieceChatPanel({
             {focused ? `${focusedPiece.id} · ${focusedPiece.label}` : "Ayuda con Despiece"}
           </div>
           <div className="sub">
-            {focused ? "Scoped · enfocado en 1 pieza" : `Scoped · viendo ${pieceCount} piezas`}
+            {flaggedPreset ? (
+              <>
+                Scoped ·{" "}
+                <span className="session-info" data-testid="chat-session-info">
+                  {flaggedPreset.sessionInfo}
+                </span>
+              </>
+            ) : focused ? (
+              "Scoped · enfocado en 1 pieza"
+            ) : (
+              `Scoped · viendo ${pieceCount} piezas`
+            )}
           </div>
         </div>
         <button
@@ -114,7 +150,7 @@ export function DespieceChatPanel({
       <ChatAuditNote quoteId={quoteId} />
 
       <div className="stream" ref={streamRef} data-testid="chat-stream">
-        {messages.length === 0 && (
+        {streamMessages.length === 0 && (
           <div
             className="font-mono"
             style={{ color: "var(--ink-mute)", fontSize: 12, textAlign: "center" }}
@@ -125,12 +161,32 @@ export function DespieceChatPanel({
               : "Hacé una pregunta o usá una sugerencia."}
           </div>
         )}
-        {messages.map((msg) =>
-          msg.role === "user" ? (
-            <UserMessage key={msg.id} message={msg} />
+        {streamMessages.map((msg, i) => {
+          // Sprint 3 error-states (mockup 17) · si el preset marca el msg
+          // como flagged, lo renderea con FlaggedMessage + btn-feedback.
+          const isFlaggedMsg = flaggedPreset && "flagged" in msg && msg.flagged === true;
+          const isLast = i === streamMessages.length - 1;
+          if (isFlaggedMsg) {
+            const relTs = ("relativeTs" in msg && msg.relativeTs) || msg.timestamp;
+            return (
+              <FlaggedMessage
+                key={msg.id}
+                name="Valentina · IA"
+                relativeTs={relTs}
+                body={msg.content}
+                alreadyFlagged={alreadyFlagged}
+                onFlag={handleFlag}
+              />
+            );
+          }
+          return msg.role === "user" ? (
+            <UserMessage key={msg.id} message={msg as ChatMessage} />
           ) : (
-            <ValentinaMessage key={msg.id} message={msg} />
-          ),
+            <ValentinaMessage key={msg.id} message={msg as ChatMessage} />
+          );
+        })}
+        {flaggedPreset && alreadyFlagged && (
+          <FeedbackBanner onReformulate={handleReformulate} onClose={onClose} />
         )}
       </div>
 
@@ -156,9 +212,10 @@ export function DespieceChatPanel({
       </div>
 
       <div className="composer">
-        <div className="field">
+        <div className={`field${flaggedPreset && draft ? "" : ""}`}>
           <input
             type="text"
+            className={flaggedPreset && draft ? "prefill" : undefined}
             placeholder={
               focused ? `Preguntá sobre ${focusedPiece.id}…` : "Preguntá sobre el despiece…"
             }
@@ -169,6 +226,7 @@ export function DespieceChatPanel({
             }}
             disabled={isStreaming}
             data-testid="chat-input"
+            autoFocus={flaggedPreset !== null}
           />
           <button
             type="button"
@@ -180,8 +238,10 @@ export function DespieceChatPanel({
             Enviar
           </button>
         </div>
-        <div className="hint">
-          Borra al cerrar · {focused ? "ve sólo esta pieza" : "ve las piezas del despiece"}
+        <div className={`hint${flaggedPreset && draft ? " warn" : ""}`} data-testid="chat-hint">
+          {flaggedPreset && draft
+            ? "➜ Última pregunta tuya pre-cargada · editá lo que quieras y ⏎ para reenviar"
+            : `Borra al cerrar · ${focused ? "ve sólo esta pieza" : "ve las piezas del despiece"}`}
         </div>
       </div>
     </aside>

--- a/web/src/components/despiece/DespieceEmptyChat.tsx
+++ b/web/src/components/despiece/DespieceEmptyChat.tsx
@@ -1,0 +1,46 @@
+/**
+ * Empty-CTA del chat lateral en mockup 15.
+ *
+ * Cuando el despiece está rejected, el chat side panel está cerrado pero
+ * muestra una CTA para abrirlo ("Si querés rehacer hablando, abrime").
+ *
+ * Reusa `.chat.fit` + `.empty-cta` ya presentes en operator-shared.css.
+ */
+"use client";
+
+interface Props {
+  onOpenChat: () => void;
+}
+
+export function DespieceEmptyChat({ onOpenChat }: Props) {
+  return (
+    <aside className="chat fit" data-testid="despiece-empty-chat">
+      <div className="head">
+        <div className="vbubble" />
+        <div>
+          <div className="title">Ayuda con Despiece</div>
+          <div className="sub">Scoped · cerrado</div>
+        </div>
+        <span className="x" aria-hidden="true">
+          →
+        </span>
+      </div>
+      <div className="empty-cta">
+        <div className="msg">
+          Si querés rehacer hablando, abrime —<br />
+          te pregunto lo que necesite.
+        </div>
+        <div className="cta">
+          <button
+            type="button"
+            className="btn ghost sm"
+            onClick={onOpenChat}
+            data-testid="empty-chat-open"
+          >
+            Abrir chat ↗
+          </button>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/web/src/components/despiece/DespieceTable.tsx
+++ b/web/src/components/despiece/DespieceTable.tsx
@@ -14,6 +14,14 @@ interface Props {
   onDeletePiece: (pieceId: string) => void;
   onOpenPieceChat: (pieceId: string) => void;
   onAddPiece: () => void;
+  /** Sprint 3 error-states (mockup 15) · cuando true, tabla se renderea
+   * `.discarded` con tag "descartado" en el header de Pieza · interacciones
+   * deshabilitadas (sin add-row, sin onUpdate, sin onDelete). */
+  discarded?: boolean;
+  /** Sprint 3 error-states (mockup 17) · ID de la pieza referida por el
+   * chat scoped abierto · se marca con `.row-chat-ref` + label "↳ chat
+   * referido a esta pieza". */
+  chatRefPieceId?: string;
 }
 
 export function DespieceTable({
@@ -23,12 +31,28 @@ export function DespieceTable({
   onDeletePiece,
   onOpenPieceChat,
   onAddPiece,
+  discarded = false,
+  chatRefPieceId,
 }: Props) {
   return (
-    <div className="etable cols-despiece mb-16" data-testid="despiece-table">
+    <div
+      className={`etable cols-despiece mb-16${discarded ? " discarded" : ""}`}
+      data-testid="despiece-table"
+      data-discarded={discarded ? "true" : "false"}
+    >
       <div className="colh">
         <div>#</div>
-        <div>Pieza</div>
+        <div>
+          Pieza
+          {discarded && (
+            <>
+              {" · "}
+              <span className="discarded-tag" data-testid="discarded-tag">
+                descartado
+              </span>
+            </>
+          )}
+        </div>
         <div>Largo (cm)</div>
         <div>Ancho (cm)</div>
         <div>Cant.</div>
@@ -42,27 +66,30 @@ export function DespieceTable({
           key={piece.id}
           piece={piece}
           focused={focusedPieceId === piece.id}
+          chatRef={chatRefPieceId === piece.id}
           onUpdate={onUpdatePiece}
           onDelete={onDeletePiece}
           onOpenChat={onOpenPieceChat}
         />
       ))}
 
-      <div
-        className="add-row"
-        role="button"
-        tabIndex={0}
-        data-testid="despiece-add-row"
-        onClick={onAddPiece}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            onAddPiece();
-          }
-        }}
-      >
-        + agregar pieza manualmente
-      </div>
+      {!discarded && (
+        <div
+          className="add-row"
+          role="button"
+          tabIndex={0}
+          data-testid="despiece-add-row"
+          onClick={onAddPiece}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              onAddPiece();
+            }
+          }}
+        >
+          + agregar pieza manualmente
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/despiece/DespieceView.tsx
+++ b/web/src/components/despiece/DespieceView.tsx
@@ -16,7 +16,7 @@
  */
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { piecesTotalM2, type Piece } from "@/lib/api";
 import { useDespiece } from "@/lib/hooks/useDespiece";
@@ -26,6 +26,9 @@ import { DespieceTable } from "./DespieceTable";
 import { DespieceTimeline } from "./DespieceTimeline";
 import { DespieceEmptyState } from "./DespieceEmptyState";
 import { DespieceChatPanel } from "./DespieceChatPanel";
+import { DespieceEmptyChat } from "./DespieceEmptyChat";
+import { RecoveryBlock } from "./RecoveryBlock";
+import { SessionInfoBanner } from "./SessionInfoBanner";
 import { IaAuditBanner } from "@/components/observability/IaAuditBanner";
 
 interface Props {
@@ -60,6 +63,8 @@ export function DespieceView({ quoteId }: Props) {
     regenerate,
     isDirty,
     editedCount,
+    rejected,
+    chatFlagged,
   } = useDespiece(quoteId);
 
   const [focusedPieceId, setFocusedPieceId] = useState<string | null>(null);
@@ -88,6 +93,18 @@ export function DespieceView({ quoteId }: Props) {
     chat.close();
     setFocusedPieceId(null);
   }
+
+  // Sprint 3 error-states (mockup 17) · cuando hay un preset flagged en la
+  // quote, abrimos el chat scoped automáticamente al mount con el preset
+  // (sesión persistente intra-quote · decisión Javi E solo copy del banner).
+  const flaggedAutoOpened = chatFlagged != null;
+  useEffect(() => {
+    if (flaggedAutoOpened && chat.panelState === "closed") {
+      chat.open();
+    }
+    // chat es estable entre renders · solo dependemos del flag.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [flaggedAutoOpened]);
 
   /* ── Loading ─────────────────────────────────────────────────────── */
   if (state === "loading") {
@@ -170,6 +187,82 @@ export function DespieceView({ quoteId }: Props) {
           onProcessWithAI={() => router.push(`/quotes/${quoteId}/brief`)}
           onCompleteManual={() => setManualMode(true)}
         />
+      </div>
+    );
+  }
+
+  /* ── Rejected · mockup 15 ──────────────────────────────────────────── */
+  if (rejected) {
+    return (
+      <div
+        data-testid="despiece-view"
+        data-state="rejected"
+        style={{ display: "grid", gridTemplateColumns: "1fr 360px", gap: 24, minHeight: 0 }}
+      >
+        <div className="col">
+          <div className="section-head">
+            <div>
+              <div className="meta">Paso 3 de 5 · Despiece</div>
+              <h2>Despiece de piezas</h2>
+            </div>
+          </div>
+
+          <IaAuditBanner quoteId={quoteId} />
+
+          <div className="ia-banner error" data-testid="rejected-banner">
+            <div className="vbubble" />
+            <div className="text">
+              Marina marcó este despiece como{" "}
+              <strong>&ldquo;esto no me sirve&rdquo;</strong>.
+              <div className="sub">Valentina toma nota y te ofrece tres caminos abajo</div>
+            </div>
+            <div className="actions">
+              <button
+                type="button"
+                className="btn ghost sm"
+                onClick={() => router.push(`/quotes/${quoteId}/calculo`)}
+                data-testid="rejected-close"
+              >
+                Cerrar
+              </button>
+            </div>
+          </div>
+
+          <DespieceTable
+            pieces={pieces}
+            focusedPieceId={null}
+            discarded
+            onUpdatePiece={() => {}}
+            onDeletePiece={() => {}}
+            onOpenPieceChat={() => {}}
+            onAddPiece={() => {}}
+          />
+
+          <RecoveryBlock
+            traceId="q_8f2a"
+            onPath={() => {
+              /* Sprint 4 wire recovery */
+            }}
+            onFeedback={() => {
+              /* Sprint 4 wire trace */
+            }}
+          />
+        </div>
+
+        <DespieceEmptyChat onOpenChat={openStepChat} />
+
+        {chatOpen && (
+          <DespieceChatPanel
+            quoteId={quoteId}
+            messages={chat.messages}
+            panelState={chat.panelState}
+            pieceCount={pieces.length}
+            editedCount={editedCount}
+            focusedPiece={focusedPiece}
+            onSend={chat.send}
+            onClose={closeChat}
+          />
+        )}
       </div>
     );
   }
@@ -291,6 +384,9 @@ export function DespieceView({ quoteId }: Props) {
         {/* Sprint 3 observability · banner explicativo cuando audit on. */}
         <IaAuditBanner quoteId={quoteId} />
 
+        {/* Sprint 3 error-states (mockup 17) · banner contexto sesión chat. */}
+        {chatFlagged && <SessionInfoBanner context={chatFlagged.sessionContext} />}
+
         {/* Banner Valentina · pristine / dirty / focused */}
         <div
           className={`ia-banner${manualMode && pieces.length === 0 ? " muted" : ""}`}
@@ -357,6 +453,7 @@ export function DespieceView({ quoteId }: Props) {
         <DespieceTable
           pieces={pieces}
           focusedPieceId={focusedPieceId}
+          chatRefPieceId={chatFlagged?.pieceRefId}
           onUpdatePiece={updatePiece}
           onDeletePiece={deletePiece}
           onOpenPieceChat={openPieceChat}
@@ -417,6 +514,7 @@ export function DespieceView({ quoteId }: Props) {
           focusedPiece={focusedPiece}
           onSend={chat.send}
           onClose={closeChat}
+          flaggedPreset={chatFlagged}
         />
       )}
     </div>

--- a/web/src/components/despiece/FeedbackBanner.tsx
+++ b/web/src/components/despiece/FeedbackBanner.tsx
@@ -1,0 +1,44 @@
+/**
+ * `.feedback-banner` post-click en btn-feedback (mockup 17).
+ *
+ * "Anotado. ¿Querés reformular la pregunta o cerrar el chat?"
+ * + 2 actions: Reformular (solid) / Cerrar chat.
+ *
+ * Sprint 3 error-states · Reformular trigger composer prefill, Cerrar
+ * llama a onClose del chat panel.
+ */
+"use client";
+
+interface Props {
+  onReformulate: () => void;
+  onClose: () => void;
+}
+
+export function FeedbackBanner({ onReformulate, onClose }: Props) {
+  return (
+    <div className="feedback-banner" data-testid="feedback-banner">
+      <div className="text">
+        <em>Anotado.</em> ¿Querés reformular la pregunta o cerrar el chat?
+        <div className="meta">Tu feedback queda en el audit log · el mensaje no se borra</div>
+      </div>
+      <div className="actions">
+        <button
+          type="button"
+          className="btn-fb solid"
+          onClick={onReformulate}
+          data-testid="feedback-reformulate"
+        >
+          Reformular
+        </button>
+        <button
+          type="button"
+          className="btn-fb"
+          onClick={onClose}
+          data-testid="feedback-close"
+        >
+          Cerrar chat
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/despiece/FlaggedMessage.tsx
+++ b/web/src/components/despiece/FlaggedMessage.tsx
@@ -1,0 +1,39 @@
+/**
+ * FlaggedMessage · variante del ValentinaMessage con btn-feedback inline
+ * (mockup 17). Cuando Marina marca la respuesta como inútil → onFlag()
+ * dispara la transición a FeedbackBanner.
+ *
+ * Reusa `.msg.v.flagged` + `.btn-feedback` + `.feedback-row` ya en CSS.
+ */
+"use client";
+
+interface Props {
+  name: string;
+  relativeTs: string;
+  body: string;
+  /** true cuando ya se hizo click (botón disabled, igual que el mockup). */
+  alreadyFlagged: boolean;
+  onFlag: () => void;
+}
+
+export function FlaggedMessage({ name, relativeTs, body, alreadyFlagged, onFlag }: Props) {
+  return (
+    <div className="msg v flagged" data-testid="flagged-message">
+      <div className="name">
+        {name} <span className="ts-inline">{relativeTs}</span>
+      </div>
+      <div className="body">{body}</div>
+      <div className="feedback-row">
+        <button
+          type="button"
+          className="btn-feedback"
+          onClick={onFlag}
+          disabled={alreadyFlagged}
+          data-testid="btn-feedback"
+        >
+          ✕ Esta respuesta no me sirvió
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/despiece/PieceRow.tsx
+++ b/web/src/components/despiece/PieceRow.tsx
@@ -20,6 +20,11 @@ import { PieceChatButton } from "./PieceChatButton";
 interface Props {
   piece: Piece;
   focused: boolean;
+  /** Sprint 3 error-states (mockup 17) · cuando true, fila marca
+   * `.row-chat-ref` + label "↳ chat referido a esta pieza". Distinto de
+   * `focused` (que es el chat focused mode) · esta es ref desde chat scoped
+   * del paso completo a una pieza específica del preset flagged. */
+  chatRef?: boolean;
   onUpdate: (pieceId: string, partial: Partial<Piece>) => void;
   onDelete: (pieceId: string) => void;
   onOpenChat: (pieceId: string) => void;
@@ -35,7 +40,14 @@ const RESET_BTN: React.CSSProperties = {
   lineHeight: 1,
 };
 
-export function PieceRow({ piece, focused, onUpdate, onDelete, onOpenChat }: Props) {
+export function PieceRow({
+  piece,
+  focused,
+  chatRef = false,
+  onUpdate,
+  onDelete,
+  onOpenChat,
+}: Props) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
 
@@ -56,7 +68,7 @@ export function PieceRow({ piece, focused, onUpdate, onDelete, onOpenChat }: Pro
     "row",
     isEdited ? "row-edited" : "",
     isManual ? "row-manual" : "",
-    focused ? "row-chat-ref" : "",
+    focused || chatRef ? "row-chat-ref" : "",
   ]
     .filter(Boolean)
     .join(" ");
@@ -95,6 +107,11 @@ export function PieceRow({ piece, focused, onUpdate, onDelete, onOpenChat }: Pro
           </span>
         )}
         {focused && <span className="sub sub-chat-ref">↳ chat enfocado aquí</span>}
+        {!focused && chatRef && (
+          <span className="sub sub-chat-ref" data-testid={`row-chat-ref-${piece.id}`}>
+            ↳ chat referido a esta pieza
+          </span>
+        )}
       </div>
 
       <PieceCell

--- a/web/src/components/despiece/RecoveryBlock.tsx
+++ b/web/src/components/despiece/RecoveryBlock.tsx
@@ -1,0 +1,124 @@
+/**
+ * RecoveryBlock · mockup 15 LITERAL.
+ *
+ * Marina marcó este despiece como "esto no me sirve". Valentina ofrece
+ * 3 caminos (A · rehacer con detalle / B · rehacer 1 pieza / C · cargo a
+ * mano) + composer feedback texto libre + trace-row con info de telemetría.
+ *
+ * Sprint 3 error-states · decisión Javi C/D: caminos A/B/C son visual-only
+ * en este PR (Sprint 4 wirea recovery real). El composer captura el texto
+ * en useState pero NO persiste (decisión D · trace simulado).
+ *
+ * Reusa clases legacy `.recovery-block`, `.v-msg`, `.recovery-paths`,
+ * `.rpath`, `.recovery-composer`, `.trace-row` ya presentes en
+ * operator-shared.css (sorpresa positiva FASE 1).
+ */
+"use client";
+
+import { useState } from "react";
+
+interface Props {
+  /** Trace ID del audit-snapshot para el row de telemetría
+   * ("Tu feedback se guarda como trace q_8f2a · rejected"). */
+  traceId: string;
+  /** Callback invocado al click en algún recovery path (visual-only por ahora).
+   *  Sprint 4 lo wirea a backend. */
+  onPath?: (path: "rehacer-detalle" | "rehacer-pieza" | "cargo-mano") => void;
+  /** Callback al enviar feedback texto libre. Mock-only en este PR. */
+  onFeedback?: (text: string) => void;
+}
+
+export function RecoveryBlock({ traceId, onPath, onFeedback }: Props) {
+  const [feedback, setFeedback] = useState("");
+  const [sent, setSent] = useState(false);
+
+  const submit = () => {
+    if (!feedback.trim()) return;
+    onFeedback?.(feedback.trim());
+    setSent(true);
+  };
+
+  return (
+    <div className="recovery-block" data-testid="recovery-block">
+      <div className="v-msg">
+        <div className="vbubble" />
+        <div>
+          <div className="name">Valentina · IA</div>
+          <div className="body">
+            Entendido — tirá esto. ¿Qué te falta o sobra?
+            <br />
+            <span className="sub">Cuanto más concreta seas, mejor lo rehago.</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="recovery-paths" data-testid="recovery-paths">
+        <button
+          type="button"
+          className="rpath"
+          onClick={() => onPath?.("rehacer-detalle")}
+          data-testid="rpath-detalle"
+        >
+          <div className="label">A · Rehacer con detalle</div>
+          <div className="desc">
+            Decime qué cambia (medidas, voladizos, bachas) y armo otro despiece desde cero.
+          </div>
+        </button>
+        <button
+          type="button"
+          className="rpath"
+          onClick={() => onPath?.("rehacer-pieza")}
+          data-testid="rpath-pieza"
+        >
+          <div className="label">B · Rehacer 1 pieza</div>
+          <div className="desc">
+            Si sólo está mal R4 (la isla, por ej.), te corrijo esa y dejo el resto.
+          </div>
+        </button>
+        <button
+          type="button"
+          className="rpath muted"
+          onClick={() => onPath?.("cargo-mano")}
+          data-testid="rpath-mano"
+        >
+          <div className="label">C · Cargo a mano</div>
+          <div className="desc">Vacío todo y lo hacés vos. Yo me callo hasta que me llames.</div>
+        </button>
+      </div>
+
+      <div className="recovery-composer" data-testid="recovery-composer">
+        <input
+          type="text"
+          value={feedback}
+          onChange={(e) => {
+            setFeedback(e.target.value);
+            if (sent) setSent(false);
+          }}
+          onKeyDown={(e) => e.key === "Enter" && submit()}
+          placeholder="O contame qué está mal — texto libre…"
+          data-testid="recovery-input"
+        />
+        <button
+          type="button"
+          className="btn primary sm"
+          onClick={submit}
+          disabled={!feedback.trim() || sent}
+          data-testid="recovery-send"
+        >
+          {sent ? "Enviado" : "Enviar feedback"}
+        </button>
+      </div>
+
+      <div className="trace-row" data-testid="trace-row">
+        <span aria-hidden="true">ⓘ</span>
+        <span>
+          Tu feedback se guarda como{" "}
+          <strong>
+            trace {traceId} · <span data-testid="trace-status">rejected</span>
+          </strong>{" "}
+          — el equipo lo revisa para mejorar prompts. Tu nombre no se comparte.
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/despiece/SessionInfoBanner.tsx
+++ b/web/src/components/despiece/SessionInfoBanner.tsx
@@ -1,0 +1,28 @@
+/**
+ * Banner `.ia-banner.system` arriba de la tabla del despiece cuando hay
+ * chat scoped abierto (mockup 17).
+ *
+ * Copy literal: "CHAT ABIERTO SOBRE R5 · ZÓCALO PERIMETRAL · HACE 8 MIN"
+ * + sub explicando persistencia intra-quote.
+ *
+ * Sprint 3 error-states decisión Javi E: feature de session persistente
+ * 24h es OUT scope (es feature backend), solo mostramos el copy del banner.
+ */
+"use client";
+
+interface Props {
+  context: string;
+}
+
+export function SessionInfoBanner({ context }: Props) {
+  return (
+    <div className="ia-banner system" data-testid="session-info-banner">
+      <div className="text">
+        {context}
+        <div className="sub">
+          Sesión persistente intra-quote · se borra cuando cierres el quote o pasen 24h sin tocarlo
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api/mocks.ts
+++ b/web/src/lib/api/mocks.ts
@@ -375,16 +375,34 @@ function buildFailedTimeline(): TimelineStep[] {
 
 async function seedPieceList(quoteId: string): Promise<PieceList> {
   const { PIECES_BY_QUOTE_ID, TIMELINE_BY_QUOTE_ID } = await import("../mocks/canonicalQuote");
-  const canon = PIECES_BY_QUOTE_ID[quoteId];
+
+  // Sprint 3 error-states · sufijos de trigger E2E (mismo patrón que -ERROR
+  // del paso-4 PR #465). El canónico (PRES-2026-018) provee los datos base.
+  const isRejected = quoteId.endsWith("-REJECTED");
+  const isFlagged = quoteId.endsWith("-FLAGGED");
+  const baseId = isRejected
+    ? quoteId.slice(0, -"-REJECTED".length)
+    : isFlagged
+      ? quoteId.slice(0, -"-FLAGGED".length)
+      : quoteId;
+
+  const canon = PIECES_BY_QUOTE_ID[baseId] ?? PIECES_BY_QUOTE_ID[quoteId];
   if (canon && canon.length > 0) {
     const pieces = deepClonePieces(canon);
     const total = piecesTotalM2(pieces);
-    return {
+    const base: PieceList = {
       pieces,
       status: "done",
-      timeline: TIMELINE_BY_QUOTE_ID[quoteId] ?? buildDoneTimeline(pieces.length, total),
+      timeline: TIMELINE_BY_QUOTE_ID[baseId] ?? buildDoneTimeline(pieces.length, total),
       warnings: [],
     };
+    if (isRejected) base.rejected = true;
+    if (isFlagged) {
+      // Preset del chat flagged · mockup 17 literal (4 mensajes sobre R5).
+      const { CHAT_FLAGGED_PRESET_018 } = await import("../mocks/canonicalQuote");
+      base.chatFlagged = CHAT_FLAGGED_PRESET_018;
+    }
+    return base;
   }
   return {
     pieces: [],
@@ -649,5 +667,21 @@ export async function getAuditSnapshot(
   options?: { signal?: AbortSignal },
 ): Promise<import("./types").AuditSnapshot> {
   await delay(120 + Math.random() * 120, options?.signal);
+
+  // Sprint 3 error-states · sufijos heredan el snapshot del baseId con
+  // marcador adicional `· rejected` en el trace (decisión Javi G del mockup
+  // 15: "Tu feedback se guarda como trace q_8f2a · rejected").
+  const isRejected = quoteId.endsWith("-REJECTED");
+  const isFlagged = quoteId.endsWith("-FLAGGED");
+  if (isRejected || isFlagged) {
+    const baseId = quoteId.slice(0, -(isRejected ? "-REJECTED" : "-FLAGGED").length);
+    const base = _auditByQuote[baseId];
+    if (base) {
+      const clone: import("./types").AuditSnapshot = JSON.parse(JSON.stringify(base));
+      if (isRejected) clone.trace.traceId = `${clone.trace.traceId} · rejected`;
+      if (isFlagged) clone.trace.traceId = `${clone.trace.traceId} · flagged`;
+      return clone;
+    }
+  }
   return _auditByQuote[quoteId] ?? _auditGeneric;
 }

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -187,6 +187,39 @@ export interface PieceList {
   status: "pending" | "inferring" | "done" | "failed";
   timeline: TimelineStep[];
   warnings: string[];
+  /** Sprint 3 error-states (mockup 15) · Marina marcó este despiece como
+   * "esto no me sirve". Cuando true, DespieceView renderea banner error +
+   * tabla `.discarded` + RecoveryBlock con 3 caminos. Mock-only · disparado
+   * por sufijo `-REJECTED` en el quoteId. Sprint 4 wirea recovery paths. */
+  rejected?: boolean;
+  /** Sprint 3 error-states (mockup 17) · chat tiene un mensaje flagged.
+   * Mock-only · disparado por sufijo `-FLAGGED`. Cuando presente, el
+   * DespieceChatPanel carga el preset (4 mensajes con el último flagged
+   * + sessionInfo + composerPrefill). */
+  chatFlagged?: ChatFlaggedPreset;
+}
+
+/** Sprint 3 error-states (mockup 17) · preset del chat flagged. */
+export interface ChatFlaggedPreset {
+  /** Mensajes del stream pre-existente (4 mock). El último es flagged. */
+  messages: Array<{
+    id: string;
+    role: "user" | "valentina";
+    content: string;
+    timestamp: string;
+    /** Solo para el último mensaje de Valentina · marca flagged en el UI. */
+    flagged?: boolean;
+    /** Etiqueta de timestamp relativo del mockup ("14:23 · hace 30s"). */
+    relativeTs?: string;
+  }>;
+  /** Sesión info del header del chat ("4 mensajes · primer turno hace 8 min"). */
+  sessionInfo: string;
+  /** Sesión info del banner sobre la tabla ("CHAT ABIERTO SOBRE R5 · HACE 8 MIN"). */
+  sessionContext: string;
+  /** ID de la pieza referida por el chat (para el .row-chat-ref de la tabla). */
+  pieceRefId: string;
+  /** Texto pre-cargado del composer (último mensaje user). */
+  composerPrefill: string;
 }
 
 /** m² unitario (half-up a 2 decimales, igual que calculator.py). */

--- a/web/src/lib/hooks/useDespiece.ts
+++ b/web/src/lib/hooks/useDespiece.ts
@@ -142,6 +142,10 @@ export function useDespiece(quoteId: string) {
     (p) => p.edited === true || p.origin === "AGREGADO_MANUAL",
   ).length;
 
+  // Sprint 3 error-states · flags del PieceList propagados al UI.
+  const rejected = data?.rejected === true;
+  const chatFlagged = data?.chatFlagged ?? null;
+
   return {
     pieces,
     timeline,
@@ -155,5 +159,7 @@ export function useDespiece(quoteId: string) {
     regenerate,
     isDirty,
     editedCount,
+    rejected,
+    chatFlagged,
   };
 }

--- a/web/src/lib/mocks/canonicalQuote.ts
+++ b/web/src/lib/mocks/canonicalQuote.ts
@@ -598,3 +598,49 @@ export const CALCULATIONS_BY_QUOTE_ID: Record<string, CalculationResult> = {
   "PRES-2026-018": CANONICAL_CALCULATION_018,
   "PRES-2026-017": CANONICAL_CALCULATION_017,
 };
+
+// ─── Sprint 3 error-states · mockup 17 (chat scoped flagged) ─────────
+// Preset literal del mockup 17-chat-error-ia.html (4 mensajes sobre R5
+// zócalo perimetral · el último de Valentina es flagged como inútil).
+export const CHAT_FLAGGED_PRESET_018: import("../api/types").ChatFlaggedPreset = {
+  sessionInfo: "4 mensajes · primer turno hace 8 min",
+  sessionContext: "CHAT ABIERTO SOBRE R5 · ZÓCALO PERIMETRAL · HACE 8 MIN",
+  pieceRefId: "R5",
+  composerPrefill:
+    "¿Y el regrueso del zócalo? Necesito saber si va con regrueso 4cm o 2cm para presupuestar bien.",
+  messages: [
+    {
+      id: "flag-m1",
+      role: "user",
+      content:
+        "R5 lo dejé en 12cm porque el cliente quiere zócalo alto. Eso me suma TOMAS según vos, ¿qué pasa si lo bajo a 8cm?",
+      timestamp: "14:15",
+      relativeTs: "14:15 · hace 8 min",
+    },
+    {
+      id: "flag-m2",
+      role: "valentina",
+      content:
+        'Si bajás R5 a 8cm ya no aplica la regla ">10cm = 1 TOMAS automático". Te queda solo la TOMAS de la alzada (R3). El cálculo del paso 4 baja en $7.818 (1 TOMAS menos). Ojo: zócalos <10cm pueden quedar visualmente cortos contra muebles altos. Decisión del cliente.',
+      timestamp: "14:16",
+      relativeTs: "14:16 · hace 7 min",
+    },
+    {
+      id: "flag-m3",
+      role: "user",
+      content:
+        "¿Y el regrueso del zócalo? Necesito saber si va con regrueso 4cm o 2cm para presupuestar bien.",
+      timestamp: "14:22",
+      relativeTs: "14:22 · hace 1 min",
+    },
+    {
+      id: "flag-m4",
+      role: "valentina",
+      content:
+        "El regrueso es una técnica de marmolería que consiste en pegar dos piezas para dar mayor espesor visual al canto. En general se usa en mesadas para dar más presencia al frente. Hay distintos espesores disponibles según el material.",
+      timestamp: "14:23",
+      relativeTs: "14:23 · hace 30s",
+      flagged: true,
+    },
+  ],
+};

--- a/web/tests/e2e/error-states.spec.ts
+++ b/web/tests/e2e/error-states.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * E2E error-states · Sprint 3 ÚLTIMO sub-PR (mockups 15 + 17).
+ *
+ * Cubre:
+ * - Estado rejected (mockup 15): banner error + tabla discarded + RecoveryBlock
+ *   con 3 caminos visual-only + composer feedback + trace-row + empty-chat side.
+ *   Trigger: sufijo `-REJECTED` en quoteId.
+ * - Estado flagged (mockup 17): SessionInfoBanner + tabla con row-chat-ref +
+ *   chat scoped con FlaggedMessage + FeedbackBanner + composer prefill warn.
+ *   Trigger: sufijo `-FLAGGED` en quoteId.
+ * - Datasource isolation, fallback gracioso, regresión despiece normal.
+ */
+import { expect, test, type Page } from "@playwright/test";
+
+async function go(page: Page, route: string) {
+  await page.goto(route);
+  await expect(page.locator(".topbar")).toBeVisible();
+}
+
+/* ─── Mockup 15 · rejected ─────────────────────────────────────────── */
+
+test("rejected · banner + tabla discarded + recovery block visibles", async ({ page }) => {
+  await go(page, "/quotes/PRES-2026-018-REJECTED/despiece");
+  await expect(page.locator('[data-testid="despiece-view"]')).toHaveAttribute(
+    "data-state",
+    "rejected",
+  );
+  await expect(page.locator('[data-testid="rejected-banner"]')).toBeVisible();
+  await expect(page.locator('[data-testid="rejected-banner"]')).toContainText("esto no me sirve");
+  await expect(page.locator('[data-testid="despiece-table"]')).toHaveAttribute(
+    "data-discarded",
+    "true",
+  );
+  await expect(page.locator('[data-testid="discarded-tag"]')).toContainText("descartado");
+  await expect(page.locator('[data-testid="recovery-block"]')).toBeVisible();
+  await expect(page.locator('[data-testid="rpath-detalle"]')).toBeVisible();
+  await expect(page.locator('[data-testid="rpath-pieza"]')).toBeVisible();
+  await expect(page.locator('[data-testid="rpath-mano"]')).toBeVisible();
+});
+
+test("rejected · trace-row con traceId q_8f2a + status rejected", async ({ page }) => {
+  await go(page, "/quotes/PRES-2026-018-REJECTED/despiece");
+  await expect(page.locator('[data-testid="trace-row"]')).toContainText("q_8f2a");
+  await expect(page.locator('[data-testid="trace-status"]')).toContainText("rejected");
+});
+
+test("rejected · composer feedback captura texto y bloquea send vacío", async ({ page }) => {
+  await go(page, "/quotes/PRES-2026-018-REJECTED/despiece");
+  const input = page.locator('[data-testid="recovery-input"]');
+  const send = page.locator('[data-testid="recovery-send"]');
+  await expect(send).toBeDisabled();
+  await input.fill("Faltó la isla y los voladizos están al revés");
+  await expect(send).toBeEnabled();
+  await send.click();
+  await expect(send).toContainText("Enviado");
+});
+
+test("rejected · empty-chat side panel con CTA abre chat", async ({ page }) => {
+  await go(page, "/quotes/PRES-2026-018-REJECTED/despiece");
+  const emptyChat = page.locator('[data-testid="despiece-empty-chat"]');
+  await expect(emptyChat).toBeVisible();
+  await page.locator('[data-testid="empty-chat-open"]').click();
+  await expect(page.locator('[data-testid="chat-panel"]')).toBeVisible();
+});
+
+/* ─── Mockup 17 · flagged ──────────────────────────────────────────── */
+
+test("flagged · session-info banner + row-chat-ref + chat auto-open con stream preset", async ({
+  page,
+}) => {
+  await go(page, "/quotes/PRES-2026-018-FLAGGED/despiece");
+  await expect(page.locator('[data-testid="session-info-banner"]')).toContainText(
+    "CHAT ABIERTO SOBRE R5",
+  );
+  await expect(page.locator('[data-testid="row-chat-ref-R5"]')).toContainText(
+    "chat referido a esta pieza",
+  );
+  // Chat se abrió solo con el preset.
+  await expect(page.locator('[data-testid="chat-panel"]')).toBeVisible();
+  await expect(page.locator('[data-testid="chat-session-info"]')).toContainText(
+    "4 mensajes · primer turno hace 8 min",
+  );
+});
+
+test("flagged · último mensaje Valentina marcado + btn-feedback disabled (post-click)", async ({
+  page,
+}) => {
+  await go(page, "/quotes/PRES-2026-018-FLAGGED/despiece");
+  const flagged = page.locator('[data-testid="flagged-message"]');
+  await expect(flagged).toBeVisible();
+  await expect(flagged).toContainText("regrueso es una técnica");
+  // alreadyFlagged arranca en true (mockup post-click)
+  await expect(page.locator('[data-testid="btn-feedback"]')).toBeDisabled();
+  await expect(page.locator('[data-testid="feedback-banner"]')).toBeVisible();
+});
+
+test("flagged · composer pre-cargado con última pregunta + hint warn", async ({ page }) => {
+  await go(page, "/quotes/PRES-2026-018-FLAGGED/despiece");
+  const input = page.locator('[data-testid="chat-input"]');
+  await expect(input).toHaveValue(/regrueso del zócalo/);
+  await expect(page.locator('[data-testid="chat-hint"]')).toContainText("pre-cargada");
+});
+
+test("flagged · click 'Reformular' resetea feedback + re-prefilllea composer", async ({ page }) => {
+  await go(page, "/quotes/PRES-2026-018-FLAGGED/despiece");
+  await page.locator('[data-testid="feedback-reformulate"]').click();
+  // Tras reformular, el banner desaparece y btn-feedback vuelve a estar enabled.
+  await expect(page.locator('[data-testid="feedback-banner"]')).not.toBeVisible();
+  await expect(page.locator('[data-testid="btn-feedback"]')).toBeEnabled();
+  // Composer queda con el prefill listo para editar.
+  await expect(page.locator('[data-testid="chat-input"]')).toHaveValue(/regrueso del zócalo/);
+});
+
+test("flagged · click 'Cerrar chat' cierra el panel", async ({ page }) => {
+  await go(page, "/quotes/PRES-2026-018-FLAGGED/despiece");
+  await page.locator('[data-testid="feedback-close"]').click();
+  await expect(page.locator('[data-testid="chat-panel"]')).not.toBeVisible();
+});
+
+/* ─── Datasource isolation + regresión ─────────────────────────────── */
+
+test("audit-tray con trace · rejected sufijo aplicado", async ({ page }) => {
+  await go(page, "/quotes/PRES-2026-018-REJECTED/despiece");
+  await page.locator('[data-testid="audit-toggle"]').click();
+  // Audit tray del PR #466 hereda el snapshot de PRES-018 + sufijo "· rejected".
+  await expect(page.locator('[data-testid="audit-tray"]')).toContainText("q_8f2a · rejected");
+});
+
+test("regresión despiece normal sin sufijo · no muestra rejected ni flagged UI", async ({
+  page,
+}) => {
+  await go(page, "/quotes/PRES-2026-018/despiece");
+  await expect(page.locator('[data-testid="despiece-view"]')).toHaveAttribute("data-state", "idle");
+  await expect(page.locator('[data-testid="rejected-banner"]')).toHaveCount(0);
+  await expect(page.locator('[data-testid="session-info-banner"]')).toHaveCount(0);
+  await expect(page.locator('[data-testid="despiece-table"]')).toHaveAttribute(
+    "data-discarded",
+    "false",
+  );
+});


### PR DESCRIPTION
## Resumen

🎯 **ÚLTIMO sub-PR del Sprint 3 oficial** · cierra a **7/7**.

Implementa los mockups **15** (IA error · "esto no me sirve") y **17** (chat scoped · error IA con feedback). Ambos son **estados de feedback negativo del usuario al output de la IA** (no errores de sistema/network/auth — el nombre "error-states" era lossy, FASE 1 lo aclaró).

## Sorpresa positiva de FASE 1

**TODAS las clases CSS necesarias ya existen** en operator-shared.css (`.ia-banner.error`, `.discarded`, `.recovery-paths`, `.rpath`, `.trace-row`, `.msg.v.flagged`, `.btn-feedback`, `.feedback-banner`, `.btn-fb`, `.row-chat-ref`, `.empty-cta`, `.discarded-tag`, `.session-info`, `.recovery-composer`, `.recovery-block`). **CSS scope = 0**. Solo JSX + lógica + tests.

## Decisiones Javi (10 features bundle A-J) — todas implementadas

| # | Decisión | Disposición |
|---|---|---|
| A | Scope solo paso-3 (ambos mockups `data-step="despiece"`) | ✅ paso-3 only |
| B | Despiece rejected es persistente | ✅ trigger via sufijo URL |
| C | Recovery paths A/B/C | ⏭ visual-only · Sprint 4 wire |
| D | Composer feedback texto libre | ⏭ captura useState · no persist |
| E | Chat session persistente 24h | ⏭ OUT scope · solo copy banner |
| F | btn-feedback funcional + transición a FeedbackBanner | ✅ funcional |
| G | Trace `· rejected` integra con AuditTray PR #466 | ✅ sufijo en traceId |
| H | Trigger E2E del rejected | ✅ sufijo `-REJECTED` |
| I | Trigger E2E del flagged | ✅ sufijo `-FLAGGED` (Opción 1 confirmada) |
| J | RowChatRef en tabla cuando chat focused/ref | ✅ chatRef prop + label |

## Componentes nuevos (5)

- `RecoveryBlock.tsx` — Banner Valentina + 3 caminos visual-only + composer feedback + trace-row
- `DespieceEmptyChat.tsx` — Chat side panel cerrado con CTA "Abrir chat" (mockup 15)
- `SessionInfoBanner.tsx` — `.ia-banner.system` con info de sesión (mockup 17)
- `FlaggedMessage.tsx` — Variante ValentinaMessage con btn-feedback inline
- `FeedbackBanner.tsx` — Banner post-flag con acciones Reformular/Cerrar

## Modificados

- `types.ts` — `PieceList.rejected` + `ChatFlaggedPreset`
- `mocks.ts` — `seedPieceList` detecta sufijos `-REJECTED` / `-FLAGGED` · `getAuditSnapshot` sufija traceId
- `canonicalQuote.ts` — `CHAT_FLAGGED_PRESET_018` con datos LITERALES del mockup 17
- `useDespiece.ts` — propaga `rejected` + `chatFlagged` al UI
- `DespieceView.tsx` — rama rejected (return early) + chatFlagged auto-open chat + SessionInfoBanner
- `DespieceTable.tsx` — props `discarded` (modifier + tag) + `chatRefPieceId`
- `PieceRow.tsx` — prop `chatRef` (distinta de `focused`) + label "↳ chat referido a esta pieza"
- `DespieceChatPanel.tsx` — soporta `flaggedPreset` (stream + sessionInfo + composer prefill + hint warn + autoFocus)

## Verificación

| Check | Resultado |
|---|---|
| lint / typecheck / unit / build | ✅ |
| E2E | ✅ **92 passed + 3 skipped** (81 prev + 11 nuevos) |
| `operator-shared.css` | ✅ intacto (CSS ya existía completo) |
| `.py` modificados | 0 |
| Middleware / Sidebar / TopBar / `[id]/layout` | ✅ intactos |
| Regresión despiece normal · paso-4 · observability · qhead | ✅ |

## Visual local verificado (Chrome MCP)

**`/quotes/PRES-2026-018-REJECTED/despiece`** (mockup 15):
- `data-state: "rejected"` ✅
- Banner error con copy literal ✅
- Tabla `data-discarded: "true"` + tag "descartado" ✅
- 3 recovery paths visibles ✅
- Trace-row "trace q_8f2a · rejected" ✅
- DespieceEmptyChat side ✅

**`/quotes/PRES-2026-018-FLAGGED/despiece`** (mockup 17):
- SessionInfoBanner "CHAT ABIERTO SOBRE R5..." ✅
- `row-chat-ref-R5` con label ✅
- Chat auto-open con `sessionInfo: "4 mensajes · primer turno hace 8 min"` ✅
- FlaggedMessage del último Valentina + `btn-feedback` disabled ✅
- FeedbackBanner visible ✅
- Composer prefill con la última pregunta + `hint warn` ✅

## Tests E2E (11 nuevos)

- 4 del rejected · banner + tabla discarded + trace + composer + empty-chat
- 5 del flagged · session banner + row-ref + auto-open + flagged-msg + Reformular/Cerrar
- 1 audit-tray hereda sufijo `· rejected`
- 1 regresión despiece normal sin sufijo

## Sprint 3 status post-merge

**7/7 oficial cerrado** 🎉 (+ 1 bonus qhead-empty-title del PR #467).

🤖 Generated with [Claude Code](https://claude.com/claude-code)