### PR TITLE
feat(sprint-4/ssr-auth): JWT Bearer en SSR via cookie httpOnly Vercel (Opción D)

### DIFF
--- a/web/src/app/api/session/route.ts
+++ b/web/src/app/api/session/route.ts
@@ -36,6 +36,14 @@ import { SESSION_COOKIE_NAME } from "@/lib/session-cookie";
 
 const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24; // 24h
 
+// Fix-up #1 PR #469 · Vercel route handlers en cold start con `NextResponse(null,
+// { status: 204 })` + Set-Cookie podían crashear con 503 (issue conocido del
+// runtime Node serverless). Forzar dynamic evita el caching agresivo, y devolver
+// cuerpo JSON (en vez de null) evita el path con body vacío. Combinado con el
+// fix de la firma del DELETE (acepta NextRequest como POST) cierra los 3 posibles
+// culpables del 503 reportado por el visual check CFC en el preview real.
+export const dynamic = "force-dynamic";
+
 function isProd(): boolean {
   return process.env.NODE_ENV === "production";
 }
@@ -56,7 +64,7 @@ export async function POST(request: NextRequest) {
   if (!token) {
     return NextResponse.json({ ok: false, reason: "missing-token" }, { status: 400 });
   }
-  const res = new NextResponse(null, { status: 204 });
+  const res = NextResponse.json({ ok: true }, { status: 200 });
   res.cookies.set({
     name: SESSION_COOKIE_NAME,
     value: token,
@@ -69,9 +77,13 @@ export async function POST(request: NextRequest) {
   return res;
 }
 
-/** DELETE `/api/session` → limpia la cookie y devuelve 204. */
-export async function DELETE() {
-  const res = new NextResponse(null, { status: 204 });
+/** DELETE `/api/session` → limpia la cookie y devuelve 200 `{ ok: true }`.
+ *
+ * Acepta `NextRequest` (firma consistente con POST aunque no la use) · evita
+ * issues de Vercel cold start con handlers sin parámetros. Devuelve JSON
+ * (no null body 204) por el mismo issue serverless. */
+export async function DELETE(_request: NextRequest) {
+  const res = NextResponse.json({ ok: true }, { status: 200 });
   res.cookies.set({
     name: SESSION_COOKIE_NAME,
     value: "",

--- a/web/src/app/api/session/route.ts
+++ b/web/src/app/api/session/route.ts
@@ -1,0 +1,85 @@
+/**
+ * Route Handler `/api/session` · Sprint 4 ssr-auth (Opción D).
+ *
+ * Sincroniza el JWT que el backend devuelve en login al frontend Vercel,
+ * en una cookie httpOnly scoped a vercel.app (same-origin con la página).
+ * Esta cookie SOLO se lee en SSR (server components) para inyectar el JWT
+ * como `Authorization: Bearer <token>` en fetches server-side hacia Railway.
+ *
+ * Por qué una cookie *extra* y no usar la de Railway:
+ * - La cookie httpOnly que setea Railway (`auth_token`) tiene
+ *   `Domain=railway.app`. El server de Vercel NUNCA la ve (es cross-origin).
+ * - El JWT viaja en el BODY de la respuesta del login (`token: body.token`)
+ *   y ya queda en localStorage del cliente. Esa misma string la usamos acá
+ *   para crear una cookie scopeada a vercel.app (same-origin → Next puede
+ *   leerla con `cookies()` de `next/headers`).
+ * - El backend FastAPI ya soporta `Authorization: Bearer <token>` como
+ *   fallback nativo del cookie cross-origin (ver
+ *   `api/app/core/auth.py:166` extract_token_from_request) → cero cambios
+ *   en el backend.
+ *
+ * Razones de las decisiones:
+ * - `httpOnly: true` → no expuesta al JS del browser (defense in depth aunque
+ *   el token también esté en localStorage por el flow de login). Igual
+ *   reduce surface en caso de XSS en otras rutas.
+ * - `sameSite: "lax"` → la cookie vive en el mismo origin que la página;
+ *   no necesita el caso cross-origin de `"none"`.
+ * - `secure: true` en prod, `false` en dev (localhost sin TLS).
+ * - `maxAge ≈ 24h` razonable. El JWT del backend tiene su propio `exp`
+ *   (~60min según APP_CONFIG); si vence antes que la cookie, el primer
+ *   401 dispara `handleApiError` → redirect /login (flujo ya cubierto).
+ * - `path: "/"` para que se vea desde cualquier ruta SSR.
+ */
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { SESSION_COOKIE_NAME } from "@/lib/session-cookie";
+
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24; // 24h
+
+function isProd(): boolean {
+  return process.env.NODE_ENV === "production";
+}
+
+interface PostBody {
+  token?: string;
+}
+
+/** POST `/api/session` body: `{ token: "<JWT>" }` → setea cookie y devuelve 204. */
+export async function POST(request: NextRequest) {
+  let body: PostBody;
+  try {
+    body = (await request.json()) as PostBody;
+  } catch {
+    return NextResponse.json({ ok: false, reason: "invalid-json" }, { status: 400 });
+  }
+  const token = typeof body.token === "string" ? body.token.trim() : "";
+  if (!token) {
+    return NextResponse.json({ ok: false, reason: "missing-token" }, { status: 400 });
+  }
+  const res = new NextResponse(null, { status: 204 });
+  res.cookies.set({
+    name: SESSION_COOKIE_NAME,
+    value: token,
+    httpOnly: true,
+    sameSite: "lax",
+    secure: isProd(),
+    maxAge: COOKIE_MAX_AGE_SECONDS,
+    path: "/",
+  });
+  return res;
+}
+
+/** DELETE `/api/session` → limpia la cookie y devuelve 204. */
+export async function DELETE() {
+  const res = new NextResponse(null, { status: 204 });
+  res.cookies.set({
+    name: SESSION_COOKIE_NAME,
+    value: "",
+    httpOnly: true,
+    sameSite: "lax",
+    secure: isProd(),
+    maxAge: 0,
+    path: "/",
+  });
+  return res;
+}

--- a/web/src/app/quotes/[id]/layout.tsx
+++ b/web/src/app/quotes/[id]/layout.tsx
@@ -15,6 +15,7 @@ import { Qhead } from "@/components/chrome/Qhead";
 import { Stepper } from "@/components/chrome/Stepper";
 import { AuditTray } from "@/components/observability/AuditTray";
 import { getQuoteMetadata } from "@/lib/api";
+import { getServerToken } from "@/lib/auth-server";
 
 export default async function QuoteLayout({
   children,
@@ -23,7 +24,12 @@ export default async function QuoteLayout({
   children: React.ReactNode;
   params: { id: string };
 }) {
-  const quote = await getQuoteMetadata(params.id);
+  // Sprint 4 ssr-auth (Opción D): JWT desde cookie httpOnly de vercel.app
+  // (sincronizada en login via `/api/session`). Si no hay (pre-login /
+  // cookie expirada / borrada), `bearerToken: null` → real.ts degrada
+  // graceful al `ssrFallbackHeader` (mismo comportamiento previo).
+  const bearerToken = getServerToken();
+  const quote = await getQuoteMetadata(params.id, { bearerToken });
 
   return (
     <div className="page">

--- a/web/src/lib/api/mocks.ts
+++ b/web/src/lib/api/mocks.ts
@@ -307,7 +307,9 @@ const GENERIC_QUOTE_HEADER: Omit<QuoteHeader, "id"> = {
 
 export async function getQuoteMetadata(
   quoteId: string,
-  options?: { signal?: AbortSignal },
+  // Sprint 4 ssr-auth: `bearerToken` se acepta en la signature compartida
+  // con real.ts pero el mock lo ignora (no hace fetch al backend).
+  options?: { signal?: AbortSignal; bearerToken?: string | null },
 ): Promise<QuoteHeader> {
   await delay(80 + Math.random() * 120, options?.signal);
   const found = DASHBOARD_QUOTES.find((q) => q.id === quoteId);

--- a/web/src/lib/api/real.ts
+++ b/web/src/lib/api/real.ts
@@ -29,10 +29,17 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
-/** fetch con credentials:include + timeout + 401 handling + merge de signal externo. */
+/** fetch con credentials:include + timeout + 401 handling + merge de signal externo.
+ *
+ * Sprint 4 ssr-auth (Opción D): `bearerToken` opcional inyecta
+ * `Authorization: Bearer <token>` cuando se pasa. SSR (`typeof window ===
+ * "undefined"`) lo usa para autenticar con el JWT leído de la cookie
+ * httpOnly vercel · client-side sigue dependiendo de la cookie cross-origin
+ * de Railway via `credentials: "include"` (no necesita el header).
+ */
 async function apiFetch(
   path: string,
-  init: RequestInit & { signal?: AbortSignal } = {},
+  init: RequestInit & { signal?: AbortSignal; bearerToken?: string | null } = {},
   timeoutMs = DEFAULT_TIMEOUT_MS,
 ): Promise<Response> {
   const ctrl = new AbortController();
@@ -41,9 +48,13 @@ async function apiFetch(
     if (init.signal.aborted) ctrl.abort();
     else init.signal.addEventListener("abort", () => ctrl.abort(), { once: true });
   }
+  const { bearerToken, ...rest } = init;
+  const headers = new Headers(rest.headers);
+  if (bearerToken) headers.set("Authorization", `Bearer ${bearerToken}`);
   try {
     const response = await fetch(`${API_URL}${path}`, {
-      ...init,
+      ...rest,
+      headers,
       credentials: "include",
       signal: ctrl.signal,
     });
@@ -176,11 +187,22 @@ function ssrFallbackHeader(quoteId: string): QuoteHeader {
  */
 export async function getQuoteMetadata(
   quoteId: string,
-  options?: { signal?: AbortSignal },
+  options?: { signal?: AbortSignal; bearerToken?: string | null },
 ): Promise<QuoteHeader> {
+  // Sprint 4 ssr-auth (Opción D): en SSR el browser no nos manda la cookie
+  // httpOnly cross-origin de Railway. El Server Component caller (layout)
+  // lee el JWT con `getServerToken()` de `@/lib/auth-server` y lo pasa por
+  // `options.bearerToken`. NO importamos `auth-server` desde acá porque
+  // este módulo se incluye en el bundle client y `next/headers` solo
+  // existe en server (Next 14 build error).
+  //
+  // Si no hay token (pre-login / cookie expirada), bearerToken queda null
+  // → request sale sin auth → backend 401 → catch degrada graceful con
+  // `ssrFallbackHeader` (mismo comportamiento previo a este PR).
   try {
     const response = await apiFetch(`/api/quotes/${encodeURIComponent(quoteId)}`, {
       signal: options?.signal,
+      bearerToken: options?.bearerToken ?? null,
     });
     if (response.status === 404) {
       throw new ApiError("QUOTE_NOT_FOUND", `Quote ${quoteId} no encontrado`, 404);

--- a/web/src/lib/auth-server.ts
+++ b/web/src/lib/auth-server.ts
@@ -1,0 +1,34 @@
+/**
+ * Server-side auth helpers · Sprint 4 ssr-auth (Opción D).
+ *
+ * Solo se importa desde Server Components o Route Handlers. NUNCA desde
+ * client components — `cookies()` de `next/headers` solo existe en server.
+ *
+ * Pareja del Route Handler `/api/session`: el cliente POSTea el JWT (que
+ * tiene en localStorage post-login) y este helper lo lee desde SSR para
+ * inyectarlo como `Authorization: Bearer <token>` en fetches al backend.
+ */
+import { cookies } from "next/headers";
+import { SESSION_COOKIE_NAME } from "@/lib/session-cookie";
+
+/**
+ * Lee la cookie httpOnly `vercel_session_token` (sincronizada en login via
+ * `/api/session`). Devuelve `null` si no hay sesión SSR válida — el caller
+ * decide cómo degradar (típicamente `ssrFallbackHeader` en `real.ts`).
+ *
+ * NUNCA throw — el comportamiento esperado en SSR sin cookie es "no auth"
+ * (caso pre-login o cookie expirada / borrada).
+ */
+export function getServerToken(): string | null {
+  try {
+    const store = cookies();
+    const cookie = store.get(SESSION_COOKIE_NAME);
+    if (!cookie) return null;
+    const value = cookie.value?.trim();
+    return value ? value : null;
+  } catch {
+    // `cookies()` lanza si se llama fuera de un Server Component / Route
+    // Handler. En esos casos retornamos null (no auth) en vez de propagar.
+    return null;
+  }
+}

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -61,8 +61,12 @@ export async function login(credentials: LoginCredentials): Promise<Session> {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ token: body.token }),
     });
-  } catch {
-    // No bloqueamos el login si la sync falla.
+  } catch (err) {
+    // Fix-up #1 PR #469 · NICE-TO-HAVE audit · loguear best-effort fails.
+    // No bloqueamos el login si la sync falla (sigue funcionando · solo SSR
+    // queda degradado al fallback), pero dejamos rastro diagnosticable en
+    // producción para que un futuro 503 / network blip se note rápido.
+    console.warn("[auth] Sync con /api/session falló (login)", err);
   }
 
   const session: Session = {
@@ -90,8 +94,9 @@ export async function logout(): Promise<void> {
   // backend la rechazará y `handleApiError` reanudará el redirect a /login.
   try {
     await fetch("/api/session", { method: "DELETE" });
-  } catch {
-    // Best-effort.
+  } catch (err) {
+    // Fix-up #1 PR #469 · NICE-TO-HAVE audit · loguear best-effort fails.
+    console.warn("[auth] Sync con /api/session falló (logout)", err);
   }
   clearSession();
 }

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -47,6 +47,24 @@ export async function login(credentials: LoginCredentials): Promise<Session> {
 
   const body = (await response.json()) as { ok: boolean; username: string; token: string };
 
+  // Sprint 4 ssr-auth (Opción D): sincronizar el JWT a una cookie httpOnly
+  // de vercel.app via `/api/session` para que `[id]/layout.tsx` (Server
+  // Component) la lea en SSR e inyecte como Bearer header al backend
+  // Railway. Esperamos esta sync ANTES de retornar — sin esto, un navigate
+  // inmediato post-login todavía vería el SSR fallback (em-dashes).
+  // Best-effort: si la sync falla (network blip), seguimos · client-side
+  // sigue funcionando con la cookie cross-origin de Railway, solo el SSR
+  // queda degradado al fallback (mismo comportamiento previo a este PR).
+  try {
+    await fetch("/api/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: body.token }),
+    });
+  } catch {
+    // No bloqueamos el login si la sync falla.
+  }
+
   const session: Session = {
     username: body.username,
     token: body.token,
@@ -66,6 +84,14 @@ export async function logout(): Promise<void> {
     } catch {
       // Best-effort — el logout client-side no depende del backend.
     }
+  }
+  // Sprint 4 ssr-auth (Opción D): limpiar cookie httpOnly vercel session.
+  // Best-effort · si falla, el SSR queda con token stale hasta 24h pero el
+  // backend la rechazará y `handleApiError` reanudará el redirect a /login.
+  try {
+    await fetch("/api/session", { method: "DELETE" });
+  } catch {
+    // Best-effort.
   }
   clearSession();
 }

--- a/web/src/lib/session-cookie.ts
+++ b/web/src/lib/session-cookie.ts
@@ -1,0 +1,8 @@
+/**
+ * Constante compartida del nombre de la cookie httpOnly que sincroniza
+ * el JWT del backend Railway a vercel.app · Sprint 4 ssr-auth.
+ *
+ * Vive en su propio módulo porque Next 14 prohíbe exports custom desde
+ * archivos `route.ts` (solo HTTP method handlers).
+ */
+export const SESSION_COOKIE_NAME = "vercel_session_token";

--- a/web/tests/e2e/session-route.spec.ts
+++ b/web/tests/e2e/session-route.spec.ts
@@ -2,21 +2,26 @@
  * E2E del Route Handler `/api/session` · Sprint 4 ssr-auth.
  *
  * Cubre:
- * - POST con body válido setea cookie httpOnly (204 + Set-Cookie).
+ * - POST con body válido setea cookie httpOnly (200 + Set-Cookie).
  * - POST sin body / sin token → 400.
- * - DELETE limpia la cookie (204 + Set-Cookie con maxAge=0).
+ * - DELETE limpia la cookie (200 + Set-Cookie con maxAge=0).
  * - La cookie tiene flags correctas (httpOnly, SameSite=lax, path=/).
+ *
+ * Fix-up #1 PR #469: status 200 + JSON body (en vez de 204 null body) por
+ * el issue de Vercel cold start que devolvía 503. El comportamiento
+ * funcional (cookie seteada / borrada) no cambia.
  *
  * NO testea que el SSR del [id]/layout use el header — eso requiere
  * backend real Railway con sesión válida (test manual + visual local).
  */
 import { expect, test } from "@playwright/test";
 
-test("POST /api/session con token válido setea cookie 204", async ({ request }) => {
+test("POST /api/session con token válido setea cookie 200", async ({ request }) => {
   const res = await request.post("/api/session", {
     data: { token: "test-jwt-value.xxx.yyy" },
   });
-  expect(res.status()).toBe(204);
+  expect(res.status()).toBe(200);
+  expect(await res.json()).toEqual({ ok: true });
   const setCookie = res.headers()["set-cookie"];
   expect(setCookie).toBeTruthy();
   expect(setCookie).toContain("vercel_session_token=test-jwt-value.xxx.yyy");
@@ -35,12 +40,29 @@ test("POST /api/session con token vacío → 400", async ({ request }) => {
   expect(res.status()).toBe(400);
 });
 
-test("DELETE /api/session limpia la cookie", async ({ request }) => {
+test("DELETE /api/session limpia la cookie con 200 (no 503 ni 204)", async ({ request }) => {
+  // Fix-up #1 PR #469 · CFC detectó 503 en preview real con la versión 204
+  // null body. Ahora 200 + JSON body evita el quirk del Vercel cold start.
   const res = await request.delete("/api/session");
-  expect(res.status()).toBe(204);
+  expect(res.status()).toBe(200);
+  expect(await res.json()).toEqual({ ok: true });
   const setCookie = res.headers()["set-cookie"];
   expect(setCookie).toBeTruthy();
   expect(setCookie).toContain("vercel_session_token=");
   expect(setCookie).toContain("Max-Age=0");
   expect(setCookie).toContain("HttpOnly");
+});
+
+test("DELETE /api/session después de POST elimina efectivamente la cookie del browser", async ({
+  request,
+}) => {
+  // Flujo completo end-to-end con el cookie jar del request context.
+  const post = await request.post("/api/session", { data: { token: "abc.def.ghi" } });
+  expect(post.status()).toBe(200);
+  const del = await request.delete("/api/session");
+  expect(del.status()).toBe(200);
+  // El siguiente fetch al endpoint (cualquiera same-origin) no debería
+  // llevar la cookie · el Max-Age=0 la invalidó.
+  const setCookieDel = del.headers()["set-cookie"] ?? "";
+  expect(setCookieDel).toMatch(/vercel_session_token=;.*Max-Age=0/);
 });

--- a/web/tests/e2e/session-route.spec.ts
+++ b/web/tests/e2e/session-route.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * E2E del Route Handler `/api/session` · Sprint 4 ssr-auth.
+ *
+ * Cubre:
+ * - POST con body válido setea cookie httpOnly (204 + Set-Cookie).
+ * - POST sin body / sin token → 400.
+ * - DELETE limpia la cookie (204 + Set-Cookie con maxAge=0).
+ * - La cookie tiene flags correctas (httpOnly, SameSite=lax, path=/).
+ *
+ * NO testea que el SSR del [id]/layout use el header — eso requiere
+ * backend real Railway con sesión válida (test manual + visual local).
+ */
+import { expect, test } from "@playwright/test";
+
+test("POST /api/session con token válido setea cookie 204", async ({ request }) => {
+  const res = await request.post("/api/session", {
+    data: { token: "test-jwt-value.xxx.yyy" },
+  });
+  expect(res.status()).toBe(204);
+  const setCookie = res.headers()["set-cookie"];
+  expect(setCookie).toBeTruthy();
+  expect(setCookie).toContain("vercel_session_token=test-jwt-value.xxx.yyy");
+  expect(setCookie).toContain("HttpOnly");
+  expect(setCookie).toContain("SameSite=lax");
+  expect(setCookie).toContain("Path=/");
+});
+
+test("POST /api/session sin body → 400", async ({ request }) => {
+  const res = await request.post("/api/session", { data: "" });
+  expect(res.status()).toBe(400);
+});
+
+test("POST /api/session con token vacío → 400", async ({ request }) => {
+  const res = await request.post("/api/session", { data: { token: "   " } });
+  expect(res.status()).toBe(400);
+});
+
+test("DELETE /api/session limpia la cookie", async ({ request }) => {
+  const res = await request.delete("/api/session");
+  expect(res.status()).toBe(204);
+  const setCookie = res.headers()["set-cookie"];
+  expect(setCookie).toBeTruthy();
+  expect(setCookie).toContain("vercel_session_token=");
+  expect(setCookie).toContain("Max-Age=0");
+  expect(setCookie).toContain("HttpOnly");
+});

--- a/web/tests/unit/auth-server.test.ts
+++ b/web/tests/unit/auth-server.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit del helper getServerToken · Sprint 4 ssr-auth.
+ *
+ * Cubre: cookie ausente, cookie vacía/whitespace, cookie válida, error
+ * de `cookies()` fuera de Server Component context.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(),
+}));
+
+import { cookies } from "next/headers";
+import { getServerToken } from "@/lib/auth-server";
+
+const mockedCookies = vi.mocked(cookies);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function withCookie(value: string | undefined) {
+  // El `cookies()` real devuelve un ReadonlyRequestCookies. Para el test
+  // mockeamos solo el método `get` que usa el helper.
+  mockedCookies.mockReturnValue({
+    get: () =>
+      value === undefined ? undefined : ({ name: "vercel_session_token", value } as never),
+  } as never);
+}
+
+describe("getServerToken", () => {
+  it("devuelve null cuando no hay cookie", () => {
+    withCookie(undefined);
+    expect(getServerToken()).toBeNull();
+  });
+
+  it("devuelve null cuando la cookie es string vacío", () => {
+    withCookie("");
+    expect(getServerToken()).toBeNull();
+  });
+
+  it("devuelve null cuando la cookie es solo whitespace (trim cae a vacío)", () => {
+    withCookie("   ");
+    expect(getServerToken()).toBeNull();
+  });
+
+  it("devuelve el token cuando la cookie está poblada (JWT-like)", () => {
+    withCookie("eyJhbGciOiJIUzI1NiJ9.payload.sig");
+    expect(getServerToken()).toBe("eyJhbGciOiJIUzI1NiJ9.payload.sig");
+  });
+
+  it("trimea whitespace alrededor del token", () => {
+    withCookie("   eyJabc.def.ghi   ");
+    expect(getServerToken()).toBe("eyJabc.def.ghi");
+  });
+
+  it("devuelve null si cookies() lanza (llamado fuera de Server Component)", () => {
+    mockedCookies.mockImplementation(() => {
+      throw new Error("cookies() called outside server context");
+    });
+    expect(getServerToken()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Resumen

Primer sub-PR Sprint 4. Resuelve la **causa raíz** del SSR fallback con em-dashes que arrastrábamos desde el Sprint 3.

**FASE 1 atajó 5-7h de trabajo**: descubrió que el backend FastAPI **ya** acepta `Authorization: Bearer <token>` como fallback nativo del cookie cross-origin (`api/app/core/auth.py:166 extract_token_from_request`). El login endpoint ya devuelve el JWT en el body. El frontend ya lo guarda en localStorage. **Solo nunca lo usó en SSR**.

## 3 opciones evaluadas → Opción D ganadora

| | Opción A · `cookies()` directo | Opción B · Proxy `/api/proxy/*` | Opción C · Client-ify layout | **Opción D · Sync cookie Vercel** |
|---|---|---|---|---|
| Funciona | ❌ cookie scope cross-origin | ⚠️ doble hop ~150ms | ⚠️ pierde SSR | ✅ |
| Tiempo | N/A | 9-11h | 4-5h | **4-5h** |
| Backend tocado | — | sí (proxy) | — | **cero** (regla absoluta Sprint 3) |
| SSE chat afectado | — | sí | — | **no** |

## Implementación

| Archivo | Cambio |
|---|---|
| `web/src/app/api/session/route.ts` (NUEVO) | Route Handler POST/DELETE · setea/limpia cookie httpOnly `vercel_session_token` |
| `web/src/lib/session-cookie.ts` (NUEVO) | `SESSION_COOKIE_NAME` const compartido (Next 14 prohibe exports custom desde `route.ts`) |
| `web/src/lib/auth-server.ts` (NUEVO) | Helper `getServerToken()` · lee cookie con `next/headers cookies()` |
| `web/src/lib/auth.ts` | `login` POSTea a `/api/session` con `await` antes de retornar · `logout` DELETE best-effort |
| `web/src/lib/api/real.ts` | `apiFetch` acepta `bearerToken` opcional · agrega `Authorization: Bearer` header |
| `web/src/lib/api/mocks.ts` | Misma signature de `options` (ignora `bearerToken`) |
| `web/src/app/quotes/[id]/layout.tsx` | Server Component lee `getServerToken()` y lo pasa a `getQuoteMetadata` |

**Por qué no importar `auth-server` desde `real.ts` directo**: ese módulo se incluye en el bundle client y `next/headers` solo existe server. El layout es el único Server Component caller — le pasa el token explícitamente.

## Cookie decisions

| Atributo | Valor | Razón |
|---|---|---|
| `httpOnly` | `true` | No expuesta a JS (defense in depth) |
| `sameSite` | `lax` | Same-origin con la página · no necesita `none` |
| `secure` | `true` en prod, `false` en dev | Standard |
| `maxAge` | 24h | JWT del backend tiene su propio `exp` ~60min; si vence antes que la cookie, 401 + `handleApiError` redirige a `/login` (flujo ya cubierto) |
| `path` | `/` | Visible desde cualquier ruta SSR |

## Verificación

| Check | Resultado |
|---|---|
| lint / typecheck / build | ✅ |
| Unit tests | ✅ **25 passed** (19 prev + 6 nuevos del `getServerToken`) |
| E2E | ✅ **96 passed + 3 skipped** (92 prev + 4 nuevos del route handler) |
| `operator-shared.css` | ✅ intacto |
| `.py` modificados | 0 |
| middleware | sigue no-op (intacto) |

## Cómo testear modo real vs mock

- **Modo mock** (default · `NEXT_PUBLIC_API_URL` ausente): los mocks ignoran `bearerToken` · todos los E2E corren igual.
- **Modo real** (Vercel preview/prod con `NEXT_PUBLIC_API_URL=https://railway...`): login → POST a `/api/session` setea cookie httpOnly · siguiente nav SSR la lee → `Authorization: Bearer` al backend → quote real renderea con nombre real.

## Test plan

- [ ] Login en preview/prod · navegar a `/quotes/<id-real>` → Qhead muestra nombre **real** del backend, NO fallback
- [ ] Logout · navegar a quote → fallback gracioso (sin crash, sin loop infinito)
- [ ] Token expirado: backend 401 → `handleApiError` redirige a `/login?reason=expired` (regresión Sprint 3 PR #463)
- [ ] AUDIT ON funciona en quotes reales (regresión PR #466)
- [ ] Quote canon `PRES-2026-018` modo mock: comportamiento idéntico al previo (regresión Sprint 3)
- [ ] Sin regresión paso-3 / paso-4 / observability / qhead / error-states

## Efectos cascada en plan Sprint 4

| Sub-PR Sprint 4 planificado | Status post-D |
|---|---|
| `qhead-context-derive` | **innecesario** — el SSR ya trae nombre real, Qhead no necesita derive client-side |
| `topbar-breadcrumb-empty` | **innecesario** — breadcrumb tendrá data real desde SSR |
| `audit-tray-polish` ("datos vacíos") | **parcialmente innecesario** — quotes reales tendrán snapshot poblado en SSR; fix-up #2 PR #466 (esconder cuando empty) sigue válido para edge cases |

**Sprint 4 baja de 16 → 14 sub-PRs.** Master/Javi confirman ajuste al plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)