### PR TITLE
feat(paso-5): estado D · revisión v2 + diff drawer (mockup 21)

### DIFF
--- a/web/src/app/quotes/[id]/pdf/page.tsx
+++ b/web/src/app/quotes/[id]/pdf/page.tsx
@@ -14,6 +14,7 @@ import {
   getContextForQuote,
   getPdfGeneratedInfo,
   getPdfTrace,
+  getPdfV2DiffData,
   getQuoteMetadata,
   listPiecesForQuote,
 } from "@/lib/api";
@@ -32,13 +33,17 @@ export default async function PdfPage({ params }: { params: { id: string } }) {
   // el quote ya pasó por `triggerPdfGeneration` en esta sesión mock.
   // SSR-seedea el estado C para que el primer paint ya muestre el sidebar
   // generated en lugar del editable.
-  const [metaR, calcR, ctxR, traceR, piecesR, genR] = await Promise.allSettled([
+  // Sprint 4 paso-5-d-revision-v2 (mockup 21) · sufijo `-REVISING` SSR-seedea
+  // el estado D · cargamos el diff data en paralelo cuando matchea.
+  const isRevising = params.id.endsWith("-REVISING");
+  const [metaR, calcR, ctxR, traceR, piecesR, genR, diffR] = await Promise.allSettled([
     getQuoteMetadata(params.id, { bearerToken }),
     getCalculationForQuote(params.id),
     getContextForQuote(params.id),
     getPdfTrace(params.id),
     listPiecesForQuote(params.id),
     getPdfGeneratedInfo(params.id),
+    isRevising ? getPdfV2DiffData(params.id) : Promise.resolve(null),
   ]);
 
   if (metaR.status === "rejected" || calcR.status === "rejected" || traceR.status === "rejected") {
@@ -79,6 +84,11 @@ export default async function PdfPage({ params }: { params: { id: string } }) {
   const initialGenerated =
     genR.status === "fulfilled" && genR.value !== null ? genR.value : null;
 
+  const initialDiffData =
+    isRevising && diffR.status === "fulfilled" && diffR.value !== null
+      ? diffR.value
+      : null;
+
   return (
     <PdfView
       quoteId={params.id}
@@ -90,6 +100,8 @@ export default async function PdfPage({ params }: { params: { id: string } }) {
       pieces={pieces}
       proyecto={proyecto}
       initialGenerated={initialGenerated}
+      initialRevising={isRevising}
+      initialDiffData={initialDiffData}
     />
   );
 }

--- a/web/src/components/pdf/PdfConfirmV2Modal.tsx
+++ b/web/src/components/pdf/PdfConfirmV2Modal.tsx
@@ -116,7 +116,27 @@ export function PdfConfirmV2Modal({
           </ul>
 
           {changeSummary.length > 0 && (
-            <div className="audit-note purple" data-testid="modal-v2-summary">
+            // Fix-up PR #474 bug 3: el selector `.modal .m-body .audit-note`
+            // del CSS shared (línea 1279) fuerza `display: flex; font-family:
+            // mono; color: ink-mute` que aplana el bloque purple a una línea
+            // mono gris. Defeat con inline-styles · cero CSS nuevo. El
+            // background/border de `.audit-note.purple` se respeta porque no
+            // hay conflicto en esas propiedades.
+            <div
+              className="audit-note purple"
+              data-testid="modal-v2-summary"
+              style={{
+                display: "block",
+                fontFamily: "inherit",
+                fontSize: 12.5,
+                color: "var(--ink)",
+                letterSpacing: 0,
+                gap: 0,
+                padding: "12px 14px",
+                borderRadius: 6,
+                marginTop: 14,
+              }}
+            >
               <div className="an-lbl">cambios resumidos</div>
               <ul className="modal-ul tight">
                 {changeSummary.map((c, i) => (

--- a/web/src/components/pdf/PdfConfirmV2Modal.tsx
+++ b/web/src/components/pdf/PdfConfirmV2Modal.tsx
@@ -1,0 +1,187 @@
+/**
+ * Modal de confirmación pre-generación v2 · mockup 21 LITERAL (segmento
+ * `.modal-backdrop.v2-confirm-modal`).
+ *
+ * Mismo patrón destructivo que `PdfConfirmModal` (PR #472):
+ * - ESC cierra · click backdrop NO cierra
+ * - role="dialog" + aria-labelledby
+ * - Footer: Cancelar (ghost) + Generar v2 → (primary)
+ *
+ * Diferencias justificadas vs v1:
+ * - Title con chip inline `<span class="version-chip draft inline">v2</span>`
+ * - 4 items en `.modal-ul` (Drive, v1 intacta, v3 futuro, audit log v1↔v2)
+ * - `audit-note.purple` con resumen de cambios (en vez de warning amber)
+ * - Filenames suffix " v2.pdf" / " v2.xlsx"
+ *
+ * Reusa clases legacy ya presentes en operator-shared.css (cero CSS nuevo).
+ */
+"use client";
+
+import { useEffect, useState } from "react";
+import type { PdfV2ChangeSummary } from "@/lib/api/types";
+
+interface Props {
+  /** PDF filename con suffix " v2.pdf". */
+  pdfFilename: string;
+  /** Excel filename con suffix " v2.xlsx". */
+  xlsxFilename: string;
+  /** Resumen de cambios v1↔v2 mostrado en `.audit-note.purple`. */
+  changeSummary: PdfV2ChangeSummary[];
+  onCancel: () => void;
+  /** Disparo async de la generación v2 · throw → banner error + Reintentar. */
+  onConfirm: () => Promise<void>;
+}
+
+export function PdfConfirmV2Modal({
+  pdfFilename,
+  xlsxFilename,
+  changeSummary,
+  onCancel,
+  onConfirm,
+}: Props) {
+  const [loading, setLoading] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !loading) onCancel();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onCancel, loading]);
+
+  const handleGenerate = async () => {
+    if (loading) return;
+    setErrorMsg(null);
+    setLoading(true);
+    try {
+      await onConfirm();
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "No se pudo generar v2.");
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div
+      className="modal-backdrop v2-confirm-modal"
+      data-testid="pdf-confirm-v2-backdrop"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div
+        className="modal w-520"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="pdf-confirm-v2-title"
+        data-testid="pdf-confirm-v2-modal"
+      >
+        <div className="m-head">
+          <div className="eyebrow">Confirmá antes de generar</div>
+          <h3 id="pdf-confirm-v2-title" className="m-title">
+            Vas a generar{" "}
+            <span className="version-chip draft inline">
+              <span className="dot" />v2
+            </span>{" "}
+            del presupuesto
+          </h3>
+        </div>
+
+        <div className="m-body">
+          <div className="impact">
+            <div>
+              <div className="lbl">Archivos a generar</div>
+              <div className="modal-mono-blob" data-testid="modal-v2-filenames">
+                📄 {pdfFilename}
+                <br />
+                📊 {xlsxFilename}
+              </div>
+            </div>
+          </div>
+
+          <ul className="modal-ul">
+            <li>
+              Se generan nuevos PDF + Excel y se suben a Drive{" "}
+              <span className="mono-inline">/Presupuestos/2026/05-mayo/</span>
+            </li>
+            <li>
+              <strong>v1 queda intacta</strong> en historial inmutable — sigue accesible
+            </li>
+            <li>
+              Cambios futuros = <strong>v3</strong> (versionado lineal)
+            </li>
+            <li>
+              Audit log entry con diff completo v1↔v2 +{" "}
+              <span className="mono-inline">trace_id</span>
+            </li>
+          </ul>
+
+          {changeSummary.length > 0 && (
+            <div className="audit-note purple" data-testid="modal-v2-summary">
+              <div className="an-lbl">cambios resumidos</div>
+              <ul className="modal-ul tight">
+                {changeSummary.map((c, i) => (
+                  <li key={`${c.field}-${i}`}>
+                    {c.field}:{" "}
+                    {c.prev && <span className="mono-inline">{c.prev} </span>}
+                    {c.outcome.startsWith("+") || c.outcome.includes("$") ? (
+                      <span className="mono-inline">{c.outcome}</span>
+                    ) : (
+                      c.outcome
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {errorMsg && (
+            <div
+              role="alert"
+              data-testid="modal-v2-error-banner"
+              style={{
+                marginTop: 14,
+                padding: "10px 14px",
+                borderRadius: 6,
+                border: "1px solid var(--error)",
+                background: "color-mix(in oklch, var(--error) 12%, transparent)",
+                color: "var(--error)",
+                fontSize: 13,
+                lineHeight: 1.4,
+              }}
+            >
+              {errorMsg}
+            </div>
+          )}
+        </div>
+
+        <div className="m-foot">
+          <button
+            type="button"
+            className="btn ghost m-cancel"
+            onClick={onCancel}
+            disabled={loading}
+            data-testid="modal-v2-cancel"
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            className="btn primary m-confirm"
+            onClick={handleGenerate}
+            disabled={loading}
+            data-testid="modal-v2-confirm"
+            data-loading={loading ? "true" : "false"}
+          >
+            {loading ? (
+              <span data-testid="modal-v2-spinner">Generando…</span>
+            ) : errorMsg ? (
+              "Reintentar"
+            ) : (
+              "Generar v2 →"
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/pdf/PdfDiffDrawer.tsx
+++ b/web/src/components/pdf/PdfDiffDrawer.tsx
@@ -1,0 +1,190 @@
+/**
+ * Drawer side-by-side de revisión v2 · mockup 21 LITERAL.
+ *
+ * Componente reusable `.diff-drawer[data-mode="interactive"]` que se monta
+ * a la derecha del PDF preview cuando el estado del paso 5 es "revising"
+ * (estado D). Compara v1 (oficial · ya enviada) vs v2 (borrador editable
+ * pendiente de generar).
+ *
+ * Layout esperado: ancho fijo 400px, ocupa la columna 3 del grid 3-col
+ * que adopta `PdfView` cuando `state === "revising"`.
+ *
+ * Inputs: visual-only en este sub-PR · no edita realmente · sub-PR posterior
+ * `paso-5-v2-editable` wirea inputs al sidebar v2 borrador.
+ *
+ * Reusa clases legacy del scope confirmado en CSS audit (FASE 1):
+ * `.diff-drawer`, `.dd-head`, `.dd-title-wrap`, `.dd-title`, `.dd-sub`,
+ * `.dd-close`, `.dd-banner`, `.dd-banner-ico`, `.dd-banner-text`,
+ * `.dd-banner-strong`, `.dd-banner-sub`, `.dd-section`, `.dd-section-head`,
+ * `.dd-section-title`, `.dd-diff-count`, `.dd-table`, `.dd-row`,
+ * `.dd-row-head`, `.dd-row.diff`, `.dd-row.diff.money`, `.dd-col-field`,
+ * `.dd-col-v1`, `.dd-col-v2`, `.dd-val`, `.dd-val.mono`, `.dd-val.diff`,
+ * `.dd-val.empty`, `.dd-trace`, `.dd-summary`, `.dd-bul`, `.dd-chip-count`,
+ * `.dd-cta`, `.dd-cancel`, `.dd-generate-v2`, `.mono`, `.prev`, `.outcome`.
+ */
+"use client";
+
+import type { PdfV2DiffRow, PdfV2ChangeSummary } from "@/lib/api/types";
+
+interface Props {
+  rows: PdfV2DiffRow[];
+  summary: PdfV2ChangeSummary[];
+  diffCount: number;
+  unchangedCount: number;
+  onClose: () => void;
+  onCancel: () => void;
+  onGenerateV2: () => void;
+  generating?: boolean;
+}
+
+export function PdfDiffDrawer({
+  rows,
+  summary,
+  diffCount,
+  unchangedCount,
+  onClose,
+  onCancel,
+  onGenerateV2,
+  generating = false,
+}: Props) {
+  return (
+    <aside
+      className="diff-drawer"
+      data-mode="interactive"
+      data-testid="pdf-diff-drawer"
+    >
+      {/* ── Header ── */}
+      <div className="dd-head">
+        <div className="dd-title-wrap">
+          <h3 className="dd-title">Revisión v2</h3>
+          <span className="dd-sub">comparar con v1 antes de generar</span>
+        </div>
+        <button
+          type="button"
+          className="dd-close"
+          aria-label="Cerrar drawer"
+          onClick={onClose}
+          data-testid="dd-close"
+        >
+          ×
+        </button>
+      </div>
+
+      {/* ── Banner amber dentro del drawer ── */}
+      <div className="dd-banner">
+        <span className="dd-banner-ico" aria-hidden="true">
+          ⚠
+        </span>
+        <div className="dd-banner-text">
+          <span className="dd-banner-strong">v1 sigue siendo la versión oficial.</span>
+          <span className="dd-banner-sub">
+            Enviada al cliente hace 2 días. Hasta que generes v2, esto es solo
+            borrador editable — nada se mandó.
+          </span>
+        </div>
+      </div>
+
+      {/* ── Tabla side-by-side · cambios detectados ── */}
+      <div className="dd-section">
+        <div className="dd-section-head">
+          <span className="dd-section-title">Cambios detectados</span>
+          <span className="dd-diff-count" data-testid="dd-diff-count">
+            {diffCount} con cambio · {unchangedCount} sin cambio
+          </span>
+        </div>
+
+        <div className="dd-table">
+          <div className="dd-row dd-row-head">
+            <span className="dd-col-field">Campo</span>
+            <span className="dd-col-v1">v1</span>
+            <span className="dd-col-v2">v2 (editable)</span>
+          </div>
+
+          {rows.map((row, i) => {
+            const isDiff = row.v1Value !== row.v2Value;
+            const isMoney = row.variant === "money";
+            const monoClass = row.display === "mono" ? " mono" : "";
+            return (
+              <div
+                key={`${row.field}-${i}`}
+                className={`dd-row${isDiff ? " diff" : ""}${
+                  isDiff && isMoney ? " money" : ""
+                }`}
+                data-testid={`dd-row-${row.field.toLowerCase().replace(/\s+/g, "-")}`}
+                data-diff={isDiff ? "true" : "false"}
+              >
+                <span className="dd-col-field">{row.field}</span>
+                <span className="dd-col-v1">
+                  <span
+                    className={`dd-val${monoClass}${row.v1Empty ? " empty" : ""}`}
+                  >
+                    {row.v1Value}
+                  </span>
+                </span>
+                <span className="dd-col-v2">
+                  <span className={`dd-val${monoClass}${isDiff ? " diff" : ""}`}>
+                    {row.v2Value}
+                  </span>
+                  {isDiff && row.trace && (
+                    <span className="dd-trace">{row.trace}</span>
+                  )}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ── Resumen ── */}
+      {summary.length > 0 && (
+        <div className="dd-section">
+          <div className="dd-section-head">
+            <span className="dd-section-title">Resumen</span>
+            <span className="dd-chip-count" data-testid="dd-chip-count">
+              {summary.length} cambio{summary.length === 1 ? "" : "s"}
+            </span>
+          </div>
+          <ul className="dd-summary">
+            {summary.map((c, i) => (
+              <li key={`${c.field}-${i}`}>
+                <span className="dd-bul">·</span> {c.field}:{" "}
+                {c.prev && <span className="mono prev">{c.prev}</span>}{" "}
+                <span
+                  className={
+                    c.outcome.startsWith("+") || /\$/.test(c.outcome)
+                      ? "mono outcome"
+                      : "outcome"
+                  }
+                >
+                  {c.outcome}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* ── CTAs ── */}
+      <div className="dd-cta">
+        <button
+          type="button"
+          className="btn ghost dd-cancel"
+          onClick={onCancel}
+          disabled={generating}
+          data-testid="dd-cancel"
+        >
+          Cancelar revisión
+        </button>
+        <button
+          type="button"
+          className="btn primary dd-generate-v2"
+          onClick={onGenerateV2}
+          disabled={generating}
+          data-testid="dd-generate-v2"
+        >
+          Generar v2 →
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/web/src/components/pdf/PdfGenBanner.tsx
+++ b/web/src/components/pdf/PdfGenBanner.tsx
@@ -1,30 +1,66 @@
 /**
- * Banner verde "v1 generado correctamente" del estado C · mockup 20 LITERAL.
- * Reusa `.gen-banner` + `.check` + `.gb-text/sub/spacer/meta` de operator-shared.css.
+ * Banner del estado C/D · mockup 20 (green) + mockup 21 (amber-revision).
+ *
+ * Variants:
+ * - "green" (default · estado C): check ✓ verde · "v1 generado correctamente"
+ * - "amber-revision" (estado D): check ✎ ámbar · "Revisión v2 en curso"
+ *
+ * Reusa `.gen-banner`, `.gen-banner.amber`, `.check`, `.gb-text/sub/spacer/meta`.
  */
 "use client";
 
+type Variant = "green" | "amber-revision";
+
 interface Props {
-  generatedAtDisplay: string;
-  generatedBy: string;
+  /** "green" para estado C · "amber-revision" para estado D. */
+  variant?: Variant;
+  /** Estado C: "Marina" · "03.05.2026 18:42" → "v1 generado correctamente". */
+  generatedAtDisplay?: string;
+  generatedBy?: string;
+  /** Estado D · texto del banner amber (sub explicativo de revisión en curso). */
+  revisionSub?: string;
+  /** trace_id mostrado a la derecha (común a ambas variantes). */
   traceId: string;
 }
 
-export function PdfGenBanner({ generatedAtDisplay, generatedBy, traceId }: Props) {
+export function PdfGenBanner({
+  variant = "green",
+  generatedAtDisplay,
+  generatedBy,
+  revisionSub,
+  traceId,
+}: Props) {
+  const isAmber = variant === "amber-revision";
   return (
-    <div className="gen-banner" data-testid="pdf-gen-banner">
+    <div
+      className={`gen-banner${isAmber ? " amber" : ""}`}
+      data-testid="pdf-gen-banner"
+      data-variant={variant}
+    >
       <div className="check" aria-hidden="true">
-        ✓
+        {isAmber ? "✎" : "✓"}
       </div>
       <div className="gb-text">
-        <strong>v1 generado correctamente.</strong>
-        <span className="gb-sub">
-          {generatedBy} · {generatedAtDisplay} · logueado en audit log
-        </span>
+        {isAmber ? (
+          <>
+            <strong>Revisión v2 en curso.</strong>
+            <span className="gb-sub">
+              {revisionSub ??
+                "v1 sigue siendo la versión oficial · Esto es borrador editable."}
+            </span>
+          </>
+        ) : (
+          <>
+            <strong>v1 generado correctamente.</strong>
+            <span className="gb-sub">
+              {generatedBy} · {generatedAtDisplay} · logueado en audit log
+            </span>
+          </>
+        )}
       </div>
       <div className="gb-spacer" />
       <div className="gb-meta" data-testid="gen-banner-trace">
-        trace_id · {traceId}
+        {isAmber ? `v1 trace · ${traceId}` : `trace_id · ${traceId}`}
       </div>
     </div>
   );

--- a/web/src/components/pdf/PdfView.tsx
+++ b/web/src/components/pdf/PdfView.tsx
@@ -145,6 +145,17 @@ export function PdfView({
     () => getPdfFilename({ client: quote.clientFull, material: quote.material, date, ext: "xlsx" }),
     [quote.clientFull, quote.material, date],
   );
+  // Fix-up PR #474 bug 4: `baseFilename` para el sidebar generated debe reflejar
+  // la versión actualmente generada. Conservamos la derivación canon desde
+  // `quote.clientFull` + `quote.material` (regresión de `paso-5-c-generado` que
+  // espera el material del dashboard, no el del pdfUrl mock — pueden diverger).
+  // Cuando `generated.pdfUrl` lleva el suffix ` v2.pdf` (post-triggerPdfV2Generation),
+  // anexamos ` v2` al filename canon así el sidebar muestra `... v2`.
+  const baseFilename = useMemo(() => {
+    const base = pdfFilename.replace(/\.pdf$/i, "");
+    const isV2 = /\sv2\.pdf$/i.test(generated?.pdfUrl ?? "");
+    return isV2 ? `${base} v2` : base;
+  }, [generated, pdfFilename]);
   // Filenames con suffix " v2" para el modal de confirmación v2 (mockup 21).
   const pdfFilenameV2 = useMemo(
     () => pdfFilename.replace(/\.pdf$/i, " v2.pdf"),
@@ -160,12 +171,16 @@ export function PdfView({
       data-testid="pdf-view"
       data-chat-open={chatOpen}
       data-state={revising ? "D" : isGenerated ? "C" : "A"}
-      // Grid 2-col (estado A/C) o 3-col (estado D · drawer 400px lateral).
+      // Grid 2-col en TODOS los estados (A/C/D).
+      // Fix-up PR #474 bug 1: estado D pasa a 2-col (PDF 1fr + drawer 400)
+      // literal al mockup 21 (regla `:has()` del CSS shared oculta el sidebar
+      // generated cuando hay drawer abierto — "modo edición v2 aislado").
+      // Bug previo: 3-col (1fr 360 400) asfixiaba el PDF a ~293px en 1389.
       // Inline para no modificar el `.body.no-chat` del chrome shell del Sprint 3.
       // El chat es overlay fixed (heredado del PR #465 fix-up #2) · no ocupa columna.
       style={{
         display: "grid",
-        gridTemplateColumns: revising ? "1fr 360px 400px" : "1fr 360px",
+        gridTemplateColumns: revising ? "1fr 400px" : "1fr 360px",
         gap: 24,
         minHeight: 0,
       }}
@@ -252,14 +267,17 @@ export function PdfView({
         <div className="pdf-stage-helper">Vista previa a tamaño real · A4 · página 1 de 1</div>
       </div>
 
-      {isGenerated && generated ? (
+      {/* Fix-up bug 1: en estado D (revising) OCULTAR el sidebar generated.
+          Mockup 21 lo hace via `.body.pdf-layout:has(.diff-drawer) > .pdf-sidebar { display: none }`.
+          Acá usamos render condicional porque el grid es inline (no `.body.pdf-layout`). */}
+      {isGenerated && generated && !revising ? (
         <PdfSidebarGenerated
-          baseFilename={pdfFilename.replace(/\.pdf$/i, "")}
+          baseFilename={baseFilename}
           info={generated}
           trace={trace}
           onCreateV2={handleCreateV2}
         />
-      ) : (
+      ) : !isGenerated ? (
         <PdfSidebar
           pdfFilename={pdfFilename}
           xlsxFilename={xlsxFilename}
@@ -268,7 +286,7 @@ export function PdfView({
           trace={trace}
           onGenerate={() => setConfirmOpen(true)}
         />
-      )}
+      ) : null}
 
       {revising && diffData && (
         <PdfDiffDrawer

--- a/web/src/components/pdf/PdfView.tsx
+++ b/web/src/components/pdf/PdfView.tsx
@@ -18,16 +18,23 @@ import type {
   CalculationResult,
   PdfGeneratedInfo,
   PdfTrace,
+  PdfV2RevisionData,
   Piece,
   QuoteHeader,
 } from "@/lib/api";
-import { triggerPdfGeneration } from "@/lib/api";
+import {
+  getPdfV2DiffData,
+  triggerPdfGeneration,
+  triggerPdfV2Generation,
+} from "@/lib/api";
 import { usePdfForm } from "@/lib/hooks/usePdfForm";
 import { formatPdfDate, getPdfFilename } from "@/lib/pdfFormat";
 import { PdfPreviewDoc } from "./PdfPreviewDoc";
 import { PdfSidebar } from "./PdfSidebar";
 import { PdfChatPanel } from "./PdfChatPanel";
 import { PdfConfirmModal } from "./PdfConfirmModal";
+import { PdfConfirmV2Modal } from "./PdfConfirmV2Modal";
+import { PdfDiffDrawer } from "./PdfDiffDrawer";
 import { PdfGenBanner } from "./PdfGenBanner";
 import { PdfSidebarGenerated } from "./PdfSidebarGenerated";
 import { IaAuditBanner } from "@/components/observability/IaAuditBanner";
@@ -58,6 +65,14 @@ interface Props {
    * resuelve canon cuando el quoteId termina en `-GENERATED` o cuando el
    * store de sesión tiene info post-triggerPdfGeneration. */
   initialGenerated?: PdfGeneratedInfo | null;
+  /** Sprint 4 paso-5-d-revision-v2 · true cuando el quoteId termina en
+   * `-REVISING` · arranca con drawer abierto + 3-col layout · v1 oficial
+   * permanece intacta hasta confirmar v2. */
+  initialRevising?: boolean;
+  /** Diff data v1↔v2 cargada SSR cuando initialRevising · null → fetch on demand
+   * cuando el usuario abre el drawer click "Crear revisión v2 →" del sidebar
+   * generated. */
+  initialDiffData?: PdfV2RevisionData | null;
 }
 
 export function PdfView({
@@ -70,6 +85,8 @@ export function PdfView({
   pieces,
   proyecto,
   initialGenerated = null,
+  initialRevising = false,
+  initialDiffData = null,
 }: Props) {
   const { state, update } = usePdfForm({
     vigenciaDias: calculation.datosPdf.vigenciaDias,
@@ -92,6 +109,30 @@ export function PdfView({
   const [generated, setGenerated] = useState<PdfGeneratedInfo | null>(initialGenerated);
   const isGenerated = generated !== null;
 
+  // Sprint 4 paso-5-d-revision-v2 (mockup 21) · estado D = revisión v2 en curso.
+  // SSR-seedeado cuando quoteId termina en `-REVISING`. Click "Crear revisión v2 →"
+  // del sidebar generated también lo activa (fetch on demand del diff).
+  const [revising, setRevising] = useState<boolean>(initialRevising);
+  const [diffData, setDiffData] = useState<PdfV2RevisionData | null>(initialDiffData);
+  const [confirmV2Open, setConfirmV2Open] = useState(false);
+  // Carga lazy del diff cuando el usuario abre el drawer sin SSR-seed.
+  const handleCreateV2 = async () => {
+    if (!diffData) {
+      try {
+        const data = await getPdfV2DiffData(quoteId);
+        setDiffData(data);
+      } catch {
+        // fallback gracioso: igual abrimos el drawer con diff vacío
+        setDiffData({ rows: [], summary: [], diffCount: 0, unchangedCount: 0 });
+      }
+    }
+    setRevising(true);
+  };
+  const handleCancelRevising = () => {
+    setRevising(false);
+    setConfirmV2Open(false);
+  };
+
   // `pdfDateIso` viene determinístico desde el server (ver pdf/page.tsx).
   // Parse a Date para los helpers · referencia estable mientras la prop no cambie.
   const date = useMemo(() => new Date(pdfDateIso), [pdfDateIso]);
@@ -104,19 +145,27 @@ export function PdfView({
     () => getPdfFilename({ client: quote.clientFull, material: quote.material, date, ext: "xlsx" }),
     [quote.clientFull, quote.material, date],
   );
+  // Filenames con suffix " v2" para el modal de confirmación v2 (mockup 21).
+  const pdfFilenameV2 = useMemo(
+    () => pdfFilename.replace(/\.pdf$/i, " v2.pdf"),
+    [pdfFilename],
+  );
+  const xlsxFilenameV2 = useMemo(
+    () => xlsxFilename.replace(/\.xlsx$/i, " v2.xlsx"),
+    [xlsxFilename],
+  );
 
   return (
     <div
       data-testid="pdf-view"
       data-chat-open={chatOpen}
-      data-state={isGenerated ? "C" : "A"}
-      // Grid 2-col interno (mismo patrón que `.body.pdf-layout` del mockup
-      // 18). Aplicado inline para no modificar el `.body.no-chat` del
-      // layout chrome shell del Sprint 3 (regla NO tocar [id]/layout).
+      data-state={revising ? "D" : isGenerated ? "C" : "A"}
+      // Grid 2-col (estado A/C) o 3-col (estado D · drawer 400px lateral).
+      // Inline para no modificar el `.body.no-chat` del chrome shell del Sprint 3.
       // El chat es overlay fixed (heredado del PR #465 fix-up #2) · no ocupa columna.
       style={{
         display: "grid",
-        gridTemplateColumns: "1fr 360px",
+        gridTemplateColumns: revising ? "1fr 360px 400px" : "1fr 360px",
         gap: 24,
         minHeight: 0,
       }}
@@ -125,20 +174,36 @@ export function PdfView({
         <div className="section-head">
           <div>
             <div className="meta">Paso 5 de 5 · Presupuesto PDF</div>
-            <h2>{isGenerated ? "Presupuesto generado" : "Preview del presupuesto"}</h2>
+            <h2>{isGenerated || revising ? "Presupuesto generado" : "Preview del presupuesto"}</h2>
             <div className="vc-wrap">
-              <span
-                className={`version-chip ${isGenerated ? "final" : "draft"}`}
-                data-testid="version-chip"
-              >
-                <span className="dot" />
-                {isGenerated ? "v1 · enviado" : "v1 · borrador"}
-              </span>
-              <span className="status-mini">
-                {isGenerated
-                  ? `guardado en /quotes/2026/ · hace 2 min`
-                  : "aún no enviado"}
-              </span>
+              {revising ? (
+                <>
+                  <span className="version-chip final" data-testid="version-chip-v1">
+                    <span className="dot" />v1 · oficial
+                  </span>
+                  <span className="version-chip draft" data-testid="version-chip-v2">
+                    <span className="dot" />v2 · borrador
+                  </span>
+                  <span className="status-mini">
+                    comparando cambios · v1 sigue activa hasta generar v2
+                  </span>
+                </>
+              ) : (
+                <>
+                  <span
+                    className={`version-chip ${isGenerated ? "final" : "draft"}`}
+                    data-testid="version-chip"
+                  >
+                    <span className="dot" />
+                    {isGenerated ? "v1 · enviado" : "v1 · borrador"}
+                  </span>
+                  <span className="status-mini">
+                    {isGenerated
+                      ? `guardado en /quotes/2026/ · hace 2 min`
+                      : "aún no enviado"}
+                  </span>
+                </>
+              )}
             </div>
           </div>
           <button
@@ -152,8 +217,16 @@ export function PdfView({
           </button>
         </div>
 
-        {isGenerated && generated && (
+        {revising && generated && (
           <PdfGenBanner
+            variant="amber-revision"
+            revisionSub="v1 (enviada hace 2 días) sigue siendo la versión oficial. Esto es borrador editable."
+            traceId={generated.traceId}
+          />
+        )}
+        {!revising && isGenerated && generated && (
+          <PdfGenBanner
+            variant="green"
             generatedAtDisplay={generated.generatedAtDisplay}
             generatedBy={generated.generatedBy}
             traceId={generated.traceId}
@@ -184,8 +257,7 @@ export function PdfView({
           baseFilename={pdfFilename.replace(/\.pdf$/i, "")}
           info={generated}
           trace={trace}
-          // Sprint 4 paso-5-d-revision-v2 (mockup 21) wirea esto · acá visual-only.
-          onCreateV2={() => {}}
+          onCreateV2={handleCreateV2}
         />
       ) : (
         <PdfSidebar
@@ -195,6 +267,34 @@ export function PdfView({
           onChange={update}
           trace={trace}
           onGenerate={() => setConfirmOpen(true)}
+        />
+      )}
+
+      {revising && diffData && (
+        <PdfDiffDrawer
+          rows={diffData.rows}
+          summary={diffData.summary}
+          diffCount={diffData.diffCount}
+          unchangedCount={diffData.unchangedCount}
+          onClose={() => setRevising(false)}
+          onCancel={handleCancelRevising}
+          onGenerateV2={() => setConfirmV2Open(true)}
+          generating={confirmV2Open}
+        />
+      )}
+
+      {confirmV2Open && diffData && (
+        <PdfConfirmV2Modal
+          pdfFilename={pdfFilenameV2}
+          xlsxFilename={xlsxFilenameV2}
+          changeSummary={diffData.summary}
+          onCancel={() => setConfirmV2Open(false)}
+          onConfirm={async () => {
+            const info = await triggerPdfV2Generation(quoteId);
+            setGenerated(info);
+            setRevising(false);
+            setConfirmV2Open(false);
+          }}
         />
       )}
 

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -48,6 +48,10 @@ export const getPdfTrace = mocks.getPdfTrace;
 export const triggerPdfGeneration = mocks.triggerPdfGeneration;
 export const getPdfGeneratedInfo = mocks.getPdfGeneratedInfo;
 
+/* ─── Paso 5 estado D · Sprint 4 paso-5-d-revision-v2 · mockup 21 ── */
+export const getPdfV2DiffData = mocks.getPdfV2DiffData;
+export const triggerPdfV2Generation = mocks.triggerPdfV2Generation;
+
 /* ─── Helpers de test (reset de stores in-memory del mock) ───────── */
 export const _resetContextStore = mocks._resetContextStore;
 export const _resetPiecesStore = mocks._resetPiecesStore;

--- a/web/src/lib/api/mocks.ts
+++ b/web/src/lib/api/mocks.ts
@@ -970,16 +970,28 @@ const _v2DiffGeneric: import("./types").PdfV2RevisionData = {
 };
 
 /** Devuelve el diff side-by-side canon para el estado D · fallback gracioso
- * a generic vacío para IDs desconocidos. Soporta sufijo `-REVISING`. */
+ * a generic vacío para IDs desconocidos. Soporta sufijo `-REVISING`.
+ *
+ * Fix-up PR #474 bug 2: tolerar formas cortas del ID (`PRES-018` →
+ * `PRES-2026-018`). Sin esto, una URL con la forma corta caía al genérico
+ * vacío y la tabla mostraba "0 con cambio · 0 sin cambio". */
 export async function getPdfV2DiffData(
   quoteId: string,
   options?: { signal?: AbortSignal },
 ): Promise<import("./types").PdfV2RevisionData> {
   await delay(80 + Math.random() * 120, options?.signal);
-  const baseId = quoteId.endsWith("-REVISING")
+  const stripped = quoteId.endsWith("-REVISING")
     ? quoteId.slice(0, -"-REVISING".length)
     : quoteId;
-  return _v2DiffByQuote[baseId] ?? _v2DiffGeneric;
+  // Lookup directo · luego intentar normalizar PRES-018 → PRES-2026-018.
+  const direct = _v2DiffByQuote[stripped];
+  if (direct) return direct;
+  const shortMatch = /^PRES-(\d{3})$/.exec(stripped);
+  if (shortMatch) {
+    const candidate = `PRES-2026-${shortMatch[1]}`;
+    if (_v2DiffByQuote[candidate]) return _v2DiffByQuote[candidate];
+  }
+  return _v2DiffGeneric;
 }
 
 /** Mock del flow de generación v2 · misma signature que `triggerPdfGeneration`

--- a/web/src/lib/api/mocks.ts
+++ b/web/src/lib/api/mocks.ts
@@ -336,6 +336,28 @@ export async function getQuoteMetadata(
     }
   }
 
+  // Sprint 4 paso-5-d-revision-v2 · sufijo `-REVISING` hereda del baseId
+  // con status "sent" (v1 sigue oficial). El SSR seedea el estado D directo
+  // via `getPdfGeneratedInfo` (v1 canon presente) + `initialRevising=true`
+  // en `PdfView` que renderea el drawer al primer paint.
+  const revisingSuffix = "-REVISING";
+  const baseIdForRevising = quoteId.endsWith(revisingSuffix)
+    ? quoteId.slice(0, -revisingSuffix.length)
+    : null;
+  if (baseIdForRevising) {
+    const base = DASHBOARD_QUOTES.find((q) => q.id === baseIdForRevising);
+    if (base) {
+      return {
+        id: quoteId,
+        client: base.client,
+        clientFull: base.clientFull,
+        material: base.material,
+        m2: base.m2,
+        status: "sent",
+      };
+    }
+  }
+
   const found = DASHBOARD_QUOTES.find((q) => q.id === quoteId);
   if (found) {
     return {
@@ -721,6 +743,16 @@ export async function getAuditSnapshot(
     }
   }
 
+  // Sprint 4 paso-5-d-revision-v2 · sufijo `-REVISING` también hereda del
+  // baseId (estado D usa el mismo trace_id v1 que el AuditTray exhibe).
+  if (quoteId.endsWith("-REVISING")) {
+    const baseId = quoteId.slice(0, -"-REVISING".length);
+    const base = _auditByQuote[baseId];
+    if (base) {
+      return JSON.parse(JSON.stringify(base)) as import("./types").AuditSnapshot;
+    }
+  }
+
   return _auditByQuote[quoteId] ?? _auditGeneric;
 }
 
@@ -834,5 +866,145 @@ export async function getPdfGeneratedInfo(
     const baseId = quoteId.slice(0, -"-GENERATED".length);
     return _generatedByQuote[baseId] ?? _generatedGeneric;
   }
+  // 3) Sprint 4 paso-5-d-revision-v2 · sufijo `-REVISING` también seedea v1
+  // generado · el estado D muestra v1 oficial intacta + drawer comparando v2.
+  if (quoteId.endsWith("-REVISING")) {
+    const baseId = quoteId.slice(0, -"-REVISING".length);
+    return _generatedByQuote[baseId] ?? _generatedGeneric;
+  }
   return null;
+}
+
+// ─── Sprint 4 paso-5-d-revision-v2 · mockup 21 ─────────────────────────────
+// Datos canon del side-by-side diff del drawer. 6 rows literales del mockup
+// para PRES-2026-018 · 4 con cambio (Vigencia, Datos envío, Notas, Subtotal
+// MO) + 2 sin cambio (Anticipo, Plazo). Mock-only · sub-PR
+// `paso-5-v2-editable` posterior wirea inputs editables al sidebar.
+
+const _v2DiffByQuote: Record<string, import("./types").PdfV2RevisionData> = {
+  "PRES-2026-018": {
+    diffCount: 4,
+    unchangedCount: 2,
+    rows: [
+      {
+        field: "Vigencia",
+        v1Value: "7 días",
+        v2Value: "15 días",
+        trace: "↳ era 7 días",
+        display: "mono",
+      },
+      {
+        field: "Anticipo",
+        v1Value: "50%",
+        v2Value: "50%",
+        display: "mono",
+      },
+      {
+        field: "Plazo entrega",
+        v1Value: "10–12 días hábiles",
+        v2Value: "10–12 días hábiles",
+        display: "mono",
+      },
+      {
+        field: "Datos de envío",
+        v1Value: "Belgrano, CABA · 4° piso (con ascensor)",
+        v2Value:
+          "Belgrano, CABA · 4° piso · ascensor de servicio · contacto en obra: Marcos +54 11 6234-9087",
+        trace: "↳ ampliado: ascensor de servicio + contacto",
+        display: "text",
+      },
+      {
+        field: "Notas internas",
+        v1Value: "— vacío",
+        v2Value: "cliente pidió piso anti-mancha · agregar a producción",
+        trace: "↳ nuevo · antes vacío",
+        display: "text",
+        v1Empty: true,
+      },
+      {
+        field: "Subtotal MO",
+        v1Value: "$494.190",
+        v2Value: "$498.450",
+        trace: "↳ era $494.190 · +$4.260 · corrección manual de colocación",
+        display: "mono",
+        variant: "money",
+      },
+    ],
+    summary: [
+      { field: "Vigencia", prev: "7 →", outcome: "15 días" },
+      {
+        field: "Datos de envío",
+        outcome: "ampliados con ascensor de servicio y contacto en obra",
+      },
+      { field: "Notas internas", outcome: "agregadas (anti-mancha)" },
+      { field: "Subtotal MO", prev: "corrección manual", outcome: "+$4.260" },
+    ],
+  },
+  "PRES-2026-017": {
+    diffCount: 1,
+    unchangedCount: 5,
+    rows: [
+      { field: "Vigencia", v1Value: "10 días", v2Value: "10 días", display: "mono" },
+      { field: "Anticipo", v1Value: "60%", v2Value: "60%", display: "mono" },
+      { field: "Plazo entrega", v1Value: "15 días hábiles", v2Value: "15 días hábiles", display: "mono" },
+      { field: "Datos de envío", v1Value: "Rosario, zona sur", v2Value: "Rosario, zona sur", display: "text" },
+      { field: "Notas internas", v1Value: "— vacío", v2Value: "— vacío", display: "text", v1Empty: true },
+      {
+        field: "Subtotal MO",
+        v1Value: "$258.430",
+        v2Value: "$262.190",
+        trace: "↳ +$3.760 · ajuste de flete",
+        display: "mono",
+        variant: "money",
+      },
+    ],
+    summary: [{ field: "Subtotal MO", prev: "ajuste flete", outcome: "+$3.760" }],
+  },
+};
+
+const _v2DiffGeneric: import("./types").PdfV2RevisionData = {
+  diffCount: 0,
+  unchangedCount: 0,
+  rows: [],
+  summary: [],
+};
+
+/** Devuelve el diff side-by-side canon para el estado D · fallback gracioso
+ * a generic vacío para IDs desconocidos. Soporta sufijo `-REVISING`. */
+export async function getPdfV2DiffData(
+  quoteId: string,
+  options?: { signal?: AbortSignal },
+): Promise<import("./types").PdfV2RevisionData> {
+  await delay(80 + Math.random() * 120, options?.signal);
+  const baseId = quoteId.endsWith("-REVISING")
+    ? quoteId.slice(0, -"-REVISING".length)
+    : quoteId;
+  return _v2DiffByQuote[baseId] ?? _v2DiffGeneric;
+}
+
+/** Mock del flow de generación v2 · misma signature que `triggerPdfGeneration`
+ * (PR #473) pero retorna info con filenames suffix `v2.pdf/v2.xlsx`. */
+export async function triggerPdfV2Generation(
+  quoteId: string,
+  options?: { signal?: AbortSignal },
+): Promise<import("./types").PdfGeneratedInfo> {
+  await delay(800 + Math.random() * 700, options?.signal);
+  if (quoteId.endsWith("-ERROR")) {
+    throw new Error("No se pudo generar v2 · servicio Drive caído (mock-only).");
+  }
+  const baseId = quoteId.endsWith("-REVISING")
+    ? quoteId.slice(0, -"-REVISING".length)
+    : quoteId;
+  const v1 = _generatedByQuote[baseId] ?? _generatedGeneric;
+  // Variante v2: filenames con suffix " v2" antes de la extensión + nuevo traceId.
+  const v2: import("./types").PdfGeneratedInfo = {
+    ...v1,
+    pdfUrl: v1.pdfUrl.replace(/\.pdf$/i, " v2.pdf"),
+    excelUrl: v1.excelUrl.replace(/\.xlsx$/i, " v2.xlsx"),
+    generatedAtIso: "2026-05-05T12:18:00-03:00",
+    generatedAtDisplay: "05.05.2026 12:18",
+    traceId: v1.traceId.replace(/-a3f9c1$/, "-b9d2e7"),
+  };
+  _generatedStore.set(quoteId, v2);
+  return v2;
 }

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -451,3 +451,49 @@ export interface PdfGeneratedInfo {
   /** Drive file id mostrado en el trace-block plegable. */
   driveId: string;
 }
+
+// ─── Sprint 4 paso-5-d-revision-v2 · mockup 21 ─────────────────────────────
+// Estado D · "Revisión v2 (drawer diff side-by-side)". Mock-only · edición
+// v2 visual-only en este sub-PR. Wire real backend en sub-PR posterior
+// (paso-5-pdf-real-wire) · inputs editables en (paso-5-v2-editable).
+
+/** Fila de la tabla diff side-by-side del drawer. */
+export interface PdfV2DiffRow {
+  /** Label del campo (ej "Vigencia", "Subtotal MO"). */
+  field: string;
+  /** Valor v1 formateado para display. */
+  v1Value: string;
+  /** Valor v2 formateado para display. Si igual a v1 → row sin clase `.diff`. */
+  v2Value: string;
+  /** Cuando difiere · explicación breve "↳ era ..." mostrada bajo el valor v2. */
+  trace?: string;
+  /** Tipo de valor para clases auxiliares (`.dd-val.mono` para números/dates,
+   * default sin mono para textos largos como "Datos de envío"). */
+  display?: "mono" | "text";
+  /** Variante de la row (`.dd-row.money` para subtotales). */
+  variant?: "default" | "money";
+  /** Para casos vacío→texto · marca el lado v1 como `.dd-val.empty`. */
+  v1Empty?: boolean;
+}
+
+/** Lista de cambios resumidos del mockup 21 · sección Resumen del drawer y
+ * del modal confirmar v2 (`.audit-note.purple` con `.modal-ul.tight`). */
+export interface PdfV2ChangeSummary {
+  /** Texto liso del cambio · admite markup ligero via `prev` y `outcome`. */
+  field: string;
+  /** "7 →" (antes) opcional. */
+  prev?: string;
+  /** "15 días" (después) · highlight visual. */
+  outcome: string;
+}
+
+/** Datos canon del estado D para un quoteId. Mock-only. */
+export interface PdfV2RevisionData {
+  /** 6 rows del side-by-side. */
+  rows: PdfV2DiffRow[];
+  /** Resumen para sección "Resumen" y modal v2. */
+  summary: PdfV2ChangeSummary[];
+  /** Count de cambios (4 con cambio · 2 sin cambio en el canon). */
+  diffCount: number;
+  unchangedCount: number;
+}

--- a/web/tests/e2e/paso-5-d-revision-v2.spec.ts
+++ b/web/tests/e2e/paso-5-d-revision-v2.spec.ts
@@ -155,6 +155,61 @@ test("PRES-2026-018 sin sufijo NO renderea drawer (regresión estado A)", async 
   await expect(page.locator('[data-testid="pdf-diff-drawer"]')).toHaveCount(0);
 });
 
+test("Fix-up bug 1 · estado D = 2-col · sidebar generated OCULTO mientras drawer abierto", async ({
+  page,
+}) => {
+  await goPdf(page, "PRES-2026-018-REVISING");
+  await expect(page.locator('[data-testid="pdf-diff-drawer"]')).toBeVisible();
+  // El sidebar generated NO debe existir durante el estado D (modo edición v2 aislado).
+  await expect(page.locator('[data-testid="pdf-sidebar-generated"]')).toHaveCount(0);
+  // Cerrar drawer → sidebar generated reaparece (estado C).
+  await page.locator('[data-testid="dd-close"]').click();
+  await expect(page.locator('[data-testid="pdf-sidebar-generated"]')).toBeVisible();
+});
+
+test("Fix-up bug 4 · post-generación v2 → sidebar muestra filename con suffix v2", async ({
+  page,
+}) => {
+  await goPdf(page, "PRES-2026-018-REVISING");
+  await page.locator('[data-testid="dd-generate-v2"]').click();
+  await page.locator('[data-testid="modal-v2-confirm"]').click();
+  // Tras confirmar, el sidebar generated debe mostrar el filename v2.
+  await expect(page.locator('[data-testid="generated-filename"]')).toContainText(" v2", {
+    timeout: 5_000,
+  });
+});
+
+test("Fix-up bug 3 · audit-note purple del modal v2 visible como bloque (no flex-collapsed)", async ({
+  page,
+}) => {
+  await goPdf(page, "PRES-2026-018-REVISING");
+  await page.locator('[data-testid="dd-generate-v2"]').click();
+  const summary = page.locator('[data-testid="modal-v2-summary"]');
+  await expect(summary).toBeVisible();
+  // Verifica que es block (no flex aplanado) · `display` computado.
+  const display = await summary.evaluate((el) => getComputedStyle(el).display);
+  expect(display).toBe("block");
+  // an-lbl visible en su línea propia.
+  await expect(summary.locator(".an-lbl")).toBeVisible();
+  await expect(summary.locator(".an-lbl")).toContainText("cambios resumidos");
+  // Background purple aplicado (no transparente · no gris neutro).
+  const bg = await summary.evaluate((el) => getComputedStyle(el).backgroundColor);
+  expect(bg).not.toBe("rgba(0, 0, 0, 0)");
+  expect(bg).not.toBe("transparent");
+});
+
+test("Fix-up bug 2 · forma corta PRES-018-REVISING resuelve canon PRES-2026-018", async ({
+  page,
+}) => {
+  // El endpoint mock tolera la forma corta sin "2026-" → debe devolver los 6 rows
+  // canon del PRES-2026-018, no fallback genérico vacío.
+  await goPdf(page, "PRES-018-REVISING");
+  await expect(page.locator('[data-testid="dd-diff-count"]')).toContainText(
+    "4 con cambio · 2 sin cambio",
+  );
+  await expect(page.locator('[data-testid="dd-row-vigencia"]')).toContainText("15 días");
+});
+
 test("PRES-018-REVISING · banner amber sigue ahí mientras drawer abierto", async ({ page }) => {
   await goPdf(page, "PRES-2026-018-REVISING");
   const banner = page.locator('[data-testid="pdf-gen-banner"][data-variant="amber-revision"]');

--- a/web/tests/e2e/paso-5-d-revision-v2.spec.ts
+++ b/web/tests/e2e/paso-5-d-revision-v2.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * E2E paso-5 estado D · "Revisión v2 (diff drawer)" · mockup 21.
+ *
+ * Triggers (mock):
+ * - Sufijo `-REVISING` → SSR seedea estado D directo (drawer abierto · v1
+ *   sigue oficial en el preview · 3-col layout).
+ * - Flow desde C → click "Crear revisión v2 →" del sidebar generated → fetch
+ *   on-demand del diff → estado D.
+ * - "Generar v2 →" del drawer → modal v2 → confirma → estado C con v2 generada.
+ */
+import { expect, test, type Page } from "@playwright/test";
+
+// Mismo cross-talk del `_generatedStore` que paso-5-c: este flujo también
+// puebla el store via `triggerPdfV2Generation`. Serial para evitar drift.
+test.describe.configure({ mode: "serial" });
+
+test.afterEach(async ({ request }) => {
+  await request.post("/api/_test/reset-pdf-store");
+});
+
+async function goPdf(page: Page, id: string) {
+  await page.goto(`/quotes/${id}/pdf`);
+  await expect(page.locator('[data-testid="pdf-view"]')).toBeVisible({ timeout: 15_000 });
+}
+
+test("PRES-018-REVISING renderea estado D · drawer + 2 chips + banner amber", async ({ page }) => {
+  await goPdf(page, "PRES-2026-018-REVISING");
+  await expect(page.locator('[data-testid="pdf-view"]')).toHaveAttribute("data-state", "D");
+  // Ambos chips simultáneos (v1 oficial + v2 borrador).
+  await expect(page.locator('[data-testid="version-chip-v1"]')).toContainText("v1 · oficial");
+  await expect(page.locator('[data-testid="version-chip-v2"]')).toContainText("v2 · borrador");
+  // Banner amber con icono ✎.
+  const banner = page.locator('[data-testid="pdf-gen-banner"][data-variant="amber-revision"]');
+  await expect(banner).toBeVisible();
+  await expect(banner).toContainText("Revisión v2 en curso");
+  await expect(banner).toContainText("v1 trace · op-2026-0847-a3f9c1");
+  // Drawer visible.
+  await expect(page.locator('[data-testid="pdf-diff-drawer"]')).toBeVisible();
+});
+
+test("drawer · 6 rows con 4 con cambio · diff-count literal", async ({ page }) => {
+  await goPdf(page, "PRES-2026-018-REVISING");
+  await expect(page.locator('[data-testid="dd-diff-count"]')).toContainText(
+    "4 con cambio · 2 sin cambio",
+  );
+  await expect(page.locator('[data-testid="dd-row-vigencia"]')).toHaveAttribute(
+    "data-diff",
+    "true",
+  );
+  await expect(page.locator('[data-testid="dd-row-vigencia"]')).toContainText("7 días");
+  await expect(page.locator('[data-testid="dd-row-vigencia"]')).toContainText("15 días");
+  await expect(page.locator('[data-testid="dd-row-anticipo"]')).toHaveAttribute(
+    "data-diff",
+    "false",
+  );
+  await expect(page.locator('[data-testid="dd-row-plazo-entrega"]')).toHaveAttribute(
+    "data-diff",
+    "false",
+  );
+  await expect(page.locator('[data-testid="dd-row-datos-de-envío"]')).toContainText(
+    "ascensor de servicio",
+  );
+  await expect(page.locator('[data-testid="dd-row-notas-internas"]')).toContainText("anti-mancha");
+  await expect(page.locator('[data-testid="dd-row-subtotal-mo"]')).toContainText("$498.450");
+  await expect(page.locator('[data-testid="dd-row-subtotal-mo"]')).toContainText("+$4.260");
+});
+
+test("drawer · sección Resumen con 4 chips · trace literal de subtotal", async ({ page }) => {
+  await goPdf(page, "PRES-2026-018-REVISING");
+  await expect(page.locator('[data-testid="dd-chip-count"]')).toContainText("4 cambios");
+  const summary = page.locator(".dd-summary");
+  await expect(summary).toContainText("Vigencia");
+  await expect(summary).toContainText("15 días");
+  await expect(summary).toContainText("ampliados con ascensor de servicio");
+  await expect(summary).toContainText("anti-mancha");
+  await expect(summary).toContainText("+$4.260");
+});
+
+test("drawer close (×) cierra drawer pero v1 sigue oficial · vuelve a estado C", async ({
+  page,
+}) => {
+  await goPdf(page, "PRES-2026-018-REVISING");
+  await page.locator('[data-testid="dd-close"]').click();
+  await expect(page.locator('[data-testid="pdf-diff-drawer"]')).toHaveCount(0);
+  // Vuelve a estado C (v1 sigue siendo la oficial).
+  await expect(page.locator('[data-testid="pdf-view"]')).toHaveAttribute("data-state", "C");
+  await expect(page.locator('[data-testid="version-chip"]')).toContainText("v1 · enviado");
+});
+
+test("drawer Cancelar revisión cierra drawer", async ({ page }) => {
+  await goPdf(page, "PRES-2026-018-REVISING");
+  await page.locator('[data-testid="dd-cancel"]').click();
+  await expect(page.locator('[data-testid="pdf-diff-drawer"]')).toHaveCount(0);
+  await expect(page.locator('[data-testid="pdf-view"]')).toHaveAttribute("data-state", "C");
+});
+
+test("Generar v2 → abre modal · ESC cierra · backdrop NO cierra", async ({ page }) => {
+  await goPdf(page, "PRES-2026-018-REVISING");
+  await page.locator('[data-testid="dd-generate-v2"]').click();
+  const modal = page.locator('[data-testid="pdf-confirm-v2-modal"]');
+  await expect(modal).toBeVisible();
+  await expect(modal).toContainText("Vas a generar");
+  await expect(modal).toContainText("v2");
+  // Filenames con suffix v2.
+  const blob = page.locator('[data-testid="modal-v2-filenames"]');
+  await expect(blob).toContainText("v2.pdf");
+  await expect(blob).toContainText("v2.xlsx");
+  // audit-note.purple con cambios resumidos.
+  const summary = page.locator('[data-testid="modal-v2-summary"]');
+  await expect(summary).toBeVisible();
+  await expect(summary).toContainText("Vigencia");
+  await expect(summary).toContainText("+$4.260");
+  // Click backdrop NO cierra (paso destructivo).
+  await page.locator('[data-testid="pdf-confirm-v2-backdrop"]').click({ position: { x: 5, y: 5 } });
+  await expect(modal).toBeVisible();
+  // ESC cierra.
+  await page.keyboard.press("Escape");
+  await expect(modal).toHaveCount(0);
+});
+
+test("Modal v2 · Cancelar cierra modal · drawer queda abierto", async ({ page }) => {
+  await goPdf(page, "PRES-2026-018-REVISING");
+  await page.locator('[data-testid="dd-generate-v2"]').click();
+  await page.locator('[data-testid="modal-v2-cancel"]').click();
+  await expect(page.locator('[data-testid="pdf-confirm-v2-modal"]')).toHaveCount(0);
+  await expect(page.locator('[data-testid="pdf-diff-drawer"]')).toBeVisible();
+});
+
+test("Generar v2 → confirma → transición a estado C con filenames v2", async ({ page }) => {
+  await goPdf(page, "PRES-2026-018-REVISING");
+  await page.locator('[data-testid="dd-generate-v2"]').click();
+  await page.locator('[data-testid="modal-v2-confirm"]').click();
+  // Post-success: drawer + modal cerrados · estado C visible.
+  await expect(page.locator('[data-testid="pdf-confirm-v2-modal"]')).toHaveCount(0, {
+    timeout: 5_000,
+  });
+  await expect(page.locator('[data-testid="pdf-diff-drawer"]')).toHaveCount(0);
+  await expect(page.locator('[data-testid="pdf-view"]')).toHaveAttribute("data-state", "C");
+});
+
+test("Flow C → click `Crear revisión v2 →` → estado D · drawer monta on-demand", async ({
+  page,
+}) => {
+  await goPdf(page, "PRES-2026-018-GENERATED");
+  await expect(page.locator('[data-testid="pdf-view"]')).toHaveAttribute("data-state", "C");
+  // El link "Crear revisión v2 →" del sidebar generated.
+  await page.locator(".v2-link").first().click();
+  await expect(page.locator('[data-testid="pdf-diff-drawer"]')).toBeVisible({ timeout: 5_000 });
+  await expect(page.locator('[data-testid="pdf-view"]')).toHaveAttribute("data-state", "D");
+});
+
+test("PRES-2026-018 sin sufijo NO renderea drawer (regresión estado A)", async ({ page }) => {
+  await goPdf(page, "PRES-2026-018");
+  await expect(page.locator('[data-testid="pdf-view"]')).toHaveAttribute("data-state", "A");
+  await expect(page.locator('[data-testid="pdf-diff-drawer"]')).toHaveCount(0);
+});
+
+test("PRES-018-REVISING · banner amber sigue ahí mientras drawer abierto", async ({ page }) => {
+  await goPdf(page, "PRES-2026-018-REVISING");
+  const banner = page.locator('[data-testid="pdf-gen-banner"][data-variant="amber-revision"]');
+  await expect(banner).toBeVisible();
+  // Cerrar drawer · banner verde NO aparece porque revising=false hace que el
+  // banner amber se oculte y rendereemos el green (v1 sigue generada).
+  await page.locator('[data-testid="dd-close"]').click();
+  await expect(banner).toHaveCount(0);
+  await expect(page.locator('[data-testid="pdf-gen-banner"][data-variant="green"]')).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Sprint 4 sub-PR #6 · estado D del paso 5 PDF · drawer side-by-side `v1 oficial` ↔ `v2 borrador editable` + modal confirmación destructiva.

- **CSS scope = 0** confirmado en FASE 1 · todas las clases del drawer + variantes (`gen-banner.amber`, `audit-note.purple`, `version-chip.draft.inline`, `modal-ul.tight`, etc.) ya existían en `operator-shared.css`.
- **Mock-only**: este sub-PR NO wirea inputs editables del sidebar v2 borrador · sub-PR posterior `paso-5-v2-editable` los conecta.
- Sufijo `-REVISING` propaga a 4 mocks (`getQuoteMetadata`, `getAuditSnapshot`, `getPdfGeneratedInfo`, `getPdfV2DiffData`) → SSR-seed directo del estado D para Marina.
- Flow C → click `Crear revisión v2 →` del sidebar generated → fetch lazy del diff → drawer.
- `triggerPdfV2Generation` reusa `_generatedStore` con filenames suffix ` v2.pdf` / ` v2.xlsx` y nuevo `trace_id`.

### Cambios

- `types.ts`: `PdfV2DiffRow`, `PdfV2ChangeSummary`, `PdfV2RevisionData`.
- `mocks.ts`: `getPdfV2DiffData(quoteId)` con CANON v1↔v2 para PRES-2026-018 (6 rows mockup literales) + `triggerPdfV2Generation(quoteId)`. Sufijo `-REVISING` en 4 mocks.
- `PdfDiffDrawer.tsx` (nuevo): header + banner amber + tabla side-by-side + sección Resumen + footer CTAs.
- `PdfConfirmV2Modal.tsx` (nuevo): mini-versión del PdfConfirmModal con chip `v2` inline + audit-note purple + 4 bullets v2.
- `PdfGenBanner.tsx`: extendido con `variant` prop (`green` | `amber-revision`).
- `PdfView.tsx`: state `revising` + grid 3-col (1fr 360 400) + render drawer/modal + wire `onCreateV2` del sidebar generated (estado C).
- `page.tsx`: detecta sufijo `-REVISING` + carga `getPdfV2DiffData` SSR.
- Tests E2E (11/11 verde local).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npx playwright test tests/e2e/paso-5-d-revision-v2.spec.ts` → **11/11 passed (18.5s)**
- [x] Regresión `paso-5-confirm-modal.spec.ts` → 10/10 verde
- [x] Regresión `paso-5-c-generado.spec.ts` → verde (corrió en el full run)
- [ ] Validación estética Javi sobre screenshot 1440×900 estado D
- [ ] Validación estética Javi sobre flow A → confirma v1 → C → click `Crear revisión v2` → D → confirma v2 → C con filenames v2

## Triggers E2E

- `PRES-2026-018-REVISING` → SSR estado D directo
- `PRES-2026-018-GENERATED` + click `.v2-link` → flow C → D on-demand
- `PRES-2026-017-REVISING` → diff con 1 cambio (subtotal MO +$3.760)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## ⚠️ Lecciones operativas nuevas aplicadas

**#43 · Grid/flex inline puede sobrescribir silenciosamente reglas `:has()` del CSS del mockup.** El mockup 21 oculta `.pdf-sidebar` vía `.body.pdf-layout:has(.diff-drawer:not(.closing)) > .pdf-sidebar { display: none }`. Mi grid inline `1fr 360 400` ignoró esa regla porque el grid estaba en el componente, no en `.body.pdf-layout`. Resultado: PDF a 293px en 1389. **Verificar en FASE 1 de futuros sub-PRs con layout complejo si hay reglas `:has()` o equivalentes en el CSS del mockup.**

**#44 · Mocks deben aceptar tolerancia de IDs (forma corta + forma larga) para robustez en sesiones reales.** `PRES-018-REVISING` caía a fallback genérico vacío porque el canon estaba indexado por `PRES-2026-018`. Solución: `getPdfV2DiffData` normaliza `PRES-018` → `PRES-2026-018` antes de buscar. Aplicable a futuros mocks-by-id.

**#45 · Las clases CSS existir en `operator-shared.css` no es suficiente — verificar cascade specificity contra reglas más específicas en contextos anidados.** `.audit-note.purple` (specificity 0,2,0) perdió contra `.modal .m-body .audit-note` (0,2,1) en `display`, `font-family`, `color`. CSS audit FASE 1 marcó scope = 0 pero no chequeó cascade. **Próximas auditorías CSS deben incluir resolución de cascade en cada contexto de uso.**

## ⚠️ Deuda explícita identificada (no resuelta en este sub-PR)

**Sub-PR posterior `sprint-4/paso-5-v2-editable`:** este sub-PR muestra v2 como visual-only con datos hardcoded del mockup. Los inputs editables del sidebar v2 borrador (vigencia / anticipo / plazo / envío / notas / subtotal MO con override) vienen en un sub-PR siguiente que wirea la edición real al diff drawer.

**Sub-PR `sprint-4/test-infra-cleanup` (identificado en PR #473):** deuda paralelismo del `_generatedStore` mock in-memory. Solución actual `describe.configure({mode:"serial"})` + `workers=1` en CI es suficiente pero no escala. Plan: aislar el store por test via `test.use({ storageState })` o factory por worker.

**Backend `triggerPdfV2Generation`:** mock-only en este sub-PR. El backend Railway aún no expone el endpoint `POST /api/quotes/{id}/pdf/v2` ni la lógica de versionado lineal (v1 → v2 → v3). Sub-PR backend posterior wirea el flow real con WeasyPrint + Drive + audit log entry v1↔v2.
