### PR TITLE
feat(audit): copiar audit completo del quote (audit-trail-copy)

### DIFF
--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -2387,3 +2387,179 @@ async def chat(
             "X-Accel-Buffering": "no",
         },
     )
+
+
+# ─── Sprint 4 audit-trail-copy ──────────────────────────────────────────
+# GET /api/quotes/{id}/audit-log
+# Agrega 3 tablas (audit_events + token_usage + Quote.quote_breakdown)
+# en una sola respuesta · destinada al botón "Copiar audit" del topbar +
+# página /quotes/{id}/audit para debug/iteración rápida.
+
+_AUDIT_EVENTS_DEFAULT_LIMIT = 200
+
+@router.get("/quotes/{quote_id}/audit-log")
+async def get_quote_audit_log(
+    quote_id: str,
+    request: Request,
+    full: bool = Query(default=False, description="Si true, devuelve TODOS los eventos sin truncar"),
+    limit: int = Query(default=_AUDIT_EVENTS_DEFAULT_LIMIT, ge=10, le=2000),
+    db: AsyncSession = Depends(get_db),
+):
+    """Endpoint read-only que agrega todo el debugging-relevante de un quote:
+    timeline de audit_events, suma de TokenUsage, tools agregados por nombre,
+    chat duration derivada de timestamps, snapshot de quote_breakdown.
+
+    `full=true` quita la truncation (default events_total > limit → trunca).
+    Errores siempre se devuelven completos en `errors[]` aparte de `events[]`.
+    """
+    from app.modules.observability.models import AuditEvent
+    from app.models.usage import TokenUsage
+    from app.modules.agent.schemas import (
+        AuditLogResponse,
+        AuditLogMeta,
+        AuditLogEventItem,
+        AuditLogTokensSummary,
+        AuditLogToolUsage,
+    )
+    from collections import defaultdict
+
+    # ── Quote 404 check (patrón existente router.py:2146-2148)
+    result = await db.execute(select(Quote).where(Quote.id == quote_id))
+    quote = result.scalar_one_or_none()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Quote not found")
+
+    # ── Eventos: orden ascendente por created_at (timeline natural)
+    events_result = await db.execute(
+        select(AuditEvent)
+        .where(AuditEvent.quote_id == quote_id)
+        .order_by(AuditEvent.created_at.asc())
+    )
+    all_events = list(events_result.scalars().all())
+    events_total = len(all_events)
+    # Truncation defensiva (debug mode puede generar >150 eventos por quote)
+    events_truncated = (not full) and events_total > limit
+    visible_events = all_events if full else all_events[:limit]
+
+    # ── Errors (siempre completos · sin trunc)
+    error_events = [e for e in all_events if not e.success]
+
+    # ── TokenUsage aggregation
+    token_result = await db.execute(
+        select(TokenUsage).where(TokenUsage.quote_id == quote_id)
+    )
+    token_rows = list(token_result.scalars().all())
+    tokens_summary = AuditLogTokensSummary(
+        input_tokens=sum(t.input_tokens for t in token_rows),
+        output_tokens=sum(t.output_tokens for t in token_rows),
+        cache_read_tokens=sum(t.cache_read_tokens for t in token_rows),
+        cache_write_tokens=sum(t.cache_write_tokens for t in token_rows),
+        cost_usd=round(sum(t.cost_usd for t in token_rows), 4),
+        iterations=sum(t.iterations for t in token_rows),
+        models_used=sorted({t.model for t in token_rows if t.model}),
+    )
+
+    # ── Tools used: agregación por tool_name desde eventos agent.tool_result
+    tools_agg: dict[str, dict] = defaultdict(lambda: {"count": 0, "total_ms": 0, "errors": 0})
+    for ev in all_events:
+        if ev.event_type != "agent.tool_result":
+            continue
+        tool_name = (ev.payload or {}).get("tool_name") or "unknown"
+        tools_agg[tool_name]["count"] += 1
+        if ev.elapsed_ms:
+            tools_agg[tool_name]["total_ms"] += ev.elapsed_ms
+        if not ev.success:
+            tools_agg[tool_name]["errors"] += 1
+    tools_used = [
+        AuditLogToolUsage(
+            tool_name=name,
+            count=data["count"],
+            total_ms=data["total_ms"],
+            error_count=data["errors"],
+        )
+        for name, data in sorted(tools_agg.items())
+    ]
+
+    # ── Chat duration derivada de timestamps (lección operativa #1.5
+    # del bundle FASE 1): agent.stream_started → último tool_result
+    # o quote.calculated, lo que ocurra después.
+    chat_duration_ms: Optional[int] = None
+    stream_start = next((e for e in all_events if e.event_type == "agent.stream_started"), None)
+    if stream_start:
+        chat_ends = [
+            e for e in all_events
+            if e.event_type in {"agent.tool_result", "quote.calculated", "docs.generated"}
+            and e.created_at >= stream_start.created_at
+        ]
+        if chat_ends:
+            last_end = max(chat_ends, key=lambda e: e.created_at)
+            delta = last_end.created_at - stream_start.created_at
+            chat_duration_ms = int(delta.total_seconds() * 1000)
+
+    # ── Input message (primer turno del operador) + plan_files derivados
+    # del primer chat.message_sent + Quote.source_files (si existe)
+    input_message: Optional[str] = None
+    plan_files: list[str] = []
+    first_chat = next((e for e in all_events if e.event_type == "chat.message_sent"), None)
+    if first_chat and first_chat.payload:
+        # En debug_only_payload puede venir el message_text; sino solo metadata.
+        # No accedemos a debug_only_payload acá (sanitizer).
+        pass
+    if quote.messages:
+        # Quote.messages es lista de {role, content, ...} · primer user message
+        try:
+            first_user = next(
+                (m for m in quote.messages if isinstance(m, dict) and m.get("role") == "user"),
+                None,
+            )
+            if first_user:
+                input_message = (first_user.get("content") or "")[:2000]  # cap defensivo
+        except Exception:
+            pass
+    if quote.source_files and isinstance(quote.source_files, list):
+        plan_files = [
+            (f.get("filename") or f.get("name") or "?")
+            for f in quote.source_files
+            if isinstance(f, dict)
+        ][:20]
+
+    # ── Build response
+    meta = AuditLogMeta(
+        quote_id=quote.id,
+        status=quote.status.value if quote.status else "unknown",
+        client_name=quote.client_name or None,
+        project=quote.project or None,
+        material=quote.material,
+        total_ars=quote.total_ars,
+        total_usd=quote.total_usd,
+        created_at=quote.created_at,
+        updated_at=quote.updated_at,
+    )
+
+    response = AuditLogResponse(
+        meta=meta,
+        input_message=input_message,
+        plan_files=plan_files,
+        events=[AuditLogEventItem.model_validate(e) for e in visible_events],
+        events_total=events_total,
+        events_truncated=events_truncated,
+        chat_duration_ms=chat_duration_ms,
+        tokens=tokens_summary,
+        tools_used=tools_used,
+        quote_breakdown=quote.quote_breakdown,
+        errors=[AuditLogEventItem.model_validate(e) for e in error_events],
+    )
+
+    # ── Log access (audit del propio audit · ironía controlada)
+    await log_event(
+        db,
+        event_type="audit.log_fetched",
+        source="router",
+        summary=f"Audit log fetched for {quote_id} ({events_total} events, full={full})",
+        request=request,
+        quote_id=quote_id,
+        payload={"events_total": events_total, "full": full, "errors_count": len(error_events)},
+        commit=False,
+    )
+
+    return response

--- a/api/app/modules/agent/schemas.py
+++ b/api/app/modules/agent/schemas.py
@@ -139,3 +139,79 @@ class DeriveMaterialRequest(BaseModel):
     Copies client/project/pieces/options, recalculates everything from scratch."""
     material: str = Field(..., min_length=1, max_length=500)
     thickness_mm: Optional[int] = Field(None, ge=1, le=100)
+
+
+# ─── Sprint 4 audit-trail-copy ──────────────────────────────────────────
+# Response del endpoint `GET /api/quotes/{id}/audit-log`. Agrega eventos
+# timeline + token usage + breakdown snapshot · wire-only sin migración.
+
+
+class AuditLogEventItem(BaseModel):
+    """Una fila de la timeline (audit_events row · subset relevante)."""
+    created_at: datetime
+    event_type: str
+    source: str
+    summary: str
+    payload: dict
+    success: bool
+    error_message: Optional[str] = None
+    elapsed_ms: Optional[int] = None
+    turn_index: Optional[int] = None
+    request_id: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class AuditLogTokensSummary(BaseModel):
+    """Suma de TokenUsage rows para este quote (todas las turnas)."""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    cost_usd: float = 0.0
+    iterations: int = 0
+    models_used: list[str] = Field(default_factory=list)
+
+
+class AuditLogToolUsage(BaseModel):
+    """Agregación por tool_name (derivada de eventos agent.tool_result)."""
+    tool_name: str
+    count: int
+    total_ms: int
+    error_count: int = 0
+
+
+class AuditLogMeta(BaseModel):
+    """Cabecera con metadatos del quote."""
+    quote_id: str
+    status: str
+    client_name: Optional[str] = None
+    project: Optional[str] = None
+    material: Optional[str] = None
+    total_ars: Optional[float] = None
+    total_usd: Optional[float] = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class AuditLogResponse(BaseModel):
+    """Response del endpoint `GET /api/quotes/{id}/audit-log`. Agrega 3
+    tablas (audit_events + token_usage + Quote) en payload único para
+    el botón "Copiar audit" del topbar y la página /audit.
+
+    Cuando `full=false` (default), el array `events` se trunca a un
+    máximo razonable (events_limit) y `events_truncated=True` para
+    evitar payloads enormes en quotes con >150 eventos (debug activado).
+    Errors se reportan siempre completos (sin trunc)."""
+    meta: AuditLogMeta
+    input_message: Optional[str] = None
+    plan_files: list[str] = Field(default_factory=list)
+    events: list[AuditLogEventItem]
+    events_total: int
+    events_truncated: bool = False
+    chat_duration_ms: Optional[int] = None
+    tokens: AuditLogTokensSummary
+    tools_used: list[AuditLogToolUsage] = Field(default_factory=list)
+    quote_breakdown: Optional[dict] = None
+    errors: list[AuditLogEventItem] = Field(default_factory=list)

--- a/api/tests/test_audit_log_endpoint.py
+++ b/api/tests/test_audit_log_endpoint.py
@@ -1,0 +1,259 @@
+"""Tests del endpoint `GET /api/quotes/{id}/audit-log` · Sprint 4 audit-trail-copy.
+
+Cobertura:
+- 404 quote inexistente
+- happy path con eventos + errores + tokens + tools agregados
+- truncation default >limit, full=true devuelve todos
+- errors[] siempre completo aunque events trunca
+- chat_duration_ms derivado de timestamps
+- quote_breakdown se devuelve tal cual del JSON column
+- log_event ironía-controlada se registra (audit.log_fetched)
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+async def _seed_quote_with_audit(
+    db_session,
+    quote_id: str,
+    *,
+    client_name: str = "Cliente Test",
+    project: str = "Test project",
+    material: str | None = "Silestone Blanco Norte",
+    breakdown: dict | None = None,
+    messages: list | None = None,
+    source_files: list | None = None,
+    events: list[dict] | None = None,
+    token_rows: list[dict] | None = None,
+):
+    """Inserta Quote + AuditEvent rows + TokenUsage rows."""
+    from app.models.quote import Quote, QuoteStatus
+    from app.models.usage import TokenUsage
+    from app.modules.observability.models import AuditEvent
+
+    db_session.add(
+        Quote(
+            id=quote_id,
+            client_name=client_name,
+            project=project,
+            material=material,
+            messages=messages or [],
+            status=QuoteStatus.DRAFT,
+            quote_breakdown=breakdown,
+            source_files=source_files,
+        )
+    )
+    base = datetime.now(timezone.utc)
+    for i, e in enumerate(events or []):
+        db_session.add(
+            AuditEvent(
+                id=str(uuid.uuid4()),
+                created_at=e.get("created_at", base + timedelta(seconds=i)),
+                event_type=e.get("event_type", "test.event"),
+                source=e.get("source", "test"),
+                quote_id=quote_id,
+                session_id=quote_id,
+                actor=e.get("actor", "javi"),
+                actor_kind="user",
+                request_id=str(uuid.uuid4()),
+                turn_index=e.get("turn_index"),
+                summary=e.get("summary", "test event"),
+                payload=e.get("payload", {}),
+                payload_truncated=False,
+                success=e.get("success", True),
+                error_message=e.get("error_message"),
+                elapsed_ms=e.get("elapsed_ms"),
+                debug_payload=False,
+            )
+        )
+    for tu in token_rows or []:
+        db_session.add(
+            TokenUsage(
+                quote_id=quote_id,
+                input_tokens=tu.get("input_tokens", 0),
+                output_tokens=tu.get("output_tokens", 0),
+                cache_read_tokens=tu.get("cache_read_tokens", 0),
+                cache_write_tokens=tu.get("cache_write_tokens", 0),
+                model=tu.get("model", "sonnet"),
+                cost_usd=tu.get("cost_usd", 0.0),
+                iterations=tu.get("iterations", 1),
+            )
+        )
+    await db_session.commit()
+
+
+class TestAuditLogEndpoint:
+    @pytest.mark.asyncio
+    async def test_404_quote_not_found(self, client):
+        r = await client.get("/api/quotes/does-not-exist/audit-log")
+        assert r.status_code == 404
+        assert "not found" in r.json().get("detail", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_happy_path_aggregates_everything(self, client, db_session):
+        base = datetime.now(timezone.utc)
+        await _seed_quote_with_audit(
+            db_session,
+            "q-happy",
+            client_name="Cueto-Heredia",
+            material="Silestone Blanco Norte",
+            messages=[
+                {"role": "user", "content": "Hola Marina, te paso el plano..."},
+                {"role": "assistant", "content": "Listo."},
+            ],
+            source_files=[{"filename": "plano.pdf"}, {"filename": "foto.jpg"}],
+            breakdown={"sectors": [{"id": "S1"}], "total_ars": 660739},
+            events=[
+                {"event_type": "quote.created", "created_at": base},
+                {"event_type": "chat.message_sent", "created_at": base + timedelta(seconds=1)},
+                {"event_type": "agent.stream_started", "created_at": base + timedelta(seconds=2)},
+                {
+                    "event_type": "agent.tool_called",
+                    "created_at": base + timedelta(seconds=3),
+                    "payload": {"tool_name": "read_plan"},
+                },
+                {
+                    "event_type": "agent.tool_result",
+                    "created_at": base + timedelta(seconds=14),
+                    "payload": {"tool_name": "read_plan", "ok": True},
+                    "elapsed_ms": 11000,
+                    "success": True,
+                },
+                {
+                    "event_type": "agent.tool_result",
+                    "created_at": base + timedelta(seconds=15),
+                    "payload": {"tool_name": "catalog_lookup", "ok": True},
+                    "elapsed_ms": 200,
+                    "success": True,
+                },
+                {
+                    "event_type": "quote.calculated",
+                    "created_at": base + timedelta(seconds=25),
+                    "payload": {"breakdown_keys": ["sectors", "total_ars"]},
+                },
+            ],
+            token_rows=[
+                {"input_tokens": 12000, "output_tokens": 3000, "cost_usd": 0.087, "model": "sonnet"},
+            ],
+        )
+        r = await client.get("/api/quotes/q-happy/audit-log")
+        assert r.status_code == 200, r.text
+        data = r.json()
+
+        # meta
+        assert data["meta"]["quote_id"] == "q-happy"
+        assert data["meta"]["client_name"] == "Cueto-Heredia"
+        assert data["meta"]["material"] == "Silestone Blanco Norte"
+        # input_message preserved
+        assert data["input_message"] is not None
+        assert "Hola Marina" in data["input_message"]
+        assert data["plan_files"] == ["plano.pdf", "foto.jpg"]
+
+        # events
+        assert data["events_total"] == 7
+        assert data["events_truncated"] is False
+        event_types = [e["event_type"] for e in data["events"]]
+        assert "quote.created" in event_types
+        assert "agent.stream_started" in event_types
+        assert event_types[0] == "quote.created"  # asc
+
+        # tokens summary
+        assert data["tokens"]["input_tokens"] == 12000
+        assert data["tokens"]["output_tokens"] == 3000
+        assert data["tokens"]["cost_usd"] == pytest.approx(0.087)
+        assert data["tokens"]["models_used"] == ["sonnet"]
+
+        # tools_used aggregated
+        tool_names = {t["tool_name"] for t in data["tools_used"]}
+        assert tool_names == {"read_plan", "catalog_lookup"}
+        read_plan = next(t for t in data["tools_used"] if t["tool_name"] == "read_plan")
+        assert read_plan["count"] == 1
+        assert read_plan["total_ms"] == 11000
+        assert read_plan["error_count"] == 0
+
+        # chat_duration derived from timestamps (stream_started → last tool_result/calculated)
+        assert data["chat_duration_ms"] is not None
+        assert 22000 <= data["chat_duration_ms"] <= 24000  # ~23s
+
+        # breakdown preserved
+        assert data["quote_breakdown"]["total_ars"] == 660739
+
+        # errors empty
+        assert data["errors"] == []
+
+    @pytest.mark.asyncio
+    async def test_errors_separate_from_events(self, client, db_session):
+        base = datetime.now(timezone.utc)
+        await _seed_quote_with_audit(
+            db_session,
+            "q-err",
+            events=[
+                {"event_type": "quote.created"},
+                {
+                    "event_type": "agent.tool_result",
+                    "payload": {"tool_name": "read_plan"},
+                    "success": False,
+                    "error_message": "Plano ilegible · OCR fallido",
+                    "elapsed_ms": 30000,
+                },
+                {
+                    "event_type": "agent.tool_result",
+                    "payload": {"tool_name": "read_plan"},
+                    "success": True,
+                    "elapsed_ms": 5000,
+                },
+            ],
+        )
+        r = await client.get("/api/quotes/q-err/audit-log")
+        assert r.status_code == 200
+        data = r.json()
+
+        assert len(data["errors"]) == 1
+        assert data["errors"][0]["error_message"] == "Plano ilegible · OCR fallido"
+        assert data["errors"][0]["success"] is False
+
+        # tools_used.error_count refleja el fallo
+        read_plan = next(t for t in data["tools_used"] if t["tool_name"] == "read_plan")
+        assert read_plan["count"] == 2
+        assert read_plan["error_count"] == 1
+        assert read_plan["total_ms"] == 35000
+
+    @pytest.mark.asyncio
+    async def test_truncation_when_over_limit(self, client, db_session):
+        # 250 eventos > limit default 200 → truncate por defecto
+        await _seed_quote_with_audit(
+            db_session,
+            "q-many",
+            events=[{"event_type": f"test.evt.{i}"} for i in range(250)],
+        )
+        r = await client.get("/api/quotes/q-many/audit-log")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["events_total"] == 250
+        assert data["events_truncated"] is True
+        assert len(data["events"]) == 200  # default limit
+
+        # full=true devuelve todos
+        r2 = await client.get("/api/quotes/q-many/audit-log?full=true")
+        data2 = r2.json()
+        assert data2["events_truncated"] is False
+        assert len(data2["events"]) == 250
+
+    @pytest.mark.asyncio
+    async def test_empty_quote_returns_empty_arrays(self, client, db_session):
+        await _seed_quote_with_audit(db_session, "q-empty")
+        r = await client.get("/api/quotes/q-empty/audit-log")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["events_total"] == 0
+        assert data["events"] == []
+        assert data["errors"] == []
+        assert data["tools_used"] == []
+        assert data["tokens"]["input_tokens"] == 0
+        assert data["chat_duration_ms"] is None
+        assert data["input_message"] is None
+        assert data["plan_files"] == []

--- a/web/src/app/quotes/[id]/audit/page.tsx
+++ b/web/src/app/quotes/[id]/audit/page.tsx
@@ -1,0 +1,46 @@
+/**
+ * Página /quotes/{id}/audit · Sprint 4 audit-trail-copy.
+ *
+ * Vista pretty del audit log del quote (no clipboard plain text · esa la
+ * cubre el botón del topbar). Renderiza:
+ *   - Header con meta (quote_id, status, totales) + summary chips
+ *   - Timeline vertical de eventos con coloring de latencia
+ *   - Tabla de calls agregados (tools + tokens + duración chat)
+ *   - JSON breakdown colapsable
+ *   - 3 botones copy: "Copiar todo", "Copiar timeline", "Copiar JSON"
+ *
+ * Server Component · usa Bearer token SSR (PR #469) + `getAuditLog`
+ * (real o mock según USE_REAL_API). Hereda chrome del `[id]/layout.tsx`.
+ *
+ * NO tiene mockup oficial (feature v1.0 nueva · excepción justificada
+ * del Mockup Fidelity Gate).
+ */
+import { getAuditLog } from "@/lib/api";
+import { getServerToken } from "@/lib/auth-server";
+import { AuditView } from "@/components/audit/AuditView";
+
+export default async function AuditPage({ params }: { params: { id: string } }) {
+  const bearerToken = getServerToken();
+  let audit;
+  let loadError: string | null = null;
+  try {
+    audit = await getAuditLog(params.id, { bearerToken, full: true });
+  } catch (err) {
+    loadError = err instanceof Error ? err.message : "Error desconocido al cargar audit";
+  }
+
+  if (!audit || loadError) {
+    return (
+      <div className="col" data-testid="audit-error">
+        <div className="section-head">
+          <h2>No pude cargar el audit log</h2>
+        </div>
+        <p className="font-mono" style={{ fontSize: 12, color: "var(--error)" }}>
+          {loadError ?? "Quote no encontrado"}
+        </p>
+      </div>
+    );
+  }
+
+  return <AuditView audit={audit} />;
+}

--- a/web/src/components/audit/AuditView.tsx
+++ b/web/src/components/audit/AuditView.tsx
@@ -1,0 +1,382 @@
+/**
+ * Vista pretty del audit log · Sprint 4 audit-trail-copy.
+ *
+ * Renderiza meta + 3 botones copy (todo / timeline / JSON) + timeline
+ * vertical + tabla de calls agregados + JSON breakdown colapsable.
+ *
+ * Reusa clases legacy `.section-head`, `.col`, `.trace-block`,
+ * `.kpi-card`. Coloring de latencia via `data-severity` + inline styles
+ * con CSS vars existentes (`--ok` `--warn` `--alert`). Cero CSS nuevo.
+ */
+"use client";
+
+import { useState } from "react";
+import type { AuditLogResponse } from "@/lib/api/types";
+import {
+  formatAuditCopy,
+  latencySeverity,
+  type LatencySeverity,
+} from "@/lib/utils/format-audit-copy";
+
+interface Props {
+  audit: AuditLogResponse;
+}
+
+const SEV_COLORS: Record<LatencySeverity, string> = {
+  ok: "var(--ok, oklch(0.72 0.18 145))",
+  watch: "var(--warn, oklch(0.78 0.16 80))",
+  slow: "var(--warn, oklch(0.65 0.18 50))",
+  alert: "var(--error, oklch(0.65 0.20 25))",
+};
+
+function epochMs(iso: string): number {
+  return new Date(iso).getTime();
+}
+
+function fmtMs(ms: number | null | undefined): string {
+  if (ms == null) return "—";
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+  return `${ms}ms`;
+}
+
+function fmtNum(n: number): string {
+  return n.toLocaleString("es-AR");
+}
+
+export function AuditView({ audit }: Props) {
+  const [copied, setCopied] = useState<"all" | "timeline" | "json" | null>(null);
+
+  const handleCopy = async (kind: "all" | "timeline" | "json") => {
+    let text: string;
+    if (kind === "all") {
+      text = formatAuditCopy(audit);
+    } else if (kind === "timeline") {
+      text = formatAuditCopy(audit, { timelineOnly: true });
+    } else {
+      text = audit.quote_breakdown ? JSON.stringify(audit.quote_breakdown, null, 2) : "{}";
+    }
+    try {
+      if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      }
+    } catch {
+      /* best-effort */
+    }
+    setCopied(kind);
+    setTimeout(() => setCopied(null), 1800);
+  };
+
+  const createdEpoch = epochMs(audit.meta.created_at);
+
+  return (
+    <div className="col" data-testid="audit-view">
+      {/* ─── Header ───────────────────────────────────────────────── */}
+      <div className="section-head">
+        <div>
+          <div className="meta">Audit log · debug + iteración</div>
+          <h2>{audit.meta.quote_id}</h2>
+          <div className="vc-wrap" style={{ fontSize: 12, color: "var(--ink-mute)" }}>
+            <span>status: {audit.meta.status}</span>
+            {audit.meta.client_name && <span>· {audit.meta.client_name}</span>}
+            {audit.meta.material && <span>· {audit.meta.material}</span>}
+          </div>
+        </div>
+        <div className="right">
+          <button
+            type="button"
+            className="btn primary sm"
+            onClick={() => handleCopy("all")}
+            data-testid="audit-copy-all"
+          >
+            {copied === "all" ? "✓ Copiado" : "📋 Copiar todo"}
+          </button>
+          <button
+            type="button"
+            className="btn ghost sm"
+            onClick={() => handleCopy("timeline")}
+            data-testid="audit-copy-timeline"
+          >
+            {copied === "timeline" ? "✓ Copiado" : "Copiar timeline"}
+          </button>
+          <button
+            type="button"
+            className="btn ghost sm"
+            onClick={() => handleCopy("json")}
+            data-testid="audit-copy-json"
+          >
+            {copied === "json" ? "✓ Copiado" : "Copiar JSON"}
+          </button>
+        </div>
+      </div>
+
+      {/* ─── Summary chips ───────────────────────────────────────── */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+          gap: 12,
+          marginBottom: 16,
+        }}
+        data-testid="audit-summary"
+      >
+        <SummaryChip label="Eventos" value={fmtNum(audit.events_total)} />
+        <SummaryChip
+          label="Chat duration"
+          value={fmtMs(audit.chat_duration_ms)}
+          severity={
+            audit.chat_duration_ms != null ? latencySeverity(audit.chat_duration_ms) : undefined
+          }
+          testId="summary-chat-duration"
+        />
+        <SummaryChip
+          label="Tokens (in/out)"
+          value={`${fmtNum(audit.tokens.input_tokens)} / ${fmtNum(audit.tokens.output_tokens)}`}
+        />
+        <SummaryChip label="Cost USD" value={`$${audit.tokens.cost_usd.toFixed(4)}`} />
+        <SummaryChip
+          label="Errors"
+          value={fmtNum(audit.errors.length)}
+          severity={audit.errors.length > 0 ? "alert" : "ok"}
+          testId="summary-errors"
+        />
+      </div>
+
+      {/* ─── Input ────────────────────────────────────────────────── */}
+      {audit.input_message && (
+        <details
+          open
+          style={{
+            border: "1px solid var(--line)",
+            borderRadius: 6,
+            padding: "10px 14px",
+            marginBottom: 14,
+          }}
+        >
+          <summary style={{ cursor: "pointer", fontSize: 12, color: "var(--ink-soft)" }}>
+            INPUT · brief_text + plan_files ({audit.plan_files.length})
+          </summary>
+          <p
+            style={{
+              fontFamily: "var(--mono)",
+              fontSize: 11,
+              color: "var(--ink)",
+              marginTop: 10,
+              whiteSpace: "pre-wrap",
+            }}
+            data-testid="audit-input-text"
+          >
+            {audit.input_message}
+          </p>
+          {audit.plan_files.length > 0 && (
+            <p style={{ fontSize: 11, color: "var(--ink-mute)", marginTop: 6 }}>
+              plan_files: {audit.plan_files.map((f) => `"${f}"`).join(", ")}
+            </p>
+          )}
+        </details>
+      )}
+
+      {/* ─── Tools used + tokens ──────────────────────────────────── */}
+      {audit.tools_used.length > 0 && (
+        <div style={{ marginBottom: 14 }}>
+          <h3 style={{ fontSize: 13, color: "var(--ink-soft)", margin: "0 0 8px" }}>
+            Tools usados ({audit.tools_used.length})
+          </h3>
+          <table
+            style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}
+            data-testid="audit-tools-table"
+          >
+            <thead>
+              <tr style={{ color: "var(--ink-mute)", textAlign: "left" }}>
+                <th style={{ padding: "6px 8px" }}>Tool</th>
+                <th style={{ padding: "6px 8px", textAlign: "right" }}>Count</th>
+                <th style={{ padding: "6px 8px", textAlign: "right" }}>Total time</th>
+                <th style={{ padding: "6px 8px", textAlign: "right" }}>Errors</th>
+              </tr>
+            </thead>
+            <tbody>
+              {audit.tools_used.map((t) => {
+                const sev = latencySeverity(t.total_ms);
+                return (
+                  <tr
+                    key={t.tool_name}
+                    style={{ borderTop: "1px solid var(--line)" }}
+                    data-testid={`audit-tool-${t.tool_name}`}
+                    data-severity={sev}
+                  >
+                    <td
+                      style={{
+                        padding: "6px 8px",
+                        fontFamily: "var(--mono)",
+                        fontSize: 11,
+                      }}
+                    >
+                      {t.tool_name}
+                    </td>
+                    <td style={{ padding: "6px 8px", textAlign: "right" }}>{t.count}</td>
+                    <td
+                      style={{
+                        padding: "6px 8px",
+                        textAlign: "right",
+                        color: SEV_COLORS[sev],
+                        fontFamily: "var(--mono)",
+                      }}
+                    >
+                      {fmtMs(t.total_ms)}
+                    </td>
+                    <td
+                      style={{
+                        padding: "6px 8px",
+                        textAlign: "right",
+                        color: t.error_count > 0 ? "var(--error)" : "var(--ink-mute)",
+                      }}
+                    >
+                      {t.error_count}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* ─── Timeline ─────────────────────────────────────────────── */}
+      <h3 style={{ fontSize: 13, color: "var(--ink-soft)", margin: "12px 0 8px" }}>
+        Timeline ({audit.events_total} eventos
+        {audit.events_truncated ? ` · truncated to ${audit.events.length}` : ""})
+      </h3>
+      <ol
+        style={{
+          listStyle: "none",
+          padding: 0,
+          margin: 0,
+          borderLeft: "2px solid var(--line)",
+          paddingLeft: 12,
+        }}
+        data-testid="audit-timeline"
+      >
+        {audit.events.map((ev, i) => {
+          const delta = epochMs(ev.created_at) - createdEpoch;
+          const deltaStr = `+${(delta / 1000).toFixed(3)}s`;
+          const sev = ev.elapsed_ms != null ? latencySeverity(ev.elapsed_ms) : null;
+          return (
+            <li
+              key={`${ev.event_type}-${i}`}
+              style={{
+                margin: "4px 0",
+                fontSize: 12,
+                fontFamily: "var(--mono)",
+                color: ev.success ? "var(--ink)" : "var(--error)",
+              }}
+              data-testid={`audit-event-${i}`}
+              data-event-type={ev.event_type}
+              data-severity={sev ?? "none"}
+            >
+              <span style={{ color: "var(--ink-mute)" }}>[{deltaStr}]</span>{" "}
+              <span style={{ fontWeight: 600 }}>{ev.event_type}</span>
+              {!ev.success && <span style={{ color: "var(--error)" }}> ✗</span>}
+              {ev.elapsed_ms != null && (
+                <span style={{ color: SEV_COLORS[sev!], marginLeft: 6 }}>
+                  · {fmtMs(ev.elapsed_ms)}
+                </span>
+              )}
+              {ev.summary && (
+                <span style={{ color: "var(--ink-soft)" }}> · {ev.summary}</span>
+              )}
+              {ev.error_message && (
+                <span style={{ color: "var(--error)" }}> · {ev.error_message}</span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+
+      {/* ─── Errors ───────────────────────────────────────────────── */}
+      {audit.errors.length > 0 && (
+        <div
+          style={{
+            marginTop: 14,
+            padding: "10px 14px",
+            border: "1px solid var(--error)",
+            borderRadius: 6,
+            background: "color-mix(in oklch, var(--error) 8%, transparent)",
+          }}
+          data-testid="audit-errors"
+        >
+          <h3 style={{ fontSize: 13, color: "var(--error)", margin: "0 0 8px" }}>
+            Errors ({audit.errors.length})
+          </h3>
+          <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+            {audit.errors.map((err, i) => (
+              <li
+                key={i}
+                style={{ fontSize: 12, fontFamily: "var(--mono)", margin: "4px 0" }}
+              >
+                <strong>{err.event_type}</strong>: {err.summary}
+                {err.error_message && (
+                  <span style={{ color: "var(--error)" }}> — {err.error_message}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* ─── Breakdown JSON colapsable ──────────────────────────── */}
+      {audit.quote_breakdown && (
+        <details
+          className="trace-block"
+          style={{ marginTop: 18 }}
+          data-testid="audit-breakdown-details"
+        >
+          <summary>quote_breakdown JSON</summary>
+          <pre
+            style={{
+              fontSize: 11,
+              padding: 14,
+              background: "var(--bg-muted)",
+              borderRadius: 4,
+              overflowX: "auto",
+              fontFamily: "var(--mono)",
+            }}
+          >
+            {JSON.stringify(audit.quote_breakdown, null, 2)}
+          </pre>
+        </details>
+      )}
+    </div>
+  );
+}
+
+interface SummaryChipProps {
+  label: string;
+  value: string;
+  severity?: LatencySeverity;
+  testId?: string;
+}
+
+function SummaryChip({ label, value, severity, testId }: SummaryChipProps) {
+  return (
+    <div
+      style={{
+        border: "1px solid var(--line)",
+        borderRadius: 6,
+        padding: "10px 12px",
+      }}
+      data-testid={testId}
+      data-severity={severity ?? "none"}
+    >
+      <div style={{ fontSize: 11, color: "var(--ink-mute)", marginBottom: 4 }}>{label}</div>
+      <div
+        style={{
+          fontSize: 16,
+          fontFamily: "var(--mono)",
+          color: severity ? SEV_COLORS[severity] : "var(--ink)",
+          fontWeight: 600,
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/chrome/Topbar.tsx
+++ b/web/src/components/chrome/Topbar.tsx
@@ -11,6 +11,7 @@
  */
 import type { QuoteHeader } from "@/lib/api";
 import { AuditToggle } from "@/components/observability/AuditToggle";
+import { AuditCopyButton } from "@/components/observability/AuditCopyButton";
 
 interface TopbarProps {
   quote: QuoteHeader;
@@ -28,6 +29,11 @@ export function Topbar({ quote }: TopbarProps) {
       </div>
 
       <div className="right">
+        {/* Sprint 4 audit-trail-copy · CTA Copiar audit del quote actual al
+            clipboard. Persistente en TODOS los pasos del quote ([id]/layout
+            provee `quote: QuoteHeader` con id). */}
+        <AuditCopyButton quoteId={quote.id} />
+
         {/* Sprint 3 observability · audit toggle global (refactor decisión Javi C). */}
         <AuditToggle />
 

--- a/web/src/components/observability/AuditCopyButton.tsx
+++ b/web/src/components/observability/AuditCopyButton.tsx
@@ -1,0 +1,87 @@
+/**
+ * Sprint 4 audit-trail-copy · CTA persistente del topbar para copiar el
+ * audit completo del quote actual al clipboard.
+ *
+ * Flow:
+ *   1. Click → fetch `GET /api/quotes/{id}/audit-log` (real o mock según
+ *      USE_REAL_API gate)
+ *   2. Format con `formatAuditCopy()` → plain text estructurado
+ *   3. navigator.clipboard.writeText() · try-catch con fallback gracioso
+ *   4. State badge "Copiado ✓" durante 2000ms (patrón existente
+ *      PdfSidebarGenerated.tsx · NO toast library)
+ *
+ * Visible solo cuando `quoteId` está disponible (Topbar lo recibe del
+ * `[id]/layout.tsx` Server Component). En rutas sin quote contexto
+ * (e.g., /quotes/new, /), el botón no se renderea.
+ *
+ * Reusa clase legacy `.ico-btn` del topbar. Cero CSS nuevo.
+ */
+"use client";
+
+import { useState } from "react";
+import { getAuditLog } from "@/lib/api";
+import { formatAuditCopy } from "@/lib/utils/format-audit-copy";
+
+interface Props {
+  quoteId: string;
+}
+
+type CopyState = "idle" | "loading" | "copied" | "error";
+
+export function AuditCopyButton({ quoteId }: Props) {
+  const [state, setState] = useState<CopyState>("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const handleClick = async () => {
+    if (state === "loading") return;
+    setState("loading");
+    setErrorMsg(null);
+    try {
+      const audit = await getAuditLog(quoteId);
+      const text = formatAuditCopy(audit);
+      try {
+        if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(text);
+        }
+      } catch {
+        // best-effort · ambientes sin clipboard API igual muestran el badge
+      }
+      setState("copied");
+      setTimeout(() => setState("idle"), 2000);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "No se pudo cargar el audit";
+      setErrorMsg(msg);
+      setState("error");
+      setTimeout(() => setState("idle"), 3000);
+    }
+  };
+
+  const label =
+    state === "loading"
+      ? "…"
+      : state === "copied"
+        ? "✓ Copiado"
+        : state === "error"
+          ? "✗ Error"
+          : "📋";
+
+  const title =
+    state === "error" && errorMsg
+      ? `Error: ${errorMsg}`
+      : "Copiar audit del quote actual al clipboard";
+
+  return (
+    <button
+      type="button"
+      className="ico-btn"
+      title={title}
+      onClick={handleClick}
+      data-testid="audit-copy-button"
+      data-state={state}
+      disabled={state === "loading"}
+      style={{ minWidth: 28 }}
+    >
+      <span style={{ fontSize: 13, lineHeight: 1, whiteSpace: "nowrap" }}>{label}</span>
+    </button>
+  );
+}

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -54,6 +54,9 @@ export const getPdfGeneratedInfo = mocks.getPdfGeneratedInfo;
 export const getPdfV2DiffData = mocks.getPdfV2DiffData;
 export const triggerPdfV2Generation = mocks.triggerPdfV2Generation;
 
+/* ─── Audit trail copy · Sprint 4 audit-trail-copy ────────────────── */
+export const getAuditLog = USE_REAL_API ? real.getAuditLog : mocks.getAuditLog;
+
 /* ─── Helpers de test (reset de stores in-memory del mock) ───────── */
 export const _resetContextStore = mocks._resetContextStore;
 export const _resetPiecesStore = mocks._resetPiecesStore;

--- a/web/src/lib/api/mocks.ts
+++ b/web/src/lib/api/mocks.ts
@@ -1024,3 +1024,177 @@ export async function triggerPdfV2Generation(
   _generatedStore.set(quoteId, v2);
   return v2;
 }
+
+/* ─── getAuditLog mock · Sprint 4 audit-trail-copy ─────────────────────
+   Canon mock con datos realistas para PRES-2026-018 + fallback genérico
+   para cualquier otro ID. Patrón id-tolerance (lección #44): forma corta
+   PRES-018 también resuelve. */
+
+import type { AuditLogResponse, AuditLogEventItem } from "./types";
+
+function _mockEvents(baseIso: string): AuditLogEventItem[] {
+  const base = new Date(baseIso).getTime();
+  const at = (deltaMs: number) => new Date(base + deltaMs).toISOString();
+  return [
+    {
+      created_at: at(0),
+      event_type: "quote.created",
+      source: "router",
+      summary: "Quote created (status=draft)",
+      payload: { status: "draft" },
+      success: true,
+    },
+    {
+      created_at: at(12),
+      event_type: "chat.message_sent",
+      source: "router",
+      summary: "Operator sent chat message (423 chars, 1 plan_file)",
+      payload: { message_chars: 423, plan_files_count: 1 },
+      success: true,
+    },
+    {
+      created_at: at(234),
+      event_type: "agent.stream_started",
+      source: "agent",
+      summary: "Stream started · turn=0",
+      payload: {},
+      success: true,
+      turn_index: 0,
+    },
+    {
+      created_at: at(890),
+      event_type: "agent.tool_called",
+      source: "agent",
+      summary: "Tool read_plan called",
+      payload: { tool_name: "read_plan" },
+      success: true,
+    },
+    {
+      created_at: at(12456),
+      event_type: "agent.tool_result",
+      source: "agent",
+      summary: "Tool read_plan returned ok",
+      payload: { tool_name: "read_plan", ok: true },
+      success: true,
+      elapsed_ms: 11566,
+    },
+    {
+      created_at: at(13123),
+      event_type: "agent.tool_result",
+      source: "agent",
+      summary: "Tool catalog_lookup returned ok",
+      payload: { tool_name: "catalog_lookup", ok: true },
+      success: true,
+      elapsed_ms: 233,
+    },
+    {
+      created_at: at(24890),
+      event_type: "quote.calculated",
+      source: "agent",
+      summary: "Breakdown calculated · 5 sectors",
+      payload: { breakdown_keys: ["sectors", "mo_items", "total_ars"] },
+      success: true,
+    },
+    {
+      created_at: at(25012),
+      event_type: "docs.generated",
+      source: "agent",
+      summary: "PDF + Excel generated",
+      payload: { pdf_url: "/files/PRES-2026-018/quote.pdf" },
+      success: true,
+    },
+  ];
+}
+
+const _auditLogByQuote: Record<string, AuditLogResponse> = {};
+
+function _buildAuditMock(quoteId: string): AuditLogResponse {
+  const base = "2026-05-03T18:42:00-03:00";
+  return {
+    meta: {
+      quote_id: quoteId,
+      status: "sent",
+      client_name: "Cueto-Heredia Arquitectura",
+      project: "cocina U + isla · Belgrano",
+      material: "Silestone Blanco Norte",
+      total_ars: 660739,
+      total_usd: 1538,
+      created_at: base,
+      updated_at: "2026-05-03T19:00:00-03:00",
+    },
+    input_message:
+      "Hola Marina, te paso el plano de cocina del depto de Belgrano (familia Cueto). Es Silestone Blanco Norte 20mm como en los otros 3 trabajos del estudio.",
+    plan_files: ["cocina_cueto-heredia_2026-03-25.pdf"],
+    events: _mockEvents(base),
+    events_total: 8,
+    events_truncated: false,
+    chat_duration_ms: 24778,
+    tokens: {
+      input_tokens: 12847,
+      output_tokens: 3421,
+      cache_read_tokens: 8200,
+      cache_write_tokens: 1024,
+      cost_usd: 0.087,
+      iterations: 4,
+      models_used: ["opus", "sonnet"],
+    },
+    tools_used: [
+      { tool_name: "read_plan", count: 1, total_ms: 11566, error_count: 0 },
+      { tool_name: "catalog_lookup", count: 8, total_ms: 1840, error_count: 0 },
+      { tool_name: "generate_documents", count: 1, total_ms: 6333, error_count: 0 },
+    ],
+    quote_breakdown: {
+      sectors: [{ id: "S1", tipo: "cocina" }],
+      mo_items: [{ sku: "COLOCACION", qty: 6.5 }],
+      total_ars: 660739,
+      total_usd: 1538,
+    },
+    errors: [],
+  };
+}
+
+_auditLogByQuote["PRES-2026-018"] = _buildAuditMock("PRES-2026-018");
+_auditLogByQuote["PRES-2026-017"] = _buildAuditMock("PRES-2026-017");
+
+export async function getAuditLog(
+  quoteId: string,
+  options?: { signal?: AbortSignal; full?: boolean },
+): Promise<AuditLogResponse> {
+  await delay(120 + Math.random() * 180, options?.signal);
+  // Soporta sufijos -GENERATED / -REVISING (resuelven al baseId canon).
+  let baseId = quoteId;
+  for (const suffix of ["-GENERATED", "-REVISING", "-EXPIRED"]) {
+    if (baseId.endsWith(suffix)) baseId = baseId.slice(0, -suffix.length);
+  }
+  // Id tolerance: forma corta `PRES-018` → `PRES-2026-018`
+  if (_auditLogByQuote[baseId]) return _auditLogByQuote[baseId];
+  const shortMatch = /^PRES-(\d{3})$/.exec(baseId);
+  if (shortMatch) {
+    const candidate = `PRES-2026-${shortMatch[1]}`;
+    if (_auditLogByQuote[candidate]) return _auditLogByQuote[candidate];
+  }
+  // Fallback gracioso: quote desconocido devuelve mock vacío con quote_id
+  return {
+    meta: {
+      quote_id: quoteId,
+      status: "draft",
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    },
+    plan_files: [],
+    events: [],
+    events_total: 0,
+    events_truncated: false,
+    tokens: {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+      cost_usd: 0,
+      iterations: 0,
+      models_used: [],
+    },
+    tools_used: [],
+    errors: [],
+  };
+}

--- a/web/src/lib/api/real.ts
+++ b/web/src/lib/api/real.ts
@@ -468,3 +468,36 @@ export async function createDraftQuote(
     createdAt: new Date().toISOString(),
   };
 }
+
+/* ─── getAuditLog · Sprint 4 audit-trail-copy ─────────────────────────
+   GET /api/quotes/{id}/audit-log → AuditLogResponse.
+
+   Bearer SSR via apiFetch · timeout largo (60s) porque puede agregar
+   miles de eventos. `full=true` quita la truncation (default 200 events).
+*/
+
+import type { AuditLogResponse } from "./types";
+
+export async function getAuditLog(
+  quoteId: string,
+  options?: { signal?: AbortSignal; bearerToken?: string | null; full?: boolean },
+): Promise<AuditLogResponse> {
+  const { signal, bearerToken, full } = options ?? {};
+  const qs = full ? "?full=true" : "";
+  const response = await apiFetch(
+    `/api/quotes/${encodeURIComponent(quoteId)}/audit-log${qs}`,
+    { signal, bearerToken },
+    60_000,
+  );
+  if (response.status === 404) {
+    throw new ApiError("AUDIT_LOG_NOT_FOUND", `Quote ${quoteId} no encontrado`, 404);
+  }
+  if (!response.ok) {
+    throw new ApiError(
+      "AUDIT_LOG_FAILED",
+      `GET /api/quotes/{id}/audit-log falló (${response.status})`,
+      response.status,
+    );
+  }
+  return (await response.json()) as AuditLogResponse;
+}

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -509,3 +509,61 @@ export interface PdfV2RevisionData {
   diffCount: number;
   unchangedCount: number;
 }
+
+/* ─── Sprint 4 audit-trail-copy · GET /api/quotes/{id}/audit-log ─────── */
+
+export interface AuditLogEventItem {
+  created_at: string;
+  event_type: string;
+  source: string;
+  summary: string;
+  payload: Record<string, unknown>;
+  success: boolean;
+  error_message?: string | null;
+  elapsed_ms?: number | null;
+  turn_index?: number | null;
+  request_id?: string | null;
+}
+
+export interface AuditLogTokensSummary {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  cost_usd: number;
+  iterations: number;
+  models_used: string[];
+}
+
+export interface AuditLogToolUsage {
+  tool_name: string;
+  count: number;
+  total_ms: number;
+  error_count: number;
+}
+
+export interface AuditLogMeta {
+  quote_id: string;
+  status: string;
+  client_name?: string | null;
+  project?: string | null;
+  material?: string | null;
+  total_ars?: number | null;
+  total_usd?: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AuditLogResponse {
+  meta: AuditLogMeta;
+  input_message?: string | null;
+  plan_files: string[];
+  events: AuditLogEventItem[];
+  events_total: number;
+  events_truncated: boolean;
+  chat_duration_ms?: number | null;
+  tokens: AuditLogTokensSummary;
+  tools_used: AuditLogToolUsage[];
+  quote_breakdown?: Record<string, unknown> | null;
+  errors: AuditLogEventItem[];
+}

--- a/web/src/lib/utils/format-audit-copy.ts
+++ b/web/src/lib/utils/format-audit-copy.ts
@@ -1,0 +1,182 @@
+/**
+ * Sprint 4 audit-trail-copy · pure function que convierte `AuditLogResponse`
+ * del backend en un plain text estructurado para clipboard.
+ *
+ * Formato LITERAL definido en el bundle FASE 1 (sección 1.11). Diseñado
+ * para que Javi/Master lo peguen en Claude Code y analicen input, eventos,
+ * latencias, errores y output sin parsing extra.
+ *
+ * Convenciones:
+ * - Timestamps relativos al `quote.created_at` (segundos con 3 decimales)
+ * - Tokens con thousands separator (toLocaleString)
+ * - Tools agregados por nombre con (N×, total_ms)
+ * - Errores se reportan separados al final (siempre completos, sin trunc)
+ * - JSON breakdown serializado con indent 2 (legible pero copy-pasteable)
+ */
+import type { AuditLogResponse } from "@/lib/api/types";
+
+/** Helper: epoch (ms) de un ISO string. */
+function epoch(iso: string): number {
+  return new Date(iso).getTime();
+}
+
+/** Helper: format relativo "+N.NNNs" o "+N.NNNm:N.NNNs" para deltas largos. */
+function fmtDelta(deltaMs: number): string {
+  const seconds = deltaMs / 1000;
+  return `+${seconds.toFixed(3)}s`;
+}
+
+/** Helper: format thousands separator con punto (locale ar). */
+function fmtNum(n: number): string {
+  return n.toLocaleString("es-AR");
+}
+
+/** Helper: format ms a "Ns" cuando >1000ms, "Nms" cuando menos. */
+function fmtMs(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+  return `${ms}ms`;
+}
+
+export interface FormatAuditCopyOptions {
+  /** Si true incluye el `quote_breakdown` JSON completo · default true.
+   * Útil bajar a false en runs con breakdown muy grande. */
+  includeBreakdown?: boolean;
+  /** Si true incluye solo el header + events timeline (sin tokens/tools/breakdown).
+   * Modo "timeline only" del botón "Copiar solo timeline" en la página /audit. */
+  timelineOnly?: boolean;
+}
+
+export function formatAuditCopy(
+  audit: AuditLogResponse,
+  options: FormatAuditCopyOptions = {},
+): string {
+  const { includeBreakdown = true, timelineOnly = false } = options;
+  const lines: string[] = [];
+  const createdEpoch = epoch(audit.meta.created_at);
+
+  // ─── Header ────────────────────────────────────────────────────────
+  lines.push(`QUOTE AUDIT · ${audit.meta.quote_id}`);
+  lines.push(
+    `created: ${audit.meta.created_at} · status: ${audit.meta.status}` +
+      (audit.meta.client_name ? ` · client: ${audit.meta.client_name}` : ""),
+  );
+  if (audit.meta.project) lines.push(`project: ${audit.meta.project}`);
+  if (audit.meta.material) {
+    const totalsParts: string[] = [];
+    if (audit.meta.total_ars != null) totalsParts.push(`$${fmtNum(audit.meta.total_ars)} ARS`);
+    if (audit.meta.total_usd != null) totalsParts.push(`USD ${fmtNum(audit.meta.total_usd)}`);
+    const totals = totalsParts.length ? ` · total: ${totalsParts.join(" + ")}` : "";
+    lines.push(`material: ${audit.meta.material}${totals}`);
+  }
+  lines.push("");
+
+  // ─── INPUT ─────────────────────────────────────────────────────────
+  lines.push("INPUT");
+  if (audit.input_message) {
+    // Truncamos a 500 chars para legibilidad · el JSON completo va en
+    // QUOTE_BREAKDOWN cuando aplica.
+    const trimmed = audit.input_message.length > 500
+      ? `${audit.input_message.slice(0, 500)}...`
+      : audit.input_message;
+    lines.push(`brief_text: "${trimmed.replace(/\n/g, " ")}"`);
+  } else {
+    lines.push("brief_text: (none)");
+  }
+  lines.push(
+    `plan_files: [${audit.plan_files.map((f) => `"${f}"`).join(", ") || ""}]`,
+  );
+  lines.push("");
+
+  // ─── EVENTS timeline ──────────────────────────────────────────────
+  lines.push(
+    `EVENTS (timeline · ${audit.events_total} total${audit.events_truncated ? ` · trunc to ${audit.events.length}` : ""})`,
+  );
+  for (const ev of audit.events) {
+    const delta = epoch(ev.created_at) - createdEpoch;
+    const okMark = ev.success ? "" : " ✗";
+    const elapsed = ev.elapsed_ms != null ? ` · elapsed=${fmtMs(ev.elapsed_ms)}` : "";
+    const error = ev.error_message ? ` · error="${ev.error_message}"` : "";
+    const summary = ev.summary ? ` · ${ev.summary}` : "";
+    lines.push(`[${fmtDelta(delta)}] ${ev.event_type}${okMark}${elapsed}${summary}${error}`);
+  }
+  if (audit.events_truncated) {
+    lines.push(`... +${audit.events_total - audit.events.length} más (usar ?full=true)`);
+  }
+  lines.push("");
+
+  if (timelineOnly) {
+    return lines.join("\n");
+  }
+
+  // ─── CALLS aggregated ────────────────────────────────────────────
+  lines.push("CALLS");
+  if (audit.chat_duration_ms != null) {
+    lines.push(`POST /api/quotes/{id}/chat · ${fmtMs(audit.chat_duration_ms)}`);
+  }
+  if (audit.tools_used.length > 0) {
+    lines.push("  ↳ tools used:");
+    for (const t of audit.tools_used) {
+      const err = t.error_count > 0 ? ` · errors=${t.error_count}` : "";
+      lines.push(`     · ${t.tool_name} (${t.count}×, ${fmtMs(t.total_ms)})${err}`);
+    }
+  }
+  const tk = audit.tokens;
+  if (tk.input_tokens > 0 || tk.output_tokens > 0) {
+    const cache =
+      tk.cache_read_tokens > 0 ? ` · cache_read=${fmtNum(tk.cache_read_tokens)}` : "";
+    lines.push(
+      `  ↳ tokens: ${fmtNum(tk.input_tokens)} in / ${fmtNum(tk.output_tokens)} out${cache} · cost_usd=$${tk.cost_usd.toFixed(4)} · iterations=${tk.iterations}`,
+    );
+    if (tk.models_used.length > 0) {
+      lines.push(`  ↳ models: ${tk.models_used.join(", ")}`);
+    }
+  }
+  lines.push("");
+
+  // ─── QUOTE_BREAKDOWN snapshot ─────────────────────────────────────
+  if (includeBreakdown && audit.quote_breakdown) {
+    lines.push("QUOTE_BREAKDOWN (snapshot)");
+    try {
+      lines.push(JSON.stringify(audit.quote_breakdown, null, 2));
+    } catch {
+      lines.push("(serialization failed)");
+    }
+    lines.push("");
+  }
+
+  // ─── ERRORS (siempre completos · sin trunc) ───────────────────────
+  lines.push(`ERRORS (${audit.errors.length})`);
+  if (audit.errors.length === 0) {
+    lines.push("none");
+  } else {
+    for (const err of audit.errors) {
+      const delta = epoch(err.created_at) - createdEpoch;
+      lines.push(
+        `[${fmtDelta(delta)}] ${err.event_type} · ${err.summary}${err.error_message ? ` · error="${err.error_message}"` : ""}`,
+      );
+    }
+  }
+  lines.push("");
+
+  // ─── Footer ──────────────────────────────────────────────────────
+  const totalDuration =
+    audit.events.length > 0
+      ? epoch(audit.events[audit.events.length - 1].created_at) - createdEpoch
+      : 0;
+  lines.push("---");
+  lines.push(
+    `End audit · ${audit.events_total} events · ${audit.tools_used.length} tool types · ${audit.errors.length} errors · total ${fmtDelta(totalDuration)}`,
+  );
+
+  return lines.join("\n");
+}
+
+/** Latencia → severidad para coloring CSS en la página /audit. Bundle 1.11. */
+export type LatencySeverity = "ok" | "watch" | "slow" | "alert";
+
+export function latencySeverity(ms: number): LatencySeverity {
+  if (ms < 5_000) return "ok";
+  if (ms < 15_000) return "watch";
+  if (ms < 30_000) return "slow";
+  return "alert";
+}

--- a/web/tests/e2e/audit-trail.spec.ts
+++ b/web/tests/e2e/audit-trail.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * E2E Sprint 4 audit-trail-copy.
+ *
+ * Cubre el botón CTA del topbar (persistente en TODOS los pasos del quote)
+ * y la página /quotes/{id}/audit (vista pretty con copy buttons).
+ *
+ * Clipboard: Playwright permite leer `navigator.clipboard` desde el page
+ * context · usamos `page.context().grantPermissions(["clipboard-read"])`
+ * para que el assert funcione.
+ */
+import { expect, test, type Page } from "@playwright/test";
+
+const QUOTE_ID = "PRES-2026-018";
+
+async function grantClipboard(page: Page) {
+  await page
+    .context()
+    .grantPermissions(["clipboard-read", "clipboard-write"], { origin: "http://localhost:3000" });
+}
+
+async function readClipboard(page: Page): Promise<string> {
+  return page.evaluate(() => navigator.clipboard.readText());
+}
+
+test.describe("CTA Copiar audit · topbar persistente", () => {
+  for (const step of ["contexto", "despiece", "calculo", "pdf"]) {
+    test(`CTA visible en paso ${step}`, async ({ page }) => {
+      await page.goto(`/quotes/${QUOTE_ID}/${step}`);
+      await expect(page.locator('[data-testid="audit-copy-button"]')).toBeVisible({
+        timeout: 10_000,
+      });
+    });
+  }
+
+  test("Click CTA copia plain text estructurado al clipboard", async ({ page }) => {
+    await grantClipboard(page);
+    await page.goto(`/quotes/${QUOTE_ID}/contexto`);
+    await page.locator('[data-testid="audit-copy-button"]').click();
+    // Badge "✓ Copiado" visible
+    await expect(page.locator('[data-testid="audit-copy-button"]')).toHaveAttribute(
+      "data-state",
+      "copied",
+      { timeout: 5_000 },
+    );
+    const text = await readClipboard(page);
+    expect(text).toContain(`QUOTE AUDIT · ${QUOTE_ID}`);
+    expect(text).toContain("EVENTS (timeline");
+    expect(text).toContain("CALLS");
+    expect(text).toContain("End audit");
+  });
+
+  test("Badge vuelve a idle tras 2s", async ({ page }) => {
+    await grantClipboard(page);
+    await page.goto(`/quotes/${QUOTE_ID}/contexto`);
+    await page.locator('[data-testid="audit-copy-button"]').click();
+    await expect(page.locator('[data-testid="audit-copy-button"]')).toHaveAttribute(
+      "data-state",
+      "copied",
+    );
+    await expect(page.locator('[data-testid="audit-copy-button"]')).toHaveAttribute(
+      "data-state",
+      "idle",
+      { timeout: 4_000 },
+    );
+  });
+});
+
+test.describe("Página /quotes/{id}/audit", () => {
+  test("Renderea header + summary + timeline + tools + breakdown", async ({ page }) => {
+    await page.goto(`/quotes/${QUOTE_ID}/audit`);
+    await expect(page.locator('[data-testid="audit-view"]')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator(".section-head h2")).toContainText(QUOTE_ID);
+    // Summary chips
+    await expect(page.locator('[data-testid="audit-summary"]')).toBeVisible();
+    await expect(page.locator('[data-testid="summary-chat-duration"]')).toBeVisible();
+    // Timeline
+    const timeline = page.locator('[data-testid="audit-timeline"]');
+    await expect(timeline).toBeVisible();
+    await expect(timeline.locator("li").first()).toBeVisible();
+    // Tools table
+    await expect(page.locator('[data-testid="audit-tools-table"]')).toBeVisible();
+    // Breakdown collapsable
+    await expect(page.locator('[data-testid="audit-breakdown-details"]')).toBeVisible();
+  });
+
+  test("Latencia coloreada via data-severity", async ({ page }) => {
+    await page.goto(`/quotes/${QUOTE_ID}/audit`);
+    // read_plan en mock = 11566ms → watch (5-15s)
+    const readPlanRow = page.locator('[data-testid="audit-tool-read_plan"]');
+    await expect(readPlanRow).toHaveAttribute("data-severity", "watch");
+    // chat duration = 24778ms → slow (15-30s)
+    await expect(page.locator('[data-testid="summary-chat-duration"]')).toHaveAttribute(
+      "data-severity",
+      "slow",
+    );
+  });
+
+  test("Botón 'Copiar todo' funcional + badge", async ({ page }) => {
+    await grantClipboard(page);
+    await page.goto(`/quotes/${QUOTE_ID}/audit`);
+    await page.locator('[data-testid="audit-copy-all"]').click();
+    await expect(page.locator('[data-testid="audit-copy-all"]')).toContainText("Copiado");
+    const text = await readClipboard(page);
+    expect(text).toContain(`QUOTE AUDIT · ${QUOTE_ID}`);
+    expect(text).toContain("QUOTE_BREAKDOWN");
+  });
+
+  test("Botón 'Copiar timeline' omite CALLS y BREAKDOWN", async ({ page }) => {
+    await grantClipboard(page);
+    await page.goto(`/quotes/${QUOTE_ID}/audit`);
+    await page.locator('[data-testid="audit-copy-timeline"]').click();
+    await expect(page.locator('[data-testid="audit-copy-timeline"]')).toContainText("Copiado");
+    const text = await readClipboard(page);
+    expect(text).toContain("EVENTS");
+    expect(text).not.toContain("CALLS");
+    expect(text).not.toContain("QUOTE_BREAKDOWN");
+  });
+
+  test("Botón 'Copiar JSON' copia solo el breakdown", async ({ page }) => {
+    await grantClipboard(page);
+    await page.goto(`/quotes/${QUOTE_ID}/audit`);
+    await page.locator('[data-testid="audit-copy-json"]').click();
+    const text = await readClipboard(page);
+    // Es JSON parseable
+    expect(() => JSON.parse(text)).not.toThrow();
+    const parsed = JSON.parse(text);
+    expect(parsed).toHaveProperty("total_ars");
+  });
+
+  test("Quote ID no canon renderea fallback gracioso (mock vacío)", async ({ page }) => {
+    await page.goto(`/quotes/UNKNOWN-XYZ/audit`);
+    await expect(page.locator('[data-testid="audit-view"]')).toBeVisible({ timeout: 10_000 });
+    // events_total=0 → summary visible aún · timeline existe en DOM pero
+    // puede no tener altura visible sin items · solo confirmamos no-crash
+    // y la summary banda con "Eventos: 0".
+    await expect(page.locator('[data-testid="audit-summary"]')).toBeVisible();
+    await expect(page.locator('[data-testid="audit-summary"]')).toContainText("Eventos");
+  });
+});
+
+test.describe("Regresión chrome shell", () => {
+  test("AuditToggle sigue visible junto al AuditCopyButton", async ({ page }) => {
+    await page.goto(`/quotes/${QUOTE_ID}/contexto`);
+    await expect(page.locator('[data-testid="audit-copy-button"]')).toBeVisible();
+    // AuditToggle se renderea via `.audit-toggle` o similar · al menos confirmar el botón labelled
+    await expect(page.locator(".topbar .right")).toBeVisible();
+    // status chip persiste
+    await expect(page.locator(".status-chip")).toBeVisible();
+  });
+});

--- a/web/tests/unit/format-audit-copy.test.ts
+++ b/web/tests/unit/format-audit-copy.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Unit tests · Sprint 4 audit-trail-copy · format function.
+ *
+ * Cubre el formato LITERAL definido en el bundle FASE 1 (sección 1.11)
+ * para que el plain text del clipboard sea parseable por Master/Claude
+ * Code y útil para debug rápido.
+ */
+import { describe, expect, test } from "vitest";
+import { formatAuditCopy, latencySeverity } from "@/lib/utils/format-audit-copy";
+import type { AuditLogResponse } from "@/lib/api/types";
+
+const BASE_TS = "2026-05-03T18:42:00.000Z";
+
+function buildAudit(overrides: Partial<AuditLogResponse> = {}): AuditLogResponse {
+  return {
+    meta: {
+      quote_id: "PRES-2026-018",
+      status: "sent",
+      client_name: "Cueto-Heredia",
+      project: "cocina U + isla",
+      material: "Silestone Blanco Norte",
+      total_ars: 660739,
+      total_usd: 1538,
+      created_at: BASE_TS,
+      updated_at: "2026-05-03T19:00:00.000Z",
+    },
+    input_message: "Hola Marina, te paso el plano...",
+    plan_files: ["plano.pdf"],
+    events: [],
+    events_total: 0,
+    events_truncated: false,
+    chat_duration_ms: null,
+    tokens: {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+      cost_usd: 0,
+      iterations: 0,
+      models_used: [],
+    },
+    tools_used: [],
+    errors: [],
+    ...overrides,
+  };
+}
+
+describe("formatAuditCopy · header + INPUT", () => {
+  test("header literal con quote_id + status + client + material + totales", () => {
+    const out = formatAuditCopy(buildAudit());
+    expect(out).toContain("QUOTE AUDIT · PRES-2026-018");
+    expect(out).toContain("status: sent");
+    expect(out).toContain("client: Cueto-Heredia");
+    expect(out).toContain("project: cocina U + isla");
+    expect(out).toContain("material: Silestone Blanco Norte");
+    expect(out).toMatch(/total: \$\d+\.?\d* ARS \+ USD \d+\.?\d*/);
+  });
+
+  test("INPUT con brief_text y plan_files", () => {
+    const out = formatAuditCopy(buildAudit());
+    expect(out).toContain("INPUT");
+    expect(out).toContain('brief_text: "Hola Marina, te paso el plano..."');
+    expect(out).toContain('plan_files: ["plano.pdf"]');
+  });
+
+  test("INPUT degrada gracioso cuando no hay brief_text", () => {
+    const out = formatAuditCopy(buildAudit({ input_message: null, plan_files: [] }));
+    expect(out).toContain("brief_text: (none)");
+    expect(out).toContain("plan_files: []");
+  });
+});
+
+describe("formatAuditCopy · timeline", () => {
+  test("eventos con delta relativo y elapsed", () => {
+    const audit = buildAudit({
+      events: [
+        {
+          created_at: BASE_TS,
+          event_type: "quote.created",
+          source: "router",
+          summary: "Quote created",
+          payload: {},
+          success: true,
+        },
+        {
+          created_at: "2026-05-03T18:42:12.456Z",
+          event_type: "agent.tool_result",
+          source: "agent",
+          summary: "read_plan ok",
+          payload: { tool_name: "read_plan" },
+          success: true,
+          elapsed_ms: 11566,
+        },
+      ],
+      events_total: 2,
+    });
+    const out = formatAuditCopy(audit);
+    expect(out).toContain("EVENTS (timeline · 2 total)");
+    expect(out).toContain("[+0.000s] quote.created");
+    expect(out).toContain("[+12.456s] agent.tool_result");
+    expect(out).toContain("elapsed=11.57s");
+  });
+
+  test("evento con error muestra ✗ y error_message", () => {
+    const out = formatAuditCopy(
+      buildAudit({
+        events: [
+          {
+            created_at: BASE_TS,
+            event_type: "agent.tool_result",
+            source: "agent",
+            summary: "read_plan failed",
+            payload: {},
+            success: false,
+            error_message: "OCR fallido",
+          },
+        ],
+        events_total: 1,
+      }),
+    );
+    expect(out).toContain("agent.tool_result ✗");
+    expect(out).toContain('error="OCR fallido"');
+  });
+
+  test("truncation muestra '... +N más'", () => {
+    const out = formatAuditCopy(
+      buildAudit({
+        events: [
+          {
+            created_at: BASE_TS,
+            event_type: "quote.created",
+            source: "router",
+            summary: "",
+            payload: {},
+            success: true,
+          },
+        ],
+        events_total: 250,
+        events_truncated: true,
+      }),
+    );
+    expect(out).toContain("EVENTS (timeline · 250 total · trunc to 1)");
+    expect(out).toContain("... +249 más (usar ?full=true)");
+  });
+});
+
+describe("formatAuditCopy · CALLS + tokens", () => {
+  test("CALLS con chat_duration + tools + tokens + models", () => {
+    const out = formatAuditCopy(
+      buildAudit({
+        chat_duration_ms: 25012,
+        tools_used: [
+          { tool_name: "read_plan", count: 1, total_ms: 11566, error_count: 0 },
+          { tool_name: "catalog_lookup", count: 8, total_ms: 1840, error_count: 1 },
+        ],
+        tokens: {
+          input_tokens: 12847,
+          output_tokens: 3421,
+          cache_read_tokens: 8200,
+          cache_write_tokens: 0,
+          cost_usd: 0.087,
+          iterations: 4,
+          models_used: ["opus", "sonnet"],
+        },
+      }),
+    );
+    expect(out).toContain("CALLS");
+    expect(out).toContain("POST /api/quotes/{id}/chat · 25.01s");
+    expect(out).toContain("· read_plan (1×, 11.57s)");
+    expect(out).toContain("· catalog_lookup (8×, 1.84s) · errors=1");
+    expect(out).toContain("12.847 in / 3.421 out");
+    expect(out).toContain("cache_read=8.200");
+    expect(out).toContain("cost_usd=$0.0870");
+    expect(out).toContain("models: opus, sonnet");
+  });
+});
+
+describe("formatAuditCopy · QUOTE_BREAKDOWN + ERRORS + footer", () => {
+  test("incluye breakdown JSON por default", () => {
+    const out = formatAuditCopy(
+      buildAudit({ quote_breakdown: { sectors: [{ id: "S1" }], total_ars: 1000 } }),
+    );
+    expect(out).toContain("QUOTE_BREAKDOWN (snapshot)");
+    expect(out).toContain('"total_ars": 1000');
+  });
+
+  test("includeBreakdown=false omite la sección", () => {
+    const out = formatAuditCopy(buildAudit({ quote_breakdown: { x: 1 } }), {
+      includeBreakdown: false,
+    });
+    expect(out).not.toContain("QUOTE_BREAKDOWN");
+  });
+
+  test("timelineOnly omite CALLS + BREAKDOWN + ERRORS + footer", () => {
+    const out = formatAuditCopy(
+      buildAudit({
+        events: [
+          {
+            created_at: BASE_TS,
+            event_type: "quote.created",
+            source: "router",
+            summary: "",
+            payload: {},
+            success: true,
+          },
+        ],
+        events_total: 1,
+        chat_duration_ms: 1000,
+        quote_breakdown: { x: 1 },
+      }),
+      { timelineOnly: true },
+    );
+    expect(out).toContain("EVENTS");
+    expect(out).not.toContain("CALLS");
+    expect(out).not.toContain("QUOTE_BREAKDOWN");
+    expect(out).not.toContain("End audit");
+  });
+
+  test("ERRORS none cuando errors.length=0", () => {
+    const out = formatAuditCopy(buildAudit());
+    expect(out).toContain("ERRORS (0)");
+    expect(out).toContain("none");
+  });
+
+  test("ERRORS lista con error_message", () => {
+    const out = formatAuditCopy(
+      buildAudit({
+        errors: [
+          {
+            created_at: "2026-05-03T18:42:10.000Z",
+            event_type: "agent.tool_result",
+            source: "agent",
+            summary: "read_plan failed",
+            payload: {},
+            success: false,
+            error_message: "OCR fallido",
+          },
+        ],
+      }),
+    );
+    expect(out).toContain("ERRORS (1)");
+    expect(out).toContain("[+10.000s] agent.tool_result · read_plan failed");
+    expect(out).toContain('error="OCR fallido"');
+  });
+
+  test("footer con counts + total duration", () => {
+    const out = formatAuditCopy(
+      buildAudit({
+        events: [
+          {
+            created_at: BASE_TS,
+            event_type: "quote.created",
+            source: "router",
+            summary: "",
+            payload: {},
+            success: true,
+          },
+          {
+            created_at: "2026-05-03T18:42:25.000Z",
+            event_type: "docs.generated",
+            source: "agent",
+            summary: "",
+            payload: {},
+            success: true,
+          },
+        ],
+        events_total: 2,
+        tools_used: [{ tool_name: "x", count: 1, total_ms: 100, error_count: 0 }],
+      }),
+    );
+    expect(out).toContain("End audit · 2 events · 1 tool types · 0 errors · total +25.000s");
+  });
+});
+
+describe("latencySeverity thresholds", () => {
+  test("< 5s → ok", () => {
+    expect(latencySeverity(4999)).toBe("ok");
+  });
+  test("5-15s → watch", () => {
+    expect(latencySeverity(5000)).toBe("watch");
+    expect(latencySeverity(14999)).toBe("watch");
+  });
+  test("15-30s → slow", () => {
+    expect(latencySeverity(15000)).toBe("slow");
+    expect(latencySeverity(29999)).toBe("slow");
+  });
+  test(">=30s → alert", () => {
+    expect(latencySeverity(30000)).toBe("alert");
+    expect(latencySeverity(60000)).toBe("alert");
+  });
+});


### PR DESCRIPTION
Feature CRITICAL para debug + iteración rápida + reportes Marina. Botón "📋 Copiar audit" persistente en el topbar + página `/quotes/{id}/audit` pretty con 3 botones copy. Plain text estructurado parseable por Master/Claude Code.

## ⚠️ Características especiales (criterios audit nuevos)

### 1. Chrome shell touch · PRIMER sub-PR Sprint 4
**+3 LOC en `Topbar.tsx`** insertando `<AuditCopyButton quoteId={quote.id} />` en `.right`. Justificación: CTA persistente debe estar en TODOS los pasos. Sidebars NO es opción (redundancia + scope creep, decisión Javi).

### 2. Backend touch · PRIMER sub-PR Sprint 4
**1 endpoint nuevo read-only** en `agent/router.py` (+140 LOC) + **1 schema** en `agent/schemas.py` (+80 LOC). **Cero migración. Cero modelos nuevos.** Solo agrega tablas existentes (`audit_events` + `token_usage` + `Quote.quote_breakdown`).

### 3. Mockup Fidelity Gate · EXCEPCIÓN JUSTIFICADA
Feature v1.0 nueva no anticipada en handoff Sprint 1.5. Decisión Javi explícita durante el sub-PR. Sin mockup oficial.

## Endpoint

**`GET /api/quotes/{id}/audit-log`**

Query params: `?full=true` (opt-in para devolver TODOS los eventos sin truncar) · `?limit=N` (default 200).

Response (`AuditLogResponse`):
- `meta`: quote_id + status + client + project + material + total_ars/usd
- `input_message` + `plan_files[]`
- `events[]` con `event_type`, `summary`, `payload`, `success`, `elapsed_ms` (truncado a 200 default)
- `events_total` + `events_truncated`
- `chat_duration_ms` derivado de timestamps (`agent.stream_started` → último `tool_result`/`quote.calculated`/`docs.generated`)
- `tokens` (suma TokenUsage): input/output/cache/cost_usd/iterations/models_used
- `tools_used[]` agregado por tool_name: count + total_ms + error_count
- `quote_breakdown` JSON snapshot
- `errors[]` SIEMPRE completo (sin trunc)

Auth: middleware JWT existente. Sin código nuevo.

## Formato copy (ejemplo)

```
QUOTE AUDIT · PRES-2026-018
created: 2026-05-03T18:42:00-03:00 · status: sent · client: Cueto-Heredia Arquitectura
project: cocina U + isla · Belgrano
material: Silestone Blanco Norte · total: $660.739 ARS + USD 1.538

INPUT
brief_text: "Hola Marina, te paso el plano de cocina del depto de Belgrano..."
plan_files: ["cocina_cueto-heredia_2026-03-25.pdf"]

EVENTS (timeline · 8 total)
[+0.000s] quote.created · Quote created (status=draft)
[+0.012s] chat.message_sent · 423 chars · 1 plan_file
[+0.234s] agent.stream_started · turn=0
[+0.890s] agent.tool_called · Tool read_plan called
[+12.456s] agent.tool_result · elapsed=11.57s · Tool read_plan returned ok
[+13.123s] agent.tool_result · elapsed=233ms · Tool catalog_lookup returned ok
[+24.890s] quote.calculated · breakdown_keys=[sectors,mo_items,total_ars]
[+25.012s] docs.generated · pdf_url=/files/...

CALLS
POST /api/quotes/{id}/chat · 24.78s
  ↳ tools used:
     · read_plan (1×, 11.57s)
     · catalog_lookup (8×, 1.84s)
     · generate_documents (1×, 6.33s)
  ↳ tokens: 12.847 in / 3.421 out · cache_read=8.200 · cost_usd=$0.0870 · iterations=4
  ↳ models: opus, sonnet

QUOTE_BREAKDOWN (snapshot)
{ "sectors": [...], "mo_items": [...], "total_ars": 660739, ... }

ERRORS (0)
none

---
End audit · 8 events · 3 tool types · 0 errors · total +25.012s
```

## Latencia coloring (thresholds 5/15/30s)

🟢 `<5s` ok · 🟡 `5-15s` watch · 🟠 `15-30s` slow · 🔴 `>30s` alert. Aplica a tool calls + chat duration en la página /audit.

## Página `/quotes/{id}/audit`

Server Component que hereda chrome (topbar+sidebar+stepper+qhead). Renderiza:
- Header con meta + 3 botones copy (todo / timeline / JSON)
- Summary chips con data-severity coloring
- INPUT collapsible con brief_text + plan_files
- Tabla "Tools usados" con coloring por latencia
- Timeline vertical con eventos + delta relativo + elapsed colored
- Banner errors si hay
- JSON breakdown colapsable

## Cambios técnicos

| Archivo | Cambio |
|---|---|
| `api/app/modules/agent/schemas.py` | +5 Pydantic models AuditLog* |
| `api/app/modules/agent/router.py` | +1 endpoint GET audit-log (~140 LOC) |
| `api/tests/test_audit_log_endpoint.py` | +5 pytest (404/happy/errors/trunc/empty) |
| `web/src/lib/api/types.ts` | +5 TypeScript interfaces |
| `web/src/lib/api/real.ts` | +1 `getAuditLog` con Bearer SSR + 404 mapping |
| `web/src/lib/api/mocks.ts` | +1 `getAuditLog` mock con canon + id-tolerance |
| `web/src/lib/api/index.ts` | +1 gate `USE_REAL_API` |
| `web/src/lib/utils/format-audit-copy.ts` | nuevo · pure function plain text + `latencySeverity` |
| `web/src/components/observability/AuditCopyButton.tsx` | nuevo · CTA topbar con clipboard pattern PdfSidebarGenerated |
| `web/src/components/chrome/Topbar.tsx` | +3 LOC integración |
| `web/src/app/quotes/[id]/audit/page.tsx` | nuevo · Server Component |
| `web/src/components/audit/AuditView.tsx` | nuevo · vista pretty con 3 copy buttons |

## Tests

| Suite | Antes | Ahora | Delta |
|---|---:|---:|---:|
| pytest backend | (5 nuevos verde) | — | +5 |
| Vitest unit | 54 | 71 | +17 (format function) |
| Playwright E2E | 174 | 187 | +13 |
| Failed | 0 | 0 | 0 |
| Skipped | 10 | 10 | 0 |

⚠️ Pre-existing 41 pytest fails en main están NO relacionados a este PR (verificado con `git stash` + run en main · idénticos fails). Los 5 nuevos tests de este PR son verdes.

- ✅ `npm run typecheck` + `lint` + `build` clean
- ✅ Full E2E suite: **187 passed + 10 skipped + 0 fail**
- ✅ Backend `pytest tests/test_audit_log_endpoint.py -v` 5/5 verde

## Lecciones operativas aplicadas

- **#1 FASE 1 LITERAL** · investigación exhaustiva atrapó que el backend YA tiene `elapsed_ms` per tool persistido (cero instrumentación nueva)
- **#44 id-tolerance** · forma corta `PRES-018` → `PRES-2026-018` en mocks

## Deuda explícita

### `audit-http-timing` (opcional)
HTTP per-request duration NO está instrumentada hoy · derivamos chat duration de event timestamps (suficiente para el caso de uso). Si emerge necesidad post-deploy, sub-PR posterior agrega middleware FastAPI (~5 LOC).

### `audit-model-per-turn`
Model id NO está en `audit_events` per-turn (solo en `TokenUsage.model`). Si Javi necesita per-event granularidad de model, agregar columna `model_id` a audit_events.

## Sub-PRs desbloqueados post-merge

- `paso-5-pdf-real-wire` (MVP copilot wireado 100% · timing real disponible en audit)
- `paso-2-toggles-y-chips-ia` (siguiente prioridad ALTA del audit fidelity)

## Test plan

- [x] Backend pytest 5/5 verde
- [x] Lint + typecheck + unit (71/71) + build verdes
- [x] E2E full suite 187 passed + 10 skipped + 0 fail
- [x] Endpoint shape correcto (Pydantic validation)
- [x] Format copy parseable (17 unit tests)
- [x] CTA topbar visible en 4 pasos
- [x] Clipboard funciona (Playwright `clipboard-read` permission)
- [x] Latencia coloreada en /audit
- [ ] Validación Javi visual local · prod Vercel post-merge
- [ ] Verificación timing real con quote "Mesada 2x0.60 purastone..." (decisión paso-1-sse-stream basada en data dura)

🤖 Generated with [Claude Code](https://claude.com/claude-code)