### PR TITLE
fix(audit): coerción content multimodal + CORS en 5xx

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,8 +1,10 @@
 import logging
 import asyncio
 import os
+import re
 import time
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from contextlib import asynccontextmanager
@@ -140,6 +142,52 @@ app.add_middleware(
     # cookies cross-origin) también se actualice y la sesión deslice.
     expose_headers=["X-Refreshed-Token"],
 )
+
+
+# ── CORS en respuestas 5xx (fix-up sprint-4/audit-log-content-fix · Bug 2) ──
+# Las excepciones NO-manejadas las captura el `ServerErrorMiddleware` de
+# Starlette, que está instalado SIEMPRE como el middleware más externo —
+# por fuera del `CORSMiddleware`. Eso es estructural: no se puede arreglar
+# reordenando los `add_middleware` (CORS ya es el último/outermost de los
+# user-middlewares; por eso los 401 de auth SÍ traen CORS). El 500 lo emite
+# `ServerErrorMiddleware` sin pasar por CORS → sale sin `Access-Control-
+# Allow-Origin` → el browser lo bloquea como "CORS error" y oculta el status
+# real (nos costó 3 vueltas diagnosticar el bug del audit-log por esto).
+#
+# Fix: handler global de `Exception` (lo invoca el propio ServerErrorMiddleware)
+# que reinyecta los headers CORS manualmente, replicando el matching de
+# `CORSMiddleware` (allow_origins exacto + allow_origin_regex). Así un 500
+# futuro se lee como 500 legítimo en el frontend en vez de un CORS error opaco.
+_cors_origin_re = (
+    re.compile(settings.CORS_ORIGIN_REGEX) if settings.CORS_ORIGIN_REGEX else None
+)
+
+
+def _cors_origin_allowed(origin: str) -> bool:
+    if not origin:
+        return False
+    if origin in settings.CORS_ORIGINS:
+        return True
+    return bool(_cors_origin_re and _cors_origin_re.fullmatch(origin))
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.exception(
+        "Unhandled exception on %s %s", request.method, request.url.path
+    )
+    headers: dict[str, str] = {}
+    origin = request.headers.get("origin", "")
+    if _cors_origin_allowed(origin):
+        headers["Access-Control-Allow-Origin"] = origin
+        headers["Access-Control-Allow-Credentials"] = "true"
+        headers["Vary"] = "Origin"
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal server error"},
+        headers=headers,
+    )
+
 
 app.include_router(auth_router, prefix="/api")
 app.include_router(usage_router, prefix="/api")

--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -2513,7 +2513,20 @@ async def get_quote_audit_log(
                 None,
             )
             if first_user:
-                input_message = (first_user.get("content") or "")[:2000]  # cap defensivo
+                # `content` puede venir como string (turns simples) o como
+                # lista de bloques multimodales Anthropic
+                # `[{"type":"text","text":"..."}, {"type":"image",...}]`.
+                # `(lista)[:2000]` NO rompe — devuelve otra lista — y luego
+                # Pydantic la rechaza (input_message: Optional[str]) → 500.
+                # Coercionamos a string extrayendo solo los bloques `text`.
+                raw = first_user.get("content")
+                if isinstance(raw, list):
+                    raw = " ".join(
+                        b.get("text", "")
+                        for b in raw
+                        if isinstance(b, dict) and b.get("type") == "text"
+                    )
+                input_message = (raw or "")[:2000] if isinstance(raw, str) else None
         except Exception:
             pass
     if quote.source_files and isinstance(quote.source_files, list):

--- a/api/tests/test_audit_log_endpoint.py
+++ b/api/tests/test_audit_log_endpoint.py
@@ -257,3 +257,105 @@ class TestAuditLogEndpoint:
         assert data["chat_duration_ms"] is None
         assert data["input_message"] is None
         assert data["plan_files"] == []
+
+    # ── Fix-up sprint-4/audit-log-content-fix · Bug 1 (regresión) ──────────
+    # En prod, `Quote.messages[].content` viene como lista de bloques
+    # multimodales Anthropic, NO como string plano (los fixtures previos
+    # usaban string → no atraparon el bug). Estos tests cubren el shape real.
+
+    @pytest.mark.asyncio
+    async def test_audit_log_with_multimodal_content(self, client, db_session):
+        await _seed_quote_with_audit(
+            db_session,
+            "q-multimodal",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Mesada de 2 x 0,60 en purastone venatino",
+                        }
+                    ],
+                },
+                {"role": "assistant", "content": "Listo."},
+            ],
+        )
+        r = await client.get("/api/quotes/q-multimodal/audit-log")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["input_message"] == "Mesada de 2 x 0,60 en purastone venatino"
+
+    @pytest.mark.asyncio
+    async def test_audit_log_handles_mixed_content_blocks(self, client, db_session):
+        await _seed_quote_with_audit(
+            db_session,
+            "q-mixed-blocks",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Mesada"},
+                        {"type": "image", "source": {"type": "base64", "data": "..."}},
+                        {"type": "text", "text": "de 2x0.60"},
+                    ],
+                }
+            ],
+        )
+        r = await client.get("/api/quotes/q-mixed-blocks/audit-log")
+        assert r.status_code == 200
+        data = r.json()
+        # Solo los bloques `text`, concatenados con espacio · el bloque image se omite.
+        assert data["input_message"] == "Mesada de 2x0.60"
+
+    @pytest.mark.asyncio
+    async def test_audit_log_with_string_content(self, client, db_session):
+        # Compat retroactiva · content como string plano sigue funcionando.
+        await _seed_quote_with_audit(
+            db_session,
+            "q-string-content",
+            messages=[{"role": "user", "content": "brief en string plano"}],
+        )
+        r = await client.get("/api/quotes/q-string-content/audit-log")
+        assert r.status_code == 200
+        assert r.json()["input_message"] == "brief en string plano"
+
+
+# ── Fix-up sprint-4/audit-log-content-fix · Bug 2 (CORS en 5xx) ────────────
+class TestUnhandledExceptionCors:
+    """El handler global de Exception reinyecta headers CORS en los 500 para
+    que el browser lea el status real en vez de un 'CORS error' opaco.
+
+    Se testea el handler directamente (no vía TestClient) porque el
+    ServerErrorMiddleware de Starlette re-raise la excepción tras emitir la
+    respuesta, lo que el cliente de test propagaría — testear la función
+    aísla la lógica de reinyección de CORS sin ese ruido."""
+
+    def _make_request(self, origin: str | None):
+        from starlette.requests import Request
+
+        headers = [(b"origin", origin.encode())] if origin else []
+        return Request({"type": "http", "method": "GET", "path": "/x", "headers": headers})
+
+    @pytest.mark.asyncio
+    async def test_5xx_returns_cors_headers_for_allowed_origin(self):
+        from app.main import unhandled_exception_handler
+        from app.core.config import settings
+
+        allowed = settings.CORS_ORIGINS[0]  # garantizado en la allow-list
+        resp = await unhandled_exception_handler(
+            self._make_request(allowed), RuntimeError("boom")
+        )
+        assert resp.status_code == 500
+        assert resp.headers.get("access-control-allow-origin") == allowed
+        assert resp.headers.get("access-control-allow-credentials") == "true"
+
+    @pytest.mark.asyncio
+    async def test_5xx_no_cors_headers_for_disallowed_origin(self):
+        from app.main import unhandled_exception_handler
+
+        resp = await unhandled_exception_handler(
+            self._make_request("https://no-permitido.example"), RuntimeError("boom")
+        )
+        assert resp.status_code == 500
+        assert resp.headers.get("access-control-allow-origin") is None


### PR DESCRIPTION
Fix-up del PR #477. Bug post-deploy detectado en uso real: `GET /api/quotes/{id}/audit-log` devolvía **500 en cualquier quote real**, enmascarado como "CORS error" en el browser.

## Bug 1 · ValidationError content multimodal
- **Causa:** `router.py` extraía `input_message = (first_user.get("content") or "")[:2000]` asumiendo string. En prod `Quote.messages[].content` es **lista de bloques Anthropic** `[{"type":"text","text":"..."}]`; `lista[:2000]` devuelve otra lista (no rompe) → `AuditLogResponse(input_message=lista)` → Pydantic ValidationError → 500.
- **Fix:** coerción type-safe — si `content` es lista, concatena solo los bloques `text` (separados por espacio); si string, se usa tal cual; en otro caso `None`.
- **Test:** shape real de prod cubierto (multimodal + mixed blocks + string plano).

## Bug 2 · CORS missing en 5xx (arquitectónico)
- **Causa:** las excepciones no-manejadas las emite el `ServerErrorMiddleware` de Starlette, instalado **siempre por fuera del `CORSMiddleware`**. El 500 sale sin `Access-Control-Allow-Origin` → el browser lo bloquea como "CORS error" y **oculta el status real** (nos costó 3 vueltas diagnosticar este bug).
- **Fix (Opción B, NO reorder):** handler global de `Exception` que reinyecta los headers CORS replicando el matching de `CORSMiddleware`. **Justificación de no usar Opción A (reorder):** CORS ya es el último/outermost `add_middleware` (por eso los 401 de auth sí traen CORS); `ServerErrorMiddleware` es estructuralmente el más externo y **no se puede envolver con user-middlewares** → reordenar no resuelve nada.
- **Test:** 5xx forzado con origin permitido reinyecta CORS / origin no permitido no.
- **Beneficio:** diagnóstico claro de bugs futuros (500 legible en vez de CORS error opaco).

## Otros endpoints con el mismo shape
Verificado (FASE 1.1): el **único reader buggy era `router.py`**. Los demás lectores de `Quote.messages[].content` ya estaban a salvo — `card_editor.py` usa el helper `_content_to_text`, `agent.py:1692` guarda con `isinstance(..., list)`. **No se tocan otros endpoints** (out-of-scope).

## Lección operativa #51 confirmada
Post-merge de sub-PRs backend, **smoke test con curl al endpoint REAL antes de declarar done**. Los fixtures con `content` string no garantizaban el shape de prod (lista de bloques) → el bug pasó los 5 tests del #477.

## Sub-PR desbloqueado
- Test funcional Javi "Mesada 2x0.60 purastone…" con audit copy.
- Decisión `paso-1-sse-stream` con data dura.
- Análisis "localidad NO extraída" (issue funcional separado).

## Verificación
- `pytest tests/test_audit_log_endpoint.py` → **10/10 verde** (5 originales + 3 content + 2 CORS).
- Suite API completa → sin regresión (15 fails pre-existentes en `evaluation/` por catálogo no seedeado en sandbox, ajenos a este cambio).
- `audit-trail.spec.ts` (frontend) → **13/13 verde**.

## Criterios de audit independiente
1. Fix 1 cubre coerción lista → string ✅
2. Fix 1 NO rompe content string plano (compat retroactiva) ✅
3. Fix 2 NO rompe auth middleware (CORS sigue outermost; el handler solo agrega headers en 5xx) ✅
4. Test regresión nuevo cubre shape real prod ✅
5. NO regresión PRs #469-#477 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)