### PR TITLE
fix(audit-copy): badge "✓ Copiado" desborda sobre AuditToggle

### DIFF
--- a/web/src/components/observability/AuditCopyButton.tsx
+++ b/web/src/components/observability/AuditCopyButton.tsx
@@ -70,6 +70,22 @@ export function AuditCopyButton({ quoteId }: Props) {
       ? `Error: ${errorMsg}`
       : "Copiar audit del quote actual al clipboard";
 
+  // Fix-up overflow: `.topbar .ico-btn` del shared CSS hardcodea
+  // `width:32px; height:32px; display:grid; place-items:center`. Cuando
+  // state cambia a "copied"/"error" el label se ensancha ("✓ Copiado")
+  // y desborda el botón, montándose sobre el AuditToggle vecino. Inline
+  // override en state expanded: ancho auto + padding horizontal para que
+  // el botón crezca a contenido. En idle preservamos 32×32 del ico-btn.
+  const isExpanded = state !== "idle";
+  const expandedStyle: React.CSSProperties = isExpanded
+    ? {
+        width: "auto",
+        minWidth: 32,
+        padding: "0 10px",
+        whiteSpace: "nowrap",
+      }
+    : {};
+
   return (
     <button
       type="button"
@@ -79,7 +95,7 @@ export function AuditCopyButton({ quoteId }: Props) {
       data-testid="audit-copy-button"
       data-state={state}
       disabled={state === "loading"}
-      style={{ minWidth: 28 }}
+      style={expandedStyle}
     >
       <span style={{ fontSize: 13, lineHeight: 1, whiteSpace: "nowrap" }}>{label}</span>
     </button>


### PR DESCRIPTION
## Bug visual reportado

Screenshot Javi · al hacer click en el botón 📋 del topbar, el badge "✓ Copiado" desborda y se monta sobre el AuditToggle (AUDIT OFF) vecino.

## Causa

\`.topbar .ico-btn\` del shared CSS (líneas 207-212) hardcodea:
\`\`\`css
width: 32px; height: 32px;
display: grid; place-items: center;
\`\`\`

Mi componente del PR #477 cambia el label de \`📋\` (un emoji) a \`"✓ Copiado"\` (8 chars), pero el contenedor sigue siendo 32×32 fijo. El label se sale del bounding box pisando el siguiente sibling.

## Fix

Inline-style override cuando \`state !== "idle"\`:
- \`width: "auto"\` libera el width fijo
- \`minWidth: 32\` preserva el tamaño mínimo del idle
- \`padding: "0 10px"\` da respiro horizontal
- \`whiteSpace: "nowrap"\` evita line breaks

En state \`idle\` el botón vuelve a sus 32×32 originales (sin styles inline).

## Cero CSS shared modificado

Override puramente inline · respeta scope = 0 del Sprint 4.

## Tests

- 13/13 \`audit-trail.spec.ts\` verde sin cambios en tests
- Lint + typecheck verde
- Build verde

## Test plan

- [x] Lint + typecheck + audit E2E verde
- [ ] Validación visual Javi: idle = 32×32 / loading "…" centrado / copied "✓ Copiado" expandido sin overlap / error "✗ Error" idem

🤖 Generated with [Claude Code](https://claude.com/claude-code)