### PR TITLE
feat(audit): instrumentation de events en text-only + dual_read flows

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -274,7 +274,29 @@ async def _run_dual_read(
     """
     import json as _json
     import hashlib as _hashlib
+    import time as _t_audit_dr
     chunks: list[dict] = []
+
+    # Sprint 4 audit-text-only-instrumentation · Bug 2 fix (path: plan flow).
+    # Antes: `_run_dual_read` corría vision + brief analyzer + context analyzer
+    # + persistencia + return early SIN emitir log_event. Mismo gap que el
+    # text-only flow (líneas 2725-2856) pero esta es la rama con plano.
+    _dr_started_at = _t_audit_dr.monotonic()
+    await _audit(
+        db=db,
+        event_type="dual_read.started",
+        source="agent",
+        summary=(
+            f"Dual-read started · crop={crop_label} · planilla_m2={planilla_m2 or 'unknown'}"
+        ),
+        quote_id=quote_id,
+        payload={
+            "crop_label": crop_label,
+            "planilla_m2": planilla_m2,
+            "plan_filename": plan_filename,
+            "has_cotas_text": bool(cotas_text),
+        },
+    )
 
     # PR #63 + #64 — dedup hash-based. El plan_bytes persiste entre turnos
     # (frontend lo re-envía con cada mensaje mientras la conversación tenga
@@ -611,8 +633,49 @@ async def _run_dual_read(
                             update(Quote).where(Quote.id == quote_id).values(quote_breakdown=_bd2)
                         )
                     await db.commit()
+                    await _audit(
+                        db=db,
+                        event_type="quote_breakdown.mutated",
+                        source="agent",
+                        summary=(
+                            "Breakdown mutated (dual_read) · keys=["
+                            "dual_read_result,dual_read_plan_hash,context_analysis_pending,"
+                            "brief_analysis]"
+                        ),
+                        quote_id=quote_id,
+                        payload={
+                            "path": "dual_read",
+                            "mutated_keys": [
+                                "dual_read_result",
+                                "dual_read_plan_hash",
+                                "dual_read_planilla_m2",
+                                "dual_read_crop_label",
+                                "context_analysis_pending",
+                                *(["brief_analysis"] if _brief_raw else []),
+                            ],
+                            "column_updates": list(_col_updates.keys()) if _col_updates else [],
+                        },
+                    )
                 except Exception as _e_px:
                     logging.warning(f"[context-analysis] persist pending failed: {_e_px}")
+                await _audit(
+                    db=db,
+                    event_type="context_analysis.pending",
+                    source="agent",
+                    summary=(
+                        f"Dual-read context pending · "
+                        f"{len(_context.get('data_known') or [])} known · "
+                        f"{len(_context.get('assumptions') or [])} assumptions · "
+                        f"{len(_context.get('pending_questions') or [])} questions"
+                    ),
+                    quote_id=quote_id,
+                    payload={
+                        "path": "dual_read",
+                        "data_known_count": len(_context.get("data_known") or []),
+                        "assumptions_count": len(_context.get("assumptions") or []),
+                        "pending_questions_count": len(_context.get("pending_questions") or []),
+                    },
+                )
                 chunks.append({
                     "type": "context_analysis",
                     "content": _json.dumps(_context, ensure_ascii=False),
@@ -649,6 +712,15 @@ async def _run_dual_read(
                     f"{len(_context.get('data_known') or [])} known, "
                     f"{len(_context.get('assumptions') or [])} assumptions, "
                     f"{len(_context.get('pending_questions') or [])} questions"
+                )
+                await _audit(
+                    db=db,
+                    event_type="dual_read.completed",
+                    source="agent",
+                    summary="Dual-read completed (context emitted, awaiting operator review)",
+                    quote_id=quote_id,
+                    payload={"path": "dual_read", "exit": "context_emitted"},
+                    elapsed_ms=int((_t_audit_dr.monotonic() - _dr_started_at) * 1000),
                 )
                 return (True, chunks)
             except Exception as _e_ctx:
@@ -2748,18 +2820,70 @@ class AgentService:
                 _tp_confirmed = False
 
             if _tp_quote is not None and not _tp_has_card and not _tp_confirmed:
+                # Sprint 4 audit-text-only-instrumentation · Bug 2 fix.
+                # Antes: text-only flow corría parse_brief_to_card +
+                # build_context_analysis + persistencia + return early SIN
+                # emitir ningún `log_event` → audit log mostraba "2 events,
+                # 0 tool types" engañoso (quote.created + chat.message_sent
+                # solamente). Ahora instrumentamos 4 puntos: started + completed
+                # del text_parse, started + completed del context_analysis,
+                # y quote_breakdown.mutated cuando persistimos.
+                import time as _t_audit
+                _text_parse_start = _t_audit.monotonic()
                 try:
                     from app.modules.quote_engine.text_parser import parse_brief_to_card
                     _info_hint = _extract_quote_info(user_message)
+                    await _audit(
+                        db=db,
+                        event_type="text_parse.started",
+                        source="agent",
+                        summary=f"Text-only brief parse started · msg_chars={len(user_message or '')}",
+                        quote_id=quote_id,
+                        payload={
+                            "message_chars": len(user_message or ""),
+                            "client_hint": _info_hint.get("client_name") or None,
+                            "material_hint": _info_hint.get("material") or None,
+                            "project_hint": _info_hint.get("project") or None,
+                        },
+                    )
                     yield {"type": "action", "content": "📐 Leyendo medidas del texto..."}
                     _text_card = await parse_brief_to_card(
                         user_message,
                         _info_hint.get("material", "") or "",
                         _info_hint.get("project", "") or "",
                     )
+                    _text_parse_elapsed_ms = int((_t_audit.monotonic() - _text_parse_start) * 1000)
+                    await _audit(
+                        db=db,
+                        event_type="text_parse.completed",
+                        source="agent",
+                        summary=(
+                            f"Text-only brief parse completed · "
+                            f"tramos={len((_text_card or {}).get('sectores', [{}])[0].get('tramos', [])) if _text_card else 0}"
+                        ),
+                        quote_id=quote_id,
+                        payload={
+                            "ok": bool(_text_card),
+                            "sectores_count": len((_text_card or {}).get("sectores", [])) if _text_card else 0,
+                        },
+                        elapsed_ms=_text_parse_elapsed_ms,
+                        success=bool(_text_card),
+                    )
                 except Exception as _e_tp:
                     logging.warning(f"[text-parse] parse_brief_to_card failed: {_e_tp}")
                     _text_card = None
+                    _text_parse_elapsed_ms = int((_t_audit.monotonic() - _text_parse_start) * 1000)
+                    await _audit(
+                        db=db,
+                        event_type="text_parse.completed",
+                        source="agent",
+                        summary=f"Text-only brief parse failed: {_e_tp}",
+                        quote_id=quote_id,
+                        payload={"ok": False},
+                        elapsed_ms=_text_parse_elapsed_ms,
+                        success=False,
+                        error_message=str(_e_tp)[:500],
+                    )
 
                 if _text_card:
                     # Apply metadata hints to Quote columns
@@ -2804,14 +2928,34 @@ class AgentService:
                                 "localidad": getattr(_tp_quote, "localidad", None),
                                 "is_building": getattr(_tp_quote, "is_building", False),
                             }
+                            _ctx_analysis_start = _t_audit.monotonic()
+                            await _audit(
+                                db=db,
+                                event_type="context_analysis.started",
+                                source="agent",
+                                summary="Text-only context analysis started",
+                                quote_id=quote_id,
+                                payload={"path": "text_only"},
+                            )
                             _context_tp = await build_context_analysis(
                                 user_message or "", _ctx_quote_tp, _text_card, _cfg_tp
                             )
+                            _ctx_analysis_elapsed_ms = int((_t_audit.monotonic() - _ctx_analysis_start) * 1000)
                         except Exception as _e_ctx_tp:
                             logging.warning(
                                 f"[text-parse] build_context_analysis failed: {_e_ctx_tp}"
                             )
                             _context_tp = None
+                            await _audit(
+                                db=db,
+                                event_type="context_analysis.pending",
+                                source="agent",
+                                summary=f"Text-only context analysis failed: {_e_ctx_tp}",
+                                quote_id=quote_id,
+                                payload={"path": "text_only", "ok": False},
+                                success=False,
+                                error_message=str(_e_ctx_tp)[:500],
+                            )
 
                         if _context_tp:
                             try:
@@ -2841,12 +2985,51 @@ class AgentService:
                                     .values(**_persist_update)
                                 )
                                 await db.commit()
+                                await _audit(
+                                    db=db,
+                                    event_type="quote_breakdown.mutated",
+                                    source="agent",
+                                    summary=(
+                                        f"Breakdown mutated (text-only) · keys=["
+                                        "dual_read_result,context_analysis_pending]"
+                                    ),
+                                    quote_id=quote_id,
+                                    payload={
+                                        "path": "text_only",
+                                        "mutated_keys": [
+                                            "dual_read_result",
+                                            "context_analysis_pending",
+                                        ],
+                                        "column_updates": list(_persist_update.keys()),
+                                    },
+                                )
                             except Exception as _e_pp_ctx:
                                 logging.warning(
                                     f"[text-parse] persist context failed: {_e_pp_ctx}"
                                 )
                             logging.info(
                                 f"[text-parse] emitted context_analysis for {quote_id}"
+                            )
+                            await _audit(
+                                db=db,
+                                event_type="context_analysis.pending",
+                                source="agent",
+                                summary=(
+                                    f"Text-only context pending · "
+                                    f"{len(_context_tp.get('data_known') or [])} known · "
+                                    f"{len(_context_tp.get('assumptions') or [])} assumptions · "
+                                    f"{len(_context_tp.get('pending_questions') or [])} questions"
+                                ),
+                                quote_id=quote_id,
+                                payload={
+                                    "path": "text_only",
+                                    "data_known_count": len(_context_tp.get("data_known") or []),
+                                    "assumptions_count": len(_context_tp.get("assumptions") or []),
+                                    "pending_questions_count": len(
+                                        _context_tp.get("pending_questions") or []
+                                    ),
+                                },
+                                elapsed_ms=_ctx_analysis_elapsed_ms,
                             )
                             yield {
                                 "type": "context_analysis",

--- a/api/tests/test_audit_log_endpoint.py
+++ b/api/tests/test_audit_log_endpoint.py
@@ -359,3 +359,191 @@ class TestUnhandledExceptionCors:
         )
         assert resp.status_code == 500
         assert resp.headers.get("access-control-allow-origin") is None
+
+
+# ── Sprint 4 audit-text-only-instrumentation · Bug 2 fix ──────────────────
+# Verifica que los nuevos event_types emitidos por agent.py (text-only +
+# dual_read paths) son persistidos correctamente y aparecen en el response
+# del endpoint sin filtros. Tests aislados: NO ejecutan agent.chat()
+# (requiere LLM mocking), seedean directamente con shape canon.
+
+class TestAuditLogTextOnlyInstrumentation:
+    @pytest.mark.asyncio
+    async def test_text_only_flow_events_appear_in_audit_log(self, client, db_session):
+        """Simula los 4 events nuevos del text-only flow + 2 baseline previos."""
+        base = datetime.now(timezone.utc)
+        await _seed_quote_with_audit(
+            db_session,
+            "q-text-only",
+            client_name="Familia Mansilla",
+            material=None,
+            messages=[
+                {"role": "user", "content": "Mesada de 2 x 0,60 en purastone venatino"}
+            ],
+            events=[
+                {"event_type": "quote.created", "created_at": base, "summary": "Quote created"},
+                {
+                    "event_type": "chat.message_sent",
+                    "created_at": base + timedelta(milliseconds=12),
+                    "summary": "Operator sent chat message",
+                },
+                {
+                    "event_type": "text_parse.started",
+                    "created_at": base + timedelta(milliseconds=120),
+                    "summary": "Text-only brief parse started · msg_chars=43",
+                    "payload": {"message_chars": 43},
+                },
+                {
+                    "event_type": "text_parse.completed",
+                    "created_at": base + timedelta(milliseconds=8456),
+                    "summary": "Text-only brief parse completed · tramos=1",
+                    "payload": {"ok": True, "sectores_count": 1},
+                    "elapsed_ms": 8336,
+                },
+                {
+                    "event_type": "context_analysis.started",
+                    "created_at": base + timedelta(milliseconds=8500),
+                    "summary": "Text-only context analysis started",
+                    "payload": {"path": "text_only"},
+                },
+                {
+                    "event_type": "quote_breakdown.mutated",
+                    "created_at": base + timedelta(milliseconds=12100),
+                    "summary": "Breakdown mutated (text-only)",
+                    "payload": {
+                        "path": "text_only",
+                        "mutated_keys": ["dual_read_result", "context_analysis_pending"],
+                    },
+                },
+                {
+                    "event_type": "context_analysis.pending",
+                    "created_at": base + timedelta(milliseconds=12150),
+                    "summary": "Text-only context pending · 3 known · 2 assumptions · 1 questions",
+                    "payload": {
+                        "path": "text_only",
+                        "data_known_count": 3,
+                        "assumptions_count": 2,
+                        "pending_questions_count": 1,
+                    },
+                    "elapsed_ms": 3600,
+                },
+            ],
+        )
+        r = await client.get("/api/quotes/q-text-only/audit-log")
+        assert r.status_code == 200, r.text
+        data = r.json()
+
+        # Total events visible (7 baseline + new instrumentation)
+        assert data["events_total"] == 7
+
+        # Los 5 event_types NUEVOS aparecen sin filtro
+        event_types = {e["event_type"] for e in data["events"]}
+        expected_new = {
+            "text_parse.started",
+            "text_parse.completed",
+            "context_analysis.started",
+            "quote_breakdown.mutated",
+            "context_analysis.pending",
+        }
+        assert expected_new.issubset(event_types), (
+            f"Faltan event_types nuevos: {expected_new - event_types}"
+        )
+
+        # Payload del context_analysis.pending preserva data_known_count
+        ctx = next(e for e in data["events"] if e["event_type"] == "context_analysis.pending")
+        assert ctx["payload"]["data_known_count"] == 3
+        assert ctx["payload"]["path"] == "text_only"
+        assert ctx["elapsed_ms"] == 3600
+
+    @pytest.mark.asyncio
+    async def test_dual_read_flow_events_appear_in_audit_log(self, client, db_session):
+        """Simula los 4 events nuevos del plan flow (_run_dual_read)."""
+        base = datetime.now(timezone.utc)
+        await _seed_quote_with_audit(
+            db_session,
+            "q-dual-read",
+            messages=[{"role": "user", "content": "leé el plano"}],
+            source_files=[{"filename": "plano.pdf"}],
+            events=[
+                {"event_type": "quote.created", "created_at": base},
+                {"event_type": "chat.message_sent", "created_at": base + timedelta(milliseconds=10)},
+                {
+                    "event_type": "dual_read.started",
+                    "created_at": base + timedelta(milliseconds=200),
+                    "summary": "Dual-read started · crop=cocina · planilla_m2=6.5",
+                    "payload": {"crop_label": "cocina", "planilla_m2": 6.5},
+                },
+                {
+                    "event_type": "quote_breakdown.mutated",
+                    "created_at": base + timedelta(seconds=15),
+                    "payload": {
+                        "path": "dual_read",
+                        "mutated_keys": [
+                            "dual_read_result",
+                            "dual_read_plan_hash",
+                            "context_analysis_pending",
+                            "brief_analysis",
+                        ],
+                    },
+                },
+                {
+                    "event_type": "context_analysis.pending",
+                    "created_at": base + timedelta(seconds=15, milliseconds=200),
+                    "summary": "Dual-read context pending",
+                    "payload": {"path": "dual_read"},
+                },
+                {
+                    "event_type": "dual_read.completed",
+                    "created_at": base + timedelta(seconds=18),
+                    "summary": "Dual-read completed",
+                    "payload": {"path": "dual_read", "exit": "context_emitted"},
+                    "elapsed_ms": 17800,
+                },
+            ],
+        )
+        r = await client.get("/api/quotes/q-dual-read/audit-log")
+        assert r.status_code == 200
+        data = r.json()
+
+        event_types = [e["event_type"] for e in data["events"]]
+        assert "dual_read.started" in event_types
+        assert "dual_read.completed" in event_types
+        # Orden ASC por created_at preservado
+        assert event_types.index("dual_read.started") < event_types.index("dual_read.completed")
+
+        # chat_duration_ms NO se computa desde dual_read.* (la lógica usa
+        # agent.stream_started → último tool_result/quote.calculated). Sin
+        # esos eventos seed, chat_duration_ms = None. Este test documenta
+        # ese comportamiento esperado · regresión-guard.
+        assert data["chat_duration_ms"] is None
+
+    @pytest.mark.asyncio
+    async def test_new_event_types_not_filtered_by_endpoint(self, client, db_session):
+        """Verifica que el endpoint NO filtra los nuevos event_types por
+        accidente (ej: una whitelist de event_types conocidos)."""
+        base = datetime.now(timezone.utc)
+        # Mix de eventos pre-existentes + nuevos
+        novel_types = [
+            "text_parse.started",
+            "text_parse.completed",
+            "context_analysis.started",
+            "context_analysis.pending",
+            "quote_breakdown.mutated",
+            "dual_read.started",
+            "dual_read.completed",
+        ]
+        events = [{"event_type": "quote.created", "created_at": base}] + [
+            {
+                "event_type": t,
+                "created_at": base + timedelta(seconds=i + 1),
+                "summary": f"{t} test",
+            }
+            for i, t in enumerate(novel_types)
+        ]
+        await _seed_quote_with_audit(db_session, "q-no-filter", events=events)
+        r = await client.get("/api/quotes/q-no-filter/audit-log")
+        assert r.status_code == 200
+        data = r.json()
+        returned_types = {e["event_type"] for e in data["events"]}
+        for t in novel_types:
+            assert t in returned_types, f"Endpoint filtró out event_type nuevo: {t}"


### PR DESCRIPTION
**Bug 2 del reporte diagnóstico post-PR #478.** Audit log en text-only mostraba "2 events, 0 tool types, total 0.549s" pese a tener `quote_breakdown` populado con `dual_read_result` + `context_analysis_pending`. Imposible en 0.5s.

Pure logging · cero cambio de lógica · backend touch JUSTIFICADO.

## 🟡 Sorpresa FASE 1 · el diagnóstico identificó el path equivocado

El diagnóstico decía que el bug era en `_run_dual_read()` (líneas 238-716). **Falso**: ese path es solo para planos (los 3 callers en 3978/4076/4123 requieren `draw_bytes`).

El **text-only flow real** es otro path paralelo en `agent.py:2725-2856`:

\`\`\`python
# Entry condition (2725-2735)
if not plan_bytes and user_message and not _is_system_trigger:
    # ...
    _text_card = await parse_brief_to_card(...)       # 2755 · LLM call #1
    _context_tp = await build_context_analysis(...)   # 2807 · LLM call #2
    # ... persistencia (2819-2843) ...
    yield context_analysis
    return  # 2856 · early exit
\`\`\`

Ambos paths comparten el mismo downstream pattern (\`build_context_analysis\` + \`dual_read_result\` persistence), por eso el diagnóstico los confundió. **Instrumenté AMBOS para no dejar gaps.**

## Cambios

### Text-only path (\`agent.py:2725-2856\`)
| Event | Cuándo | Payload |
|---|---|---|
| \`text_parse.started\` | Entry | message_chars, hints (client/material/project) |
| \`text_parse.completed\` | Post-LLM | elapsed_ms, ok, sectores_count |
| \`context_analysis.started\` | Pre-context | path="text_only" |
| \`quote_breakdown.mutated\` | Post-persist | mutated_keys, column_updates |
| \`context_analysis.pending\` | Post-emit | data_known/assumptions/pending_questions counts |

### Plan path (\`_run_dual_read 238-716\`)
| Event | Cuándo | Payload |
|---|---|---|
| \`dual_read.started\` | Entry | crop_label, planilla_m2, plan_filename |
| \`quote_breakdown.mutated\` | Post-persist | mutated_keys (incluye brief_analysis si presente) |
| \`context_analysis.pending\` | Post-emit | counts |
| \`dual_read.completed\` | Pre-return | elapsed total |

## Verificación

- \`agent.py:16\` ya importa \`log_event as _audit\` · reutilizado
- Endpoint \`/api/quotes/{id}/audit-log\` (mi PR #477) NO filtra por event_type · query plana \`WHERE quote_id = ? ORDER BY created_at ASC\` · nuevos types pasan automáticamente
- \`log_event\` helper tiene try/catch interno · NUNCA interrumpe el flow del operador
- Sintaxis Python: ✅ ast.parse OK

## Tests

3 nuevos en \`test_audit_log_endpoint.py\` (TestAuditLogTextOnlyInstrumentation):

1. **test_text_only_flow_events_appear_in_audit_log**: seedea los 5 events nuevos del text-only, verifica que aparecen en response con orden ASC + payload preservado (data_known_count, path="text_only", elapsed_ms)
2. **test_dual_read_flow_events_appear_in_audit_log**: seedea los 4 events del plan flow, verifica orden ASC + documenta que \`chat_duration_ms\` se computa desde \`agent.stream_started\` (no afectado por estos events)
3. **test_new_event_types_not_filtered_by_endpoint**: regression-guard contra filtro accidental por whitelist

| Suite | Resultado |
|---|---|
| \`test_audit_log_endpoint.py\` | **13/13 verde** (10 previos + 3 nuevos) |
| Agent-related tests (\`-k agent\`) | **49/49 verde** (zero regression) |
| Pre-existing fails en main | 16 fails NO relacionados (mismos confirmados con \`git stash\`) |

## Smoke test post-merge OBLIGATORIO (lección #51)

Tras deploy a Railway:

\`\`\`bash
# 1. Create quote
QUOTE_ID=$(curl -s -X POST https://...railway.app/api/quotes \\
  -H "Authorization: Bearer ..." -d '{}' | jq -r .id)

# 2. Process text-only
curl -X POST https://...railway.app/api/quotes/$QUOTE_ID/chat \\
  -H "Authorization: Bearer ..." \\
  -F "message=Mesada de 2x0.60 en purastone venatino..."

# 3. Check audit
curl https://...railway.app/api/quotes/$QUOTE_ID/audit-log \\
  -H "Authorization: Bearer ..." | jq '.events_total, [.events[].event_type]'
\`\`\`

**Esperado:** \`events_total\` ≥ 6 con event_types incluyendo \`text_parse.started\`, \`text_parse.completed\`, \`context_analysis.started\`, \`quote_breakdown.mutated\`, \`context_analysis.pending\`.

**Si solo aparecen 2 events post-deploy** → 🔴 CRIT · debug deploy + verificar que el branch correcto se desplegó.

## Sub-PRs desbloqueados

- **Bug 1 (paso-2-context-wire-real)**: ahora podemos ver empíricamente qué shape genera el backend en text-only (data_known counts en \`context_analysis.pending.payload\`)
- **Bug 3 (brief-analyzer-project-validation)**: \`text_parse.started.payload\` incluye \`project_hint\` extraído por \`_extract_quote_info()\` · debug del LLM hallucination más fácil

## Lección operativa nueva

**#53 · Instrumentación debe cubrir TODOS los flows, no solo el path principal.** Si existen fast-paths / early-exits que esquivan el loop con instrumentación, también necesitan \`log_event\`. Patrón a verificar en FASE 1 de futuros sub-PRs que toquen agent.py.

## Test plan

- [x] \`pytest tests/test_audit_log_endpoint.py -v\` → 13/13 verde
- [x] \`pytest -k agent\` → 49/49 verde
- [x] Sintaxis Python ast.parse OK
- [ ] Smoke test post-deploy (Javi/CI)
- [ ] Verificación visual de \`/quotes/{id}/audit\` con audit data nueva

🤖 Generated with [Claude Code](https://claude.com/claude-code)