### PR TITLE
fix(sidebar): wire CTA "+ Nuevo presupuesto" del sidebar

### DIFF
--- a/web/src/components/chrome/Sidebar.tsx
+++ b/web/src/components/chrome/Sidebar.tsx
@@ -56,18 +56,29 @@ export function Sidebar() {
       {/* Spacer empuja el CTA + avatar al fondo */}
       <div style={{ flex: 1 }} />
 
-      {/* CTA "+ Nuevo presupuesto" · placeholder no clickeable */}
-      <div
+      {/* CTA "+ Nuevo presupuesto" · Sprint 4 fix-up · antes era `<div>`
+          placeholder no clickeable (Sprint 2 chrome-refactor). Cuando el
+          operador estaba dentro de un quote y quería arrancar otro, el
+          click no hacía nada · ahora navega a /quotes/new. */}
+      <button
+        type="button"
         className="nav-i"
         style={{
           border: "1px dashed var(--line-strong)",
           justifyContent: "center",
           color: "var(--accent)",
+          background: "transparent",
+          width: "100%",
+          textAlign: "center",
+          cursor: "pointer",
+          font: "inherit",
         }}
         data-v2-nav="new-quote"
+        data-testid="sidebar-new-quote-cta"
+        onClick={() => router.push("/quotes/new")}
       >
         + Nuevo presupuesto
-      </div>
+      </button>
 
       {/* User avatar · "M" de Marina */}
       <div

--- a/web/tests/e2e/smoke.spec.ts
+++ b/web/tests/e2e/smoke.spec.ts
@@ -56,3 +56,17 @@ test("stepper se actualiza al navegar entre rutas", async ({ page }) => {
   await expect(page.locator('.stepper .step[data-step="despiece"]')).toHaveClass(/done/);
   await expect(page.locator('.stepper .step[data-step="pdf"]')).not.toHaveClass(/done|now/);
 });
+
+/* ─── Sprint 4 fix-up sidebar-new-quote-cta ───────────────────────── */
+
+test("Sidebar CTA '+ Nuevo presupuesto' navega a /quotes/new desde dentro de un quote", async ({
+  page,
+}) => {
+  // Bug reportado por Javi via screenshot: dentro de /quotes/{id}/contexto
+  // el CTA del sidebar no andaba (era `<div>` placeholder sin handler).
+  await page.goto("/quotes/PRES-2026-018/contexto");
+  await expect(page.locator('[data-testid="sidebar-new-quote-cta"]')).toBeVisible();
+  await page.locator('[data-testid="sidebar-new-quote-cta"]').click();
+  await page.waitForURL("**/quotes/new", { timeout: 5000 });
+  await expect(page.locator('[data-testid="brief-dropzone"]')).toBeVisible();
+});


### PR DESCRIPTION
## Bug visual reportado

Screenshot Javi · dentro de \`/quotes/{id}/contexto\`, el CTA \`+ Nuevo presupuesto\` del sidebar no andaba al clickearlo.

## Causa

\`Sidebar.tsx:59-70\` · el CTA era un \`<div>\` placeholder de **Sprint 2 chrome-refactor** con comentario LITERAL inline:
\`\`\`tsx
{/* CTA "+ Nuevo presupuesto" · placeholder no clickeable */}
<div className="nav-i" style={{...}} data-v2-nav="new-quote">
  + Nuevo presupuesto
</div>
\`\`\`
Nunca se wireó cuando el routing real llegó en sprints siguientes.

## Fix

Cambiar el \`<div>\` a \`<button>\` con \`onClick={() => router.push("/quotes/new")}\`. \`useRouter\` ya estaba importado (lo usa el logout handler del Sprint 3).

Estilos visuales preservados (border dashed, color accent, full width centrado). Inline overrides para \`background: transparent\`, \`font: inherit\` y \`cursor: pointer\` evitan que el browser le aplique estilo de button default.

## Tests

- E2E smoke nuevo: **Sidebar CTA '+ Nuevo presupuesto' navega a /quotes/new desde dentro de un quote**
- Smoke completo: 4/4 verde (3 originales + 1 nuevo)
- Lint + typecheck verde

## Cero CSS shared modificado

🤖 Generated with [Claude Code](https://claude.com/claude-code)