### PR TITLE
fix(audit): commit=True en events post-último-db.commit + CALLS terminators

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -713,6 +713,11 @@ async def _run_dual_read(
                     f"{len(_context.get('assumptions') or [])} assumptions, "
                     f"{len(_context.get('pending_questions') or [])} questions"
                 )
+                # Sprint 4 audit-instrumentation-gap-fix · commit=True CRÍTICO.
+                # Mismo bug que el path text-only: este event se emite después
+                # del último `db.commit()` (línea 707), seguido por `return`
+                # que cierra el generator. Sin commit=True, el event queda en
+                # la transaction abierta y get_db() lo rollea al cerrar.
                 await _audit(
                     db=db,
                     event_type="dual_read.completed",
@@ -721,6 +726,7 @@ async def _run_dual_read(
                     quote_id=quote_id,
                     payload={"path": "dual_read", "exit": "context_emitted"},
                     elapsed_ms=int((_t_audit_dr.monotonic() - _dr_started_at) * 1000),
+                    commit=True,
                 )
                 return (True, chunks)
             except Exception as _e_ctx:
@@ -2873,6 +2879,9 @@ class AgentService:
                     logging.warning(f"[text-parse] parse_brief_to_card failed: {_e_tp}")
                     _text_card = None
                     _text_parse_elapsed_ms = int((_t_audit.monotonic() - _text_parse_start) * 1000)
+                    # commit=True · si parse_brief_to_card falla, _text_card=None
+                    # hace skip del bloque persist (no hay db.commit posterior). Sin
+                    # commit acá, el event de fallo se perdería.
                     await _audit(
                         db=db,
                         event_type="text_parse.completed",
@@ -2881,6 +2890,7 @@ class AgentService:
                         quote_id=quote_id,
                         payload={"ok": False},
                         elapsed_ms=_text_parse_elapsed_ms,
+                        commit=True,
                         success=False,
                         error_message=str(_e_tp)[:500],
                     )
@@ -2946,6 +2956,10 @@ class AgentService:
                                 f"[text-parse] build_context_analysis failed: {_e_ctx_tp}"
                             )
                             _context_tp = None
+                            # commit=True · si build_context_analysis falla, no hay
+                            # db.commit posterior (skip del bloque persist por
+                            # _context_tp=None). Sin commit, este event de fallo se
+                            # perdería.
                             await _audit(
                                 db=db,
                                 event_type="context_analysis.pending",
@@ -2955,6 +2969,7 @@ class AgentService:
                                 payload={"path": "text_only", "ok": False},
                                 success=False,
                                 error_message=str(_e_ctx_tp)[:500],
+                                commit=True,
                             )
 
                         if _context_tp:
@@ -3010,6 +3025,18 @@ class AgentService:
                             logging.info(
                                 f"[text-parse] emitted context_analysis for {quote_id}"
                             )
+                            # Sprint 4 audit-instrumentation-gap-fix · commit=True
+                            # CRÍTICO. `log_event` por default usa commit=False (deja
+                            # el event en la transaction abierta para rollback safety).
+                            # En este path, después del `db.commit()` del Quote update
+                            # (línea 2987), el `quote_breakdown.mutated` (línea ~2988)
+                            # y este `context_analysis.pending` quedan en transaction
+                            # SIN commit. Luego `yield` + `return` (3038-3039) cierra
+                            # el generator y `get_db()` cierra la session sin commit →
+                            # ambos events se rollean. PR #480 los registró pero nunca
+                            # se persistían. `commit=True` acá flushea AMBOS events
+                            # (mutated + pending) porque son la única escritura
+                            # pendiente. Equivalente a `await db.commit()` explícito.
                             await _audit(
                                 db=db,
                                 event_type="context_analysis.pending",
@@ -3030,6 +3057,7 @@ class AgentService:
                                     ),
                                 },
                                 elapsed_ms=_ctx_analysis_elapsed_ms,
+                                commit=True,
                             )
                             yield {
                                 "type": "context_analysis",

--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -2486,9 +2486,23 @@ async def get_quote_audit_log(
     chat_duration_ms: Optional[int] = None
     stream_start = next((e for e in all_events if e.event_type == "agent.stream_started"), None)
     if stream_start:
+        # Sprint 4 audit-instrumentation-gap-fix: extendido con los terminators
+        # de los fast-paths text-only y dual_read. Antes solo cubría el loop
+        # agéntico (tool_result/calculated/docs.generated) → text-only y
+        # dual_read quedaban con chat_duration_ms=None (CALLS section vacía
+        # en el copy plain text). Ahora text_parse.completed y
+        # context_analysis.pending y dual_read.completed también cuentan
+        # como terminators legítimos de la "call".
         chat_ends = [
             e for e in all_events
-            if e.event_type in {"agent.tool_result", "quote.calculated", "docs.generated"}
+            if e.event_type in {
+                "agent.tool_result",
+                "quote.calculated",
+                "docs.generated",
+                "text_parse.completed",
+                "context_analysis.pending",
+                "dual_read.completed",
+            }
             and e.created_at >= stream_start.created_at
         ]
         if chat_ends:

--- a/api/tests/test_audit_log_endpoint.py
+++ b/api/tests/test_audit_log_endpoint.py
@@ -511,11 +511,70 @@ class TestAuditLogTextOnlyInstrumentation:
         # Orden ASC por created_at preservado
         assert event_types.index("dual_read.started") < event_types.index("dual_read.completed")
 
-        # chat_duration_ms NO se computa desde dual_read.* (la lógica usa
-        # agent.stream_started → último tool_result/quote.calculated). Sin
-        # esos eventos seed, chat_duration_ms = None. Este test documenta
-        # ese comportamiento esperado · regresión-guard.
+        # Sin agent.stream_started en el seed, chat_duration_ms = None
+        # (no hay punto de inicio para computar delta).
         assert data["chat_duration_ms"] is None
+
+    @pytest.mark.asyncio
+    async def test_chat_duration_derived_from_text_only_terminators(self, client, db_session):
+        """Sprint 4 audit-instrumentation-gap-fix · CALLS section vacía bug.
+        chat_duration_ms ahora cubre los terminators de fast-paths
+        (text_parse.completed, context_analysis.pending, dual_read.completed)
+        además de los del loop agéntico (tool_result, calculated, docs.generated).
+        """
+        base = datetime.now(timezone.utc)
+        await _seed_quote_with_audit(
+            db_session,
+            "q-text-only-duration",
+            events=[
+                {"event_type": "quote.created", "created_at": base},
+                {
+                    "event_type": "agent.stream_started",
+                    "created_at": base + timedelta(milliseconds=200),
+                },
+                {
+                    "event_type": "text_parse.completed",
+                    "created_at": base + timedelta(milliseconds=6100),
+                    "elapsed_ms": 5900,
+                },
+                {
+                    "event_type": "context_analysis.pending",
+                    "created_at": base + timedelta(milliseconds=12500),
+                    "elapsed_ms": 6300,
+                },
+            ],
+        )
+        r = await client.get("/api/quotes/q-text-only-duration/audit-log")
+        data = r.json()
+        # stream_started @ 200ms, last terminator context_analysis.pending @
+        # 12500ms → chat_duration_ms ≈ 12300ms (delta absoluto).
+        assert data["chat_duration_ms"] is not None
+        assert 12000 <= data["chat_duration_ms"] <= 12600
+
+    @pytest.mark.asyncio
+    async def test_chat_duration_derived_from_dual_read_completed(self, client, db_session):
+        """Mismo bug · path dual_read."""
+        base = datetime.now(timezone.utc)
+        await _seed_quote_with_audit(
+            db_session,
+            "q-dual-read-duration",
+            events=[
+                {"event_type": "quote.created", "created_at": base},
+                {
+                    "event_type": "agent.stream_started",
+                    "created_at": base + timedelta(milliseconds=100),
+                },
+                {
+                    "event_type": "dual_read.completed",
+                    "created_at": base + timedelta(seconds=18),
+                    "elapsed_ms": 17800,
+                },
+            ],
+        )
+        r = await client.get("/api/quotes/q-dual-read-duration/audit-log")
+        data = r.json()
+        assert data["chat_duration_ms"] is not None
+        assert 17500 <= data["chat_duration_ms"] <= 18100
 
     @pytest.mark.asyncio
     async def test_new_event_types_not_filtered_by_endpoint(self, client, db_session):
@@ -547,3 +606,40 @@ class TestAuditLogTextOnlyInstrumentation:
         returned_types = {e["event_type"] for e in data["events"]}
         for t in novel_types:
             assert t in returned_types, f"Endpoint filtró out event_type nuevo: {t}"
+
+
+# ── Sprint 4 audit-instrumentation-gap-fix · regresión de commit=True ──
+# Verifica que log_event(commit=True) efectivamente persiste el event
+# aunque el caller no llame a db.commit() después.
+
+class TestLogEventCommitSemantics:
+    @pytest.mark.asyncio
+    async def test_log_event_with_commit_true_persists_immediately(self, client, db_session):
+        """Si el caller emite log_event(commit=True) sin un db.commit posterior,
+        el event DEBE persistir. Reproduce el bug PR #480 donde los 2 events
+        finales del text-only flow se rolleaban al cerrar la session."""
+        from app.modules.observability import log_event
+        from app.models.quote import Quote, QuoteStatus
+
+        # Seed quote sin commit explícito
+        db_session.add(Quote(
+            id="q-commit-true", client_name="Test", project="Test",
+            messages=[], status=QuoteStatus.DRAFT,
+        ))
+        await db_session.commit()
+
+        # Event con commit=True — debe persistir aunque no haya commit posterior
+        await log_event(
+            db_session,
+            event_type="test.with_commit_true",
+            source="test",
+            summary="should persist",
+            quote_id="q-commit-true",
+            commit=True,
+        )
+
+        # Verificar via endpoint
+        r = await client.get("/api/quotes/q-commit-true/audit-log")
+        assert r.status_code == 200
+        types = [e["event_type"] for e in r.json()["events"]]
+        assert "test.with_commit_true" in types


### PR DESCRIPTION
**Fix de 2 bugs reportados por Javi en audit log post-PR #480** (text-only "Mesada 2x0.60 purastone..." test). Pure logging fix · cero cambio de lógica.

## Bug 1 · 2 events del text-only flow + 1 del dual_read no se persistían

### Diagnóstico FASE 1

\`log_event()\` helper (\`observability/helper.py:266+\`) usa \`commit: bool = False\` por default · solo hace \`db.add(event)\` + \`await db.flush()\`. **El event queda en la transaction abierta sin commit.**

\`get_db()\` dependency (\`core/database.py\`):
\`\`\`python
async def get_db():
    async with AsyncSessionLocal() as session:
        try: yield session
        finally: await session.close()  # ← NO commit
\`\`\`

**Sin commit explícito → events rolleados al cerrar la session.**

### Text-only path (\`agent.py:2725-3039\`)

| Línea | Evento | Estado |
|---|---|---|
| 2987 | \`await db.commit()\` (Quote update) | ✅ flushea text_parse.started/completed + context_analysis.started (previos) |
| 2988 | \`_audit(quote_breakdown.mutated)\` | ❌ sin commit posterior |
| 3013 | \`_audit(context_analysis.pending)\` | ❌ sin commit posterior |
| 3034-3038 | \`yield\` SSE chunks | — |
| 3039 | \`return\` | ❌ session close → events rolleados |

### Dual_read path (\`agent.py:238-725\`)

| Línea | Evento | Estado |
|---|---|---|
| 707 | \`await db.commit()\` (messages) | ✅ flushea quote_breakdown.mutated + context_analysis.pending |
| 716 | \`_audit(dual_read.completed)\` | ❌ sin commit posterior |
| 725 | \`return\` | ❌ session close → event rolleado |

### Fix

Agregado \`commit=True\` al LAST \`_audit\` call de cada path (por proximidad de session, el commit flushea también los events previos sin commit). Plus en branches de fallo donde no hay \`db.commit\` posterior natural:

- \`text_parse.completed\` (failure case, \`agent.py:2876+\`)
- \`context_analysis.pending\` (text-only failure, \`agent.py:2949+\`)
- \`context_analysis.pending\` (text-only success final, \`agent.py:3013+\`)
- \`dual_read.completed\` (dual_read success final, \`agent.py:716+\`)

## Bug 2 · CALLS section vacía en audit-trail-copy

### Diagnóstico

\`router.py:2486\` derivaba \`chat_duration_ms\` desde \`agent.stream_started → último {tool_result | quote.calculated | docs.generated}\`. **Ninguno de esos events se emite en text-only ni dual_read fast-paths** (saltan el loop agéntico) → \`chat_duration_ms = None\` → format-audit-copy.ts skipea la línea \`POST /chat duration\` → CALLS section sin contenido principal.

### Fix

Extender \`chat_ends\` set con los terminators de los fast-paths:

\`\`\`python
chat_ends = [e for e in all_events if e.event_type in {
    "agent.tool_result",
    "quote.calculated",
    "docs.generated",
    "text_parse.completed",       # text-only fast-path
    "context_analysis.pending",   # ambos paths (último ⇒ usado por max)
    "dual_read.completed",        # dual_read fast-path
} and e.created_at >= stream_start.created_at]
\`\`\`

## Tests · 3 nuevos

1. **\`test_chat_duration_derived_from_text_only_terminators\`**: confirma derivation con stream_started + text_parse.completed + context_analysis.pending → chat_duration_ms ~12s
2. **\`test_chat_duration_derived_from_dual_read_completed\`**: ídem dual_read terminator → ~18s
3. **\`test_log_event_with_commit_true_persists_immediately\`**: regression-guard que confirma que \`commit=True\` persiste el event sin commit posterior (test directo del helper)

| Suite | Resultado |
|---|---|
| \`test_audit_log_endpoint.py\` | **16/16 verde** (13 previos + 3 nuevos) |
| Agent + audit related (\`-k\`) | **91/91 verde** · zero regression |
| Pre-existing fails en main | NO relacionados (verificado con stash) |

## Smoke test post-deploy OBLIGATORIO (lección #51)

\`\`\`bash
QUOTE_ID=$(curl -s -X POST https://...railway.app/api/quotes \\
  -H "Authorization: Bearer ..." -d '{}' | jq -r .id)
curl -X POST https://...railway.app/api/quotes/$QUOTE_ID/chat \\
  -H "Authorization: Bearer ..." \\
  -F "message=Mesada 2x0.60 en purastone venatino · obra Rosario · colocación"
curl https://...railway.app/api/quotes/$QUOTE_ID/audit-log \\
  -H "Authorization: Bearer ..." | jq '{
    events_total,
    chat_duration_ms,
    event_types: [.events[].event_type]
  }'
\`\`\`

**Esperado:**
- \`events_total\` **≥ 7** (no 5)
- event_types incluye \`quote_breakdown.mutated\` + \`context_analysis.pending\`
- \`chat_duration_ms\` **NOT null** (~5-15s típico)

Si \`events_total < 7\` post-deploy → 🔴 CRIT · debug.

## Lecciones operativas reforzadas + nueva

**#51 (refuerzo)** · Smoke test post-deploy es OBLIGATORIO. Tests pytest con seed directo NO atrapan bugs de transaction lifecycle. Si hubiera pegado el endpoint prod inmediatamente post-merge de #480, este bug se atrapa en 10 min en vez de re-deploy.

**#54 NUEVA** · \`log_event(commit=False)\` es default por safety (rollback si endpoint falla post-evento) pero requiere que el caller commitee después. **Si \`_audit\` es el último write antes de yield/return/session-close, DEBE usar \`commit=True\`.** Patrón a auditar en futuros sub-PRs que instrumenten flows agéntico.

## Test plan

- [x] Tests pytest 16/16 verde
- [x] Agent + audit 91/91 verde
- [x] ast.parse OK
- [ ] Smoke test post-deploy Railway con curl
- [ ] Visual audit-log endpoint en prod con quote text-only fresh
- [ ] Confirmar CALLS section ahora tiene línea \`POST /api/quotes/{id}/chat\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)