### PR TITLE
feat(paso-2): wire real adapter del contexto desde breakdown (Mockup Fidelity Gate parcial)

### DIFF
--- a/web/src/lib/api/adapters/context-from-breakdown.ts
+++ b/web/src/lib/api/adapters/context-from-breakdown.ts
@@ -1,0 +1,245 @@
+/**
+ * Pure adapter · Sprint 4 paso-2-context-wire-real · Bug 1 fix.
+ *
+ * Traduce el `quote_breakdown` que devuelve el backend (`GET /api/quotes/{id}`)
+ * a un `ContextResponse` que el UI del paso 2 ya consume sin cambios.
+ *
+ * Precedencia de fuentes dentro del breakdown:
+ *
+ *   1. `verified_context_analysis` (cuando el operador confirmó el contexto)
+ *   2. `context_analysis_pending` (estado pending · habitual al llegar al paso 2)
+ *   3. `_brief_analysis_raw` (raw del brief_analyzer · fallback más débil)
+ *
+ * Mapping backend `source` (8 valores) → ContextOrigin (5 valores):
+ *
+ *   - "brief" | "brief+rule" | "brief+dual_read" | "quote" → "BRIEF"
+ *     · "quote" se mapea a BRIEF por consistencia con tratamiento de
+ *       fields operador-input. Semánticamente cuestionable hasta que
+ *       Bug 3 (paso-1 project_name extraction) ajuste el setter de
+ *       Quote.project · ver deuda explícita en PR description.
+ *   - "dual_read" | "rule" | "inferred"                  → "INFERIDO"
+ *   - "config_default"                                   → "DEFAULT"
+ *   - field no encontrado                                → "FALTA"
+ *
+ * Pure function · vitest-testable · sin side effects.
+ */
+import type { ContextField, ContextOrigin, ContextResponse } from "../types";
+
+// ─── Tipos del breakdown que consumimos ───────────────────────────────
+
+interface BreakdownEntry {
+  field: string;
+  value: string;
+  source: string;
+  note?: string;
+}
+
+interface ContextAnalysis {
+  data_known?: BreakdownEntry[];
+  assumptions?: BreakdownEntry[];
+  tech_detections?: unknown[];
+  pending_questions?: unknown[];
+}
+
+interface BriefAnalysisRaw {
+  client_name?: string | null;
+  project?: string | null;
+  material?: string | null;
+  localidad?: string | null;
+  work_types?: string[] | null;
+  zocalos?: string | null;
+  alzada?: string | null;
+  colocacion?: string | null;
+  pileta_mentioned?: boolean | null;
+  pileta_type?: string | null;
+  pileta_count?: number | null;
+  pileta_simple_doble?: string | null;
+  anafe_mentioned?: boolean | null;
+  anafe_count?: number | null;
+  regrueso_mentioned?: boolean | null;
+  forma_pago?: string | null;
+  demora_dias?: string | number | null;
+  es_edificio?: boolean | null;
+  [key: string]: unknown;
+}
+
+export interface QuoteBreakdownLike {
+  verified_context_analysis?: ContextAnalysis | null;
+  context_analysis_pending?: ContextAnalysis | null;
+  _brief_analysis_raw?: BriefAnalysisRaw | null;
+  [key: string]: unknown;
+}
+
+// ─── Source mapping 8 → 5 ────────────────────────────────────────────
+
+export function mapBackendSourceToOrigin(source: string | null | undefined): ContextOrigin {
+  if (!source) return "FALTA";
+  // brief variants + quote → BRIEF
+  if (source === "brief" || source.startsWith("brief+") || source === "quote") {
+    return "BRIEF";
+  }
+  if (source === "dual_read" || source === "rule" || source === "inferred") {
+    return "INFERIDO";
+  }
+  if (source === "config_default") {
+    return "DEFAULT";
+  }
+  // Fallback defensivo · source desconocido se trata como inferido para
+  // no esconderlo como FALTA (que implica "campo vacío").
+  return "INFERIDO";
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+/** Crea un ContextField · null + FALTA cuando no hay valor. */
+function field<T extends string | number | boolean | null>(
+  value: T,
+  origin: ContextOrigin,
+): ContextField<T> {
+  if (value === null || value === undefined || value === "") {
+    return { value: null as T, origin: "FALTA" };
+  }
+  return { value, origin };
+}
+
+/** Busca un field exacto en data_known/assumptions y devuelve {value, source}. */
+function findEntry(
+  analysis: ContextAnalysis | null | undefined,
+  fieldName: string,
+): BreakdownEntry | null {
+  if (!analysis) return null;
+  return (
+    analysis.data_known?.find((e) => e.field === fieldName) ??
+    analysis.assumptions?.find((e) => e.field === fieldName) ??
+    null
+  );
+}
+
+/** Resuelve un string field con precedencia verified > pending > raw fallback. */
+function resolveString(
+  verified: ContextAnalysis | null | undefined,
+  pending: ContextAnalysis | null | undefined,
+  fieldName: string,
+  rawFallback: string | null | undefined,
+): ContextField<string | null> {
+  const entry = findEntry(verified, fieldName) ?? findEntry(pending, fieldName);
+  if (entry && entry.value) {
+    return field<string | null>(entry.value, mapBackendSourceToOrigin(entry.source));
+  }
+  if (rawFallback && String(rawFallback).trim()) {
+    return field<string | null>(String(rawFallback).trim(), "BRIEF");
+  }
+  return field<string | null>(null, "FALTA");
+}
+
+// ─── Adapter principal ───────────────────────────────────────────────
+
+export function breakdownToContext(breakdown: QuoteBreakdownLike | null | undefined): ContextResponse {
+  const verified = breakdown?.verified_context_analysis ?? null;
+  const pending = breakdown?.context_analysis_pending ?? null;
+  const raw: BriefAnalysisRaw = breakdown?._brief_analysis_raw ?? {};
+
+  // ── Cliente
+  const cliente = resolveString(verified, pending, "Cliente", raw.client_name);
+
+  // ── Contacto · NO está en backend canon (deuda · backend no extrae
+  // phone/email del brief). Siempre FALTA hasta sub-PR posterior.
+  const contacto = field<string | null>(null, "FALTA");
+
+  // ── Localidad
+  const localidad = resolveString(verified, pending, "Localidad", raw.localidad);
+
+  // ── Material
+  const material = resolveString(verified, pending, "Material", raw.material);
+
+  // ── Tipología · derivada de work_types[] del raw (eg "cocina, baño")
+  let tipologia: ContextField<string | null>;
+  const workTypes = raw.work_types;
+  if (Array.isArray(workTypes) && workTypes.length > 0) {
+    tipologia = field<string | null>(workTypes.join(", "), "BRIEF");
+  } else {
+    tipologia = resolveString(verified, pending, "Tipo de trabajo", null);
+  }
+
+  // ── Tipo de obra · particular | edificio (es_edificio bool del raw)
+  let tipoObra: ContextField<"particular" | "edificio">;
+  if (raw.es_edificio === true) {
+    tipoObra = { value: "edificio", origin: "BRIEF" };
+  } else if (raw.es_edificio === false) {
+    tipoObra = { value: "particular", origin: "BRIEF" };
+  } else {
+    tipoObra = { value: "particular", origin: "DEFAULT" };
+  }
+
+  // ── Plazo · de assumptions "Demora" o raw.demora_dias
+  const plazoEntry = findEntry(verified, "Demora") ?? findEntry(pending, "Demora");
+  let plazo: ContextField<string | null>;
+  if (plazoEntry?.value) {
+    plazo = field<string | null>(plazoEntry.value, mapBackendSourceToOrigin(plazoEntry.source));
+  } else if (raw.demora_dias) {
+    plazo = field<string | null>(
+      typeof raw.demora_dias === "number" ? `${raw.demora_dias} días` : String(raw.demora_dias),
+      "BRIEF",
+    );
+  } else {
+    plazo = field<string | null>(null, "FALTA");
+  }
+
+  // ── Pileta · assumptions "Pileta" o derivar de raw.pileta_*
+  const piletaEntry = findEntry(verified, "Pileta") ?? findEntry(pending, "Pileta");
+  let pileta: ContextField<string | null>;
+  if (piletaEntry?.value) {
+    pileta = field<string | null>(piletaEntry.value, mapBackendSourceToOrigin(piletaEntry.source));
+  } else if (raw.pileta_type) {
+    pileta = field<string | null>(raw.pileta_type, "BRIEF");
+  } else if (raw.pileta_mentioned === true) {
+    pileta = field<string | null>("mencionada", "BRIEF");
+  } else {
+    pileta = field<string | null>(null, "FALTA");
+  }
+
+  // ── Zócalo · assumptions "Zócalos" o raw.zocalos
+  const zocaloEntry = findEntry(verified, "Zócalos") ?? findEntry(pending, "Zócalos");
+  let zocalo: ContextField<string | null>;
+  if (zocaloEntry?.value) {
+    zocalo = field<string | null>(zocaloEntry.value, mapBackendSourceToOrigin(zocaloEntry.source));
+  } else if (raw.zocalos) {
+    zocalo = field<string | null>(raw.zocalos, "BRIEF");
+  } else {
+    zocalo = field<string | null>(null, "FALTA");
+  }
+
+  // ── Regrueso · raw.regrueso_mentioned (bool → "Sí"/"No"/FALTA)
+  let regrueso: ContextField<string | null>;
+  if (raw.regrueso_mentioned === true) {
+    regrueso = field<string | null>("Sí", "BRIEF");
+  } else if (raw.regrueso_mentioned === false) {
+    regrueso = field<string | null>("No", "DEFAULT");
+  } else {
+    regrueso = field<string | null>(null, "FALTA");
+  }
+
+  // ── Anafe · boolean directo
+  let anafe: ContextField<boolean>;
+  if (raw.anafe_mentioned === true) {
+    anafe = { value: true, origin: "BRIEF" };
+  } else if (raw.anafe_mentioned === false) {
+    anafe = { value: false, origin: "DEFAULT" };
+  } else {
+    anafe = { value: false, origin: "FALTA" };
+  }
+
+  return {
+    cliente,
+    contacto,
+    localidad,
+    plazo,
+    tipologia,
+    tipo_obra: tipoObra,
+    material,
+    pileta,
+    zocalo,
+    regrueso,
+    anafe,
+  };
+}

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -24,8 +24,13 @@ export const getQuoteMetadata = USE_REAL_API ? real.getQuoteMetadata : mocks.get
    (POST /api/quotes → POST /api/quotes/{id}/chat con SSE drained internamente). */
 export const createDraftQuote = USE_REAL_API ? real.createDraftQuote : mocks.createDraftQuote;
 
+/* Sprint 4 paso-2-context-wire-real · wire del paso 2 contexto contra el
+   backend Railway (GET /api/quotes/{id} + adapter sobre quote_breakdown).
+   Cuando NEXT_PUBLIC_API_URL está definida → real client.getContextForQuote
+   con bearer SSR + adapter `breakdownToContext()`. Sin env var → mock canon. */
+export const getContextForQuote = USE_REAL_API ? real.getContextForQuote : mocks.getContextForQuote;
+
 /* ─── Siempre en mock (B3 incremental · sin endpoint REST equivalente) ── */
-export const getContextForQuote = mocks.getContextForQuote;
 export const updateContextForQuote = mocks.updateContextForQuote;
 export const getDashboardKpis = mocks.getDashboardKpis;
 export const getValentinaBriefSummary = mocks.getValentinaBriefSummary;

--- a/web/src/lib/api/real.ts
+++ b/web/src/lib/api/real.ts
@@ -501,3 +501,53 @@ export async function getAuditLog(
   }
   return (await response.json()) as AuditLogResponse;
 }
+
+/* ─── getContextForQuote · Sprint 4 paso-2-context-wire-real (Bug 1 fix) ──
+   GET /api/quotes/{id} → QuoteDetailResponse · adapter sobre el breakdown.
+
+   El backend devuelve `quote_breakdown` como JSON-libre dentro del response.
+   El adapter `breakdownToContext()` (pure function) traduce el shape backend
+   (`context_analysis_pending` / `verified_context_analysis` / `_brief_analysis_raw`)
+   al shape `ContextResponse` que el UI del paso 2 ya consume.
+
+   Manejo de errores:
+   - 404 → ApiError CONTEXT_QUOTE_NOT_FOUND
+   - 5xx → ApiError CONTEXT_LOAD_FAILED
+   - response sin breakdown → adapter devuelve fields FALTA (preserva
+     current "—" behavior · no crashea)
+*/
+
+import { breakdownToContext, type QuoteBreakdownLike } from "./adapters/context-from-breakdown";
+import type { ContextResponse } from "./types";
+
+interface RealQuoteDetailResponse {
+  id: string;
+  quote_breakdown?: QuoteBreakdownLike | null;
+  [key: string]: unknown;
+}
+
+export async function getContextForQuote(
+  quoteId: string,
+  options?: { signal?: AbortSignal; bearerToken?: string | null },
+): Promise<ContextResponse> {
+  const { signal, bearerToken } = options ?? {};
+  const response = await apiFetch(
+    `/api/quotes/${encodeURIComponent(quoteId)}`,
+    { signal, bearerToken },
+    30_000,
+  );
+  if (response.status === 404) {
+    throw new ApiError("CONTEXT_QUOTE_NOT_FOUND", `Quote ${quoteId} no encontrado`, 404);
+  }
+  if (!response.ok) {
+    throw new ApiError(
+      "CONTEXT_LOAD_FAILED",
+      `GET /api/quotes/{id} falló (${response.status})`,
+      response.status,
+    );
+  }
+  const detail = (await response.json()) as RealQuoteDetailResponse;
+  // Adapter tolera breakdown null/undefined → devuelve todos los fields
+  // como FALTA (preserva el current "—" behavior del UI).
+  return breakdownToContext(detail.quote_breakdown ?? null);
+}

--- a/web/tests/unit/context-from-breakdown.test.ts
+++ b/web/tests/unit/context-from-breakdown.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Unit tests · Sprint 4 paso-2-context-wire-real · Bug 1 fix.
+ *
+ * Cubre el adapter pure function `breakdownToContext()` que traduce
+ * `quote_breakdown` del backend a `ContextResponse` del frontend.
+ *
+ * Casos cubiertos (12):
+ * - happy path data_known con Localidad/Material/Cliente
+ * - assumptions con Zócalos/Pileta
+ * - _brief_analysis_raw fallback cuando data_known vacío
+ * - source mapping 8→5 (BRIEF / INFERIDO / DEFAULT)
+ * - "quote" source mapea a BRIEF (deuda documentada Bug 3)
+ * - verified_context_analysis > pending precedencia
+ * - breakdown null → todos FALTA (preserva "—" behavior)
+ * - work_types[] array → tipologia string concatenado
+ * - es_edificio bool → tipo_obra particular/edificio
+ * - regrueso_mentioned bool → "Sí"/"No"
+ * - anafe_mentioned bool → boolean directo
+ * - "brief+rule" multi-source → BRIEF
+ */
+import { describe, expect, test } from "vitest";
+import {
+  breakdownToContext,
+  mapBackendSourceToOrigin,
+} from "@/lib/api/adapters/context-from-breakdown";
+
+describe("mapBackendSourceToOrigin · 8 → 5 source mapping", () => {
+  test("brief variants → BRIEF", () => {
+    expect(mapBackendSourceToOrigin("brief")).toBe("BRIEF");
+    expect(mapBackendSourceToOrigin("brief+rule")).toBe("BRIEF");
+    expect(mapBackendSourceToOrigin("brief+dual_read")).toBe("BRIEF");
+  });
+
+  test("quote → BRIEF (deuda Bug 3 documentada · operador-input consistency)", () => {
+    expect(mapBackendSourceToOrigin("quote")).toBe("BRIEF");
+  });
+
+  test("dual_read / rule / inferred → INFERIDO", () => {
+    expect(mapBackendSourceToOrigin("dual_read")).toBe("INFERIDO");
+    expect(mapBackendSourceToOrigin("rule")).toBe("INFERIDO");
+    expect(mapBackendSourceToOrigin("inferred")).toBe("INFERIDO");
+  });
+
+  test("config_default → DEFAULT", () => {
+    expect(mapBackendSourceToOrigin("config_default")).toBe("DEFAULT");
+  });
+
+  test("null/undefined/empty → FALTA", () => {
+    expect(mapBackendSourceToOrigin(null)).toBe("FALTA");
+    expect(mapBackendSourceToOrigin(undefined)).toBe("FALTA");
+    expect(mapBackendSourceToOrigin("")).toBe("FALTA");
+  });
+
+  test("source desconocido → INFERIDO (defensivo · no esconde como FALTA)", () => {
+    expect(mapBackendSourceToOrigin("unknown_source")).toBe("INFERIDO");
+  });
+});
+
+describe("breakdownToContext · null/undefined/empty input", () => {
+  test("breakdown null → todos los fields FALTA · preserva '—' behavior", () => {
+    const ctx = breakdownToContext(null);
+    expect(ctx.localidad.value).toBeNull();
+    expect(ctx.localidad.origin).toBe("FALTA");
+    expect(ctx.cliente.value).toBeNull();
+    expect(ctx.cliente.origin).toBe("FALTA");
+    expect(ctx.material.value).toBeNull();
+    expect(ctx.material.origin).toBe("FALTA");
+    expect(ctx.contacto.value).toBeNull();
+    expect(ctx.contacto.origin).toBe("FALTA");
+  });
+
+  test("breakdown vacío {} → todos FALTA", () => {
+    const ctx = breakdownToContext({});
+    expect(ctx.localidad.origin).toBe("FALTA");
+    expect(ctx.material.origin).toBe("FALTA");
+  });
+
+  test("anafe defaults a false + FALTA cuando no hay raw", () => {
+    const ctx = breakdownToContext({});
+    expect(ctx.anafe.value).toBe(false);
+    expect(ctx.anafe.origin).toBe("FALTA");
+  });
+
+  test("tipo_obra defaults a particular + DEFAULT cuando es_edificio undefined", () => {
+    const ctx = breakdownToContext({});
+    expect(ctx.tipo_obra.value).toBe("particular");
+    expect(ctx.tipo_obra.origin).toBe("DEFAULT");
+  });
+});
+
+describe("breakdownToContext · data_known precedencia y mapping", () => {
+  test("data_known con Localidad/Material/Cliente → BRIEF mapeo correcto", () => {
+    const ctx = breakdownToContext({
+      context_analysis_pending: {
+        data_known: [
+          { field: "Cliente", value: "Cueto-Heredia", source: "brief" },
+          { field: "Localidad", value: "Rosario", source: "brief" },
+          { field: "Material", value: "Purastone Venatino", source: "brief" },
+          { field: "Tipo de trabajo", value: "Cocina", source: "brief" },
+        ],
+      },
+    });
+    expect(ctx.cliente.value).toBe("Cueto-Heredia");
+    expect(ctx.cliente.origin).toBe("BRIEF");
+    expect(ctx.localidad.value).toBe("Rosario");
+    expect(ctx.localidad.origin).toBe("BRIEF");
+    expect(ctx.material.value).toBe("Purastone Venatino");
+    expect(ctx.material.origin).toBe("BRIEF");
+  });
+
+  test("data_known con source='quote' → BRIEF (Bug 3 deuda)", () => {
+    const ctx = breakdownToContext({
+      context_analysis_pending: {
+        data_known: [{ field: "Cliente", value: "Estudio Vidal", source: "quote" }],
+      },
+    });
+    expect(ctx.cliente.value).toBe("Estudio Vidal");
+    expect(ctx.cliente.origin).toBe("BRIEF");
+  });
+
+  test("assumptions con Zócalos / Pileta → mapeo a INFERIDO con source rule", () => {
+    const ctx = breakdownToContext({
+      context_analysis_pending: {
+        assumptions: [
+          {
+            field: "Zócalos",
+            value: "Trasero por tramo, 7 cm",
+            source: "config_default",
+          },
+          { field: "Pileta", value: "empotrada", source: "inferred" },
+        ],
+      },
+    });
+    expect(ctx.zocalo.value).toBe("Trasero por tramo, 7 cm");
+    expect(ctx.zocalo.origin).toBe("DEFAULT");
+    expect(ctx.pileta.value).toBe("empotrada");
+    expect(ctx.pileta.origin).toBe("INFERIDO");
+  });
+});
+
+describe("breakdownToContext · precedencia verified > pending > raw", () => {
+  test("verified gana sobre pending para el mismo field", () => {
+    const ctx = breakdownToContext({
+      verified_context_analysis: {
+        data_known: [{ field: "Localidad", value: "CABA · Belgrano", source: "quote" }],
+      },
+      context_analysis_pending: {
+        data_known: [{ field: "Localidad", value: "Rosario", source: "brief" }],
+      },
+    });
+    expect(ctx.localidad.value).toBe("CABA · Belgrano");
+  });
+
+  test("pending wins cuando verified no tiene el field", () => {
+    const ctx = breakdownToContext({
+      verified_context_analysis: { data_known: [] },
+      context_analysis_pending: {
+        data_known: [{ field: "Localidad", value: "Rosario", source: "brief" }],
+      },
+    });
+    expect(ctx.localidad.value).toBe("Rosario");
+  });
+
+  test("raw fallback cuando ningún analysis tiene el field", () => {
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: {
+        localidad: "Rosario",
+        material: "Purastone Venatino",
+        client_name: "Familia X",
+      },
+    });
+    expect(ctx.localidad.value).toBe("Rosario");
+    expect(ctx.localidad.origin).toBe("BRIEF");
+    expect(ctx.material.value).toBe("Purastone Venatino");
+    expect(ctx.cliente.value).toBe("Familia X");
+  });
+});
+
+describe("breakdownToContext · derived fields", () => {
+  test("work_types[] array → tipologia concatenado con ', '", () => {
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: { work_types: ["cocina", "baño"] },
+    });
+    expect(ctx.tipologia.value).toBe("cocina, baño");
+    expect(ctx.tipologia.origin).toBe("BRIEF");
+  });
+
+  test("work_types vacío → FALTA", () => {
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: { work_types: [] },
+    });
+    expect(ctx.tipologia.origin).toBe("FALTA");
+  });
+
+  test("es_edificio=true → tipo_obra='edificio' BRIEF", () => {
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: { es_edificio: true },
+    });
+    expect(ctx.tipo_obra.value).toBe("edificio");
+    expect(ctx.tipo_obra.origin).toBe("BRIEF");
+  });
+
+  test("es_edificio=false → tipo_obra='particular' BRIEF", () => {
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: { es_edificio: false },
+    });
+    expect(ctx.tipo_obra.value).toBe("particular");
+    expect(ctx.tipo_obra.origin).toBe("BRIEF");
+  });
+
+  test("regrueso_mentioned=true → 'Sí' BRIEF", () => {
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: { regrueso_mentioned: true },
+    });
+    expect(ctx.regrueso.value).toBe("Sí");
+    expect(ctx.regrueso.origin).toBe("BRIEF");
+  });
+
+  test("anafe_mentioned=true → boolean true BRIEF", () => {
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: { anafe_mentioned: true },
+    });
+    expect(ctx.anafe.value).toBe(true);
+    expect(ctx.anafe.origin).toBe("BRIEF");
+  });
+
+  test("pileta_type fallback al raw cuando no hay assumption", () => {
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: { pileta_type: "Johnson PEGADOPILETA" },
+    });
+    expect(ctx.pileta.value).toBe("Johnson PEGADOPILETA");
+    expect(ctx.pileta.origin).toBe("BRIEF");
+  });
+
+  test("demora_dias number → plazo formateado con 'días'", () => {
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: { demora_dias: 15 },
+    });
+    expect(ctx.plazo.value).toBe("15 días");
+    expect(ctx.plazo.origin).toBe("BRIEF");
+  });
+});
+
+describe("breakdownToContext · contacto siempre FALTA (deuda documentada)", () => {
+  test("contacto siempre null + FALTA · backend no extrae phone/email", () => {
+    const ctx = breakdownToContext({
+      context_analysis_pending: {
+        data_known: [
+          // Mock backend hipotético: incluso si trajera Contacto, lo
+          // ignoramos en este sub-PR.
+          { field: "Contacto", value: "+54 11 1234-5678", source: "brief" },
+        ],
+      },
+    });
+    expect(ctx.contacto.value).toBeNull();
+    expect(ctx.contacto.origin).toBe("FALTA");
+  });
+});
+
+describe("breakdownToContext · canon real PRES-2026-018 shape", () => {
+  test("shape realista del audit log de Javi (Mesada 2x0.60 purastone)", () => {
+    // Replicar el shape que el backend devuelve para la prueba real
+    // post-PR #482 (smoke test).
+    const ctx = breakdownToContext({
+      context_analysis_pending: {
+        data_known: [
+          { field: "Material", value: "Purastone Venatino", source: "brief" },
+          { field: "Localidad", value: "Rosario", source: "brief" },
+          { field: "Tipo de trabajo", value: "Cocina", source: "brief" },
+        ],
+        assumptions: [
+          {
+            field: "Zócalos",
+            value: "Trasero por tramo, 7 cm",
+            source: "config_default",
+            note: "default del config si no se especifica",
+          },
+          {
+            field: "Colocación",
+            value: "Incluida",
+            source: "brief",
+          },
+        ],
+      },
+      _brief_analysis_raw: {
+        material: "Purastone Venatino",
+        localidad: "Rosario",
+        work_types: ["cocina"],
+        zocalos: "Trasero",
+        alzada: "sí",
+        colocacion: "sí",
+        es_edificio: false,
+      },
+    });
+    expect(ctx.material.value).toBe("Purastone Venatino");
+    expect(ctx.material.origin).toBe("BRIEF");
+    expect(ctx.localidad.value).toBe("Rosario");
+    expect(ctx.localidad.origin).toBe("BRIEF");
+    expect(ctx.tipologia.value).toBe("cocina");
+    expect(ctx.zocalo.value).toBe("Trasero por tramo, 7 cm");
+    expect(ctx.zocalo.origin).toBe("DEFAULT");
+    expect(ctx.tipo_obra.value).toBe("particular");
+    expect(ctx.tipo_obra.origin).toBe("BRIEF");
+  });
+});


### PR DESCRIPTION
**Bug 1 del reporte diagnóstico · DEUDA HEREDADA Sprint 2 cerrada.**

## Bug fixed · paso 2 muestra "—" + FALTA en data extraída

UI paso 2 mostraba \`Localidad: —\` con chip \`FALTA\` aunque backend tuviera \`quote_breakdown._brief_analysis_raw.localidad = "Rosario"\`.

**Causa raíz:** \`getContextForQuote\` estaba HARDCODED a mock en \`web/src/lib/api/index.ts:28\` · fuera del gate \`USE_REAL_API\`. Para UUIDs reales de quotes nuevas (PR #475 createDraftQuote), el mock fallback genérico devolvía todos los fields como \`{value: null, origin: "FALTA"}\` → UI mostraba "—" + chip FALTA.

**Wire-only fix · cero backend touch · cero CSS shared modificado.**

## Cambios

### 1. Pure adapter \`breakdownToContext()\`
\`web/src/lib/api/adapters/context-from-breakdown.ts\`

- Precedencia: \`verified_context_analysis\` > \`context_analysis_pending\` > \`_brief_analysis_raw\`
- 11 fields del \`ContextResponse\` cubiertos
- Source mapping 8 → 5:

| Backend source | → | ContextOrigin |
|---|---|---|
| \`brief\` / \`brief+rule\` / \`brief+dual_read\` / \`quote\` | → | \`BRIEF\` |
| \`dual_read\` / \`rule\` / \`inferred\` | → | \`INFERIDO\` |
| \`config_default\` | → | \`DEFAULT\` |
| null/undefined | → | \`FALTA\` |
| unknown source | → | \`INFERIDO\` (defensivo) |

- Derived fields: \`tipologia\` (join work_types), \`tipo_obra\` (es_edificio bool), \`regrueso\` ("Sí"/"No"), \`anafe\` (bool directo), \`plazo\` (Demora assumption o raw)

### 2. \`real.getContextForQuote()\` en \`real.ts\`
- GET \`/api/quotes/{id}\` con Bearer SSR (PR #469)
- Adapter sobre \`detail.quote_breakdown\`
- Errores: 404 → \`CONTEXT_QUOTE_NOT_FOUND\` · 5xx → \`CONTEXT_LOAD_FAILED\`
- breakdown null/undefined → fields FALTA (preserva "—" behavior)

### 3. Gate \`USE_REAL_API\` en \`index.ts:28\`
- mocks intactos para E2E sin env var (regresión zero)

\`ContextField.tsx\` **INTACTO** · render \`null → "—"\` preservado.

## Mockup Fidelity Gate · parcial · solo wire-fix

### Items wireados (✅)
- Field "Localidad" con value real + chip origin correcto
- Fields \`data_known\` del backend mapeados a ContextResponse
- Source mapping 8→5 documentado en código + tests

### Items DIFERIDOS (a \`paso-2-toggles-y-chips-ia\`)
- ❌ Toggles enum \`.toggle-sw\` para tipo_obra / pileta / zócalo
- ❌ \`vmini-chip\` con tooltips IA (match arquitecta, inferí empotrada, etc.)
- ❌ Chip text literal "DEL BRIEF" vs render actual "BRIEF" (uppercase enum)
- ❌ Banner Valentina con contadores breakdown numérico
- ❌ Botón split \`regen-split\` con kebab menu

## Deudas explícitas

### \`contacto\` field
Backend no extrae phone/email del brief → siempre \`null\` + \`FALTA\`. Sub-PR \`paso-2-contacto-extraction\` posterior agrega extractor o input manual.

### \`quote\` source → BRIEF mapping
Semánticamente cuestionable hasta que Bug 3 fix-up (paso-1 project_name extraction) ajuste el setter de \`Quote.project\`. Consistencia mantenida con tratamiento de fields operador-input.

### Source desconocido → INFERIDO defensivo
Si el backend agrega nuevos sources sin actualizar el adapter, NO romperá pero quedará marcado como INFERIDO genérico. Documentado en código.

## Tests

| Suite | Resultado |
|---|---|
| **Unit vitest** (\`context-from-breakdown.test.ts\`) | **26/26 verde** |
| Unit vitest total | **97/97** (71 previos + 26 nuevos) |
| **E2E** \`contexto.spec.ts\` regression | **6/6 verde** |
| E2E full suite | **188 passed + 10 skipped + 0 fail** |
| Lint + typecheck + build | ✅ clean |

**Cobertura unit del adapter:**
- ✅ source mapping 8→5 (incluyendo \`quote\` → BRIEF deuda documentada)
- ✅ precedencia verified > pending > raw
- ✅ null/undefined/empty input → todos FALTA
- ✅ derived fields (work_types, es_edificio, regrueso, anafe, demora)
- ✅ canon real PRES-018 shape (Mesada 2x0.60 purastone)

**Tests E2E gated NO incluidos.** El patrón \`brief-upload-real.spec.ts\` (PR #475) requiere \`NEXT_PUBLIC_API_URL\` build-time, complejo de mantener. Cobertura via unit tests exhaustivos + smoke test post-deploy.

## Smoke test post-deploy OBLIGATORIO (lección #51)

Una vez Vercel deploy success, Javi reprueba con brief en prod:
\`"Mesada de 2 x 0,60 en purastone venatino, con zocalo y alzada, obra en rosario con colocacion"\`

**Esperado en UI paso 2:**
| Field | Value esperado | Chip esperado |
|---|---|---|
| Localidad | Rosario | BRIEF |
| Material | Purastone Venatino | BRIEF |
| Tipología | Cocina | BRIEF |
| Zócalos | Trasero por tramo, 7 cm | DEFAULT |
| Tipo obra | particular | BRIEF |
| Contacto | — | FALTA (deuda) |

**Criterio de aceptación:** los 4 primeros fields aparecen poblados (no "—" + FALTA) → Bug 1 cerrado.

Si siguen "—" + FALTA post-deploy → reportar para diagnóstico del adapter contra shape real del backend.

## Sub-PRs desbloqueados

- \`paso-2-toggles-y-chips-ia\` (gaps Mockup Fidelity restantes · 24h)
- \`paso-5-pdf-real-wire\` (siguiente prioridad Fase 1)

## Lecciones operativas aplicadas

- **#1 FASE 1 LITERAL** · diagnóstico previo verificado antes de fixear (getContextForQuote efectivamente hardcoded)
- **#47 Mockup Fidelity Gate** · aplicado al alcance que cubrimos · gaps diferidos documentados explícitamente
- **#51 Smoke test post-deploy** OBLIGATORIO
- **#53 Tests con UUIDs dinámicos** · cubierto vía smoke test post-deploy (adapter aislado vía unit tests)
- **#54 FASE 1 verifica diagnóstico previo** · validar el bug reportado antes de fixear

## Test plan

- [x] \`npm run typecheck\` + \`lint\` + \`build\` clean
- [x] Unit tests 97/97 verde
- [x] E2E full suite 188 passed + 10 skipped + 0 fail
- [x] Mocks Sprint 2-3 intactos (contexto.spec.ts 6/6 verde)
- [ ] Smoke test post-deploy Javi con brief "Mesada 2x0.60 purastone..." → verificar Localidad: Rosario · chip BRIEF
- [ ] Visual side-by-side con mockup 01-contexto-A · documentar gaps diferidos

🤖 Generated with [Claude Code](https://claude.com/claude-code)