### PR TITLE
fix(context_analyzer): regla pileta cede ante brief explícito de apoyo

### DIFF
--- a/api/app/modules/quote_engine/context_analyzer.py
+++ b/api/app/modules/quote_engine/context_analyzer.py
@@ -211,9 +211,14 @@ def _build_assumptions(
     has_banio = any((s.get("tipo") or "").lower() in ("baño", "banio") for s in sectores)
 
     # Regla D'Angelo: en cocina, pileta SIEMPRE empotrada (no apoyo).
-    # Solo agregar la assumption si hay cocina Y pileta mencionada/detectada.
+    # Solo agregar la assumption si hay cocina Y pileta mencionada/detectada,
+    # Y el brief NO declaró explícitamente `pileta_type="apoyo"` (Bug 4
+    # · brief explícito gana a la regla por defecto · #483-followup).
+    # Si brief dice "apoyo", la regla cede y el echo del brief (línea 324)
+    # marca la entrada como excepción a la regla D'Angelo.
     pileta_mentioned = analysis.get("pileta_mentioned") or _card_has_pileta(dual_result)
-    if has_cocina and pileta_mentioned:
+    brief_pileta_type = analysis.get("pileta_type")  # "apoyo" | "empotrada" | "bajomesada" | None
+    if has_cocina and pileta_mentioned and brief_pileta_type != "apoyo":
         assumptions.append({
             "field": "Pileta (tipo de montaje)",
             "value": "Empotrada (PEGADOPILETA)",
@@ -322,10 +327,22 @@ def _build_assumptions(
         })
 
     if analysis.get("pileta_type"):
+        montaje_value = analysis["pileta_type"].capitalize()
+        # Bug 4 follow-up — si brief dice "apoyo" Y hay cocina, marcar
+        # la entrada como excepción explícita a la regla D'Angelo (que
+        # cedió arriba). Sin esta nota, Marina no entiende por qué la
+        # regla "cocina → empotrada" no aparece como assumption.
+        montaje_note: str | None = None
+        if analysis["pileta_type"] == "apoyo" and has_cocina:
+            montaje_note = (
+                "Excepción a la regla D'Angelo (cocina normalmente "
+                "empotrada). Brief explícito pidió apoyo."
+            )
         assumptions.append({
             "field": "Pileta — montaje",
-            "value": analysis["pileta_type"].capitalize(),
+            "value": montaje_value,
             "source": "brief",
+            "note": montaje_note,
         })
     if analysis.get("mentions_johnson"):
         sku = analysis.get("johnson_sku") or "(modelo en brief)"

--- a/api/tests/test_context_analyzer.py
+++ b/api/tests/test_context_analyzer.py
@@ -96,6 +96,76 @@ class TestBuildContextAnalysis:
         out = build_context_analysis("", None, _dual(has_cocina=False))
         assert not any("Pileta" in a["field"] for a in out["assumptions"])
 
+    # ── Bug 4 · brief explícito de apoyo gana a la regla D'Angelo ──────
+    # El brief de Micaela ("AGUJEROAPOYO + cotizar bacha") declara
+    # explícitamente pileta de apoyo. Antes del fix: regla pisaba el
+    # brief → 2 assumptions opuestas en la card. Post-fix: regla cede,
+    # el echo del brief queda con note de excepción.
+
+    def test_brief_apoyo_overrides_rule_in_cocina(self):
+        # Brief explícito "pileta de apoyo" + cocina → regla cede.
+        out = build_context_analysis(
+            "cocina con pileta de apoyo", None, _dual(has_cocina=True),
+        )
+        # La regla cocina→empotrada NO debe disparar.
+        rule_entry = next(
+            (a for a in out["assumptions"]
+             if a["source"] == "rule" and "Pileta" in a["field"]),
+            None,
+        )
+        assert rule_entry is None, (
+            f"Regla pisó el brief explícito: {rule_entry}"
+        )
+        # El echo del brief sí debe estar con value=Apoyo + note de excepción.
+        brief_entry = next(
+            (a for a in out["assumptions"] if a["field"] == "Pileta — montaje"),
+            None,
+        )
+        assert brief_entry is not None
+        assert brief_entry["value"] == "Apoyo"
+        assert brief_entry["source"] == "brief"
+        assert brief_entry["note"] is not None
+        assert "Excepción" in brief_entry["note"]
+
+    def test_brief_empotrada_does_not_conflict_with_rule(self):
+        # Brief dice empotrada + regla dice empotrada. Pueden coexistir
+        # (no se contradicen) y ambas describen el mismo concepto. El
+        # bug 4 era el conflicto opuesto; coincidente no rompe nada.
+        out = build_context_analysis(
+            "cocina con pileta empotrada", None, _dual(has_cocina=True),
+        )
+        pileta_fields = [
+            a for a in out["assumptions"]
+            if "Pileta" in a["field"] and "montaje" in a["field"].lower()
+        ]
+        assert len(pileta_fields) >= 1
+        # Todas las entradas que aparezcan deben describir empotrada
+        # (no debe haber contradicción).
+        for f in pileta_fields:
+            assert "empotrada" in f["value"].lower(), (
+                f"Entrada inconsistente: {f}"
+            )
+
+    def test_brief_no_pileta_type_rule_applies_normally(self):
+        # Brief menciona pileta pero NO el tipo → regla dispara normal,
+        # no hay echo del brief (porque no hay pileta_type que ecotar).
+        # Acá nada que ceder · el comportamiento previo se mantiene.
+        out = build_context_analysis(
+            "cocina con pileta", None, _dual(has_cocina=True),
+        )
+        rule_entry = next(
+            (a for a in out["assumptions"]
+             if a["source"] == "rule" and "Pileta" in a["field"]),
+            None,
+        )
+        assert rule_entry is not None
+        assert "empotrada" in rule_entry["value"].lower()
+        # El echo del brief NO debe aparecer cuando pileta_type es None.
+        brief_montaje = [
+            a for a in out["assumptions"] if a["field"] == "Pileta — montaje"
+        ]
+        assert brief_montaje == []
+
     def test_con_zocalos_triggers_assumption(self):
         out = build_context_analysis("cocina con zocalos en rosario", None, _dual())
         zoc = [a for a in out["assumptions"] if a["field"] == "Zócalos"]


### PR DESCRIPTION
## Bug 4 fixed

**Causa**: [`context_analyzer.py:213-223`](api/app/modules/quote_engine/context_analyzer.py#L213-L223) sin guard de brief. La regla D'Angelo "en cocina, pileta siempre empotrada" disparaba assumption con \`source=\"rule\"\` aunque el brief declarara explícitamente \`pileta_type=\"apoyo\"\`.

**Síntoma operativo** (caso Micaela Volattire — brief: \`"AGUJEROAPOYO + cotizar bacha"\`):

| field | value | source |
|---|---|---|
| \`Pileta (tipo de montaje)\` | \`Empotrada (PEGADOPILETA)\` | \`rule\` ← bug |
| \`Pileta — montaje\` | \`Apoyo\` | \`brief\` |

Marina veía 2 valores opuestos para el mismo concepto, sin pista de cuál ganaba.

**Fix**: Opción A surgical · 1 archivo · ~10 LOC.

\`\`\`python
brief_pileta_type = analysis.get("pileta_type")
if has_cocina and pileta_mentioned and brief_pileta_type != \"apoyo\":
    # Regla solo aplica si brief NO dice apoyo explícito
    assumptions.append({..., \"source\": \"rule\", ...})
\`\`\`

Plus: en el echo del brief, agregar \`note=\"Excepción a la regla D'Angelo...\"\` cuando es \`apoyo + cocina\` para que Marina entienda por qué la regla no aparece como assumption.

## Patrón arquitectónico

Auditoría de 14 sites con \`\"source\":\` en \`_build_assumptions()\`:

| Comportamiento | Sites |
|---|---|
| brief > rule (reconcile / fallback / brief+rule combinado) | 13 |
| rule sin chequear brief | **1** (línea 220 — el bug) |

La línea 220 era la única outlier. Patrón "brief > rule" YA es estándar implícito en el módulo.

**Opción B (helper genérico \`_apply_rule_with_brief_override()\`) descartada**: agrega abstracción especulativa sin payoff hoy. Si en 6 meses aparecen 2+ reglas más con el mismo patrón, promovemos en PR separado.

## Tests · 3 nuevos · zero regresión

| Test | Cubre |
|---|---|
| \`test_brief_apoyo_overrides_rule_in_cocina\` | brief explícito apoyo + cocina → regla cede; echo del brief con \`note\` de excepción |
| \`test_brief_empotrada_does_not_conflict_with_rule\` | brief y regla coinciden en empotrada · sin contradicción |
| \`test_brief_no_pileta_type_rule_applies_normally\` | brief menciona pileta sin tipo → regla aplica normal (comportamiento previo) |

**Test existente preservado**: \`test_cocina_triggers_pileta_empotrada_rule\` (l.79) sigue verde sin cambios — brief literal \`\"cocina con pileta\"\` no matchea \`\\bapoyo\\b\` → \`pileta_type=None\` → regla aplica como antes.

\`\`\`
$ pytest tests/test_context_analyzer.py -v
=================================== 61 passed, 2 warnings in 0.08s ===================================

$ pytest tests/ --ignore=tests/evaluation --ignore=tests/test_observability_e2e.py
=================================== 2229 passed, 93 skipped, 1 xfailed, 2 errors ===================================
\`\`\`

Los 2 errors son **preexistentes** en \`test_pdf_snapshots.py\` (fixtures \`pres_2026_0{17,18}_data\` faltantes) — deuda independiente, no relacionada con context_analyzer.

## Smoke test post-deploy plan (OBLIGATORIO · lección #51)

Tras Railway deploy success, re-probar brief de Micaela en prod:

\`\`\`
Lead completo
Contacto: Micaela Volattire — Tel: 3464696027 — Email: micaelavolattire.1234@gmail.com
Trabajo: Cocina:
- mesada: 1,40 × 0,55 m
- Total: 0,77 m² de mesada
Material: Granito Gris Perla
Detalles confirmados
- Colocación: No
- Pileta: compra en D'Angelo → AGUJEROAPOYO + cotizar bacha
- Zócalo: Sí ...
- Anafe: Pendiente
- Ciudad: Casilda
\`\`\`

**Verificar en audit del quote**:
- \`assumptions\` **NO tiene** \`Pileta (tipo de montaje)\` con \`source=rule\` + \`Empotrada\`
- \`assumptions\` **SÍ tiene** \`Pileta — montaje\` = \`Apoyo\` · \`source=brief\` · \`note=\"Excepción a la regla D'Angelo...\"\`
- **Cero conflicto** · solo 1 field describe el montaje

## Lecciones aplicadas

- #1 FASE 1 obligatoria · diagnóstico read-only precedió implementación
- #51 Smoke test post-deploy obligatorio documentado
- #54 FASE 1 verifica diagnóstico previo

## Sub-PR desbloqueado

- paso-5-pdf-real-wire (sub-PR 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)