### PR TITLE
fix(brief_analyzer): schema ternary yes/no para frentin/regrueso/pulido + temperature=0

### DIFF
--- a/api/app/modules/quote_engine/brief_analyzer.py
+++ b/api/app/modules/quote_engine/brief_analyzer.py
@@ -80,10 +80,16 @@ EMPTY_SCHEMA: dict = {
     "descuento_tipo": None,  # "arquitecta" | "cliente" | null
     "descuento_pct": None,
 
-    # Frentin / regrueso / pulido
-    "frentin_mentioned": False,
-    "regrueso_mentioned": False,
-    "pulido_mentioned": False,
+    # Frentin / regrueso / pulido — Bug 5 fix · PR #485.
+    # Migrados de `*_mentioned: bool` a ternary `"yes"|"no"|null` para
+    # distinguir "Brief dice 'Frentín: No' explícito" (= "no") vs "Brief
+    # no menciona frentín en absoluto" (= null). Antes ambos colapsaban
+    # a `False` y el sistema perdía la información del operador. Patrón
+    # replicado de `colocacion`/`zocalos`/`alzada`. Activa el Issue
+    # follow-up del PR #425.
+    "frentin": None,   # "yes" | "no" | null
+    "regrueso": None,  # "yes" | "no" | null
+    "pulido": None,    # "yes" | "no" | null
 
     # Metadata
     "raw_notes": "",
@@ -130,8 +136,13 @@ trabajo, null/false/[] si no están presentes.
     "departamentos", "tipologías", edificio X, etc.
 13. `mentions_johnson` + `johnson_sku`: true/string si menciona Johnson
     (ej "Johnson LUXOR S171" → johnson_sku="LUXOR S171").
-14. `frentin_mentioned`, `regrueso_mentioned`, `pulido_mentioned`:
-    true si el brief menciona estos trabajos extra.
+14. `frentin`, `regrueso`, `pulido`: ternary "yes"|"no"|null.
+    - "yes" si brief dice "con frentín" / "lleva frentín" / "Frentín: Sí".
+    - "no" si brief dice "sin frentín" / "Frentín: No" / "no lleva frentín".
+    - null si NO se menciona en absoluto.
+    Idem para regrueso y pulido. Importante: distinguir "No" explícito
+    del operador de "no mencionado" — son operativamente distintos
+    (el primero es decisión, el segundo es ausencia de información).
 15. `raw_notes`: copia de frases sueltas que no categorizas (ej
     aclaraciones específicas del cliente).
 
@@ -170,9 +181,9 @@ trabajo, null/false/[] si no están presentes.
   "descuento_mentioned": bool,
   "descuento_tipo": "arquitecta"|"cliente"|null,
   "descuento_pct": float|null,
-  "frentin_mentioned": bool,
-  "regrueso_mentioned": bool,
-  "pulido_mentioned": bool,
+  "frentin": "yes"|"no"|null,
+  "regrueso": "yes"|"no"|null,
+  "pulido": "yes"|"no"|null,
   "raw_notes": string
 }
 ```
@@ -222,19 +233,56 @@ _LAVADERO = re.compile(r"\blavadero\b", re.IGNORECASE)
 _EDIFICIO = re.compile(r"\b(edificio|tipolog[ií]a|unidades|departamentos?|dptos?)\b", re.IGNORECASE)
 _DESCUENTO_ARQ = re.compile(r"\barquitect[oa]\b", re.IGNORECASE)
 _DESCUENTO_PCT = re.compile(r"(\d+)\s*%", re.IGNORECASE)
+# Regex de presencia literal — usado por el validator anti-alucinación
+# (PR #425) que chequea que la palabra esté en el brief. NO se usa para
+# decidir yes/no (eso lo hacen _X_YES / _X_NO abajo).
 _FRENTIN = re.compile(r"\bfrent[ií]n\b", re.IGNORECASE)
 _REGRUESO = re.compile(r"\bregrueso\b", re.IGNORECASE)
 _PULIDO = re.compile(r"\bpulido\b", re.IGNORECASE)
 
+# Bug 5 fix · PR #485 — patrones espejo de zócalos para distinguir
+# "Sí" / "No" / null en el regex fallback. Captura todos los formatos
+# de brief estructurado típicos:
+#   - "con frentín" / "lleva frentín" / "Frentín: Sí"
+#   - "sin frentín" / "no lleva frentín" / "Frentín: No"
+# Si el operador escribe formatos atípicos ("frentín? si"), el LLM
+# Haiku ya lo captura con temperature=0. El regex es solo fallback.
+_FRENTIN_YES = re.compile(
+    r"\b(con\s+frent[ií]n|lleva(n)?\s+frent[ií]n|frent[ií]n\s*:?\s*s[ií])",
+    re.IGNORECASE,
+)
+_FRENTIN_NO = re.compile(
+    r"\b(sin\s+frent[ií]n|no\s+(lleva|van)\s+frent[ií]n|frent[ií]n\s*:?\s*no\b)",
+    re.IGNORECASE,
+)
+_REGRUESO_YES = re.compile(
+    r"\b(con\s+regrueso|lleva(n)?\s+regrueso|regrueso\s*:?\s*s[ií])",
+    re.IGNORECASE,
+)
+_REGRUESO_NO = re.compile(
+    r"\b(sin\s+regrueso|no\s+(lleva|van)\s+regrueso|regrueso\s*:?\s*no\b)",
+    re.IGNORECASE,
+)
+_PULIDO_YES = re.compile(
+    r"\b(con\s+pulido|lleva(n)?\s+pulido|pulido\s*:?\s*s[ií])",
+    re.IGNORECASE,
+)
+_PULIDO_NO = re.compile(
+    r"\b(sin\s+pulido|no\s+(lleva|van)\s+pulido|pulido\s*:?\s*no\b)",
+    re.IGNORECASE,
+)
 
-# Map de flags que el LLM puede marcar como `true` y que validamos
-# contra el brief literal con word-boundary. PR #425 — fix
-# alucinación del LLM Haiku que confundía "frente regrueso" con
-# "frentín". Ver `_validate_llm_word_mentions` abajo.
+
+# Map de flags ternary que el LLM puede setear y que validamos contra
+# el brief literal con word-boundary. PR #425 — fix alucinación del LLM
+# Haiku que confundía "frente regrueso" con "frentín". Post-Bug-5 (PR
+# #485) los flags son ternary `"yes"|"no"|null` en vez de bool: si el
+# LLM dijo "yes" o "no" pero la palabra literal NO aparece en el brief,
+# override a `None` (no había nada que decidir).
 _LLM_WORD_VALIDATIONS = (
-    ("frentin_mentioned", _FRENTIN, "frent[ií]n"),
-    ("regrueso_mentioned", _REGRUESO, "regrueso"),
-    ("pulido_mentioned", _PULIDO, "pulido"),
+    ("frentin", _FRENTIN, "frent[ií]n"),
+    ("regrueso", _REGRUESO, "regrueso"),
+    ("pulido", _PULIDO, "pulido"),
 )
 
 
@@ -254,30 +302,32 @@ def _validate_llm_word_mentions(brief: str, result: dict) -> None:
     Endurecer el system prompt es frágil (review feedback: "el
     system prompt es demasiado frágil en conversaciones largas").
     Garantía dura: post-process con los mismos regex word-boundary
-    que ya usa el fallback. Si el LLM dice `true` pero la palabra
-    literal NO está en el brief, override a `False` con log.
+    que ya usa el fallback. Si el LLM setea un valor pero la palabra
+    literal NO está en el brief, override a `None` con log.
 
-    **Edge case conocido**: "sin frentín" → `frentin_mentioned: true`
-    porque la palabra literal aparece. Es técnicamente correcto a
-    nivel del analyzer (la mención está). Sonnet maneja la negación
-    contextualmente. No es responsabilidad de este filtro detectar
-    negación — anotado en Issue follow-up.
+    **Post Bug 5 (PR #485):** los flags son ternary `"yes"|"no"|null`.
+    Si el LLM dijo `"yes"` o `"no"` (cualquier no-null) pero la
+    palabra literal NO aparece en el brief → override a `None`. El
+    caso "sin frentín" → "no" (la palabra SÍ aparece, el regex YES/NO
+    decide la semántica) ya NO es deuda — el analyzer distingue
+    explícitamente Sí/No/sin mencionar.
 
     Muta `result` in-place. NO tira excepciones — la observabilidad
     nunca rompe el flow (warning log + continúa).
     """
     for flag_key, regex, word_label in _LLM_WORD_VALIDATIONS:
-        if not result.get(flag_key):
-            continue
+        if result.get(flag_key) is None:
+            continue  # LLM no decidió nada → no hay nada que validar
         if regex.search(brief):
-            continue  # LLM y regex coinciden — OK
-        # LLM dijo true pero la palabra literal no está → alucinación.
+            continue  # LLM y palabra literal coinciden — OK
+        # LLM decidió yes/no pero la palabra literal no está → alucinación.
         logger.warning(
             f"[brief-analyzer] LLM hallucination override: "
-            f"{flag_key}=true sin literal '{word_label}' en brief. "
-            f"Override → False. Brief snippet: {brief[:150]!r}"
+            f"{flag_key}={result.get(flag_key)!r} sin literal "
+            f"'{word_label}' en brief. Override → None. "
+            f"Brief snippet: {brief[:150]!r}"
         )
-        result[flag_key] = False
+        result[flag_key] = None
 
 
 def _extract_material_regex(brief: str) -> str | None:
@@ -379,12 +429,21 @@ def _analyze_regex_fallback(brief: str) -> dict:
         except ValueError:
             pass
 
-    if _FRENTIN.search(b):
-        result["frentin_mentioned"] = True
-    if _REGRUESO.search(b):
-        result["regrueso_mentioned"] = True
-    if _PULIDO.search(b):
-        result["pulido_mentioned"] = True
+    # Bug 5 fix · PR #485 — ternary "yes"/"no"/null replicando pattern
+    # de zócalos. Prioridad: NO antes que YES (porque "sin frentín" no
+    # debe matchear `_FRENTIN_YES` aunque contenga "frentín").
+    if _FRENTIN_NO.search(b):
+        result["frentin"] = "no"
+    elif _FRENTIN_YES.search(b):
+        result["frentin"] = "yes"
+    if _REGRUESO_NO.search(b):
+        result["regrueso"] = "no"
+    elif _REGRUESO_YES.search(b):
+        result["regrueso"] = "yes"
+    if _PULIDO_NO.search(b):
+        result["pulido"] = "no"
+    elif _PULIDO_YES.search(b):
+        result["pulido"] = "yes"
 
     return result
 
@@ -414,6 +473,12 @@ async def analyze_brief(brief: str) -> dict:
             client.messages.create(
                 model=BRIEF_ANALYZER_MODEL,
                 max_tokens=900,
+                # Bug 5 fix · PR #485 — temperature=0 elimina
+                # variabilidad entre runs idénticos (Run1≠Run2 con
+                # mismo brief). El SDK Anthropic default es 1.0, que
+                # introduce stochasticidad inaceptable para extracción
+                # estructurada user-facing. Ver lección #56.
+                temperature=0,
                 system=_SYSTEM_PROMPT,
                 messages=[{
                     "role": "user",

--- a/api/app/modules/quote_engine/context_analyzer.py
+++ b/api/app/modules/quote_engine/context_analyzer.py
@@ -394,13 +394,26 @@ def _build_assumptions(
             "note": "Si el cliente tiene descuento (arquitecta u otro), corregí.",
         })
 
-    # Trabajos extra mencionados (frentin, regrueso, pulido)
-    if analysis.get("frentin_mentioned"):
-        assumptions.append({"field": "Frentín", "value": "Mencionado", "source": "brief"})
-    if analysis.get("regrueso_mentioned"):
-        assumptions.append({"field": "Regrueso", "value": "Mencionado", "source": "brief"})
-    if analysis.get("pulido_mentioned"):
-        assumptions.append({"field": "Pulido especial", "value": "Mencionado", "source": "brief"})
+    # Trabajos extra (frentín, regrueso, pulido) — Bug 5 fix · PR #485.
+    # Migrados de `*_mentioned: bool` (ambiguo: "No" colapsaba a False
+    # igual que "no mencionado") a ternary `"yes"|"no"|null`. Mapeo
+    # 2-branch replicando patrón de `colocacion` (líneas 246-257). El
+    # caso null (no mencionado) es silencio — no agrega assumption.
+    for field_key, label in (
+        ("frentin", "Frentín"),
+        ("regrueso", "Regrueso"),
+        ("pulido", "Pulido especial"),
+    ):
+        v = analysis.get(field_key)
+        if v == "yes":
+            assumptions.append({
+                "field": label, "value": "Sí lleva", "source": "brief",
+            })
+        elif v == "no":
+            assumptions.append({
+                "field": label, "value": "No lleva", "source": "brief",
+            })
+        # v is None → silencio: brief no mencionó este trabajo extra
 
     return assumptions
 

--- a/api/tests/test_brief_analyzer.py
+++ b/api/tests/test_brief_analyzer.py
@@ -102,11 +102,65 @@ class TestRegexFallback:
         assert out["descuento_tipo"] == "arquitecta"
         assert out["descuento_pct"] == 5.0
 
-    def test_frentin_regrueso_pulido(self):
-        out = _analyze_regex_fallback("con frentin y regrueso y pulido")
-        assert out["frentin_mentioned"] is True
-        assert out["regrueso_mentioned"] is True
-        assert out["pulido_mentioned"] is True
+    def test_frentin_regrueso_pulido_yes(self):
+        # Bug 5 (PR #485) — schema ternary. Brief estructurado típico
+        # tiene cada trabajo extra en su propia línea con "X: Sí".
+        out = _analyze_regex_fallback(
+            "Frentín: Sí\nRegrueso: Sí\nPulido: Sí"
+        )
+        assert out["frentin"] == "yes"
+        assert out["regrueso"] == "yes"
+        assert out["pulido"] == "yes"
+
+    # ── Bug 5 · PR #485 · frentin/regrueso/pulido ternary ─────────────
+
+    def test_frentin_brief_explicit_no(self):
+        """Brief estructurado típico: 'Frentín: No'. Antes colapsaba a
+        `frentin_mentioned=False` (igual que 'no mencionado') y el
+        sistema perdía la decisión del operador. Ahora es `frentin='no'`
+        explícito."""
+        out = _analyze_regex_fallback("Frentín: No")
+        assert out["frentin"] == "no"
+
+    def test_regrueso_brief_explicit_no(self):
+        out = _analyze_regex_fallback("Regrueso: No")
+        assert out["regrueso"] == "no"
+
+    def test_pulido_brief_explicit_si(self):
+        out = _analyze_regex_fallback("Pulido: Sí")
+        assert out["pulido"] == "yes"
+
+    def test_sin_frentin_is_no(self):
+        # Activación Issue follow-up PR #425. Antes "sin frentín"
+        # daba `frentin_mentioned=True` y se documentaba como deuda.
+        # Hoy ese formato es claramente "no".
+        out = _analyze_regex_fallback("Mesada sin frentín, solo zócalo")
+        assert out["frentin"] == "no"
+
+    def test_frentin_not_mentioned_is_null(self):
+        """Si el brief no menciona frentín en absoluto → null (distinto
+        de 'no' explícito). Importante para el mapping a card: null
+        es silencio, 'no' es decisión."""
+        out = _analyze_regex_fallback("Mesada 2x0.60 en silestone")
+        assert out["frentin"] is None
+        assert out["regrueso"] is None
+        assert out["pulido"] is None
+
+    def test_brief_micaela_e2e_yes_no_extraction(self):
+        """E2E del brief estructurado de Micaela Volattire — debe
+        extraer frentin='no' Y regrueso='no' (ambos explícitos en
+        el brief con 'X: No')."""
+        brief = (
+            "Lead completo. Cliente Micaela. Cocina mesada 1.40 × 0.55. "
+            "Material Granito Gris Perla. Colocación: No. "
+            "Pileta: compra en D'Angelo. "
+            "Zócalo: Sí. Frentín: No. Regrueso: No. Ciudad: Casilda."
+        )
+        out = _analyze_regex_fallback(brief)
+        assert out["frentin"] == "no"
+        assert out["regrueso"] == "no"
+        # Pulido no se menciona → silencio.
+        assert out["pulido"] is None
 
 
 # ── LLM entry point con fallback ────────────────────────────────────────────
@@ -193,3 +247,28 @@ class TestAnalyzeBriefFallback:
         assert out["zocalos"] == "no"
         assert out["anafe_count"] == 2
         assert out["pileta_simple_doble"] == "doble"
+
+    @pytest.mark.asyncio
+    async def test_llm_call_uses_temperature_zero(self):
+        """Bug 5 fix · PR #485 — drift guard. El LLM call DEBE usar
+        temperature=0 para output determinístico. Sin este lock,
+        Run1≠Run2 con mismo brief (causa raíz de variabilidad
+        observada en briefs de Micaela)."""
+        json_payload = '{"client_name": "X"}'
+        mock_response = type("R", (), {
+            "content": [type("B", (), {"text": json_payload})()]
+        })()
+        fake_client = type("F", (), {})()
+        fake_client.messages = type("M", (), {})()
+        fake_client.messages.create = AsyncMock(return_value=mock_response)
+        with patch(
+            "app.modules.quote_engine.brief_analyzer.anthropic.AsyncAnthropic",
+            return_value=fake_client,
+        ):
+            await analyze_brief("any brief")
+        # Asegurar que `temperature=0` se pasó al call.
+        call_kwargs = fake_client.messages.create.call_args.kwargs
+        assert call_kwargs.get("temperature") == 0, (
+            "LLM call DEBE usar temperature=0 para output determinístico. "
+            "Si esto cambia, revisar lección #56 antes de mergear."
+        )

--- a/api/tests/test_brief_analyzer_llm_hallucination.py
+++ b/api/tests/test_brief_analyzer_llm_hallucination.py
@@ -1,45 +1,43 @@
-"""Tests para PR #425 — fix alucinación del LLM Haiku que confunde
-"frente regrueso" con "frentín".
+"""Tests para PR #425 (validator anti-alucinación) + PR #485 (Bug 5 —
+schema ternary yes/no/null).
 
-**Caso DYSCON 29/04/2026:**
+## Historia
 
-El "Análisis de contexto" del operador mostraba:
-- "Frentín: Mencionado _(brief)_"
+**PR #425 — caso DYSCON 29/04/2026:**
 
-PERO el brief NO contenía la palabra "frentín". Sí contenía "M1 frente
-regrueso × 24" (las piezas frente regrueso del despiece).
+El "Análisis de contexto" del operador mostraba "Frentín: Mencionado"
+para un brief que decía "M1 frente regrueso × 24" pero NO "frentín".
+El LLM Haiku interpretaba "frente regrueso" como "frentín" — son
+términos distintos:
+- frentín / faldón = pieza vertical pegada al borde frontal (5-10 cm).
+- frente regrueso = pieza horizontal que aumenta espesor visual.
 
-**Causa raíz:** `brief_analyzer.py` usa Haiku como fuente primaria con
-regex como fallback. El LLM interpretaba "frente regrueso" como
-"frentín" — son términos distintos:
-- frentín / faldón = pieza vertical pegada al borde frontal de la
-  mesada (5–10 cm de alto), MO con SKU FALDON.
-- frente regrueso = pieza horizontal que aumenta el espesor visual
-  del frente (5 cm), MO con SKU REGRUESO.
+Fix PR #425: post-process con regex word-boundary. Si LLM marcaba
+`frentin_mentioned=true` pero la palabra literal NO aparece, override
+a False.
 
-El regex fallback `\\bfrent[ií]n\\b` con word boundary NO matchearía
-"frente regrueso" — pero el regex es solo fallback, no se ejecuta
-cuando el LLM responde.
+**PR #485 — Bug 5 (Issue follow-up activado):**
 
-**Fix (review feedback "no toques el system prompt"):** post-process
-con regex word-boundary después del LLM. Si LLM dice
-`frentin_mentioned: true` pero la palabra literal NO aparece →
-override a False con log.
+Los flags `frentin_mentioned: bool` no distinguían "Brief dice 'Frentín:
+No'" (operador explícito) vs "Brief no menciona frentín" (silencio).
+El test `test_sin_frentin_keeps_flag_true` documentaba esa deuda como
+expected behavior. Caso Micaela (Run1 ≠ Run2) confirmó variabilidad.
 
-**Tests cubren:**
+Fix PR #485: schema ternary `"yes"|"no"|null`. El validator ahora:
+- Si LLM setea valor no-null pero palabra NO aparece → override a None.
+- "sin frentín" → el regex de fallback decide `"no"` (la palabra está).
+- Drift guard de tuple `_LLM_WORD_VALIDATIONS` actualizado a 3 keys
+  nuevas: `frentin`, `regrueso`, `pulido`.
+
+## Tests cubren
 
 1. **Caso DYSCON real**: "frente regrueso" en el brief → frentin
-   override a False, regrueso queda en True.
-2. **Caso positivo legítimo**: "con frentín h:5cm" → no se override.
-3. **Edge case "sin frentín"**: la palabra aparece → flag queda True
-   aunque sea negación contextual. Documentado en docstring del
-   helper — Sonnet maneja la negación, no el analyzer.
-4. **Drift guard**: el helper se ejecuta en la rama LLM (no en regex
-   fallback, donde no hay false positives por construcción).
-5. **Análogos para regrueso/pulido**: el LLM puede alucinar
-   cualquiera de los 3 — el helper los cubre simétricamente.
-6. **No-op cuando LLM responde correctamente**: si LLM dice false,
-   el helper no toca nada.
+   override a None, regrueso queda en "yes" (palabra sí aparece).
+2. **Casos positivos legítimos**: "con frentín" → no se override.
+3. **No-op**: si LLM dijo None, el helper no toca nada.
+4. **Drift guards**: el helper y la tupla de validation cubren los 3
+   campos. Si se agrega un flag nuevo, drift guard rompe.
+5. **Logging**: override emite warning con snippet del brief.
 """
 from __future__ import annotations
 
@@ -58,8 +56,8 @@ from app.modules.quote_engine.brief_analyzer import (
 class TestDysconHallucination:
     def test_frente_regrueso_does_not_imply_frentin(self):
         """Caso real DYSCON: brief con "M1 frente regrueso × 24" y
-        análogos. LLM marca frentin_mentioned=true (alucinación).
-        Override a False post-process."""
+        análogos. LLM marca frentin="yes" (alucinación). Override a
+        None post-process."""
         brief = (
             "CLIENTE: DYSCON S.A.\n"
             "OBRA: Unidad Penal N°8 — Piñero\n"
@@ -67,31 +65,31 @@ class TestDysconHallucination:
             "M2 mesada (Office 32), M2 zócalo atrás, M2 frente regrueso\n"
         )
         result = {
-            "frentin_mentioned": True,   # ← alucinación del LLM
-            "regrueso_mentioned": True,  # ← legítimo (sí dice "regrueso")
-            "pulido_mentioned": False,
+            "frentin": "yes",    # ← alucinación del LLM
+            "regrueso": "yes",   # ← legítimo (sí dice "regrueso")
+            "pulido": None,
         }
         _validate_llm_word_mentions(brief, result)
-        assert result["frentin_mentioned"] is False, (
+        assert result["frentin"] is None, (
             "Override fallido: 'frente regrueso' no debe disparar frentin"
         )
-        assert result["regrueso_mentioned"] is True, (
+        assert result["regrueso"] == "yes", (
             "Regrueso es legítimo — la palabra 'regrueso' aparece word-boundary"
         )
-        assert result["pulido_mentioned"] is False  # invariante
+        assert result["pulido"] is None  # invariante
 
     def test_only_frente_no_regrueso_overrides_both(self):
         """Brief que dice 'frente' pero no 'regrueso' explícito (raro
         pero posible). LLM podría marcar ambos por confusión."""
         brief = "Mesada con frente plano de 5cm"
         result = {
-            "frentin_mentioned": True,
-            "regrueso_mentioned": True,  # también alucinación si no dice "regrueso"
-            "pulido_mentioned": False,
+            "frentin": "yes",
+            "regrueso": "yes",  # también alucinación si no dice "regrueso"
+            "pulido": None,
         }
         _validate_llm_word_mentions(brief, result)
-        assert result["frentin_mentioned"] is False
-        assert result["regrueso_mentioned"] is False
+        assert result["frentin"] is None
+        assert result["regrueso"] is None
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -100,39 +98,39 @@ class TestDysconHallucination:
 
 
 class TestLegitimateMentions:
-    def test_frentin_literal_keeps_true(self):
-        """'con frentín h:5cm' → la palabra está, flag queda True."""
+    def test_frentin_literal_keeps_yes(self):
+        """'con frentín h:5cm' → la palabra está, valor queda en 'yes'."""
         brief = "Mesada con frentín h:5cm"
-        result = {"frentin_mentioned": True, "regrueso_mentioned": False, "pulido_mentioned": False}
+        result = {"frentin": "yes", "regrueso": None, "pulido": None}
         _validate_llm_word_mentions(brief, result)
-        assert result["frentin_mentioned"] is True
+        assert result["frentin"] == "yes"
 
-    def test_frentin_no_tilde_keeps_true(self):
+    def test_frentin_no_tilde_keeps_yes(self):
         """'frentin' (sin tilde) también es literal — el regex matchea
         ambos `\\bfrent[ií]n\\b`."""
         brief = "Mesada con frentin de 5cm"
-        result = {"frentin_mentioned": True, "regrueso_mentioned": False, "pulido_mentioned": False}
+        result = {"frentin": "yes", "regrueso": None, "pulido": None}
         _validate_llm_word_mentions(brief, result)
-        assert result["frentin_mentioned"] is True
+        assert result["frentin"] == "yes"
 
-    def test_frentin_uppercase_keeps_true(self):
+    def test_frentin_uppercase_keeps_yes(self):
         """Case-insensitive — 'FRENTÍN' debería match."""
         brief = "Mesada CON FRENTÍN H:5CM"
-        result = {"frentin_mentioned": True, "regrueso_mentioned": False, "pulido_mentioned": False}
+        result = {"frentin": "yes", "regrueso": None, "pulido": None}
         _validate_llm_word_mentions(brief, result)
-        assert result["frentin_mentioned"] is True
+        assert result["frentin"] == "yes"
 
-    def test_regrueso_literal_keeps_true(self):
+    def test_regrueso_literal_keeps_yes(self):
         brief = "Regrueso de 5cm en frente"
-        result = {"frentin_mentioned": False, "regrueso_mentioned": True, "pulido_mentioned": False}
+        result = {"frentin": None, "regrueso": "yes", "pulido": None}
         _validate_llm_word_mentions(brief, result)
-        assert result["regrueso_mentioned"] is True
+        assert result["regrueso"] == "yes"
 
-    def test_pulido_literal_keeps_true(self):
+    def test_pulido_literal_keeps_yes(self):
         brief = "Pulido especial en cantos visibles"
-        result = {"frentin_mentioned": False, "regrueso_mentioned": False, "pulido_mentioned": True}
+        result = {"frentin": None, "regrueso": None, "pulido": "yes"}
         _validate_llm_word_mentions(brief, result)
-        assert result["pulido_mentioned"] is True
+        assert result["pulido"] == "yes"
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -140,22 +138,26 @@ class TestLegitimateMentions:
 # ═══════════════════════════════════════════════════════════════════════
 
 
-class TestNegationEdgeCase:
-    def test_sin_frentin_keeps_flag_true(self):
-        """**Edge case (review feedback)**: 'sin frentín' contiene la
-        palabra literal → flag queda True. Es responsabilidad de
-        Sonnet manejar la negación contextualmente, NO del analyzer
-        filtrar negaciones. Anotado en Issue follow-up.
+class TestNegationHandling:
+    def test_sin_frentin_validator_keeps_no(self):
+        """**Activación Issue follow-up PR #425** (cerrado por PR #485).
 
-        Si el día de mañana se decide filtrar negaciones a este
-        nivel, este test SE ROMPERÁ y obligará a actualizar la
-        documentación + el flow."""
+        Antes: el validator era binary (`True`/`False`) y "sin frentín"
+        contenía la palabra literal → flag quedaba `True`. Sonnet
+        debía manejar la negación. Caso Micaela demostró que NO la
+        manejaba consistentemente (Run1≠Run2).
+
+        Hoy: el schema es ternary y el LLM ya devuelve `"no"`
+        directamente. El validator solo chequea presencia literal —
+        si la palabra está y LLM devolvió `"no"`, queda `"no"` (es
+        decisión legítima del operador). Si la palabra NO está y LLM
+        devolvió cualquier valor, override a None."""
         brief = "Mesada sin frentín, solo zócalo atrás"
-        result = {"frentin_mentioned": True, "regrueso_mentioned": False, "pulido_mentioned": False}
+        result = {"frentin": "no", "regrueso": None, "pulido": None}
         _validate_llm_word_mentions(brief, result)
-        assert result["frentin_mentioned"] is True, (
-            "Negación NO se filtra acá — Sonnet maneja contexto. "
-            "Si esto cambia, ver Issue follow-up del PR #425."
+        assert result["frentin"] == "no", (
+            "Validator debe preservar 'no' cuando la palabra está. "
+            "Sonnet ya NO maneja la negación — el analyzer la captura."
         )
 
 
@@ -165,19 +167,19 @@ class TestNegationEdgeCase:
 
 
 class TestNoOpWhenLLMCorrect:
-    def test_llm_says_false_no_change(self):
-        """Si LLM dice False, el helper NO toca nada (incluso si la
-        palabra aparece — confiamos en el LLM cuando dice False)."""
+    def test_llm_says_null_no_change(self):
+        """Si LLM dice None (no decidió), el helper NO toca nada —
+        no hay nada que validar."""
         brief = "Mesada con frentín h:5cm"
-        result = {"frentin_mentioned": False, "regrueso_mentioned": False, "pulido_mentioned": False}
+        result = {"frentin": None, "regrueso": None, "pulido": None}
         _validate_llm_word_mentions(brief, result)
-        assert result["frentin_mentioned"] is False  # sin cambios
+        assert result["frentin"] is None  # sin cambios
 
-    def test_all_flags_false_no_op(self):
+    def test_all_flags_null_no_op(self):
         brief = "Brief sin trabajos extra"
-        result = {"frentin_mentioned": False, "regrueso_mentioned": False, "pulido_mentioned": False}
+        result = {"frentin": None, "regrueso": None, "pulido": None}
         _validate_llm_word_mentions(brief, result)
-        assert result == {"frentin_mentioned": False, "regrueso_mentioned": False, "pulido_mentioned": False}
+        assert result == {"frentin": None, "regrueso": None, "pulido": None}
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -192,20 +194,20 @@ class TestObservability:
         muchas veces, sabemos que el LLM aluciona seguido."""
         import logging
         brief = "M1 frente regrueso × 24"
-        result = {"frentin_mentioned": True, "regrueso_mentioned": True, "pulido_mentioned": False}
+        result = {"frentin": "yes", "regrueso": "yes", "pulido": None}
         with caplog.at_level(logging.WARNING, logger="app.modules.quote_engine.brief_analyzer"):
             _validate_llm_word_mentions(brief, result)
         warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
         assert any("hallucination" in m.lower() for m in warnings), (
             f"Esperaba warning de hallucination, vi {warnings}"
         )
-        assert any("frentin_mentioned" in m for m in warnings)
+        assert any("frentin" in m for m in warnings)
 
     def test_no_override_no_warning(self, caplog):
         """Sin override → ningún warning del helper."""
         import logging
         brief = "Mesada con frentín h:5cm"
-        result = {"frentin_mentioned": True, "regrueso_mentioned": False, "pulido_mentioned": False}
+        result = {"frentin": "yes", "regrueso": None, "pulido": None}
         with caplog.at_level(logging.WARNING, logger="app.modules.quote_engine.brief_analyzer"):
             _validate_llm_word_mentions(brief, result)
         warnings = [
@@ -228,27 +230,27 @@ class TestDriftGuards:
         result = {}  # ← shape incompleta
         _validate_llm_word_mentions(brief, result)  # no debe romper
         # No agrega keys que no estaban
-        assert "frentin_mentioned" not in result
+        assert "frentin" not in result
 
-    def test_empty_brief_no_op(self):
+    def test_empty_brief_overrides_to_null(self):
         """Brief vacío → nada que validar. Helper no tira."""
-        result = {"frentin_mentioned": True, "regrueso_mentioned": True, "pulido_mentioned": True}
+        result = {"frentin": "yes", "regrueso": "yes", "pulido": "yes"}
         _validate_llm_word_mentions("", result)
-        # Brief vacío → todas las palabras "no aparecen" → todos override.
-        assert result["frentin_mentioned"] is False
-        assert result["regrueso_mentioned"] is False
-        assert result["pulido_mentioned"] is False
+        # Brief vacío → todas las palabras "no aparecen" → todos override a None.
+        assert result["frentin"] is None
+        assert result["regrueso"] is None
+        assert result["pulido"] is None
 
     def test_validation_map_has_three_entries(self):
         """Drift guard: si alguien agrega un nuevo flag al schema
-        (ej. `inglete_mentioned`), tiene que agregarlo también al
-        mapa de validation. Test recuerda."""
+        (ej. `inglete`), tiene que agregarlo también al mapa de
+        validation. Test recuerda."""
         from app.modules.quote_engine.brief_analyzer import _LLM_WORD_VALIDATIONS
         flag_keys = {entry[0] for entry in _LLM_WORD_VALIDATIONS}
         assert flag_keys == {
-            "frentin_mentioned", "regrueso_mentioned", "pulido_mentioned",
+            "frentin", "regrueso", "pulido",
         }, (
             f"Validation map cambió: {flag_keys}. Si agregaste un nuevo "
-            "flag de tipo `*_mentioned`, agregalo a _LLM_WORD_VALIDATIONS "
-            "para protegerlo de alucinaciones del LLM."
+            "flag ternary (yes/no/null) de trabajo extra, agregalo a "
+            "_LLM_WORD_VALIDATIONS para protegerlo de alucinaciones del LLM."
         )


### PR DESCRIPTION
## Bug 5 fixed

Brief de Micaela Volattire daba **outputs distintos en 2 runs idénticos** (Run1: \`frentin_mentioned=true\`, Run2: \`false\`). 2 causas entrelazadas:

| Causa | Síntoma | Fix |
|---|---|---|
| **Raíz: temperature 1.0** | Run1 ≠ Run2 con mismo input | \`temperature=0\` en LLM call |
| **Estructural: schema bool** | \"Brief dice 'Frentín: No'\" vs \"no mencionado\" colapsan ambos a \`False\` | Schema ternary \`\"yes\"\|\"no\"\|null\` |

## Patrón aplicado

Replica el patrón existente de \`colocacion\`/\`zocalos\`/\`alzada\` — 13 de 14 sites del módulo YA respetan ternary. Los 3 \`*_mentioned\` eran outliers.

## Cambios

### Backend

| Archivo | Cambio |
|---|---|
| \`brief_analyzer.py\` EMPTY_SCHEMA | \`frentin_mentioned: False\` → \`frentin: None\` (idem regrueso, pulido) |
| \`brief_analyzer.py\` prompt regla 14 | Instruye distinguir \"X: Sí\" / \"X: No\" / \"no mencionado\" |
| \`brief_analyzer.py\` regex | Agrega \`_X_YES\` + \`_X_NO\` espejo del patrón zócalos |
| \`brief_analyzer.py\` \`_validate_llm_word_mentions\` | Semántica ternary — override a \`None\` (antes \`False\`) |
| \`brief_analyzer.py\` \`_LLM_WORD_VALIDATIONS\` tuple | 3 keys renombradas |
| \`brief_analyzer.py\` \`_analyze_regex_fallback\` | 2 branches por field (NO antes que YES) |
| \`brief_analyzer.py\` \`analyze_brief\` | \`temperature=0\` |
| \`context_analyzer.py\` líneas 397-403 | Loop 2-branch · \`yes\` → \"Sí lleva\" · \`no\` → \"No lleva\" · \`null\` → silencio |

## Tests · 6 nuevos + 1 renamed + 10 migrados

### \`test_brief_analyzer.py\`

- **Renamed**: \`test_frentin_regrueso_pulido\` → \`*_yes\` (formato realista).
- **Nuevos**:
  - \`test_frentin_brief_explicit_no\` · \"Frentín: No\" → \"no\"
  - \`test_regrueso_brief_explicit_no\` · \"Regrueso: No\" → \"no\"
  - \`test_pulido_brief_explicit_si\` · \"Pulido: Sí\" → \"yes\"
  - \`test_sin_frentin_is_no\` · activa Issue follow-up PR #425
  - \`test_frentin_not_mentioned_is_null\` · null distinto de \"no\"
  - \`test_brief_micaela_e2e_yes_no_extraction\` · golden test del bug
  - \`test_llm_call_uses_temperature_zero\` · drift guard de determinismo

### \`test_brief_analyzer_llm_hallucination.py\`

10 tests migrados de bool a ternary. \`test_sin_frentin_keeps_flag_true\` → \`test_sin_frentin_validator_keeps_no\` (activación literal del Issue follow-up PR #425). Drift guard del tuple actualizado.

\`\`\`
$ pytest tests/test_brief_analyzer.py tests/test_brief_analyzer_llm_hallucination.py tests/test_context_analyzer.py
=================================== 107 passed ===================================

$ pytest tests/ --ignore=tests/evaluation --ignore=tests/test_observability_e2e.py
=================================== 2236 passed, 93 skipped, 1 xfailed, 2 errors ===================================
\`\`\`

Los 2 errors son **preexistentes** en \`test_pdf_snapshots.py\` (fixtures \`pres_2026_0{17,18}_data\` faltantes) — deuda independiente.

## Activación Issue follow-up PR #425

El docstring de \`test_sin_frentin_keeps_flag_true\` (PR #425) documentaba la deuda como deliberada:

> \"Si el día de mañana se decide filtrar negaciones a este nivel, este test SE ROMPERÁ y obligará a actualizar la documentación + el flow.\"

Hoy se cumple: test renamed + flow actualizado + docstring del módulo actualizado con historia PR #425 → PR #485.

## Deudas explícitas NO cerradas

Otros campos \`_mentioned: bool\` siguen binary:
- \`isla_mentioned\`, \`mentions_johnson\`, \`descuento_mentioned\`
- \`anafe_gas_y_electrico\`, \`es_edificio\`, \`anafe_mentioned\`, \`pileta_mentioned\`

Bajo riesgo en briefs reales — rara vez se listan como \"X: No\" explícito. Si en el futuro aparecen briefs con \"Isla: No\" o \"Anafe: No\", retomar siguiendo este mismo patrón.

## Smoke test post-deploy plan (OBLIGATORIO · lección #51)

Reprobar brief de Micaela en prod:

\`\`\`
Cocina: mesada 1.40 × 0.55 · Material: Granito Gris Perla
Pileta: compra en D'Angelo → AGUJEROAPOYO + cotizar bacha
Frentín: No
Regrueso: No
Anafe: Pendiente · Ciudad: Casilda
\`\`\`

**Verificar 3 runs IDÉNTICOS** del mismo brief:
- \`frentin = \"no\"\` en los 3 (sin variabilidad)
- \`regrueso = \"no\"\` en los 3
- \`pulido = null\` (no mencionado)

**Verificar card de assumptions del audit**:
- \"Frentín: No lleva\" · \`source=brief\` (NO \"Mencionado\")
- \"Regrueso: No lleva\" · \`source=brief\`
- \"Pulido especial\" NO aparece (silencio)

## Lecciones aplicadas

- #1 FASE 1 obligatoria · diagnóstico precise antes de implementar
- #51 Smoke test post-deploy obligatorio documentado
- #53 Tests fixtures con shape real prod (brief Micaela E2E)
- #54 FASE 1 verifica diagnóstico previo
- #56 (refuerzo) determinismo en LLM calls obligatorio — agregada drift guard \`test_llm_call_uses_temperature_zero\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)