### PR TITLE
fix(adapter): paso 2 context sync con schema ternary post-PR #485

### DIFF
--- a/web/src/lib/api/adapters/context-from-breakdown.ts
+++ b/web/src/lib/api/adapters/context-from-breakdown.ts
@@ -56,7 +56,13 @@ interface BriefAnalysisRaw {
   pileta_simple_doble?: string | null;
   anafe_mentioned?: boolean | null;
   anafe_count?: number | null;
-  regrueso_mentioned?: boolean | null;
+  // PR #485 (sub-PR Bug 5) · schema ternary post-migración. Antes
+  // estos eran `*_mentioned: bool` y este adapter los leía como tal —
+  // el sub-PR Bug 7 (este) corrige el mismatch. `pulido` no tiene UI
+  // row hoy (ContextData no tiene field separado), se ignora.
+  frentin?: "yes" | "no" | null;
+  regrueso?: "yes" | "no" | null;
+  pulido?: "yes" | "no" | null;
   forma_pago?: string | null;
   demora_dias?: string | number | null;
   es_edificio?: boolean | null;
@@ -113,6 +119,42 @@ function findEntry(
     analysis.assumptions?.find((e) => e.field === fieldName) ??
     null
   );
+}
+
+/** Combina frentin + regrueso ternary en 1 string para el row UI
+ * "Frentín / Regrueso" (mapea al field `regrueso` de ContextData).
+ *
+ * Matriz confirmada con operador · sub-PR Bug 7:
+ *
+ *   frentin | regrueso | output
+ *   ----------------------------------------------------------
+ *   null    | null     | null
+ *   no      | no       | "No lleva"
+ *   yes     | yes      | "Frentín + Regrueso"
+ *   yes     | no       | "Frentín: Sí · Regrueso: No"
+ *   no      | yes      | "Frentín: No · Regrueso: Sí"
+ *   yes     | null     | "Frentín: Sí · Regrueso: —"
+ *   null    | yes      | "Frentín: — · Regrueso: Sí"
+ *   no      | null     | "Frentín: No · Regrueso: —"
+ *   null    | no       | "Frentín: — · Regrueso: No"
+ *
+ * Razón del formato explícito en disjoint: Marina necesita ver AMBOS
+ * valores cuando difieren — el formato compacto ("No lleva") solo es
+ * legible cuando ambos coinciden.
+ */
+export function combineFrentinRegrueso(
+  frentin: "yes" | "no" | null,
+  regrueso: "yes" | "no" | null,
+): string | null {
+  if (frentin === null && regrueso === null) return null;
+  if (frentin === "no" && regrueso === "no") return "No lleva";
+  if (frentin === "yes" && regrueso === "yes") return "Frentín + Regrueso";
+  // Disjoint · formato explícito.
+  const fLabel =
+    frentin === "yes" ? "Sí" : frentin === "no" ? "No" : "—";
+  const rLabel =
+    regrueso === "yes" ? "Sí" : regrueso === "no" ? "No" : "—";
+  return `Frentín: ${fLabel} · Regrueso: ${rLabel}`;
 }
 
 /** Resuelve un string field con precedencia verified > pending > raw fallback. */
@@ -185,8 +227,21 @@ export function breakdownToContext(breakdown: QuoteBreakdownLike | null | undefi
     plazo = field<string | null>(null, "FALTA");
   }
 
-  // ── Pileta · assumptions "Pileta" o derivar de raw.pileta_*
-  const piletaEntry = findEntry(verified, "Pileta") ?? findEntry(pending, "Pileta");
+  // ── Pileta · assumptions con name canónico del backend o derivar de raw
+  // PR #485-followup (Bug 7): el backend NO emite assumption "Pileta"
+  // sin sufijo. Emite 4 fields con nombres específicos. Probamos en
+  // orden de prioridad operativa:
+  //   1. "Pileta — montaje" — echo del brief con pileta_type explícito
+  //      (post bug 4 fix · PR #484). Es la fuente más confiable cuando
+  //      el operador declara apoyo/empotrada.
+  //   2. "Pileta (tipo de montaje)" — regla D'Angelo cocina→empotrada
+  //      (líneas 218-223 de context_analyzer.py).
+  //   3. fallback a raw.pileta_type (el brief crudo).
+  const piletaEntry =
+    findEntry(verified, "Pileta — montaje") ??
+    findEntry(pending, "Pileta — montaje") ??
+    findEntry(verified, "Pileta (tipo de montaje)") ??
+    findEntry(pending, "Pileta (tipo de montaje)");
   let pileta: ContextField<string | null>;
   if (piletaEntry?.value) {
     pileta = field<string | null>(piletaEntry.value, mapBackendSourceToOrigin(piletaEntry.source));
@@ -209,17 +264,37 @@ export function breakdownToContext(breakdown: QuoteBreakdownLike | null | undefi
     zocalo = field<string | null>(null, "FALTA");
   }
 
-  // ── Regrueso · raw.regrueso_mentioned (bool → "Sí"/"No"/FALTA)
-  let regrueso: ContextField<string | null>;
-  if (raw.regrueso_mentioned === true) {
-    regrueso = field<string | null>("Sí", "BRIEF");
-  } else if (raw.regrueso_mentioned === false) {
-    regrueso = field<string | null>("No", "DEFAULT");
-  } else {
-    regrueso = field<string | null>(null, "FALTA");
-  }
+  // ── Frentín / Regrueso · UI combina ambos en 1 row (label "Frentín
+  // / Regrueso" mapeado al field `regrueso` de ContextData).
+  //
+  // Post PR #485 el schema del backend es ternary:
+  //   raw.frentin:  "yes" | "no" | null
+  //   raw.regrueso: "yes" | "no" | null
+  //
+  // Matriz de combinación (confirmada con operador · sub-PR Bug 7):
+  //   null/null  → null + FALTA
+  //   no/no      → "No lleva"
+  //   yes/yes    → "Frentín + Regrueso"
+  //   disjoint   → "Frentín: X · Regrueso: Y" (explícito sin ambigüedad)
+  //
+  // Razón: en casos disjoint el formato explícito previene que Marina
+  // confunda cuál campo dijo qué. Ambos visibles siempre.
+  const regrueso = field<string | null>(
+    combineFrentinRegrueso(raw.frentin ?? null, raw.regrueso ?? null),
+    raw.frentin === undefined && raw.regrueso === undefined ? "FALTA"
+      : raw.frentin === null && raw.regrueso === null ? "FALTA"
+        : "BRIEF",
+  );
 
   // ── Anafe · boolean directo
+  //
+  // ⚠️ Deuda documentada (sub-PR Bug 7): cuando `anafe_mentioned ===
+  // undefined`, devolvemos `value: false, origin: "FALTA"`. La UI
+  // renderea `value=false` como "No" y `origin=FALTA` como chip → el
+  // operador ve "No + FALTA simultáneo" (inconsistente). El type
+  // `boolean` no admite null, por eso no podemos representar "sin
+  // valor". El fix requiere migrar a `boolean | null` + refactor
+  // de la UI row anafe — scope separado coordinado con maqueta.
   let anafe: ContextField<boolean>;
   if (raw.anafe_mentioned === true) {
     anafe = { value: true, origin: "BRIEF" };

--- a/web/tests/unit/context-from-breakdown.test.ts
+++ b/web/tests/unit/context-from-breakdown.test.ts
@@ -119,6 +119,14 @@ describe("breakdownToContext · data_known precedencia y mapping", () => {
   });
 
   test("assumptions con Zócalos / Pileta → mapeo a INFERIDO con source rule", () => {
+    // Sub-PR Bug 7 · ajuste: el backend NO emite assumption con field
+    // exacto `"Pileta"`. Los nombres reales son `"Pileta — montaje"`,
+    // `"Pileta (tipo de montaje)"`, `"Pileta — bachas"`, `"Pileta —
+    // marca"`. Para la regla cocina→empotrada (source="rule"), el
+    // backend usa `"Pileta (tipo de montaje)"` (líneas 218-223 de
+    // context_analyzer.py). Tests específicos de los 4 nombres reales
+    // viven en el bloque "Bug 7 · pileta · assumption name canónico
+    // backend" abajo. Acá lo dejamos cubierto con el caso regla.
     const ctx = breakdownToContext({
       context_analysis_pending: {
         assumptions: [
@@ -127,13 +135,17 @@ describe("breakdownToContext · data_known precedencia y mapping", () => {
             value: "Trasero por tramo, 7 cm",
             source: "config_default",
           },
-          { field: "Pileta", value: "empotrada", source: "inferred" },
+          {
+            field: "Pileta (tipo de montaje)",
+            value: "Empotrada (PEGADOPILETA)",
+            source: "rule",
+          },
         ],
       },
     });
     expect(ctx.zocalo.value).toBe("Trasero por tramo, 7 cm");
     expect(ctx.zocalo.origin).toBe("DEFAULT");
-    expect(ctx.pileta.value).toBe("empotrada");
+    expect(ctx.pileta.value).toBe("Empotrada (PEGADOPILETA)");
     expect(ctx.pileta.origin).toBe("INFERIDO");
   });
 });
@@ -208,13 +220,10 @@ describe("breakdownToContext · derived fields", () => {
     expect(ctx.tipo_obra.origin).toBe("BRIEF");
   });
 
-  test("regrueso_mentioned=true → 'Sí' BRIEF", () => {
-    const ctx = breakdownToContext({
-      _brief_analysis_raw: { regrueso_mentioned: true },
-    });
-    expect(ctx.regrueso.value).toBe("Sí");
-    expect(ctx.regrueso.origin).toBe("BRIEF");
-  });
+  // Test legacy migrado · sub-PR Bug 7. El schema viejo era
+  // `regrueso_mentioned: bool` (deprecated por PR #485). Hoy el
+  // backend devuelve `regrueso: "yes"|"no"|null` y el adapter combina
+  // con `frentin`. Ver tests ternary abajo.
 
   test("anafe_mentioned=true → boolean true BRIEF", () => {
     const ctx = breakdownToContext({
@@ -301,5 +310,209 @@ describe("breakdownToContext · canon real PRES-2026-018 shape", () => {
     expect(ctx.zocalo.origin).toBe("DEFAULT");
     expect(ctx.tipo_obra.value).toBe("particular");
     expect(ctx.tipo_obra.origin).toBe("BRIEF");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Sub-PR Bug 7 · adapter sync post-PR #485
+//
+// PR #485 migró el schema brief_analyzer de bool a ternary:
+//   frentin_mentioned: bool → frentin: "yes" | "no" | null
+//   regrueso_mentioned: bool → regrueso: "yes" | "no" | null
+//
+// El adapter no se había actualizado · sub-PR Bug 7 cierra esa deuda
+// + agrega lectura de `frentin` (que NUNCA estuvo cubierta en PR #483
+// inicial — el UI siempre mostró "—" para el field combinado).
+// ─────────────────────────────────────────────────────────────────────
+
+describe("Bug 7 · frentin/regrueso ternary · matriz combinación", () => {
+  test("null/null → null + FALTA", () => {
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: { frentin: null, regrueso: null },
+    });
+    expect(ctx.regrueso.value).toBeNull();
+    expect(ctx.regrueso.origin).toBe("FALTA");
+  });
+
+  test("no/no → 'No lleva' + BRIEF", () => {
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: { frentin: "no", regrueso: "no" },
+    });
+    expect(ctx.regrueso.value).toBe("No lleva");
+    expect(ctx.regrueso.origin).toBe("BRIEF");
+  });
+
+  test("yes/yes → 'Frentín + Regrueso' + BRIEF", () => {
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: { frentin: "yes", regrueso: "yes" },
+    });
+    expect(ctx.regrueso.value).toBe("Frentín + Regrueso");
+    expect(ctx.regrueso.origin).toBe("BRIEF");
+  });
+
+  test("yes/no disjoint → 'Frentín: Sí · Regrueso: No' + BRIEF", () => {
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: { frentin: "yes", regrueso: "no" },
+    });
+    expect(ctx.regrueso.value).toBe("Frentín: Sí · Regrueso: No");
+    expect(ctx.regrueso.origin).toBe("BRIEF");
+  });
+
+  test("no/yes disjoint → 'Frentín: No · Regrueso: Sí' + BRIEF", () => {
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: { frentin: "no", regrueso: "yes" },
+    });
+    expect(ctx.regrueso.value).toBe("Frentín: No · Regrueso: Sí");
+    expect(ctx.regrueso.origin).toBe("BRIEF");
+  });
+
+  test("yes/null partial → 'Frentín: Sí · Regrueso: —' + BRIEF", () => {
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: { frentin: "yes", regrueso: null },
+    });
+    expect(ctx.regrueso.value).toBe("Frentín: Sí · Regrueso: —");
+    expect(ctx.regrueso.origin).toBe("BRIEF");
+  });
+
+  test("null/yes partial → 'Frentín: — · Regrueso: Sí' + BRIEF", () => {
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: { frentin: null, regrueso: "yes" },
+    });
+    expect(ctx.regrueso.value).toBe("Frentín: — · Regrueso: Sí");
+    expect(ctx.regrueso.origin).toBe("BRIEF");
+  });
+});
+
+describe("Bug 7 · pileta · assumption name canónico backend", () => {
+  test("'Pileta — montaje' (post bug 4 fix) → mapping correcto", () => {
+    // Caso brief Micaela post-PR #484: backend genera assumption con
+    // este field exacto cuando brief declara pileta_type.
+    const ctx = breakdownToContext({
+      context_analysis_pending: {
+        assumptions: [
+          {
+            field: "Pileta — montaje",
+            value: "Apoyo",
+            source: "brief",
+            note: "Excepción a la regla D'Angelo",
+          },
+        ],
+      },
+    });
+    expect(ctx.pileta.value).toBe("Apoyo");
+    expect(ctx.pileta.origin).toBe("BRIEF");
+  });
+
+  test("'Pileta (tipo de montaje)' (regla cocina→empotrada) → INFERIDO", () => {
+    const ctx = breakdownToContext({
+      context_analysis_pending: {
+        assumptions: [
+          {
+            field: "Pileta (tipo de montaje)",
+            value: "Empotrada (PEGADOPILETA)",
+            source: "rule",
+          },
+        ],
+      },
+    });
+    expect(ctx.pileta.value).toBe("Empotrada (PEGADOPILETA)");
+    expect(ctx.pileta.origin).toBe("INFERIDO");
+  });
+
+  test("'Pileta — montaje' tiene prioridad sobre 'Pileta (tipo de montaje)'", () => {
+    // Si el operador declaró pileta_type explícito (echo del brief), gana
+    // sobre la regla. Replica el mismo patrón brief > rule del backend.
+    const ctx = breakdownToContext({
+      context_analysis_pending: {
+        assumptions: [
+          {
+            field: "Pileta (tipo de montaje)",
+            value: "Empotrada (PEGADOPILETA)",
+            source: "rule",
+          },
+          {
+            field: "Pileta — montaje",
+            value: "Apoyo",
+            source: "brief",
+          },
+        ],
+      },
+    });
+    expect(ctx.pileta.value).toBe("Apoyo");
+    expect(ctx.pileta.origin).toBe("BRIEF");
+  });
+});
+
+describe("Bug 7 · drift guard · adapter no resucita schemas obsoletos", () => {
+  test("regression: el adapter NO lee `regrueso_mentioned` (PR #485 deprecated)", () => {
+    // Si alguien resucita el field viejo en un commit futuro y NO
+    // setea `regrueso` (nuevo), el adapter debe igualmente caer a
+    // FALTA — no debe revivir el comportamiento pre-#485.
+    // Cast a Record para inyectar key legacy sin romper TypeScript
+    // (BriefAnalysisRaw tiene `[key: string]: unknown` que la admite,
+    // pero queremos que el test sea explícito sobre que es legacy).
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: { regrueso_mentioned: true } as Record<string, unknown>,
+    });
+    expect(ctx.regrueso.origin).toBe("FALTA");
+    expect(ctx.regrueso.value).toBeNull();
+  });
+
+  test("regression: el adapter NO lee `frentin_mentioned`", () => {
+    // `frentin_mentioned` NUNCA existió en el adapter — drift guard
+    // contra resurrección futura del schema obsoleto.
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: { frentin_mentioned: true } as Record<string, unknown>,
+    });
+    expect(ctx.regrueso.origin).toBe("FALTA");
+    expect(ctx.regrueso.value).toBeNull();
+  });
+});
+
+describe("Bug 7 · smoke E2E · brief Micaela post-PR #485", () => {
+  test("shape real prod · pileta apoyo + frentin/regrueso ambos no", () => {
+    // Replica el shape que el backend devuelve para el brief Micaela
+    // post-PR #485 + PR #484. Pre-fix: pileta=—, frentin/regrueso=—.
+    // Post-fix: pileta="Apoyo" + regrueso="No lleva".
+    const ctx = breakdownToContext({
+      context_analysis_pending: {
+        data_known: [
+          { field: "Cliente", value: "Micaela Volattire", source: "brief" },
+          { field: "Material", value: "Granito Gris Perla", source: "brief" },
+          { field: "Localidad", value: "Casilda", source: "brief" },
+          { field: "Tipo de trabajo", value: "Cocina", source: "brief" },
+        ],
+        assumptions: [
+          {
+            field: "Pileta — montaje",
+            value: "Apoyo",
+            source: "brief",
+            note: "Excepción a la regla D'Angelo (cocina normalmente empotrada).",
+          },
+          { field: "Zócalos", value: "Trasero por tramo, 5 cm", source: "brief+rule" },
+          { field: "Frentín", value: "No lleva", source: "brief" },
+          { field: "Regrueso", value: "No lleva", source: "brief" },
+        ],
+      },
+      _brief_analysis_raw: {
+        client_name: "Micaela Volattire",
+        material: "Granito Gris Perla",
+        localidad: "Casilda",
+        work_types: ["cocina"],
+        pileta_type: "apoyo",
+        frentin: "no",
+        regrueso: "no",
+        pulido: null,
+        anafe_mentioned: false,
+        es_edificio: false,
+      },
+    });
+    expect(ctx.cliente.value).toBe("Micaela Volattire");
+    expect(ctx.localidad.value).toBe("Casilda");
+    expect(ctx.material.value).toBe("Granito Gris Perla");
+    expect(ctx.pileta.value).toBe("Apoyo");
+    expect(ctx.pileta.origin).toBe("BRIEF");
+    expect(ctx.regrueso.value).toBe("No lleva");
+    expect(ctx.regrueso.origin).toBe("BRIEF");
   });
 });


### PR DESCRIPTION
## Bug 7 fixed

PR #485 migró schema brief_analyzer a ternary (\`*_mentioned: bool\` → \`*: \"yes\"|\"no\"|null\`). El adapter \`context-from-breakdown.ts\` no se actualizó.

**Brief de Micaela en UI paso 2 mostraba**:

| Campo | Pre-fix | Post-fix |
|---|---|---|
| Pileta | \"—\" · FALTA | **\"Apoyo\" · BRIEF** |
| Frentín / Regrueso | \"—\" · FALTA | **\"No lleva\" · BRIEF** |
| Zócalo | \"Trasero por tramo, 5 cm\" · BRIEF ✅ | sin cambio |

3 campos rotos. Backend perfecto (assumptions y \`_brief_analysis_raw\` correctos). UI no leía del breakdown nuevo.

## Cambios

### 1. Frentín / Regrueso · matriz combinación

Helper exportado nuevo \`combineFrentinRegrueso(frentin, regrueso)\` con matriz confirmada por operador:

| frentin | regrueso | output |
|---|---|---|
| null | null | null (→ FALTA) |
| no | no | \"No lleva\" |
| yes | yes | \"Frentín + Regrueso\" |
| yes | no | \"Frentín: Sí · Regrueso: No\" |
| no | yes | \"Frentín: No · Regrueso: Sí\" |
| yes | null | \"Frentín: Sí · Regrueso: —\" |
| null | yes | \"Frentín: — · Regrueso: Sí\" |
| no | null | \"Frentín: No · Regrueso: —\" |
| null | no | \"Frentín: — · Regrueso: No\" |

**Razón del formato explícito en disjoint**: Marina necesita ver AMBOS valores cuando difieren. \"No lleva\" solo es legible cuando coinciden.

### 2. Pileta · nombres canónicos del backend

Antes el adapter buscaba \`findEntry(\"Pileta\")\` exact match. El backend NUNCA emite ese field — usa 4 sufijos específicos:

| field name | source típico | Prioridad |
|---|---|---|
| \`\"Pileta — montaje\"\` | brief explícito (post bug 4) | **1** |
| \`\"Pileta (tipo de montaje)\"\` | regla cocina→empotrada | 2 |
| \`raw.pileta_type\` | fallback raw | 3 |

## Deudas explícitas NO cerradas

### Anafe \"No + FALTA simultáneo\" (scope separado)

\`ContextField<boolean>\` no admite null. Cuando \`anafe_mentioned === undefined\`, devolvemos \`{value: false, origin: \"FALTA\"}\`. UI renderea \"No\" + chip FALTA. Fix requiere migrar a \`boolean | null\` + refactor UI row. **Documentado como comentario inline en el adapter**.

### Pulido sin UI row

Backend emite \`pulido: \"yes\"|\"no\"|null\` pero \`ContextData\` no tiene field. Si Marina lo necesita visible, sub-PR posterior agregar row al UI + field a \`ContextData\`.

### \`frentin\` nunca estuvo cubierto en PR #483 original

El adapter inicial leía \`regrueso_mentioned\` pero \`frentin_mentioned\` nunca. **Este sub-PR cierra deuda acumulada · NO solo regresión PR #485 sino gap original PR #483**.

## Tests · 1 migrado + 14 nuevos · 38/38 verde

\`\`\`
$ vitest run tests/unit/context-from-breakdown.test.ts
=================================== 38 passed (38) ===================================

$ vitest run
=================================== 109 passed (109) ===================================
\`\`\`

TypeScript: \`tsc --noEmit\` exit 0.

### Cobertura

- **Migrado** (PR #483 legacy): \`regrueso_mentioned: true\` ya no se lee · comentario legacy.
- **Migrado** (PR #483 legacy): assumption \`\"Pileta\"\` → \`\"Pileta (tipo de montaje)\"\` (nombre real del backend).
- **Bug 7 · matriz frentin/regrueso (7 tests)**: 7 casos no-trivial de la matriz · value + origin.
- **Bug 7 · pileta · nombres canónicos (3 tests)**: \`Pileta — montaje\`, \`Pileta (tipo de montaje)\`, precedencia entre ambos.
- **Bug 7 · drift guards (2 tests)**: regression contra resurrección de \`regrueso_mentioned\` / \`frentin_mentioned\`.
- **Bug 7 · smoke E2E brief Micaela (1 test)**: shape realista del backend post-#484 + #485.

## Smoke test post-deploy plan (OBLIGATORIO · lección #51)

Tras Vercel deploy success, reprobar brief Micaela en prod:

\`\`\`
Cocina: mesada 1.40 × 0.55 · Material: Granito Gris Perla
Pileta: compra en D'Angelo → AGUJEROAPOYO + cotizar bacha
Frentín: No
Regrueso: No
Anafe: Pendiente
Ciudad: Casilda
\`\`\`

**UI paso 2 esperado**:

| Campo | Esperado |
|---|---|
| Pileta | \"Apoyo\" · BRIEF |
| Frentín / Regrueso | \"No lleva\" · BRIEF |
| Anafe | sigue \"No + FALTA simultáneo\" (deuda documentada · NO fix en este PR) |
| Zócalo | sin cambio (ya funcionaba) |

## Reglas seguidas

- Backend touch: cero ✓
- Otros wires: cero ✓
- Adapter sigue pure function · sin side effects ✓
- Tests existentes intactos o migrados (no deleted) ✓
- \`combineFrentinRegrueso\` exportado para testabilidad independiente ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)