### PR TITLE
feat(audit): audit copy 3-layer state (adapter + UI render) · /contexto

### DIFF
--- a/web/src/components/contexto/ContextField.tsx
+++ b/web/src/components/contexto/ContextField.tsx
@@ -139,7 +139,10 @@ function formatForInput(value: string | number | boolean | null): string {
   return String(value);
 }
 
-function formatForDisplay(value: string | number | boolean | null): string {
+// Exportado (Sprint 4 audit-copy-3-layer-state): el snapshot de [UI RENDER]
+// reusa este formatter exacto para que el audit copy refleje 1:1 lo que el
+// usuario ve (value ?? "—", bool → "Sí"/"No").
+export function formatForDisplay(value: string | number | boolean | null): string {
   if (value === null || value === undefined) return "—";
   if (typeof value === "boolean") return value ? "Sí" : "No";
   return String(value);

--- a/web/src/components/contexto/ContextForm.tsx
+++ b/web/src/components/contexto/ContextForm.tsx
@@ -14,19 +14,22 @@ import { useRouter } from "next/navigation";
 import type { ContextData, ContextResponse } from "@/lib/api";
 import { ContextField } from "./ContextField";
 
-interface FieldDef {
+export interface FieldDef {
   name: keyof ContextData;
   label: string;
   hint: string;
   type?: "text" | "boolean";
 }
 
-interface Group {
+export interface Group {
   title: string;
   fields: FieldDef[];
 }
 
-const GROUPS: Group[] = [
+// Exportado (Sprint 4 audit-copy-3-layer-state): fuente única de la
+// estructura secciones/labels · el snapshot de [UI RENDER] del audit copy
+// la reusa para garantizar que matchee el render real.
+export const GROUPS: Group[] = [
   {
     title: "Cliente",
     fields: [

--- a/web/src/components/contexto/ContextView.tsx
+++ b/web/src/components/contexto/ContextView.tsx
@@ -13,8 +13,14 @@ import { useEffect, useState } from "react";
 import { useContextForm } from "@/lib/hooks/useContextForm";
 import { useChatScoped } from "@/lib/hooks/useChatScoped";
 import { getValentinaBriefSummary } from "@/lib/api";
-import { ContextForm } from "./ContextForm";
+import { ContextForm, GROUPS } from "./ContextForm";
+import { formatForDisplay } from "./ContextField";
 import { ChatPanel } from "./ChatPanel";
+import {
+  registerSnapshot,
+  unregisterSnapshot,
+  type AuditUiRenderSection,
+} from "@/lib/audit-snapshot";
 
 interface Props {
   quoteId: string;
@@ -43,6 +49,30 @@ export function ContextView({ quoteId }: Props) {
       ctrl.abort();
     };
   }, [quoteId]);
+
+  // Sprint 4 audit-copy-3-layer-state · registra el snapshot 3-capa del paso 2
+  // (ContextResponse del adapter + UI render) en el registry module-level para
+  // que el 📋 del Topbar lo incluya. Se re-registra cuando `context` cambia
+  // (load inicial + cada edit). El `uiRender` usa los MISMOS `GROUPS` y
+  // `formatForDisplay` que el render real → matchea 1:1 lo que se ve. Cleanup
+  // desregistra por quoteId (anti-stale al cambiar de quote).
+  useEffect(() => {
+    if (!context) return;
+    const uiRender: AuditUiRenderSection[] = GROUPS.map((group) => ({
+      title: group.title,
+      fields: group.fields.map((f) => ({
+        label: f.label,
+        displayValue: formatForDisplay(context[f.name].value),
+        origin: context[f.name].origin,
+      })),
+    }));
+    registerSnapshot(quoteId, {
+      step: "/contexto",
+      contextResponse: context,
+      uiRender,
+    });
+    return () => unregisterSnapshot(quoteId);
+  }, [quoteId, context]);
 
   if (state === "loading" && !context) {
     return (

--- a/web/src/components/observability/AuditCopyButton.tsx
+++ b/web/src/components/observability/AuditCopyButton.tsx
@@ -21,6 +21,7 @@
 import { useState } from "react";
 import { getAuditLog } from "@/lib/api";
 import { formatAuditCopy } from "@/lib/utils/format-audit-copy";
+import { getSnapshot } from "@/lib/audit-snapshot";
 
 interface Props {
   quoteId: string;
@@ -38,7 +39,12 @@ export function AuditCopyButton({ quoteId }: Props) {
     setErrorMsg(null);
     try {
       const audit = await getAuditLog(quoteId);
-      const text = formatAuditCopy(audit);
+      // Sprint 4 audit-copy-3-layer-state · snapshot del paso actual (adapter
+      // output + UI render) si el paso lo registró. getSnapshot valida que
+      // el quoteId matchee (anti-stale) · null → audit copy sin las 2
+      // secciones nuevas (backward compat).
+      const snapshot = getSnapshot(quoteId);
+      const text = formatAuditCopy(audit, { snapshot });
       try {
         if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
           await navigator.clipboard.writeText(text);

--- a/web/src/lib/audit-snapshot.ts
+++ b/web/src/lib/audit-snapshot.ts
@@ -1,0 +1,73 @@
+/**
+ * Registry module-level del snapshot de UI del paso actual del wizard ·
+ * Sprint 4 audit-copy-3-layer-state.
+ *
+ * Bridge entre la página del paso (que tiene el `ContextResponse` del adapter
+ * + el UI state, client-side) y el `AuditCopyButton` (que vive en el Topbar,
+ * un árbol de componentes separado bajo `[id]/layout`). Sigue el patrón de
+ * `useAuditMode`: estado module-level, sin Zustand/Redux/Context.
+ *
+ * Caveat anti-stale (decisión Javi): el registry guarda `{ quoteId, snapshot }`.
+ * `getSnapshot(currentQuoteId)` devuelve el snapshot SOLO si el quoteId pedido
+ * matchea el registrado. Si navegaste a otro quote y la página vieja todavía
+ * no desregistró (unmount tardío), `getSnapshot(nuevoId)` devuelve `null` →
+ * el audit copy omite las 2 secciones nuevas (backward compat · silent fail).
+ */
+import type { ContextResponse } from "./api/types";
+
+/** Un field tal como lo muestra la UI (value formateado + chip origin). */
+export interface AuditUiRenderField {
+  label: string;
+  /** Texto exacto que renderea ContextField (`value ?? "—"`, bool → "Sí"/"No"). */
+  displayValue: string;
+  /** Chip de origen ("BRIEF" | "INFERIDO" | "DEFAULT" | "EDITADO" | "FALTA"). */
+  origin: string;
+}
+
+/** Una sección del form (Cliente / Proyecto / Detalles) con sus fields. */
+export interface AuditUiRenderSection {
+  title: string;
+  fields: AuditUiRenderField[];
+}
+
+/** Snapshot 3-capa del paso actual · capa adapter + capa UI render. */
+export interface AuditSnapshot {
+  /** Ruta del paso que registró el snapshot (ej. "/contexto"). */
+  step: string;
+  /** Output del adapter (lo que `getContextForQuote` devolvió). */
+  contextResponse: ContextResponse | null;
+  /** Lo que la UI efectivamente muestra · null si el paso no lo expone. */
+  uiRender: AuditUiRenderSection[] | null;
+}
+
+let _state: { quoteId: string | null; snapshot: AuditSnapshot | null } = {
+  quoteId: null,
+  snapshot: null,
+};
+
+/** Registra (o reemplaza) el snapshot del quote activo. */
+export function registerSnapshot(quoteId: string, snapshot: AuditSnapshot): void {
+  _state = { quoteId, snapshot };
+}
+
+/**
+ * Desregistra el snapshot. Solo limpia si el quoteId que desregistra es el
+ * que está activo — así un unmount tardío de la página vieja NO borra el
+ * snapshot que la página nueva ya registró.
+ */
+export function unregisterSnapshot(quoteId: string): void {
+  if (_state.quoteId === quoteId) {
+    _state = { quoteId: null, snapshot: null };
+  }
+}
+
+/** Devuelve el snapshot solo si matchea el quote pedido (anti-stale). */
+export function getSnapshot(quoteId: string): AuditSnapshot | null {
+  if (!quoteId || _state.quoteId !== quoteId) return null;
+  return _state.snapshot;
+}
+
+/** Helper de test · resetea el registry. NO usar en runtime. */
+export function _resetSnapshotRegistry(): void {
+  _state = { quoteId: null, snapshot: null };
+}

--- a/web/src/lib/utils/format-audit-copy.ts
+++ b/web/src/lib/utils/format-audit-copy.ts
@@ -14,6 +14,7 @@
  * - JSON breakdown serializado con indent 2 (legible pero copy-pasteable)
  */
 import type { AuditLogResponse } from "@/lib/api/types";
+import type { AuditSnapshot } from "@/lib/audit-snapshot";
 
 /** Helper: epoch (ms) de un ISO string. */
 function epoch(iso: string): number {
@@ -44,13 +45,17 @@ export interface FormatAuditCopyOptions {
   /** Si true incluye solo el header + events timeline (sin tokens/tools/breakdown).
    * Modo "timeline only" del botón "Copiar solo timeline" en la página /audit. */
   timelineOnly?: boolean;
+  /** Sprint 4 audit-copy-3-layer-state · snapshot 3-capa del paso actual
+   * (adapter output + UI render). Si se provee, append de 2 secciones nuevas.
+   * Default null → output IDÉNTICO al actual (backward compat estricta). */
+  snapshot?: AuditSnapshot | null;
 }
 
 export function formatAuditCopy(
   audit: AuditLogResponse,
   options: FormatAuditCopyOptions = {},
 ): string {
-  const { includeBreakdown = true, timelineOnly = false } = options;
+  const { includeBreakdown = true, timelineOnly = false, snapshot = null } = options;
   const lines: string[] = [];
   const createdEpoch = epoch(audit.meta.created_at);
 
@@ -157,6 +162,38 @@ export function formatAuditCopy(
     }
   }
   lines.push("");
+
+  // ─── Capa 2+3 · ADAPTER OUTPUT + UI RENDER (Sprint 4 audit-copy-3-layer) ──
+  // Solo si el paso actual registró un snapshot (ver audit-snapshot.ts).
+  // Sin snapshot → estas secciones se omiten · output idéntico al previo.
+  if (snapshot) {
+    const SEP = "═══════════════════════════════════════════════";
+
+    if (snapshot.contextResponse) {
+      lines.push(SEP);
+      lines.push(`[ADAPTER OUTPUT · ContextResponse · ${snapshot.step}]`);
+      lines.push(SEP);
+      for (const [key, f] of Object.entries(snapshot.contextResponse)) {
+        const val = f?.value;
+        const valStr = val === null || val === undefined ? "null" : JSON.stringify(val);
+        lines.push(`${key}: {value=${valStr}, origin="${f?.origin ?? "?"}"}`);
+      }
+      lines.push("");
+    }
+
+    if (snapshot.uiRender && snapshot.uiRender.length > 0) {
+      lines.push(SEP);
+      lines.push(`[UI RENDER · ${snapshot.step}]`);
+      lines.push(SEP);
+      for (const section of snapshot.uiRender) {
+        lines.push(`${section.title.toUpperCase()} (${section.fields.length} campos):`);
+        for (const fld of section.fields) {
+          lines.push(`  ${fld.label}: "${fld.displayValue}" · ${fld.origin}`);
+        }
+      }
+      lines.push("");
+    }
+  }
 
   // ─── Footer ──────────────────────────────────────────────────────
   const totalDuration =

--- a/web/tests/unit/audit-snapshot.test.ts
+++ b/web/tests/unit/audit-snapshot.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests · Sprint 4 audit-copy-3-layer-state · registry module-level.
+ *
+ * Cubre el caveat anti-stale: getSnapshot solo devuelve si el quoteId pedido
+ * matchea el registrado (evita que el 📋 del Topbar copie un snapshot viejo
+ * tras navegar a otro quote).
+ */
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  registerSnapshot,
+  unregisterSnapshot,
+  getSnapshot,
+  _resetSnapshotRegistry,
+  type AuditSnapshot,
+} from "@/lib/audit-snapshot";
+
+const SNAP: AuditSnapshot = {
+  step: "/contexto",
+  contextResponse: null,
+  uiRender: [{ title: "Detalles", fields: [] }],
+};
+
+afterEach(() => {
+  _resetSnapshotRegistry();
+});
+
+describe("audit-snapshot registry", () => {
+  test("register + get con mismo quoteId → devuelve el snapshot", () => {
+    registerSnapshot("quote-A", SNAP);
+    expect(getSnapshot("quote-A")).toBe(SNAP);
+  });
+
+  test("register quote A + get con quote B → null (anti-stale)", () => {
+    registerSnapshot("quote-A", SNAP);
+    expect(getSnapshot("quote-B")).toBeNull();
+  });
+
+  test("unregister → get devuelve null", () => {
+    registerSnapshot("quote-A", SNAP);
+    unregisterSnapshot("quote-A");
+    expect(getSnapshot("quote-A")).toBeNull();
+  });
+
+  test("unregister de otro quoteId NO borra el activo (unmount tardío)", () => {
+    registerSnapshot("quote-A", SNAP);
+    // La página vieja (quote-B) se desmonta tarde · NO debe limpiar quote-A.
+    unregisterSnapshot("quote-B");
+    expect(getSnapshot("quote-A")).toBe(SNAP);
+  });
+
+  test("getSnapshot con quoteId vacío → null", () => {
+    registerSnapshot("quote-A", SNAP);
+    expect(getSnapshot("")).toBeNull();
+  });
+});

--- a/web/tests/unit/format-audit-copy.test.ts
+++ b/web/tests/unit/format-audit-copy.test.ts
@@ -289,3 +289,80 @@ describe("latencySeverity thresholds", () => {
     expect(latencySeverity(60000)).toBe("alert");
   });
 });
+
+// ── Sprint 4 audit-copy-3-layer-state · secciones ADAPTER + UI RENDER ──────
+import type { AuditSnapshot } from "@/lib/audit-snapshot";
+import type { ContextResponse } from "@/lib/api/types";
+
+function buildSnapshot(overrides: Partial<AuditSnapshot> = {}): AuditSnapshot {
+  const contextResponse = {
+    cliente: { value: "Micaela Volattire", origin: "BRIEF" },
+    contacto: { value: null, origin: "FALTA" },
+    localidad: { value: "Casilda", origin: "BRIEF" },
+    plazo: { value: "30 días", origin: "DEFAULT" },
+    tipologia: { value: "Cocina", origin: "BRIEF" },
+    tipo_obra: { value: "particular", origin: "DEFAULT" },
+    material: { value: "Granito Gris Perla", origin: "BRIEF" },
+    pileta: { value: "Apoyo", origin: "BRIEF" },
+    zocalo: { value: "Trasero por tramo, 5 cm", origin: "BRIEF" },
+    regrueso: { value: null, origin: "FALTA" },
+    anafe: { value: false, origin: "FALTA" },
+  } as unknown as ContextResponse;
+  return {
+    step: "/contexto",
+    contextResponse,
+    uiRender: [
+      {
+        title: "Detalles",
+        fields: [
+          { label: "Pileta", displayValue: "Apoyo", origin: "BRIEF" },
+          { label: "Zócalo", displayValue: "Trasero por tramo, 5 cm", origin: "BRIEF" },
+          { label: "Frentín / Regrueso", displayValue: "—", origin: "FALTA" },
+          { label: "Anafe", displayValue: "No", origin: "FALTA" },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("formatAuditCopy · snapshot 3-layer (ADAPTER + UI RENDER)", () => {
+  test("sin snapshot → output IDÉNTICO al actual (backward compat)", () => {
+    const audit = buildAudit();
+    const sinSnapshot = formatAuditCopy(audit);
+    const conNull = formatAuditCopy(audit, { snapshot: null });
+    expect(conNull).toBe(sinSnapshot);
+    expect(sinSnapshot).not.toContain("[ADAPTER OUTPUT");
+    expect(sinSnapshot).not.toContain("[UI RENDER");
+    expect(sinSnapshot).not.toContain("═══");
+  });
+
+  test("con snapshot completo → 2 secciones nuevas correctas", () => {
+    const out = formatAuditCopy(buildAudit(), { snapshot: buildSnapshot() });
+    expect(out).toContain("[ADAPTER OUTPUT · ContextResponse · /contexto]");
+    expect(out).toContain("[UI RENDER · /contexto]");
+    // adapter dump
+    expect(out).toContain('cliente: {value="Micaela Volattire", origin="BRIEF"}');
+    expect(out).toContain('localidad: {value="Casilda", origin="BRIEF"}');
+    // UI render
+    expect(out).toContain("DETALLES (4 campos):");
+    expect(out).toContain('Pileta: "Apoyo" · BRIEF');
+  });
+
+  test("snapshot con contextResponse pero sin uiRender → solo [ADAPTER OUTPUT]", () => {
+    const out = formatAuditCopy(buildAudit(), {
+      snapshot: buildSnapshot({ uiRender: null }),
+    });
+    expect(out).toContain("[ADAPTER OUTPUT");
+    expect(out).not.toContain("[UI RENDER");
+  });
+
+  test("caso Micaela · regrueso=null en adapter + '—'+FALTA en UI (regresión Bug 7)", () => {
+    const out = formatAuditCopy(buildAudit(), { snapshot: buildSnapshot() });
+    // Capa adapter: regrueso null + FALTA
+    expect(out).toContain('regrueso: {value=null, origin="FALTA"}');
+    // Capa UI render: lo que el usuario ve
+    expect(out).toContain('Frentín / Regrueso: "—" · FALTA');
+    // El bug es visible y consistente entre las 2 capas → diagnóstico sin screenshot.
+  });
+});


### PR DESCRIPTION
Mejora del operating system: el audit copy (📋 del Topbar, PR #477) ahora incluye **2 capas nuevas** — output del **adapter** (`ContextResponse`) + **UI render** del paso actual — para diagnosticar bugs entre layers **sin screenshots**.

**Motivación:** Bug 7 residual (Frentín/Regrueso sigue "—"+FALTA en UI post-#486) solo se detectó con screenshot. Con esto, un copy del 📋 muestra las 3 capas (backend + adapter + UI) y el bug se ubica exacto.

**Frontend-only · cero backend touch · backward compat estricta.**

## Cambios

### Registry module-level · `web/src/lib/audit-snapshot.ts` (nuevo)
Bridge entre la página del paso (state client-side) y el `AuditCopyButton` (Topbar, árbol separado). Patrón de `useAuditMode` — sin Zustand/Redux/Context.

**Caveat anti-stale (decisión Javi):** guarda `{ quoteId, snapshot }`. `getSnapshot(id)` devuelve solo si matchea el quoteId activo → tras navegar a otro quote, `null` → audit copy omite las 2 secciones (backward compat). `unregisterSnapshot` solo limpia si el quoteId activo matchea (unmount tardío de la página vieja NO borra el snapshot de la nueva).

### `format-audit-copy.ts` · +2 secciones OPCIONALES
`options.snapshot` (default `null`). **Sin snapshot → output IDÉNTICO al actual** (test lo verifica). Con snapshot:
- `[ADAPTER OUTPUT · ContextResponse]`: dump field-by-field `{value, origin}`.
- `[UI RENDER]`: secciones + `label: "displayValue" · origin` (lo que se ve).

### `AuditCopyButton.tsx`
`getSnapshot(quoteId)` → `formatAuditCopy(audit, { snapshot })`.

### `ContextView.tsx` · registra el snapshot del paso 2
`useEffect` re-registra cuando `context` cambia (load + cada edit); cleanup desregistra. El `uiRender` se arma desde los **mismos** `GROUPS` y `formatForDisplay` que el render real → el `[UI RENDER]` matchea **1:1** lo que el usuario ve (la fidelidad es el propósito de la capa).

### Deviación del file-list del prompt (justificada)
El prompt listaba `ContextView`. Adicionalmente exporté **2 símbolos puros**: `GROUPS` (de `ContextForm`) y `formatForDisplay` (de `ContextField`), para reusarlos en el snapshot builder. Razón: el `[UI RENDER]` debe usar el MISMO formatter/estructura que el render para garantizar fidelidad (si duplicara la lógica, podría divergir). **Cero cambio de comportamiento de render** — solo se agregó `export` a 2 helpers.

## Scope
Solo `/contexto` en este sub-PR · despiece/calculo/pdf como follow-up.

## Tests (lección #59 · format function con shape real)
- `format-audit-copy.test.ts` **+4**: sin snapshot→idéntico (backward compat) · snapshot completo→2 secciones · contextResponse sin uiRender→solo ADAPTER · **caso Micaela** (regresión Bug 7: `regrueso={value=null,origin="FALTA"}` en adapter + `Frentín / Regrueso: "—" · FALTA` en UI).
- `audit-snapshot.test.ts` **+5** (nuevo): register/get same id · get id distinto→null (anti-stale) · unregister→null · unmount tardío no borra el activo · id vacío→null.

| Suite | Resultado |
|---|---|
| Unit vitest total | **118/118** |
| E2E full CI mode | **188 passed + 10 skipped + 0 fail** |
| Lint + typecheck + build | ✅ clean |

## Smoke test post-deploy (Javi)
Reprobar brief Micaela → click 📋 → verificar que el copy incluye `[BACKEND]` (sin cambios) + `[ADAPTER OUTPUT · ContextResponse]` + `[UI RENDER · /contexto]` con fields/values/chips. Confirma el diagnóstico de Bug 7 sin screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)