### PR TITLE
fix(adapter): leer _brief_analysis_raw desde context_analysis_pending (nested) · path equivocado pre-existente desde PR #483

### DIFF
--- a/web/src/lib/api/adapters/context-from-breakdown.ts
+++ b/web/src/lib/api/adapters/context-from-breakdown.ts
@@ -39,6 +39,11 @@ interface ContextAnalysis {
   assumptions?: BreakdownEntry[];
   tech_detections?: unknown[];
   pending_questions?: unknown[];
+  // Bug 7 RESIDUAL fix · el backend emite `_brief_analysis_raw` ANIDADO
+  // dentro de `context_analysis_pending` (o `verified_context_analysis`),
+  // NO en top-level del breakdown. Tipado explícito acá para que las
+  // fixtures de tests no requieran castings.
+  _brief_analysis_raw?: BriefAnalysisRaw;
 }
 
 interface BriefAnalysisRaw {
@@ -179,7 +184,28 @@ function resolveString(
 export function breakdownToContext(breakdown: QuoteBreakdownLike | null | undefined): ContextResponse {
   const verified = breakdown?.verified_context_analysis ?? null;
   const pending = breakdown?.context_analysis_pending ?? null;
-  const raw: BriefAnalysisRaw = breakdown?._brief_analysis_raw ?? {};
+  // Bug 7 RESIDUAL fix · pre-existente desde PR #483.
+  //
+  // Antes: `breakdown._brief_analysis_raw` (top-level). El backend NUNCA
+  // emite el raw en top-level · siempre va anidado dentro de
+  // `context_analysis_pending` (estado actual) o `verified_context_analysis`
+  // (post-confirmación humana). Resultado: raw={} en runtime SIEMPRE →
+  // todos los campos que dependen SOLO del raw (frentin/regrueso/anafe)
+  // caían a FALTA · campos con fallback a data_known/assumptions
+  // (Cliente/Material/Pileta/etc.) funcionaban por casualidad.
+  //
+  // Precedencia: verified (humano confirmó) > pending (estado actual del
+  // brief_analyzer) > top-level (fallback legacy por si algún quote viejo
+  // o test legacy lo tiene así).
+  //
+  // Lección operativa #60: fixtures de tests del adapter deben REPLICAR
+  // shape REAL del upstream. PR #486 testeaba contra shape ficticia
+  // top-level que NUNCA emite el backend · tests verde + bug prod.
+  const raw: BriefAnalysisRaw =
+    verified?._brief_analysis_raw
+    ?? pending?._brief_analysis_raw
+    ?? breakdown?._brief_analysis_raw
+    ?? {};
 
   // ── Cliente
   const cliente = resolveString(verified, pending, "Cliente", raw.client_name);

--- a/web/tests/unit/context-from-breakdown.test.ts
+++ b/web/tests/unit/context-from-breakdown.test.ts
@@ -222,7 +222,7 @@ describe("breakdownToContext · derived fields", () => {
 
   // Test legacy migrado · sub-PR Bug 7. El schema viejo era
   // `regrueso_mentioned: bool` (deprecated por PR #485). Hoy el
-  // backend devuelve `regrueso: "yes"|"no"|null` y el adapter combina
+  // backend devuelve `regrueso: "yes" as const|"no"|null` y el adapter combina
   // con `frentin`. Ver tests ternary abajo.
 
   test("anafe_mentioned=true → boolean true BRIEF", () => {
@@ -317,8 +317,8 @@ describe("breakdownToContext · canon real PRES-2026-018 shape", () => {
 // Sub-PR Bug 7 · adapter sync post-PR #485
 //
 // PR #485 migró el schema brief_analyzer de bool a ternary:
-//   frentin_mentioned: bool → frentin: "yes" | "no" | null
-//   regrueso_mentioned: bool → regrueso: "yes" | "no" | null
+//   frentin_mentioned: bool → frentin: "yes" as const | "no" | null
+//   regrueso_mentioned: bool → regrueso: "yes" as const | "no" | null
 //
 // El adapter no se había actualizado · sub-PR Bug 7 cierra esa deuda
 // + agrega lectura de `frentin` (que NUNCA estuvo cubierta en PR #483
@@ -336,7 +336,7 @@ describe("Bug 7 · frentin/regrueso ternary · matriz combinación", () => {
 
   test("no/no → 'No lleva' + BRIEF", () => {
     const ctx = breakdownToContext({
-      _brief_analysis_raw: { frentin: "no", regrueso: "no" },
+      _brief_analysis_raw: { frentin: "no" as const, regrueso: "no" as const },
     });
     expect(ctx.regrueso.value).toBe("No lleva");
     expect(ctx.regrueso.origin).toBe("BRIEF");
@@ -344,7 +344,7 @@ describe("Bug 7 · frentin/regrueso ternary · matriz combinación", () => {
 
   test("yes/yes → 'Frentín + Regrueso' + BRIEF", () => {
     const ctx = breakdownToContext({
-      _brief_analysis_raw: { frentin: "yes", regrueso: "yes" },
+      _brief_analysis_raw: { frentin: "yes" as const, regrueso: "yes" as const },
     });
     expect(ctx.regrueso.value).toBe("Frentín + Regrueso");
     expect(ctx.regrueso.origin).toBe("BRIEF");
@@ -352,7 +352,7 @@ describe("Bug 7 · frentin/regrueso ternary · matriz combinación", () => {
 
   test("yes/no disjoint → 'Frentín: Sí · Regrueso: No' + BRIEF", () => {
     const ctx = breakdownToContext({
-      _brief_analysis_raw: { frentin: "yes", regrueso: "no" },
+      _brief_analysis_raw: { frentin: "yes" as const, regrueso: "no" as const },
     });
     expect(ctx.regrueso.value).toBe("Frentín: Sí · Regrueso: No");
     expect(ctx.regrueso.origin).toBe("BRIEF");
@@ -360,7 +360,7 @@ describe("Bug 7 · frentin/regrueso ternary · matriz combinación", () => {
 
   test("no/yes disjoint → 'Frentín: No · Regrueso: Sí' + BRIEF", () => {
     const ctx = breakdownToContext({
-      _brief_analysis_raw: { frentin: "no", regrueso: "yes" },
+      _brief_analysis_raw: { frentin: "no" as const, regrueso: "yes" as const },
     });
     expect(ctx.regrueso.value).toBe("Frentín: No · Regrueso: Sí");
     expect(ctx.regrueso.origin).toBe("BRIEF");
@@ -368,7 +368,7 @@ describe("Bug 7 · frentin/regrueso ternary · matriz combinación", () => {
 
   test("yes/null partial → 'Frentín: Sí · Regrueso: —' + BRIEF", () => {
     const ctx = breakdownToContext({
-      _brief_analysis_raw: { frentin: "yes", regrueso: null },
+      _brief_analysis_raw: { frentin: "yes" as const, regrueso: null },
     });
     expect(ctx.regrueso.value).toBe("Frentín: Sí · Regrueso: —");
     expect(ctx.regrueso.origin).toBe("BRIEF");
@@ -376,7 +376,7 @@ describe("Bug 7 · frentin/regrueso ternary · matriz combinación", () => {
 
   test("null/yes partial → 'Frentín: — · Regrueso: Sí' + BRIEF", () => {
     const ctx = breakdownToContext({
-      _brief_analysis_raw: { frentin: null, regrueso: "yes" },
+      _brief_analysis_raw: { frentin: null, regrueso: "yes" as const },
     });
     expect(ctx.regrueso.value).toBe("Frentín: — · Regrueso: Sí");
     expect(ctx.regrueso.origin).toBe("BRIEF");
@@ -500,8 +500,8 @@ describe("Bug 7 · smoke E2E · brief Micaela post-PR #485", () => {
         localidad: "Casilda",
         work_types: ["cocina"],
         pileta_type: "apoyo",
-        frentin: "no",
-        regrueso: "no",
+        frentin: "no" as const,
+        regrueso: "no" as const,
         pulido: null,
         anafe_mentioned: false,
         es_edificio: false,
@@ -514,5 +514,187 @@ describe("Bug 7 · smoke E2E · brief Micaela post-PR #485", () => {
     expect(ctx.pileta.origin).toBe("BRIEF");
     expect(ctx.regrueso.value).toBe("No lleva");
     expect(ctx.regrueso.origin).toBe("BRIEF");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Bug 7 RESIDUAL · adapter leía _brief_analysis_raw desde top-level
+// cuando el backend lo emite SIEMPRE anidado dentro de
+// context_analysis_pending (o verified_context_analysis).
+//
+// Pre-existente desde PR #483 · oculto en prod hasta brief de Micaela
+// porque Cliente/Material/Pileta/etc. tienen fallback a data_known +
+// assumptions. Frentín/Regrueso/Anafe SOLO leen del raw → caían a FALTA.
+//
+// Tests del PR #486 cubrían shape FICTICIA top-level (legacy compat).
+// Los tests abajo replican el SHAPE REAL emitido por el backend:
+//   { context_analysis_pending: { _brief_analysis_raw: {...} } }
+//
+// Lección operativa #60: las fixtures de tests del adapter deben
+// REPLICAR shape REAL del upstream. Si la fixture difiere del shape de
+// prod, el test no certifica nada · drift silencioso.
+// ─────────────────────────────────────────────────────────────────────
+
+describe("Bug 7 RESIDUAL · _brief_analysis_raw anidado (shape REAL del backend)", () => {
+  test("regression · audit literal Micaela · prod 2026-06-12", () => {
+    // Dump literal del audit-log de prod (quote d8e85524) confirmado
+    // por Javi. Si este test rompe, el backend cambió su shape · NO
+    // tocar el adapter sin coordinación.
+    const realBackendShape = {
+      dual_read_result: { sectores: [{ id: "sector_1", tipo: "cocina" }] },
+      context_analysis_pending: {
+        data_known: [
+          { field: "Cliente", value: "Micaela Volattire", source: "brief" },
+          { field: "Material", value: "Granito Gris Perla", source: "quote" },
+          { field: "Localidad", value: "Casilda", source: "brief" },
+          { field: "Tipo de trabajo", value: "Cocina", source: "brief" },
+        ],
+        assumptions: [
+          {
+            field: "Zócalos",
+            value: "Trasero por tramo, 5 cm",
+            source: "brief+rule",
+          },
+          { field: "Colocación", value: "No incluye", source: "brief" },
+          {
+            field: "Pileta — montaje",
+            value: "Apoyo",
+            source: "brief",
+          },
+          { field: "Forma de pago", value: "Contado", source: "config_default" },
+          { field: "Demora", value: "30 días", source: "config_default" },
+          { field: "Tipo", value: "Particular", source: "inferred" },
+          { field: "Descuento", value: "No aplica", source: "config_default" },
+          { field: "Frentín", value: "No lleva", source: "brief" },
+          { field: "Regrueso", value: "No lleva", source: "brief" },
+        ],
+        _brief_analysis_raw: {
+          client_name: "Micaela Volattire",
+          project: null,
+          material: "Granito Gris Perla",
+          localidad: "Casilda",
+          work_types: ["cocina"],
+          zocalos: "yes",
+          zocalos_alto_cm: 5,
+          alzada: "yes",
+          colocacion: "no",
+          pileta_mentioned: true,
+          pileta_type: "apoyo",
+          anafe_mentioned: true,
+          anafe_count: null,
+          frentin: "no" as const,
+          regrueso: "no" as const,
+          pulido: null,
+          es_edificio: false,
+        },
+      },
+    };
+    const ctx = breakdownToContext(realBackendShape);
+
+    // Campos que ya funcionaban (vienen de pending.data_known / assumptions)
+    expect(ctx.cliente.value).toBe("Micaela Volattire");
+    expect(ctx.cliente.origin).toBe("BRIEF");
+    expect(ctx.localidad.value).toBe("Casilda");
+    expect(ctx.localidad.origin).toBe("BRIEF");
+    expect(ctx.material.value).toBe("Granito Gris Perla");
+    expect(ctx.material.origin).toBe("BRIEF"); // source=quote → BRIEF
+    expect(ctx.pileta.value).toBe("Apoyo");
+    expect(ctx.pileta.origin).toBe("BRIEF");
+    expect(ctx.zocalo.value).toBe("Trasero por tramo, 5 cm");
+
+    // Campos rotos por Bug 7 RESIDUAL · ahora deben funcionar
+    expect(ctx.regrueso.value).toBe("No lleva");
+    expect(ctx.regrueso.origin).toBe("BRIEF");
+    expect(ctx.anafe.value).toBe(true);
+    expect(ctx.anafe.origin).toBe("BRIEF");
+
+    // tipo_obra: es_edificio=false → "particular" + BRIEF
+    expect(ctx.tipo_obra.value).toBe("particular");
+    expect(ctx.tipo_obra.origin).toBe("BRIEF");
+  });
+
+  test("frentin/regrueso en pending._brief_analysis_raw nested · no/no → No lleva BRIEF", () => {
+    const ctx = breakdownToContext({
+      context_analysis_pending: {
+        _brief_analysis_raw: { frentin: "no" as const, regrueso: "no" as const },
+      },
+    });
+    expect(ctx.regrueso.value).toBe("No lleva");
+    expect(ctx.regrueso.origin).toBe("BRIEF");
+  });
+
+  test("anafe_mentioned=true nested → true + BRIEF", () => {
+    const ctx = breakdownToContext({
+      context_analysis_pending: {
+        _brief_analysis_raw: { anafe_mentioned: true },
+      },
+    });
+    expect(ctx.anafe.value).toBe(true);
+    expect(ctx.anafe.origin).toBe("BRIEF");
+  });
+
+  test("anafe nested NO impacta tipo_obra (regresión cross-field)", () => {
+    const ctx = breakdownToContext({
+      context_analysis_pending: {
+        _brief_analysis_raw: { anafe_mentioned: true, es_edificio: true },
+      },
+    });
+    expect(ctx.anafe.value).toBe(true);
+    expect(ctx.tipo_obra.value).toBe("edificio");
+    expect(ctx.tipo_obra.origin).toBe("BRIEF");
+  });
+});
+
+describe("Bug 7 RESIDUAL · precedencia verified > pending > top-level (drift guard)", () => {
+  test("verified gana sobre pending para _brief_analysis_raw", () => {
+    const breakdown = {
+      context_analysis_pending: {
+        _brief_analysis_raw: { frentin: "no" as const, regrueso: "no" as const },
+      },
+      verified_context_analysis: {
+        _brief_analysis_raw: { frentin: "yes" as const, regrueso: "yes" as const },
+      },
+    };
+    const ctx = breakdownToContext(breakdown);
+    // verified gana → yes/yes → "Frentín + Regrueso"
+    expect(ctx.regrueso.value).toBe("Frentín + Regrueso");
+    expect(ctx.regrueso.origin).toBe("BRIEF");
+  });
+
+  test("pending gana sobre top-level legacy", () => {
+    const breakdown = {
+      _brief_analysis_raw: { frentin: "yes" as const, regrueso: "yes" as const }, // top-level legacy
+      context_analysis_pending: {
+        _brief_analysis_raw: { frentin: "no" as const, regrueso: "no" as const }, // pending real
+      },
+    };
+    const ctx = breakdownToContext(breakdown);
+    // pending gana → no/no → "No lleva"
+    expect(ctx.regrueso.value).toBe("No lleva");
+  });
+
+  test("backwards compat · top-level _brief_analysis_raw sigue funcionando", () => {
+    // Quotes viejos o tests legacy podrían tener el raw en top-level
+    // del breakdown. El adapter debe seguir aceptándolo como 3er
+    // fallback (NO romper compat retroactiva).
+    const ctx = breakdownToContext({
+      _brief_analysis_raw: {
+        frentin: "no" as const,
+        regrueso: "no" as const,
+        anafe_mentioned: true,
+      },
+    });
+    expect(ctx.regrueso.value).toBe("No lleva");
+    expect(ctx.anafe.value).toBe(true);
+  });
+
+  test("verified vacío + pending con raw → usa pending (no se confunde con verified)", () => {
+    const ctx = breakdownToContext({
+      verified_context_analysis: { data_known: [] }, // sin _brief_analysis_raw
+      context_analysis_pending: {
+        _brief_analysis_raw: { anafe_mentioned: true },
+      },
+    });
+    expect(ctx.anafe.value).toBe(true);
   });
 });


### PR DESCRIPTION
**Bug 7 RESIDUAL · path equivocado pre-existente desde PR #483.**

PR #486 cerró Bug 7 (schema ternary frentin/regrueso) contra **fixtures ficticias top-level**. Smoke test post-deploy reveló que el bug persiste: en brief de Micaela los campos Frentín/Regrueso/Anafe siguen mostrando "—" + FALTA aunque el backend tiene los datos.

## Causa raíz

Adapter `context-from-breakdown.ts:182` leía:

```ts
const raw = breakdown?._brief_analysis_raw ?? {};
```

Path: `breakdown._brief_analysis_raw` (top-level).

**Pero el backend SIEMPRE emite el raw ANIDADO:**

```json
{
  "context_analysis_pending": {
    "data_known": [...],
    "assumptions": [...],
    "_brief_analysis_raw": {        ← nested
      "frentin": "no",
      "regrueso": "no",
      "anafe_mentioned": true,
      ...
    }
  }
}
```

Confirmado por audit literal de prod (quote `d8e85524-9101-4509-a0fa-1ca1da5713a1`).

→ `raw = {}` en runtime SIEMPRE → todos los fields que dependen SOLO del raw caían a FALTA.

## Por qué Pileta/Cliente/Material funcionan pero Frentín/Regrueso/Anafe no

| Campo | Path lookup | ¿Funciona? |
|---|---|---|
| Cliente | data_known["Cliente"] (pending) | ✅ via fallback |
| Localidad | data_known["Localidad"] (pending) | ✅ via fallback |
| Material | data_known["Material"] (pending) | ✅ via fallback |
| Pileta | assumptions["Pileta — montaje"] (pending) | ✅ via fallback |
| Zócalo | assumptions["Zócalos"] (pending) | ✅ via fallback |
| **Frentín/Regrueso** | **SOLO raw.frentin/regrueso** (sin fallback) | ❌ raw vacío |
| **Anafe** | **SOLO raw.anafe_mentioned** (sin fallback) | ❌ raw vacío |

## Fix

### 1. Path lookup con precedencia · `context-from-breakdown.ts:182`

```ts
const raw: BriefAnalysisRaw =
  verified?._brief_analysis_raw      // post-confirm humano (gana)
  ?? pending?._brief_analysis_raw    // estado actual del brief_analyzer
  ?? breakdown?._brief_analysis_raw  // legacy compat (3er fallback)
  ?? {};
```

### 2. Interface `ContextAnalysis` extendido

\`_brief_analysis_raw?: BriefAnalysisRaw\` añadido. Modeling shape real del backend → fixtures de tests no requieren casts.

## Tests · 8 nuevos

### Regresión literal prod (anclaje al backend real)
- `regression · audit literal Micaela · prod 2026-06-12` · dump literal del audit de Javi. Si el backend cambia, este test rompe primero · evita drift silencioso.

### Bug 7 RESIDUAL · shape REAL nested
- `frentin/regrueso nested → No lleva BRIEF`
- `anafe_mentioned nested → true BRIEF`
- `cross-field no se confunden`

### Drift guard · precedencia
- `verified > pending`
- `pending > top-level legacy`
- `backwards compat top-level funciona`
- `verified vacío + pending → usa pending`

**Tests legacy del PR #486 preservados intactos** (siguen pasando · validan backwards-compat path top-level).

## Verificación

| Suite | Resultado |
|---|---|
| **Unit tests** `context-from-breakdown.test.ts` | **46/46 verde** (38 previos + 8 nuevos) |
| Unit total | **117/117 verde** (109 previos + 8 nuevos) |
| E2E contexto regression | **6/6 verde** · mocks intactos |
| Lint + typecheck + build | ✅ clean |

## Smoke test post-deploy OBLIGATORIO (lección #51)

Reprobar brief Micaela en prod. UI paso 2 esperado:

| Campo | Antes (bug) | Post-fix esperado |
|---|---|---|
| Pileta | "Apoyo" · BRIEF | "Apoyo" · BRIEF (sin cambio · ya funcionaba) |
| Frentín / Regrueso | "—" · FALTA ❌ | **"No lleva" · BRIEF** ✅ |
| Anafe | "No" · FALTA ❌ | **"Sí" · BRIEF** ✅ (anafe_mentioned=true) |
| Zócalo | sin cambio | sin cambio |

Si los 4 fields aparecen correctamente → Bug 7 RESIDUAL cerrado.

## Lección operativa #60 NUEVA

**Las fixtures de tests del adapter deben REPLICAR shape REAL del upstream.**

PR #486 testeaba contra shape ficticia top-level que NUNCA emite el backend · tests verde + bug prod. Drift silencioso entre fixture y realidad.

**Patrón a verificar:** si el bug reportado pasa cuando uso la fixture del test pero falla en prod, la fixture es ficticia.

**Solución implementada:** anclar al menos UN test al dump LITERAL del audit de prod (`regression · audit literal Micaela`). Si el backend cambia su shape, ese test rompe primero · señal de coordinación necesaria.

## Test plan

- [x] Unit tests 117/117 verde (8 nuevos del Bug 7 RESIDUAL)
- [x] E2E contexto regression 6/6 verde
- [x] Lint + typecheck + build clean
- [ ] Smoke test post-deploy Javi con brief Micaela
- [ ] Confirmar UI muestra Anafe "Sí" + BRIEF, Frentín/Regrueso "No lleva" + BRIEF

🤖 Generated with [Claude Code](https://claude.com/claude-code)