### PR TITLE
feat(contacto): brief_analyzer extrae phone + email · backend + adapter (lección #58)

### DIFF
--- a/api/app/modules/quote_engine/brief_analyzer.py
+++ b/api/app/modules/quote_engine/brief_analyzer.py
@@ -33,6 +33,15 @@ BRIEF_ANALYZER_TIMEOUT_SECONDS = 20
 EMPTY_SCHEMA: dict = {
     # Globales
     "client_name": None,
+    # Contacto del cliente — sub-PR sprint-4/contacto-extraction-fix
+    # cierra deuda documentada desde PR #483 (sub-PR 9.3). Extrae del
+    # bloque "Contacto:" del brief o de las palabras-ancla típicas
+    # ("Tel:", "Email:", etc.). Persistido en el JSON pero NO mirroreado
+    # a `Quote.client_phone` / `Quote.client_email` (las columnas
+    # existen pero el wire post-confirm es follow-up de otro sub-PR
+    # — toca agent.py).
+    "phone": None,   # string | null  · ej "3464696027"
+    "email": None,   # string | null  · ej "x@y.com"
     "project": None,
     "material": None,
     "localidad": None,
@@ -113,37 +122,45 @@ trabajo, null/false/[] si no están presentes.
 2. `client_name`: SOLO el nombre, sin texto pegado. "Erica Bernardi" ✓;
    "Erica Bernardi SIN zocalos" ✗. Parar en mayúsculas all-caps, puntos,
    palabras funcionales (sin, con, en, de).
-3. `material`: nombre limpio del material. Ej: "Puraprima Onix White
+3. `phone` / `email`: extraé del bloque "Contacto:" del brief o cuando
+   se declaren explícitamente con palabras-ancla: "Tel:", "Cel:",
+   "Teléfono:", "WhatsApp:", "Móvil:" para phone · "Email:", "Mail:"
+   para email. SOLO si están ancladas a esas palabras — NO extraigas
+   IDs (ej "DA-1781136799652-KVZU"), DNI ("12345678"), CUITs
+   ("20-12345678-9") ni números de orden sueltos. Phone: devolvé solo
+   los dígitos sin espacios/guiones (ej "3464696027" no
+   "3464-696027"). Email: formato estándar. null si no se mencionan.
+4. `material`: nombre limpio del material. Ej: "Puraprima Onix White
    Mate", "Silestone Blanco Norte", "Granito Negro Brasil". NO pegues
    "Cliente:" ni texto extra.
-4. `localidad`: ciudad principal capitalizada. "Rosario", "Funes",
+5. `localidad`: ciudad principal capitalizada. "Rosario", "Funes",
    "Puerto San Martín".
-5. `work_types`: lista de sectores mencionados. Valores válidos:
+6. `work_types`: lista de sectores mencionados. Valores válidos:
    "cocina", "baño", "lavadero", "otro". Puede haber múltiples.
-6. `zocalos`: "yes" si brief dice "con zócalos" / "lleva". "no" si
+7. `zocalos`: "yes" si brief dice "con zócalos" / "lleva". "no" si
    "sin zócalos" / "no lleva". null si no menciona. Alto en cm si dice.
-7. `pileta_type` (para baño): "apoyo" si dice "pileta de apoyo";
+8. `pileta_type` (para baño): "apoyo" si dice "pileta de apoyo";
    "empotrada" si "empotrada" / "bajomesada"; null si ambigüo.
-8. `pileta_simple_doble` (para cocina): "doble" si "pileta doble",
+9. `pileta_simple_doble` (para cocina): "doble" si "pileta doble",
    "2 bachas"; "simple" si "1 bacha", "simple"; null si no aclara.
-9. `anafe_count`: número explícito. "2 anafes", "anafe gas + eléctrico"
-   → 2. "1 anafe" → 1. null si no dice. `anafe_gas_y_electrico` si
-   menciona ambos explícitos.
-10. `isla_mentioned`: true si el brief menciona isla explícitamente.
-11. `descuento_tipo`: "arquitecta" si menciona arquitecta, "cliente"
+10. `anafe_count`: número explícito. "2 anafes", "anafe gas + eléctrico"
+    → 2. "1 anafe" → 1. null si no dice. `anafe_gas_y_electrico` si
+    menciona ambos explícitos.
+11. `isla_mentioned`: true si el brief menciona isla explícitamente.
+12. `descuento_tipo`: "arquitecta" si menciona arquitecta, "cliente"
     si descuento al cliente, null si no.
-12. `es_edificio`: true si menciona "edificio", "unidades",
+13. `es_edificio`: true si menciona "edificio", "unidades",
     "departamentos", "tipologías", edificio X, etc.
-13. `mentions_johnson` + `johnson_sku`: true/string si menciona Johnson
+14. `mentions_johnson` + `johnson_sku`: true/string si menciona Johnson
     (ej "Johnson LUXOR S171" → johnson_sku="LUXOR S171").
-14. `frentin`, `regrueso`, `pulido`: ternary "yes"|"no"|null.
+15. `frentin`, `regrueso`, `pulido`: ternary "yes"|"no"|null.
     - "yes" si brief dice "con frentín" / "lleva frentín" / "Frentín: Sí".
     - "no" si brief dice "sin frentín" / "Frentín: No" / "no lleva frentín".
     - null si NO se menciona en absoluto.
     Idem para regrueso y pulido. Importante: distinguir "No" explícito
     del operador de "no mencionado" — son operativamente distintos
     (el primero es decisión, el segundo es ausencia de información).
-15. `raw_notes`: copia de frases sueltas que no categorizas (ej
+16. `raw_notes`: copia de frases sueltas que no categorizas (ej
     aclaraciones específicas del cliente).
 
 **Schema exacto (todas las keys presentes siempre):**
@@ -151,6 +168,8 @@ trabajo, null/false/[] si no están presentes.
 ```json
 {
   "client_name": string | null,
+  "phone": string | null,
+  "email": string | null,
   "project": string | null,
   "material": string | null,
   "localidad": string | null,
@@ -198,6 +217,24 @@ Devolvé SOLO el JSON. Sin markdown, sin comentarios."""
 _CLIENT_RE = re.compile(
     r"cliente\s*[:=]?\s*"
     r"([A-ZÁÉÍÓÚÑ][a-záéíóúñ]+(?:\s+[A-ZÁÉÍÓÚÑ][a-záéíóúñ]+){0,3})",
+)
+# Contacto · sub-PR sprint-4/contacto-extraction-fix.
+# Phone requiere palabra-ancla cercana (Tel/Cel/Teléfono/WhatsApp/Móvil)
+# para evitar falsos positivos: DNI (8 dígitos sueltos), CUIT (11 con
+# dashes), IDs internos (ej "DA-1781136799652-KVZU" del brief Micaela),
+# números de orden. Brief AR típico tiene formatos variados que
+# normalizamos a solo dígitos al persistir: "3464696027" / "3464 696027"
+# / "+54 9 3464 696027" / "(0346) 4-696027".
+_PHONE_RE = re.compile(
+    r"\b(?:tel|cel|tel[ée]fono|whats?app|m[oó]vil)\s*[:.\-=]?\s*"
+    r"(\+?[\d(][\d\s\-().]{6,18}\d)",
+    re.IGNORECASE,
+)
+_PHONE_CLEAN = re.compile(r"[\s\-().]")  # elimina espacios/guiones/paréntesis
+# Email · regex estándar simple. No restringe TLD para no fallar con
+# dominios largos (.com.ar, etc.).
+_EMAIL_RE = re.compile(
+    r"\b([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})",
 )
 _MATERIAL_KEYS = ("silestone", "dekton", "neolith", "puraprima", "pura prima",
                   "purastone", "laminatto", "granito", "mármol", "marmol",
@@ -358,6 +395,20 @@ def _analyze_regex_fallback(brief: str) -> dict:
     m = _CLIENT_RE.search(b)
     if m:
         result["client_name"] = m.group(1).strip()
+
+    # Phone con palabra-ancla · sub-PR contacto-extraction. Limpiamos
+    # formato (espacios/guiones/paréntesis) y validamos rango 8-16
+    # dígitos. 8 dígitos legítimos (ej "Tel: 12345678") quedan — la
+    # ancla es el filtro contra DNI/CUIT sueltos.
+    m = _PHONE_RE.search(b)
+    if m:
+        cleaned = _PHONE_CLEAN.sub("", m.group(1))
+        if 8 <= len(cleaned) <= 16:
+            result["phone"] = cleaned
+
+    m = _EMAIL_RE.search(b)
+    if m:
+        result["email"] = m.group(1)
 
     mat = _extract_material_regex(b)
     if mat:

--- a/api/app/modules/quote_engine/context_analyzer.py
+++ b/api/app/modules/quote_engine/context_analyzer.py
@@ -154,6 +154,26 @@ def _build_data_known(
         source = "quote" if (quote or {}).get("client_name") else "brief"
         known.append({"field": "Cliente", "value": client, "source": source})
 
+    # Contacto · sub-PR sprint-4/contacto-extraction-fix. Cierra deuda
+    # documentada desde PR #483. Si phone o email presentes en el brief,
+    # generamos data_known entry con formato unificado. Va en data_known
+    # (no assumptions) porque son datos DECLARADOS por el operador, no
+    # inferidos ni asumidos. Adapter frontend ya tenía field `contacto`
+    # esperando este wire.
+    phone = analysis.get("phone")
+    email = analysis.get("email")
+    if phone or email:
+        parts = []
+        if phone:
+            parts.append(f"Tel: {phone}")
+        if email:
+            parts.append(f"Email: {email}")
+        known.append({
+            "field": "Contacto",
+            "value": " · ".join(parts),
+            "source": "brief",
+        })
+
     # Proyecto
     project = (quote or {}).get("project") or analysis.get("project")
     if project:

--- a/api/tests/test_brief_analyzer.py
+++ b/api/tests/test_brief_analyzer.py
@@ -32,6 +32,74 @@ class TestRegexFallback:
         assert out["client_name"] is not None
         assert "Perez" in out["client_name"]
 
+    # ── Sub-PR sprint-4/contacto-extraction-fix · phone + email ────────
+    # Cierra deuda documentada desde PR #483 (sub-PR 9.3). Backend ahora
+    # extrae phone y email del bloque "Contacto:" del brief o de las
+    # palabras-ancla típicas. Filtra falsos positivos (IDs, DNIs, CUITs).
+
+    def test_phone_with_tel_ancla(self):
+        """'Tel: X' → phone extraído (limpio sin formato)."""
+        out = _analyze_regex_fallback("Tel: 3464696027")
+        assert out["phone"] == "3464696027"
+
+    def test_phone_with_cel_ancla_formatted(self):
+        """'Cel: (0346) 4-696027' → '03464696027' (sin formato)."""
+        out = _analyze_regex_fallback("Cel: (0346) 4-696027")
+        assert out["phone"] == "03464696027"
+
+    def test_phone_ignores_naked_id_without_ancla(self):
+        """ID del brief Micaela 'DA-1781136799652-KVZU' sin palabra-ancla
+        → phone=null. Sin ancla no extraemos."""
+        out = _analyze_regex_fallback("Order ID: DA-1781136799652-KVZU")
+        assert out["phone"] is None
+
+    def test_phone_ignores_naked_dni_without_ancla(self):
+        """'DNI: 12345678' (sin 'Tel:') → phone=null."""
+        out = _analyze_regex_fallback("DNI 12345678 cliente Juan")
+        assert out["phone"] is None
+
+    def test_email_extracted(self):
+        """'Email: x@y.com' → email extraído."""
+        out = _analyze_regex_fallback(
+            "Cliente Marina Email: marina@example.com en Rosario"
+        )
+        assert out["email"] == "marina@example.com"
+
+    def test_email_handles_compound_tld(self):
+        """TLDs largos tipo .com.ar funcionan."""
+        out = _analyze_regex_fallback("contacto@dangelo.com.ar")
+        assert out["email"] == "contacto@dangelo.com.ar"
+
+    def test_no_phone_no_email_both_null(self):
+        """Brief sin Tel ni Email → ambos campos null."""
+        out = _analyze_regex_fallback("Mesada 2x0.60 silestone en rosario")
+        assert out["phone"] is None
+        assert out["email"] is None
+
+    def test_brief_micaela_e2e_phone_and_email(self):
+        """Caso real del brief Micaela: 'Contacto: ... — Tel: ... —
+        Email: ...'. Ambos extraídos."""
+        brief = (
+            "Lead completo\n"
+            "Contacto: Micaela Volattire — Tel: 3464696027 — "
+            "Email: micaelavolattire.1234@gmail.com\n"
+            "Trabajo: Cocina"
+        )
+        out = _analyze_regex_fallback(brief)
+        assert out["phone"] == "3464696027"
+        assert out["email"] == "micaelavolattire.1234@gmail.com"
+
+    def test_micaela_id_not_confused_with_phone(self):
+        """Drift guard del brief Micaela real: el ID interno
+        'DA-1781136799652-KVZU' aparece en el mismo brief que el tel
+        legítimo. No debe confundirse — solo el que tiene 'Tel:' ancla."""
+        brief = (
+            "DA-1781136799652-KVZU\n"
+            "Contacto: Micaela — Tel: 3464696027"
+        )
+        out = _analyze_regex_fallback(brief)
+        assert out["phone"] == "3464696027"
+
     def test_material_clean(self):
         out = _analyze_regex_fallback("material pura prima onix white mate Cliente: Juan")
         assert out["material"] is not None

--- a/api/tests/test_context_analyzer.py
+++ b/api/tests/test_context_analyzer.py
@@ -76,6 +76,45 @@ class TestBuildContextAnalysis:
         out = build_context_analysis("cliente en rosario", None, _dual())
         assert any(r["field"] == "Localidad" for r in out["data_known"])
 
+    # ── Sub-PR sprint-4/contacto-extraction-fix ────────────────────────
+    # Caveat 1 resolved: Contacto va en data_known (no assumptions)
+    # porque son datos DECLARADOS por el operador. resolveString del
+    # adapter ya busca en data_known + assumptions vía findEntry.
+
+    def test_contacto_phone_only(self):
+        """phone presente sin email → entry 'Contacto' con 'Tel: X'."""
+        out = build_context_analysis("Cliente Juan Tel: 3464696027", None, _dual())
+        entries = [r for r in out["data_known"] if r["field"] == "Contacto"]
+        assert len(entries) == 1
+        assert entries[0]["value"] == "Tel: 3464696027"
+        assert entries[0]["source"] == "brief"
+
+    def test_contacto_email_only(self):
+        """email presente sin phone → entry 'Contacto' con 'Email: Y'."""
+        out = build_context_analysis(
+            "Cliente Maria Email: maria@example.com", None, _dual(),
+        )
+        entries = [r for r in out["data_known"] if r["field"] == "Contacto"]
+        assert len(entries) == 1
+        assert entries[0]["value"] == "Email: maria@example.com"
+
+    def test_contacto_both_phone_and_email(self):
+        """Ambos presentes → entry 'Contacto' con 'Tel: X · Email: Y'."""
+        out = build_context_analysis(
+            "Tel: 3464696027 Email: micaela@ejemplo.com", None, _dual(),
+        )
+        entries = [r for r in out["data_known"] if r["field"] == "Contacto"]
+        assert len(entries) == 1
+        assert entries[0]["value"] == "Tel: 3464696027 · Email: micaela@ejemplo.com"
+
+    def test_no_contacto_when_both_null(self):
+        """Brief sin phone ni email → NO se agrega entry 'Contacto'."""
+        out = build_context_analysis(
+            "Mesada 2x0.60 silestone en rosario", None, _dual(),
+        )
+        entries = [r for r in out["data_known"] if r["field"] == "Contacto"]
+        assert entries == []
+
     def test_cocina_triggers_pileta_empotrada_rule(self):
         # La regla aplica cuando hay cocina Y pileta mencionada (evita
         # agregar la regla cuando el trabajo no tiene pileta).

--- a/web/src/lib/api/adapters/context-from-breakdown.ts
+++ b/web/src/lib/api/adapters/context-from-breakdown.ts
@@ -210,9 +210,12 @@ export function breakdownToContext(breakdown: QuoteBreakdownLike | null | undefi
   // ── Cliente
   const cliente = resolveString(verified, pending, "Cliente", raw.client_name);
 
-  // ── Contacto · NO está en backend canon (deuda · backend no extrae
-  // phone/email del brief). Siempre FALTA hasta sub-PR posterior.
-  const contacto = field<string | null>(null, "FALTA");
+  // ── Contacto · sub-PR sprint-4/contacto-extraction-fix (deuda
+  // cerrada desde PR #483 sub-PR 9.3). Backend ahora extrae phone +
+  // email del bloque "Contacto:" del brief y genera data_known entry
+  // "Contacto" con value formateado "Tel: X · Email: Y". `resolveString`
+  // busca en `data_known + assumptions` (findEntry orden).
+  const contacto = resolveString(verified, pending, "Contacto", null);
 
   // ── Localidad
   const localidad = resolveString(verified, pending, "Localidad", raw.localidad);

--- a/web/tests/unit/context-from-breakdown.test.ts
+++ b/web/tests/unit/context-from-breakdown.test.ts
@@ -250,19 +250,93 @@ describe("breakdownToContext · derived fields", () => {
   });
 });
 
-describe("breakdownToContext · contacto siempre FALTA (deuda documentada)", () => {
-  test("contacto siempre null + FALTA · backend no extrae phone/email", () => {
+// ─────────────────────────────────────────────────────────────────────
+// Sub-PR sprint-4/contacto-extraction-fix · activación deuda PR #483
+//
+// Antes: el adapter hardcodeaba `contacto = null + FALTA` con comentario
+// "deuda · backend no extrae phone/email del brief". Hoy el backend
+// (brief_analyzer + context_analyzer) extrae phone+email y genera
+// data_known entry "Contacto" con value formateado. El adapter ahora
+// usa resolveString igual que Cliente / Localidad / Material.
+//
+// Shape REAL del backend (lección #60): el data_known entry vive
+// anidado dentro de `context_analysis_pending`.
+// ─────────────────────────────────────────────────────────────────────
+
+describe("contacto-extraction-fix · contacto del backend canon", () => {
+  test("data_known 'Contacto' nested → contacto populated + BRIEF", () => {
     const ctx = breakdownToContext({
       context_analysis_pending: {
         data_known: [
-          // Mock backend hipotético: incluso si trajera Contacto, lo
-          // ignoramos en este sub-PR.
-          { field: "Contacto", value: "+54 11 1234-5678", source: "brief" },
+          {
+            field: "Contacto",
+            value: "Tel: 3464696027 · Email: micaela@ejemplo.com",
+            source: "brief",
+          },
+        ],
+      },
+    });
+    expect(ctx.contacto.value).toBe(
+      "Tel: 3464696027 · Email: micaela@ejemplo.com",
+    );
+    expect(ctx.contacto.origin).toBe("BRIEF");
+  });
+
+  test("data_known 'Contacto' phone only → 'Tel: X' + BRIEF", () => {
+    const ctx = breakdownToContext({
+      context_analysis_pending: {
+        data_known: [
+          { field: "Contacto", value: "Tel: 3464696027", source: "brief" },
+        ],
+      },
+    });
+    expect(ctx.contacto.value).toBe("Tel: 3464696027");
+    expect(ctx.contacto.origin).toBe("BRIEF");
+  });
+
+  test("sin data_known 'Contacto' → contacto null + FALTA (current UX preservada)", () => {
+    const ctx = breakdownToContext({
+      context_analysis_pending: {
+        data_known: [
+          { field: "Cliente", value: "Juan", source: "brief" },
         ],
       },
     });
     expect(ctx.contacto.value).toBeNull();
     expect(ctx.contacto.origin).toBe("FALTA");
+  });
+
+  test("regression · audit literal Micaela post-fix · 3 fields contacto-relacionados", () => {
+    // Anclaje al dump literal esperado post-deploy (lección #60).
+    // Si el backend cambia su shape, este test rompe primero.
+    const ctx = breakdownToContext({
+      context_analysis_pending: {
+        data_known: [
+          { field: "Cliente", value: "Micaela Volattire", source: "brief" },
+          {
+            field: "Contacto",
+            value:
+              "Tel: 3464696027 · Email: micaelavolattire.1234@gmail.com",
+            source: "brief",
+          },
+          { field: "Localidad", value: "Casilda", source: "brief" },
+          { field: "Material", value: "Granito Gris Perla", source: "brief" },
+        ],
+        _brief_analysis_raw: {
+          client_name: "Micaela Volattire",
+          phone: "3464696027",
+          email: "micaelavolattire.1234@gmail.com",
+          localidad: "Casilda",
+          material: "Granito Gris Perla",
+        },
+      },
+    });
+    expect(ctx.cliente.value).toBe("Micaela Volattire");
+    expect(ctx.contacto.value).toBe(
+      "Tel: 3464696027 · Email: micaelavolattire.1234@gmail.com",
+    );
+    expect(ctx.contacto.origin).toBe("BRIEF");
+    expect(ctx.localidad.value).toBe("Casilda");
   });
 });
 


### PR DESCRIPTION
## Deuda cerrada (sub-PR 9.3 del PR #483 prometía esto)

Adapter línea 213-214 tenía deuda explícita: *\"Contacto · NO está en backend canon. Siempre FALTA hasta sub-PR posterior.\"* Hoy se cumple.

**Brief de Micaela** contenía:
\`\`\`
Contacto: Micaela Volattire — Tel: 3464696027 — Email: micaelavolattire.1234@gmail.com
\`\`\`

| Capa | Pre-fix | Post-fix |
|---|---|---|
| Backend \`_brief_analysis_raw\` | client_name=\"Micaela\" · phone=∅ · email=∅ | + phone=\"3464696027\" + email=\"...@gmail.com\" |
| Backend \`data_known\` | Cliente, Material, Localidad | + entry \`\"Contacto\"\` |
| Frontend ContextResponse | contacto={null, FALTA} hardcoded | contacto={\"Tel: X · Email: Y\", BRIEF} |
| UI paso 2 | \"Contacto: —\" · FALTA | **\"Tel: 3464696027 · Email: ...@gmail.com\" · BRIEF** |

## Lección #58 aplicada · cierre full-stack en MISMO PR

Backend + adapter + tests viven en este PR para evitar el patrón de bugs Bug 5 → Bug 7 (PR #485 backend → PR #486 adapter wrong fixtures → PR #487 audit tooling → PR #488 real adapter fix).

## Caveat 1 (verificación pre-código) · Contacto va en \`data_known\`

\`findEntry\` busca PRIMERO en \`data_known\`, después en \`assumptions\`. \`resolveString\` reusa \`findEntry\` → ambos paths cubiertos. Decisión: Contacto en \`data_known\` (semánticamente correcto · es dato DECLARADO por el operador, no inferido). Cero cambio al adapter resolver.

## Cambios

### Backend · \`brief_analyzer.py\` (+81 LOC)

1. \`EMPTY_SCHEMA\` · 2 fields nuevos post-\`client_name\` (\`phone\`, \`email\`)
2. **Prompt** regla nueva como #3 (renumeradas 4-16) instruyendo extracción ancla con \"Tel:\" / \"Cel:\" / \"Teléfono:\" / \"WhatsApp:\" / \"Móvil:\" / \"Email:\" / \"Mail:\". Anti-falsos-positivos: IDs internos (\"DA-1781136799652-KVZU\"), DNI, CUIT, números de orden sueltos.
3. **Schema JSON** del prompt actualizado.
4. **Regex** · 2 patterns nuevos:
   - \`_PHONE_RE\` · contextual con palabra-ancla. Acepta \"3464696027\" / \"(0346) 4-696027\" / \"+54 9 ...\"
   - \`_PHONE_CLEAN\` · helper que elimina formato
   - \`_EMAIL_RE\` · estándar simple sin TLD restrictivo (acepta .com.ar)
5. **Branch** en \`_analyze_regex_fallback\` · phone con validación 8-16 dígitos post-limpieza.

### Backend · \`context_analyzer.py\` (+20 LOC)

Inserción post-\`Cliente\` · si \`phone\` o \`email\` presentes → data_known entry:
\`\`\`json
{\"field\": \"Contacto\", \"value\": \"Tel: X · Email: Y\", \"source\": \"brief\"}
\`\`\`

Si ambos null → NO se agrega entry (UX FALTA preservada).

### Frontend · \`context-from-breakdown.ts\` (3 LOC)

\`\`\`ts
// Antes:
const contacto = field<string | null>(null, \"FALTA\");  // hardcoded deuda
// Ahora:
const contacto = resolveString(verified, pending, \"Contacto\", null);
\`\`\`

## Tests · 13 nuevos · 0 regresión

| Capa | Tests | Estado |
|---|---|---|
| brief_analyzer regex | +9 | 120/120 verde |
| context_analyzer | +4 | suite intact |
| adapter frontend | +4 | 49/49 verde |
| Suite backend completa | — | 2249 passed (2 errors PDF preexistentes) |
| Vitest completo | — | 129/129 verde |
| TypeScript | — | \`tsc --noEmit\` exit 0 |

### Cobertura lección #60 · shape REAL prod

- \`test_micaela_id_not_confused_with_phone\` · brief Micaela tiene tanto el ID interno \`DA-1781136799652-KVZU\` como el tel legítimo. Solo el del \"Tel:\" se extrae.
- \`regression · audit literal Micaela post-fix\` (adapter) · anclaje al dump esperado · drift guard contra cambios de shape backend.

## Smoke test post-deploy plan (OBLIGATORIO · lección #51 + #59)

Tras Vercel deploy, reprobar brief Micaela. Usar **audit copy 3-layers (PR #487)** para validar sin screenshot:

\`\`\`
[BACKEND]:
  _brief_analysis_raw.phone: \"3464696027\"
  _brief_analysis_raw.email: \"micaelavolattire.1234@gmail.com\"
  data_known: [..., {\"field\": \"Contacto\", \"value\": \"Tel: 3464696027 · Email: micaelavolattire.1234@gmail.com\", \"source\": \"brief\"}, ...]

[ADAPTER OUTPUT · ContextResponse]:
  contacto: {value: \"Tel: 3464696027 · Email: ...\", origin: \"BRIEF\"}

[UI RENDER · /contexto]:
  Contacto: \"Tel: 3464696027 · Email: micaelavolattire.1234@gmail.com\" · BRIEF
\`\`\`

Si las 3 capas matchean → deuda cerrada end-to-end.

## Deudas explícitas NO cerradas (follow-up)

### Wire \`Quote.client_phone\` / \`Quote.client_email\` post-confirm

Las columnas existen (\`api/app/models/quote.py:56-57\`) pero solo se setean vía PATCH del operador. Post este PR, el breakdown JSON tiene el phone/email del brief — pero el agent.py no los mirrorea a las columnas tras context_confirm. **Sub-PR posterior** (toca agent.py · fuera de scope).

### Otras deudas conocidas

- Bug 3 · \`Quote.project\` source (\"quote\" vs \"brief\")
- Bug 6 · \`m2_total\` UX (no bloqueante)

## Lecciones aplicadas

- **#51** Smoke test post-deploy obligatorio documentado
- **#57** \`temperature=0\` ya aplicado en brief_analyzer (PR #485)
- **#58** Backend + frontend en MISMO PR (cierre full-stack)
- **#59** Audit copy 3-layers para smoke sin screenshot (PR #487)
- **#60** Fixtures con shape REAL prod (regression Micaela ancla literal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)