### PR TITLE
feat(config): UI editable 6 defaults + BUG FIX zócalo 7→5cm

### DIFF
--- a/api/catalog/config.json
+++ b/api/catalog/config.json
@@ -74,8 +74,15 @@
   },
   "measurements": {
     "default_depth": 0.6,
-    "default_zocalo_height": 0.07,
+    "default_zocalo_height": 0.05,
+    "default_alzada_height": 0.6,
     "tall_zocalo_threshold": 0.1
+  },
+  "defaults": {
+    "_comment": "Defaults operativos editables desde /configuracion (sub-PR 22.2.a). Consumidos por context_analyzer + agent cuando el brief no especifica.",
+    "colocacion_particulares": true,
+    "delivery_zone_sku": "ENVIOROS",
+    "forma_pago": "Contado"
   },
   "colocacion": {
     "min_quantity": 1.0

--- a/api/tests/test_config_endpoint.py
+++ b/api/tests/test_config_endpoint.py
@@ -1,0 +1,132 @@
+"""Tests del endpoint `GET/PUT /api/catalog/config` · Sprint 4 sub-PR
+22.2.a config-ui-page.
+
+Cobertura:
+- GET devuelve las 4 keys nuevas del scope 22.2.a
+- GET muestra default_zocalo_height = 0.05 (BUG PROD FIX · master Regla 10)
+- PUT con dict válido persiste + invalida cache + GET subsecuente devuelve cambios
+- PUT con body inválido (content=null) rechaza 422
+- Fixtures con shape REAL del config.json (lección #60)
+"""
+from __future__ import annotations
+
+import pytest
+
+
+class TestConfigEndpointGet:
+    @pytest.mark.asyncio
+    async def test_get_config_contains_new_keys_from_22_2_a(self, client):
+        """Verifica que las 4 keys agregadas en este sub-PR aparezcan en GET."""
+        r = await client.get("/api/catalog/config")
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert isinstance(data, dict)
+        assert "measurements" in data
+        # Bug fix prod · default zócalo alineado al master (era 0.07)
+        assert data["measurements"]["default_zocalo_height"] == 0.05
+        # NUEVO · default alzada
+        assert data["measurements"]["default_alzada_height"] == 0.6
+        # NUEVO bloque defaults operativos
+        assert "defaults" in data
+        assert data["defaults"]["colocacion_particulares"] is True
+        assert data["defaults"]["delivery_zone_sku"] == "ENVIOROS"
+        assert data["defaults"]["forma_pago"] == "Contado"
+
+    @pytest.mark.asyncio
+    async def test_get_config_preserves_existing_keys(self, client):
+        """Regresión · los bloques previos (iva, delivery_days, discount,
+        company, conditions, etc.) NO se rompen al agregar `defaults`."""
+        r = await client.get("/api/catalog/config")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["iva"]["multiplier"] == 1.21
+        assert data["delivery_days"]["default"] == 30
+        assert "company" in data
+        assert "conditions" in data
+        assert "ai_engine" in data
+
+
+class TestConfigEndpointPut:
+    @pytest.mark.asyncio
+    async def test_put_config_persists_and_get_returns_updated(self, client):
+        """PUT con dict válido persiste a DB. GET subsecuente devuelve la
+        versión nueva (incluye invalidación de cache module-level)."""
+        # GET inicial
+        r0 = await client.get("/api/catalog/config")
+        original = r0.json()
+        # Modificamos un field editable del scope 22.2.a
+        new_config = {**original}
+        new_config["measurements"] = {
+            **original["measurements"],
+            "default_alzada_height": 0.75,  # cambiamos 0.6 → 0.75
+        }
+        # PUT
+        r1 = await client.put(
+            "/api/catalog/config",
+            json={"content": new_config},
+        )
+        assert r1.status_code == 200, r1.text
+        body = r1.json()
+        assert body == {"ok": True, "catalog": "config"}
+        # GET subsecuente refleja el cambio
+        r2 = await client.get("/api/catalog/config")
+        assert r2.json()["measurements"]["default_alzada_height"] == 0.75
+
+    @pytest.mark.asyncio
+    async def test_put_config_null_content_rejected(self, client):
+        """Pydantic rechaza body con content=null (preserva validator
+        existente · regresión)."""
+        r = await client.put(
+            "/api/catalog/config",
+            json={"content": None},
+        )
+        assert r.status_code == 422
+
+
+class TestConfigEndpointCacheInvalidation:
+    @pytest.mark.asyncio
+    async def test_put_config_invokes_cache_invalidation_handlers(self, client, monkeypatch):
+        """Verifica que el endpoint invoca las 3 funciones de cache
+        invalidation (catalog_tool + document_tool + company_config) al
+        recibir PUT sobre `config`.
+
+        Razón del approach: en multi-worker prod, los caches son
+        module-level por proceso. El endpoint llama 3 invalidates pero solo
+        afectan al worker actual. UI debe decir "puede tardar unos segundos
+        en producción" (caveat documentado en bundle FASE 1 punto 6).
+
+        El test NO verifica propagación real (requeriría multi-process
+        coordination) · verifica que las llamadas SE HACEN. Suficiente
+        para regresión-guard del wire.
+        """
+        calls = {"catalog": False, "company": False, "config": False}
+
+        def _spy_catalog(name):
+            calls["catalog"] = True
+
+        def _spy_company():
+            calls["company"] = True
+
+        def _spy_config():
+            calls["config"] = True
+
+        # Patch las 3 funciones que el router llama tras PUT
+        monkeypatch.setattr(
+            "app.modules.catalog.router.invalidate_catalog_cache", _spy_catalog
+        )
+        monkeypatch.setattr(
+            "app.modules.catalog.router.invalidate_company_config_cache", _spy_company
+        )
+        monkeypatch.setattr(
+            "app.core.company_config.invalidate_config_cache", _spy_config
+        )
+
+        r = await client.put(
+            "/api/catalog/config",
+            json={"content": {"measurements": {"default_zocalo_height": 0.05}}},
+        )
+        assert r.status_code == 200
+
+        assert calls["catalog"], "invalidate_catalog_cache no fue invocado"
+        assert calls["company"], "invalidate_company_config_cache no fue invocado"
+        assert calls["config"], "invalidate_config_cache no fue invocado"

--- a/web/src/app/(chrome)/configuracion/page.tsx
+++ b/web/src/app/(chrome)/configuracion/page.tsx
@@ -1,23 +1,35 @@
 /**
- * Configuración · placeholder · Sprint 4 sidebar-and-navigation-fix.
+ * Configuración · sub-PR 22.2.a config-ui-page.
  *
- * Cierra ruta 404. Defaults editables (zócalo, alzada, plazo, anticipo,
- * IVA toggles, etc.) vienen en sub-PR posterior de UI editable.
+ * Reemplaza el placeholder por el ConfigForm real con 6 defaults
+ * operativos editables. Fetch + persist viven en el component cliente
+ * (los catálogos son cross-quote · no necesitan SSR aggressive).
+ *
+ * Scope CSS: `.config-v2` wrapper · ver globals.css (~15-20 LOC media
+ * query) · operator-shared.css INTACTO.
  */
+import { ConfigForm } from "@/components/config/ConfigForm";
+
 export default function ConfiguracionPage() {
   return (
-    <>
+    <div className="config-v2">
       <div className="topbar">
         <div className="crumbs">
           <span className="now">Configuración</span>
         </div>
       </div>
-      <div className="body" data-testid="configuracion-placeholder">
-        <p>Próximamente · UI de configuración.</p>
-        <p style={{ color: "var(--ink-mute)", fontSize: 12, marginTop: 8 }}>
-          Defaults editables (zócalo, alzada, plazo, anticipo) en sub-PR posterior.
-        </p>
+      <div className="body" data-testid="configuracion-page">
+        <div className="col">
+          <div className="section-head">
+            <h2>Defaults operativos</h2>
+            <span className="meta">
+              Aplican cuando el brief no especifica · editás y guardás · Marina puede sobrescribir
+              manualmente en cada presupuesto desde /contexto.
+            </span>
+          </div>
+          <ConfigForm />
+        </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -107,3 +107,21 @@
   .dashboard-v2 .dashboard-list-desktop { display: none; }
   .dashboard-v2 .dashboard-list-mobile { display: block; }
 }
+
+/* ─────────────────────────────────────────────────────────
+   Sprint 4 config-ui-page (sub-PR 22.2.a) · scope `.config-v2`
+   ~18 LOC media query · operator-shared.css INTACTO (lección #66).
+   ───────────────────────────────────────────────────────── */
+.config-v2 .config-fields-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px 24px;
+  max-width: 720px;
+}
+.config-v2 .config-fields-grid .input { width: 100%; box-sizing: border-box; }
+@media (max-width: 767px) {
+  .config-v2 .body { padding: 16px; }
+  .config-v2 .config-fields-grid { grid-template-columns: 1fr; gap: 16px; }
+  .config-v2 .config-actions { flex-wrap: wrap; }
+  .config-v2 .config-actions .btn { flex: 1; min-width: 120px; }
+}

--- a/web/src/components/config/ConfigDiffModal.tsx
+++ b/web/src/components/config/ConfigDiffModal.tsx
@@ -1,0 +1,158 @@
+/**
+ * Modal de confirmación pre-save · sub-PR 22.2.a config-ui-page.
+ *
+ * Reusa el pattern de PdfConfirmModal (paso destructivo · ESC cierra,
+ * click backdrop no cierra). Muestra tabla antes/después de los fields
+ * que cambiaron · si nada cambió, el caller no debe abrirlo.
+ *
+ * Cero CSS nuevo · todas las clases vienen de operator-shared.css.
+ */
+"use client";
+
+import { useEffect, useState } from "react";
+
+export interface DiffRow {
+  label: string;
+  before: string;
+  after: string;
+}
+
+interface Props {
+  rows: DiffRow[];
+  onCancel: () => void;
+  /** Async handler que dispara PUT a backend. Si throw → banner error. */
+  onConfirm: () => Promise<void>;
+}
+
+export function ConfigDiffModal({ rows, onCancel, onConfirm }: Props) {
+  const [loading, setLoading] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !loading) onCancel();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onCancel, loading]);
+
+  const handleConfirm = async () => {
+    if (loading) return;
+    setErrorMsg(null);
+    setLoading(true);
+    try {
+      await onConfirm();
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "No se pudo guardar la configuración.");
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div
+      className="modal-backdrop"
+      data-testid="config-diff-backdrop"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div
+        className="modal w-520"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="config-diff-title"
+        data-testid="config-diff-modal"
+      >
+        <div className="m-head">
+          <div className="eyebrow">Confirmá los cambios</div>
+          <h3 id="config-diff-title">Vas a actualizar la configuración</h3>
+        </div>
+
+        <div className="m-body">
+          <table
+            data-testid="config-diff-table"
+            style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}
+          >
+            <thead>
+              <tr style={{ color: "var(--ink-mute)", textAlign: "left" }}>
+                <th style={{ padding: "6px 8px", fontWeight: 500 }}>Campo</th>
+                <th style={{ padding: "6px 8px", fontWeight: 500 }}>Antes</th>
+                <th style={{ padding: "6px 8px", fontWeight: 500 }}>Después</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr
+                  key={r.label}
+                  data-testid={`diff-row-${r.label}`}
+                  style={{ borderTop: "1px solid var(--border)" }}
+                >
+                  <td style={{ padding: "8px" }}>{r.label}</td>
+                  <td style={{ padding: "8px", color: "var(--ink-mute)" }}>
+                    <span className="mono-inline">{r.before}</span>
+                  </td>
+                  <td style={{ padding: "8px", color: "var(--ink)" }}>
+                    <span className="mono-inline">{r.after}</span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div className="audit-note mt-14" data-testid="config-diff-warning">
+            <span className="warn-icon-amber" aria-hidden="true">
+              ⚠
+            </span>{" "}
+            Aplica a presupuestos NUEVOS · los que están en draft retienen los valores actuales en
+            su breakdown.
+          </div>
+
+          {errorMsg && (
+            <div
+              role="alert"
+              data-testid="config-error-banner"
+              style={{
+                marginTop: 14,
+                padding: "10px 14px",
+                borderRadius: 6,
+                border: "1px solid var(--error)",
+                background: "color-mix(in oklch, var(--error) 12%, transparent)",
+                color: "var(--error)",
+                fontSize: 13,
+                lineHeight: 1.4,
+              }}
+            >
+              {errorMsg}
+            </div>
+          )}
+        </div>
+
+        <div className="m-foot">
+          <button
+            type="button"
+            className="btn ghost"
+            onClick={onCancel}
+            disabled={loading}
+            data-testid="config-modal-cancel"
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            className="btn primary"
+            onClick={handleConfirm}
+            disabled={loading}
+            data-testid="config-modal-confirm"
+            data-loading={loading ? "true" : "false"}
+          >
+            {loading ? (
+              <span data-testid="config-modal-spinner">Guardando…</span>
+            ) : errorMsg ? (
+              "Reintentar"
+            ) : (
+              "Guardar cambios"
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/config/ConfigForm.tsx
+++ b/web/src/components/config/ConfigForm.tsx
@@ -1,0 +1,291 @@
+/**
+ * ConfigForm · sub-PR 22.2.a config-ui-page.
+ *
+ * 6 defaults operativos editables:
+ *   - default_depth (m · profundidad de mesada)
+ *   - default_zocalo_height (m · BUG PROD FIX 0.07→0.05)
+ *   - default_alzada_height (m)
+ *   - colocacion_particulares (bool)
+ *   - delivery_zone_sku (string · SKU de delivery-zones.json)
+ *   - forma_pago (string)
+ *
+ * Flow: fetch initial blob → editable state local → "Guardar" abre diff
+ * modal (solo si hay cambios) → onConfirm → PUT → badge "Guardado" 3s.
+ *
+ * Cero CSS nuevo en operator-shared.css. Scope CSS responsive vive en
+ * globals.css bajo `.config-v2` (Step 6 · ~15-20 LOC media query).
+ */
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  applyEditableFields,
+  extractEditableFields,
+  type CatalogConfig,
+  type ConfigEditableFields,
+} from "@/lib/api/types";
+import { getCatalogConfig, updateCatalogConfig } from "@/lib/api";
+import { ConfigDiffModal, type DiffRow } from "./ConfigDiffModal";
+
+interface FieldDef {
+  key: keyof ConfigEditableFields;
+  label: string;
+  helper?: string;
+  type: "number_m" | "text" | "bool";
+  step?: string;
+}
+
+const FIELDS: FieldDef[] = [
+  {
+    key: "default_zocalo_height",
+    label: "Alto de zócalo (m)",
+    helper: "Default master D'Angelo = 5cm",
+    type: "number_m",
+    step: "0.01",
+  },
+  {
+    key: "default_alzada_height",
+    label: "Alto de alzada (m)",
+    helper: "Default cuando brief no especifica = 60cm",
+    type: "number_m",
+    step: "0.01",
+  },
+  {
+    key: "default_depth",
+    label: "Profundidad de mesada (m)",
+    helper: "Default 60cm cuando brief no aclara",
+    type: "number_m",
+    step: "0.01",
+  },
+  {
+    key: "delivery_zone_sku",
+    label: "Zona de flete por defecto (SKU)",
+    helper: "SKU de delivery-zones.json · default ENVIOROS (Rosario)",
+    type: "text",
+  },
+  {
+    key: "forma_pago",
+    label: "Forma de pago default",
+    helper: "Texto que aparece en el PDF",
+    type: "text",
+  },
+  {
+    key: "colocacion_particulares",
+    label: "Colocación incluida para particulares",
+    helper: "Edificios siempre van sin colocación (regla aparte)",
+    type: "bool",
+  },
+];
+
+function formatValue(key: keyof ConfigEditableFields, value: unknown): string {
+  if (typeof value === "boolean") return value ? "sí" : "no";
+  if (
+    key === "default_depth" ||
+    key === "default_zocalo_height" ||
+    key === "default_alzada_height"
+  ) {
+    return `${(value as number).toFixed(2)} m`;
+  }
+  return String(value);
+}
+
+function diffRows(prev: ConfigEditableFields, next: ConfigEditableFields): DiffRow[] {
+  const rows: DiffRow[] = [];
+  for (const f of FIELDS) {
+    if (prev[f.key] !== next[f.key]) {
+      rows.push({
+        label: f.label,
+        before: formatValue(f.key, prev[f.key]),
+        after: formatValue(f.key, next[f.key]),
+      });
+    }
+  }
+  return rows;
+}
+
+export function ConfigForm() {
+  const [baseBlob, setBaseBlob] = useState<CatalogConfig | null>(null);
+  const [original, setOriginal] = useState<ConfigEditableFields | null>(null);
+  const [draft, setDraft] = useState<ConfigEditableFields | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [showModal, setShowModal] = useState(false);
+  const [savedBadge, setSavedBadge] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const blob = await getCatalogConfig();
+        if (cancelled) return;
+        const edits = extractEditableFields(blob);
+        setBaseBlob(blob);
+        setOriginal(edits);
+        setDraft(edits);
+      } catch (err) {
+        if (!cancelled) {
+          setLoadError(err instanceof Error ? err.message : "Error desconocido");
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!savedBadge) return;
+    const t = setTimeout(() => setSavedBadge(false), 3000);
+    return () => clearTimeout(t);
+  }, [savedBadge]);
+
+  if (loadError) {
+    return (
+      <div data-testid="config-load-error" role="alert" style={{ color: "var(--error)" }}>
+        No pude cargar la configuración: {loadError}
+      </div>
+    );
+  }
+
+  if (!draft || !original || !baseBlob) {
+    return (
+      <div data-testid="config-loading" style={{ color: "var(--ink-mute)" }}>
+        Cargando configuración…
+      </div>
+    );
+  }
+
+  const rowsToDiff = diffRows(original, draft);
+  const hasChanges = rowsToDiff.length > 0;
+
+  const handleField = <K extends keyof ConfigEditableFields>(
+    key: K,
+    value: ConfigEditableFields[K],
+  ) => {
+    setDraft((d) => (d ? { ...d, [key]: value } : d));
+  };
+
+  const handleReset = () => {
+    setDraft(original);
+  };
+
+  const handleSubmit = async () => {
+    if (!baseBlob || !draft) return;
+    const nextBlob = applyEditableFields(baseBlob, draft);
+    await updateCatalogConfig(nextBlob);
+    setBaseBlob(nextBlob);
+    setOriginal(draft);
+    setShowModal(false);
+    setSavedBadge(true);
+  };
+
+  return (
+    <form
+      data-testid="config-form"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (hasChanges) setShowModal(true);
+      }}
+      style={{ display: "flex", flexDirection: "column", gap: 16 }}
+    >
+      <div className="config-fields-grid">
+        {FIELDS.map((f) => {
+          const val = draft[f.key];
+          const id = `config-field-${f.key}`;
+          return (
+            <div
+              key={f.key}
+              data-testid={`config-row-${f.key}`}
+              style={{ display: "flex", flexDirection: "column", gap: 4 }}
+            >
+              <label htmlFor={id} style={{ fontSize: 13, color: "var(--ink)", fontWeight: 500 }}>
+                {f.label}
+              </label>
+              {f.type === "bool" ? (
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <input
+                    id={id}
+                    data-testid={`config-input-${f.key}`}
+                    type="checkbox"
+                    checked={val as boolean}
+                    onChange={(e) => handleField(f.key, e.target.checked as never)}
+                  />
+                  <span style={{ fontSize: 13, color: "var(--ink-mute)" }}>
+                    {(val as boolean) ? "Activada" : "Desactivada"}
+                  </span>
+                </div>
+              ) : f.type === "number_m" ? (
+                <input
+                  id={id}
+                  data-testid={`config-input-${f.key}`}
+                  className="input num"
+                  type="number"
+                  step={f.step}
+                  min="0"
+                  value={val as number}
+                  onChange={(e) => handleField(f.key, Number(e.target.value) as never)}
+                />
+              ) : (
+                <input
+                  id={id}
+                  data-testid={`config-input-${f.key}`}
+                  className="input"
+                  type="text"
+                  value={val as string}
+                  onChange={(e) => handleField(f.key, e.target.value as never)}
+                />
+              )}
+              {f.helper && (
+                <span
+                  data-testid={`config-helper-${f.key}`}
+                  style={{ fontSize: 11, color: "var(--ink-mute)" }}
+                >
+                  {f.helper}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <div
+        className="config-actions"
+        style={{ display: "flex", gap: 8, alignItems: "center", marginTop: 8 }}
+      >
+        <button
+          type="submit"
+          className="btn primary"
+          disabled={!hasChanges}
+          data-testid="config-save"
+        >
+          Guardar
+        </button>
+        <button
+          type="button"
+          className="btn ghost"
+          disabled={!hasChanges}
+          onClick={handleReset}
+          data-testid="config-reset"
+        >
+          Descartar
+        </button>
+        {savedBadge && (
+          <span
+            data-testid="config-saved-badge"
+            role="status"
+            style={{ fontSize: 12, color: "var(--ok, #4ade80)" }}
+          >
+            ✓ Guardado · aplicará a próximos presupuestos (puede tardar unos segundos en producción)
+          </span>
+        )}
+      </div>
+
+      {showModal && (
+        <ConfigDiffModal
+          rows={rowsToDiff}
+          onCancel={() => setShowModal(false)}
+          onConfirm={handleSubmit}
+        />
+      )}
+    </form>
+  );
+}

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -62,6 +62,13 @@ export const triggerPdfV2Generation = mocks.triggerPdfV2Generation;
 /* ─── Audit trail copy · Sprint 4 audit-trail-copy ────────────────── */
 export const getAuditLog = USE_REAL_API ? real.getAuditLog : mocks.getAuditLog;
 
+/* ─── Catalog config · sub-PR 22.2.a config-ui-page ──────────────── */
+export const getCatalogConfig = USE_REAL_API ? real.getCatalogConfig : mocks.getCatalogConfig;
+export const updateCatalogConfig = USE_REAL_API
+  ? real.updateCatalogConfig
+  : mocks.updateCatalogConfig;
+export const _resetCatalogConfigStore = mocks._resetCatalogConfigStore;
+
 /* ─── Helpers de test (reset de stores in-memory del mock) ───────── */
 export const _resetContextStore = mocks._resetContextStore;
 export const _resetPiecesStore = mocks._resetPiecesStore;

--- a/web/src/lib/api/mocks.ts
+++ b/web/src/lib/api/mocks.ts
@@ -785,8 +785,10 @@ export function _resetGeneratedStore() {
 
 const _generatedByQuote: Record<string, import("./types").PdfGeneratedInfo> = {
   "PRES-2026-018": {
-    pdfUrl: "/quotes/2026/PRES-2026-018/Cueto-Heredia Arquitectura - Silestone Blanco Norte - 03.05.2026.pdf",
-    excelUrl: "/quotes/2026/PRES-2026-018/Cueto-Heredia Arquitectura - Silestone Blanco Norte - 03.05.2026.xlsx",
+    pdfUrl:
+      "/quotes/2026/PRES-2026-018/Cueto-Heredia Arquitectura - Silestone Blanco Norte - 03.05.2026.pdf",
+    excelUrl:
+      "/quotes/2026/PRES-2026-018/Cueto-Heredia Arquitectura - Silestone Blanco Norte - 03.05.2026.xlsx",
     driveUrl: "https://drive.google.com/drive/folders/PRES-2026-018-mock",
     driveFolderPath: "/Presupuestos/2026/05-mayo/",
     pdfSizeKb: 926,
@@ -799,7 +801,8 @@ const _generatedByQuote: Record<string, import("./types").PdfGeneratedInfo> = {
   },
   "PRES-2026-017": {
     pdfUrl: "/quotes/2026/PRES-2026-017/Familia Pereyra - Silestone Blanco Norte - 03.05.2026.pdf",
-    excelUrl: "/quotes/2026/PRES-2026-017/Familia Pereyra - Silestone Blanco Norte - 03.05.2026.xlsx",
+    excelUrl:
+      "/quotes/2026/PRES-2026-017/Familia Pereyra - Silestone Blanco Norte - 03.05.2026.xlsx",
     driveUrl: "https://drive.google.com/drive/folders/PRES-2026-017-mock",
     driveFolderPath: "/Presupuestos/2026/05-mayo/",
     pdfSizeKb: 718,
@@ -842,9 +845,7 @@ export async function triggerPdfGeneration(
 ): Promise<import("./types").PdfGeneratedInfo> {
   await delay(800 + Math.random() * 700, options?.signal);
   if (quoteId.endsWith("-ERROR")) {
-    throw new Error(
-      "No se pudo generar el presupuesto · servicio Drive caído (mock-only).",
-    );
+    throw new Error("No se pudo generar el presupuesto · servicio Drive caído (mock-only).");
   }
   const baseId = quoteId.endsWith("-GENERATED") ? quoteId.slice(0, -"-GENERATED".length) : quoteId;
   const info = _generatedByQuote[baseId] ?? _generatedGeneric;
@@ -950,9 +951,25 @@ const _v2DiffByQuote: Record<string, import("./types").PdfV2RevisionData> = {
     rows: [
       { field: "Vigencia", v1Value: "10 días", v2Value: "10 días", display: "mono" },
       { field: "Anticipo", v1Value: "60%", v2Value: "60%", display: "mono" },
-      { field: "Plazo entrega", v1Value: "15 días hábiles", v2Value: "15 días hábiles", display: "mono" },
-      { field: "Datos de envío", v1Value: "Rosario, zona sur", v2Value: "Rosario, zona sur", display: "text" },
-      { field: "Notas internas", v1Value: "— vacío", v2Value: "— vacío", display: "text", v1Empty: true },
+      {
+        field: "Plazo entrega",
+        v1Value: "15 días hábiles",
+        v2Value: "15 días hábiles",
+        display: "mono",
+      },
+      {
+        field: "Datos de envío",
+        v1Value: "Rosario, zona sur",
+        v2Value: "Rosario, zona sur",
+        display: "text",
+      },
+      {
+        field: "Notas internas",
+        v1Value: "— vacío",
+        v2Value: "— vacío",
+        display: "text",
+        v1Empty: true,
+      },
       {
         field: "Subtotal MO",
         v1Value: "$258.430",
@@ -984,9 +1001,7 @@ export async function getPdfV2DiffData(
   options?: { signal?: AbortSignal },
 ): Promise<import("./types").PdfV2RevisionData> {
   await delay(80 + Math.random() * 120, options?.signal);
-  const stripped = quoteId.endsWith("-REVISING")
-    ? quoteId.slice(0, -"-REVISING".length)
-    : quoteId;
+  const stripped = quoteId.endsWith("-REVISING") ? quoteId.slice(0, -"-REVISING".length) : quoteId;
   // Lookup directo · luego intentar normalizar PRES-018 → PRES-2026-018.
   const direct = _v2DiffByQuote[stripped];
   if (direct) return direct;
@@ -1008,9 +1023,7 @@ export async function triggerPdfV2Generation(
   if (quoteId.endsWith("-ERROR")) {
     throw new Error("No se pudo generar v2 · servicio Drive caído (mock-only).");
   }
-  const baseId = quoteId.endsWith("-REVISING")
-    ? quoteId.slice(0, -"-REVISING".length)
-    : quoteId;
+  const baseId = quoteId.endsWith("-REVISING") ? quoteId.slice(0, -"-REVISING".length) : quoteId;
   const v1 = _generatedByQuote[baseId] ?? _generatedGeneric;
   // Variante v2: filenames con suffix " v2" antes de la extensión + nuevo traceId.
   const v2: import("./types").PdfGeneratedInfo = {
@@ -1197,4 +1210,56 @@ export async function getAuditLog(
     tools_used: [],
     errors: [],
   };
+}
+
+/* ─── Catalog config · sub-PR 22.2.a config-ui-page ──────────────────
+   Store in-memory que refleja el shape REAL de api/catalog/config.json
+   (lección #60). Solo expone los campos editables del scope + algunos
+   bloques representativos para que el adapter no rompa.
+
+   Para tests: _resetCatalogConfigStore() restaura defaults canónicos.
+*/
+
+import type { CatalogConfig } from "./types";
+
+const _catalogConfigDefaults: CatalogConfig = {
+  iva: { multiplier: 1.21, percentage: 21 },
+  delivery_days: { default: 30 },
+  measurements: {
+    default_depth: 0.6,
+    default_zocalo_height: 0.05,
+    default_alzada_height: 0.6,
+    tall_zocalo_threshold: 0.1,
+  },
+  defaults: {
+    _comment: "Mock fixture · shape REAL del config.json",
+    colocacion_particulares: true,
+    delivery_zone_sku: "ENVIOROS",
+    forma_pago: "Contado",
+  },
+  company: {
+    name: "D'ANGELO",
+    subtitle: "MARMOLERIA",
+    address: "SAN NICOLAS 1160",
+    phone: "341-3082996",
+    email: "marmoleriadangelo@gmail.com",
+  },
+  conditions: { general: "", payment: "" },
+};
+
+let _catalogConfigStore: CatalogConfig = structuredClone(_catalogConfigDefaults);
+
+export async function getCatalogConfig(): Promise<CatalogConfig> {
+  return structuredClone(_catalogConfigStore);
+}
+
+export async function updateCatalogConfig(
+  content: CatalogConfig,
+): Promise<{ ok: boolean; catalog: string }> {
+  _catalogConfigStore = structuredClone(content);
+  return { ok: true, catalog: "config" };
+}
+
+export function _resetCatalogConfigStore(): void {
+  _catalogConfigStore = structuredClone(_catalogConfigDefaults);
 }

--- a/web/src/lib/api/real.ts
+++ b/web/src/lib/api/real.ts
@@ -551,3 +551,55 @@ export async function getContextForQuote(
   // como FALTA (preserva el current "—" behavior del UI).
   return breakdownToContext(detail.quote_breakdown ?? null);
 }
+
+/* ─── getCatalogConfig / updateCatalogConfig · sub-PR 22.2.a ──────────
+   GET /api/catalog/config → CatalogConfig blob.
+   PUT /api/catalog/config { content } → { ok, catalog }.
+
+   Endpoint backend ya existe (catalog/router.py · ALLOWED). PUT dispara
+   3 invalidaciones de cache module-level en el worker actual · caveat
+   multi-worker: otros workers tardan unos segundos. */
+
+import type { CatalogConfig } from "./types";
+
+export async function getCatalogConfig(options?: {
+  signal?: AbortSignal;
+  bearerToken?: string | null;
+}): Promise<CatalogConfig> {
+  const { signal, bearerToken } = options ?? {};
+  const response = await apiFetch(`/api/catalog/config`, { signal, bearerToken }, 15_000);
+  if (!response.ok) {
+    throw new ApiError(
+      "CONFIG_LOAD_FAILED",
+      `GET /api/catalog/config falló (${response.status})`,
+      response.status,
+    );
+  }
+  return (await response.json()) as CatalogConfig;
+}
+
+export async function updateCatalogConfig(
+  content: CatalogConfig,
+  options?: { signal?: AbortSignal; bearerToken?: string | null },
+): Promise<{ ok: boolean; catalog: string }> {
+  const { signal, bearerToken } = options ?? {};
+  const response = await apiFetch(
+    `/api/catalog/config`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content }),
+      signal,
+      bearerToken,
+    },
+    20_000,
+  );
+  if (!response.ok) {
+    throw new ApiError(
+      "CONFIG_SAVE_FAILED",
+      `PUT /api/catalog/config falló (${response.status})`,
+      response.status,
+    );
+  }
+  return (await response.json()) as { ok: boolean; catalog: string };
+}

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -567,3 +567,81 @@ export interface AuditLogResponse {
   quote_breakdown?: Record<string, unknown> | null;
   errors: AuditLogEventItem[];
 }
+
+/* ─── CatalogConfig · Sprint 4 sub-PR 22.2.a config-ui-page ──────────
+   Shape del catálogo `config` (api/catalog/config.json). Frontend
+   GET/PUT del blob completo, pero solo edita las 6 keys del scope. */
+
+export interface CatalogConfigMeasurements {
+  default_depth: number;
+  default_zocalo_height: number;
+  default_alzada_height: number;
+  tall_zocalo_threshold?: number;
+  [k: string]: unknown;
+}
+
+export interface CatalogConfigDefaults {
+  colocacion_particulares: boolean;
+  delivery_zone_sku: string;
+  forma_pago: string;
+  [k: string]: unknown;
+}
+
+export interface CatalogConfig {
+  measurements: CatalogConfigMeasurements;
+  defaults: CatalogConfigDefaults;
+  [k: string]: unknown;
+}
+
+/** Los 6 campos editables desde /configuracion (sub-PR 22.2.a). */
+export interface ConfigEditableFields {
+  default_depth: number;
+  default_zocalo_height: number;
+  default_alzada_height: number;
+  colocacion_particulares: boolean;
+  delivery_zone_sku: string;
+  forma_pago: string;
+}
+
+export const CONFIG_EDITABLE_KEYS: ReadonlyArray<keyof ConfigEditableFields> = [
+  "default_depth",
+  "default_zocalo_height",
+  "default_alzada_height",
+  "colocacion_particulares",
+  "delivery_zone_sku",
+  "forma_pago",
+];
+
+export function extractEditableFields(cfg: CatalogConfig): ConfigEditableFields {
+  return {
+    default_depth: cfg.measurements?.default_depth ?? 0.6,
+    default_zocalo_height: cfg.measurements?.default_zocalo_height ?? 0.05,
+    default_alzada_height: cfg.measurements?.default_alzada_height ?? 0.6,
+    colocacion_particulares: cfg.defaults?.colocacion_particulares ?? true,
+    delivery_zone_sku: cfg.defaults?.delivery_zone_sku ?? "ENVIOROS",
+    forma_pago: cfg.defaults?.forma_pago ?? "Contado",
+  };
+}
+
+/** Devuelve un nuevo blob con los 6 fields del UI aplicados sobre el
+ * blob original (preserva todas las keys que NO edita el UI). */
+export function applyEditableFields(
+  base: CatalogConfig,
+  edits: ConfigEditableFields,
+): CatalogConfig {
+  return {
+    ...base,
+    measurements: {
+      ...(base.measurements ?? {}),
+      default_depth: edits.default_depth,
+      default_zocalo_height: edits.default_zocalo_height,
+      default_alzada_height: edits.default_alzada_height,
+    },
+    defaults: {
+      ...(base.defaults ?? {}),
+      colocacion_particulares: edits.colocacion_particulares,
+      delivery_zone_sku: edits.delivery_zone_sku,
+      forma_pago: edits.forma_pago,
+    },
+  };
+}

--- a/web/tests/e2e/configuracion.spec.ts
+++ b/web/tests/e2e/configuracion.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * E2E /configuracion · Sprint 4 sub-PR 22.2.a config-ui-page.
+ *
+ * Cubre 6 defaults editables + diff modal + responsive + bug fix
+ * zócalo prod. Fixtures con shape REAL del config.json (lección #60).
+ */
+import { expect, test } from "@playwright/test";
+
+test.describe("Configuración · render base", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("topbar 'Configuración' + form con 6 fields renderizados", async ({ page }) => {
+    await page.goto("/configuracion");
+    await expect(page.locator('[data-testid="configuracion-page"]')).toBeVisible();
+    await expect(page.locator(".topbar .crumbs .now")).toContainText("Configuración");
+    await expect(page.locator('[data-testid="config-form"]')).toBeVisible();
+    for (const key of [
+      "default_zocalo_height",
+      "default_alzada_height",
+      "default_depth",
+      "delivery_zone_sku",
+      "forma_pago",
+      "colocacion_particulares",
+    ]) {
+      await expect(page.locator(`[data-testid="config-row-${key}"]`)).toBeVisible();
+    }
+  });
+
+  test("zócalo arranca en 0.05 (BUG PROD FIX 7→5cm · master Regla 10)", async ({ page }) => {
+    await page.goto("/configuracion");
+    const input = page.locator('[data-testid="config-input-default_zocalo_height"]');
+    await expect(input).toHaveValue("0.05");
+    await expect(page.locator('[data-testid="config-helper-default_zocalo_height"]')).toContainText(
+      "5cm",
+    );
+  });
+
+  test("helper de alzada muestra '60cm'", async ({ page }) => {
+    await page.goto("/configuracion");
+    await expect(page.locator('[data-testid="config-helper-default_alzada_height"]')).toContainText(
+      "60cm",
+    );
+  });
+});
+
+test.describe("Configuración · edición y diff modal", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("sin cambios · botón Guardar disabled", async ({ page }) => {
+    await page.goto("/configuracion");
+    await expect(page.locator('[data-testid="config-form"]')).toBeVisible();
+    await expect(page.locator('[data-testid="config-save"]')).toBeDisabled();
+  });
+
+  test("cambio en zócalo habilita Guardar y abre diff modal con antes/después", async ({
+    page,
+  }) => {
+    await page.goto("/configuracion");
+    const input = page.locator('[data-testid="config-input-default_zocalo_height"]');
+    await input.fill("0.06");
+    const save = page.locator('[data-testid="config-save"]');
+    await expect(save).toBeEnabled();
+    await save.click();
+    await expect(page.locator('[data-testid="config-diff-modal"]')).toBeVisible();
+    const row = page.locator('[data-testid="diff-row-Alto de zócalo (m)"]');
+    await expect(row).toContainText("0.05 m");
+    await expect(row).toContainText("0.06 m");
+  });
+
+  test("confirmar persiste + badge 'Guardado' visible + modal cierra", async ({ page }) => {
+    await page.goto("/configuracion");
+    await page.locator('[data-testid="config-input-forma_pago"]').fill("Contado / Transferencia");
+    await page.locator('[data-testid="config-save"]').click();
+    await page.locator('[data-testid="config-modal-confirm"]').click();
+    await expect(page.locator('[data-testid="config-diff-modal"]')).toBeHidden();
+    const badge = page.locator('[data-testid="config-saved-badge"]');
+    await expect(badge).toBeVisible();
+    await expect(badge).toContainText("Guardado");
+    await expect(badge).toContainText("puede tardar unos segundos en producción");
+  });
+
+  test("Descartar restaura valores originales", async ({ page }) => {
+    await page.goto("/configuracion");
+    const zocalo = page.locator('[data-testid="config-input-default_zocalo_height"]');
+    await zocalo.fill("0.08");
+    await page.locator('[data-testid="config-reset"]').click();
+    await expect(zocalo).toHaveValue("0.05");
+    await expect(page.locator('[data-testid="config-save"]')).toBeDisabled();
+  });
+});
+
+test.describe("Configuración · responsive mobile", () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test("grid 1 col en mobile + form visible", async ({ page }) => {
+    await page.goto("/configuracion");
+    await expect(page.locator('[data-testid="config-form"]')).toBeVisible();
+    const grid = page.locator(".config-fields-grid");
+    const cols = await grid.evaluate(
+      (el) => getComputedStyle(el).gridTemplateColumns.split(" ").length,
+    );
+    expect(cols).toBe(1);
+  });
+});

--- a/web/tests/e2e/sidebar-navigation.spec.ts
+++ b/web/tests/e2e/sidebar-navigation.spec.ts
@@ -39,11 +39,13 @@ test.describe("Items del Sidebar navegan (Next Link nativo)", () => {
     await expect(page.locator(".crumbs .now")).toContainText("Catálogo");
   });
 
-  test("click Configuración navega a /configuracion · renderea placeholder", async ({ page }) => {
+  test("click Configuración navega a /configuracion · renderea form real", async ({ page }) => {
+    // Sub-PR 22.2.a config-ui-page reemplazó el placeholder por el form
+    // real (`configuracion-page` + `config-form`). Antes: configuracion-placeholder.
     await page.goto("/");
     await page.locator('[data-testid="sidebar-nav-configuracion"]').click();
     await page.waitForURL("**/configuracion");
-    await expect(page.locator('[data-testid="configuracion-placeholder"]')).toBeVisible();
+    await expect(page.locator('[data-testid="configuracion-page"]')).toBeVisible();
   });
 
   test("click Clientes navega a /clientes · renderea placeholder", async ({ page }) => {


### PR DESCRIPTION
## Summary

- **Backend**: bloque `defaults` nuevo en `api/catalog/config.json` (`colocacion_particulares`, `delivery_zone_sku`, `forma_pago`) + `measurements.default_alzada_height` (0.6) + **BUG PROD FIX** `measurements.default_zocalo_height` `0.07 → 0.05`.
- **Frontend**: nueva página `/configuracion` con form editable (6 inputs), diff modal pre-save reusando pattern de `PdfConfirmModal`, badge "Guardado" 3s, scope CSS `.config-v2` (~18 LOC en globals.css · operator-shared **intacto**).
- **Tests**: 5 backend pytest (GET keys nuevas + PUT persiste + cache spies) + 7 frontend e2e Playwright (render base + edición + diff + responsive mobile 375px).

## BUG FIX prod · zócalo 7→5cm (CRÍTICO leer antes del merge)

- **Cambio `default_zocalo_height` 0.07 → 0.05 cierra BUG DE PRODUCCIÓN.**
- **Master Notion Regla 10 dice 5cm desde siempre · `config.json` estaba con 7cm.**
- **Impacto: ~40% más material de zócalo cotizado erróneamente por quote** desde la versión vieja del config.
- **Aplica a quotes NUEVOS** · quotes existentes en draft retienen valor viejo en su `breakdown` · Marina edita manualmente en `/contexto` si necesita.
- **Sub-PR follow-up potencial**: `audit-quotes-zocalo-7cm-impact` (a definir con Agos).

## Multi-worker caveat (gunicorn prod)

El endpoint `PUT /api/catalog/config` invalida 3 caches module-level (`catalog_tool` + `document_tool` + `company_config`) pero **solo en el worker actual**. Otros workers tardan unos segundos en propagar. La UI lo dice explícito en el badge post-save: **"✓ Guardado · aplicará a próximos presupuestos (puede tardar unos segundos en producción)"**.

## AUDIT INDEP OBLIGATORIO antes del merge

Master sugiere fuerte audit indep esta vez **sin skip**:
- Backend + frontend + producción en el mismo PR.
- Cambio en **valor monetario real** (zócalo 7→5cm afecta cotizaciones).
- CI no detecta UX edge cases ni regression visual ni cache invalidation issues.

## Verificación local

- [x] `node_modules/.bin/tsc --noEmit` · 0 errores
- [x] `npm run lint` · 0 errors en archivos del PR (5 warnings pre-existentes en `tests/unit/context-from-breakdown.test.ts` fuera de scope)
- [x] `npm run test:unit` · 129/129 pass
- [x] `pytest api/tests/test_config_endpoint.py` · 5/5 pass
- [x] `npm run build` · `/configuracion` 3.43 kB

## Test plan

- [ ] **Smoke prod post-deploy**: `GET /api/catalog/config` devuelve `measurements.default_zocalo_height = 0.05` (verifica que el seed pisó el valor viejo)
- [ ] Login → `/configuracion` → form renderea con 6 fields + zócalo en `0.05`
- [ ] Editar zócalo a `0.06` → "Guardar" → diff modal muestra `0.05 m → 0.06 m`
- [ ] Confirmar → badge "Guardado..." visible 3s → reload → zócalo en `0.06`
- [ ] Crear quote nuevo en draft → `breakdown` usa el nuevo zócalo
- [ ] Mobile (375px viewport): grid 1 col, botones full-width, modal scrollea
- [ ] **AUDIT INDEP** antes del merge (ver bloque arriba)

🤖 Generated with [Claude Code](https://claude.com/claude-code)