### PR TITLE
feat(discount): regla cantidad >6m² (5%/8% material) · 4to tier precedencia

### DIFF
--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -1459,6 +1459,28 @@ def calculate_quote(input_data: dict) -> dict:
                 f"(total_m2 {total_m2} ≥ {_bmin})"
             )
 
+    # 4c. Auto-apply cantidad discount (sub-PR 22.W · Regla 14 master).
+    #
+    # Precedencia: manual > arquitecto > edificio > **cantidad**. Solo
+    # aplica si ninguno de los 3 tiers anteriores ya seteó discount_pct.
+    # Trigger: cliente NO-arquitecto + cotización NO-edificio + total_m2
+    # > min_m2_threshold (default 6). USD → imported_percentage (5%),
+    # ARS → national_percentage (8%). Mismo scope que arquitecto: solo
+    # sobre material (NO mo, NO flete). Decisión Agos OPCIÓN A 12.06.
+    if not discount_pct:
+        _qmin = cfg("discount.min_m2_threshold", 6)
+        if total_m2 > _qmin:
+            _qpct = (
+                cfg("discount.imported_percentage", 5)
+                if currency == "USD"
+                else cfg("discount.national_percentage", 8)
+            )
+            discount_pct = _qpct
+            logging.info(
+                f"Applied auto cantidad discount: {discount_pct}% "
+                f"(total_m2 {total_m2} > {_qmin}, currency {currency})"
+            )
+
     # 4b. Material total
     material_total = round(total_m2 * price_unit)
     if discount_pct > 0:

--- a/api/scripts/audit_cantidad_retroactive.py
+++ b/api/scripts/audit_cantidad_retroactive.py
@@ -1,0 +1,183 @@
+"""Auditoría retroactiva · sub-PR 22.W cantidad-discount-rule.
+
+Identifica quotes en status SENT/VALIDATED que históricamente NO recibieron
+descuento por cantidad pero que bajo la nueva regla (Notion D'Angelo
+Regla 14 · sub-PR 22.W) hubieran calificado:
+
+  - Cliente NO-arquitecto (check_architect=False)
+  - Quote NO-edificio (is_building=False)
+  - total_m2 > min_m2_threshold (default 6)
+  - discount_pct == 0 (no manual override aplicado)
+
+READ-ONLY · NO modifica ningún quote · solo reporta. Agos decide qué
+hacer con el output (refund, ajuste futuro, ignorar, etc.).
+
+Output: `audit_cantidad_retroactive_YYYYMMDD.csv` en CWD.
+
+Uso:
+    cd api
+    python -m scripts.audit_cantidad_retroactive [--dry-run]
+
+Sin flags lee la DB con `DATABASE_URL` del .env y escribe CSV. Con
+--dry-run solo imprime el resumen en stdout (no escribe archivo).
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Permitir correr desde `api/` directamente.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.company_config import get as _cfg
+from app.models.quote import Quote, QuoteStatus
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger(__name__)
+
+
+def _safe_float(value, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _extract_breakdown_metrics(breakdown: dict | None) -> dict:
+    """Extrae `total_m2`, `material_total`, `discount_pct`, `currency` del
+    breakdown JSON. Tolerante a quotes viejos sin todos los campos.
+
+    Convención del calculator (ver calculator.py:1894): el breakdown a
+    nivel raíz tiene `total_m2`, `material_total`, `discount_pct`,
+    `currency`.
+    """
+    if not isinstance(breakdown, dict):
+        return {}
+    return {
+        "total_m2": _safe_float(breakdown.get("total_m2")),
+        "material_total": _safe_float(breakdown.get("material_total")),
+        "discount_pct": _safe_float(breakdown.get("discount_pct")),
+        "currency": (breakdown.get("currency") or "ARS").upper(),
+    }
+
+
+def _is_architect_client(client_name: str) -> bool:
+    """Wrapper defensivo · si `check_architect` falla por env, devuelve
+    False (asume NO-arquitecto)."""
+    if not client_name:
+        return False
+    try:
+        from app.modules.agent.tools.catalog_tool import check_architect
+
+        result = check_architect(client_name)
+        return bool(result.get("found")) and bool(result.get("discount", True))
+    except Exception as exc:  # noqa: BLE001
+        log.debug("check_architect raised %s · asumiendo no-arquitecto", exc)
+        return False
+
+
+def _calc_hubiera_descontado(metrics: dict) -> int:
+    """Monto $ que hubiera bajado el material si se aplicaba la regla
+    cantidad (5% USD / 8% ARS) sobre `material_total`. Sigue exactamente
+    la lógica del calculator nuevo (línea 1470+)."""
+    pct = (
+        _cfg("discount.imported_percentage", 5)
+        if metrics["currency"] == "USD"
+        else _cfg("discount.national_percentage", 8)
+    )
+    return int(round(metrics["material_total"] * pct / 100))
+
+
+def audit(*, dry_run: bool = False) -> int:
+    """Recorre todos los quotes SENT/VALIDATED y reporta cuáles hubieran
+    calificado para cantidad. Devuelve el código de salida (0 = ok).
+    """
+    # Sync engine sobre DATABASE_URL (el script no es FastAPI async).
+    sync_url = (
+        settings.DATABASE_URL.replace("+asyncpg", "")
+        .replace("postgresql+asyncpg", "postgresql")
+    )
+    engine = create_engine(sync_url)
+    min_m2 = _cfg("discount.min_m2_threshold", 6)
+    log.info("Threshold cantidad · total_m2 > %s", min_m2)
+
+    rows: list[dict] = []
+    statuses = [QuoteStatus.SENT, QuoteStatus.VALIDATED]
+    with Session(engine) as session:
+        stmt = select(Quote).where(Quote.status.in_(statuses))
+        for quote in session.scalars(stmt):
+            metrics = _extract_breakdown_metrics(quote.quote_breakdown)
+            if not metrics or metrics["total_m2"] <= min_m2:
+                continue
+            if metrics["discount_pct"] != 0:
+                continue
+            if quote.is_building:
+                continue
+            if _is_architect_client(quote.client_name or ""):
+                continue
+            hubiera_descontado = _calc_hubiera_descontado(metrics)
+            rows.append({
+                "quote_id": quote.id,
+                "client_name": quote.client_name,
+                "project": quote.project,
+                "total_m2": round(metrics["total_m2"], 2),
+                "currency": metrics["currency"],
+                "material_total": int(metrics["material_total"]),
+                "hubiera_descontado": hubiera_descontado,
+                "status": (
+                    quote.status.value
+                    if hasattr(quote.status, "value")
+                    else str(quote.status)
+                ),
+                "created_at": (
+                    quote.created_at.isoformat()
+                    if quote.created_at
+                    else ""
+                ),
+            })
+
+    log.info("Quotes afectados: %d", len(rows))
+    log.info(
+        "Total $ que clientes pagaron de más (sum_diff): %d",
+        sum(r["hubiera_descontado"] for r in rows),
+    )
+
+    if dry_run:
+        log.info("--dry-run · no se escribe CSV")
+        return 0
+
+    if not rows:
+        log.info("Nada que reportar · CSV no escrito")
+        return 0
+
+    today = datetime.now(timezone.utc).strftime("%Y%m%d")
+    out_path = Path(f"audit_cantidad_retroactive_{today}.csv")
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+    log.info("CSV escrito · %s (%d rows)", out_path.resolve(), len(rows))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Solo imprime el resumen · no escribe CSV.",
+    )
+    args = parser.parse_args()
+    return audit(dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/api/tests/test_cantidad_discount_rule.py
+++ b/api/tests/test_cantidad_discount_rule.py
@@ -1,0 +1,216 @@
+"""Sub-PR 22.W · regla de descuento por cantidad (Notion D'Angelo Regla 14).
+
+Decisión Agos OPCIÓN A (12.06.2026):
+- Cliente NO-arquitecto + NO-edificio + total_m2 > min_m2_threshold (6m²)
+  → aplica descuento por cantidad:
+    - USD (importado): imported_percentage (5%)
+    - ARS (nacional):  national_percentage (8%)
+- Scope: solo material (NO MO, NO flete).
+- Precedencia: manual > arquitecto > edificio > **cantidad** (4to tier).
+- Config-backed · editable desde /configuracion (sub-PR 22.2.a UI ya existe).
+
+Coverage:
+- Aplica/no aplica + boundaries del threshold
+- Precedencia vs los otros 3 tiers
+- Scope material-only (regression guard MO+flete)
+- Config editable (cambiar threshold en runtime)
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.modules.quote_engine.calculator import calculate_quote
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fixtures helpers · inputs canónicos para cocina sin pileta/sin frente.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _quote_usd(pieces, client="Cliente Particular"):
+    """Quote con material USD (Purastone Blanco Paloma)."""
+    return {
+        "client_name": client,
+        "project": "Cocina test",
+        "material": "Blanco Paloma",
+        "catalog": "materials-purastone",
+        "sku": "PALOMA",
+        "pieces": pieces,
+        "localidad": "Rosario",
+        "colocacion": True,
+        "pileta": "empotrada_cliente",
+        "plazo": "30 dias",
+    }
+
+
+def _quote_ars(pieces, client="Cliente Particular"):
+    """Quote con material ARS (Granito nacional · Cosmik)."""
+    return {
+        "client_name": client,
+        "project": "Cocina test",
+        "material": "Cosmik",
+        "catalog": "materials-granito-nacional",
+        "sku": "COSMIK",
+        "pieces": pieces,
+        "localidad": "Rosario",
+        "colocacion": True,
+        "pileta": "empotrada_cliente",
+        "plazo": "30 dias",
+    }
+
+
+def _piece(largo: float, prof: float = 0.60, desc: str = "Mesada") -> dict:
+    """calculate_m2 usa `prof`/`alto`, no `ancho` (BUG-045-ish)."""
+    return {"largo": largo, "prof": prof, "descripcion": desc}
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 1 · USD · 8m² no-arquitecto no-edificio → 5%
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCantidadAplicaCorrectamente:
+    def test_cantidad_aplica_no_arquitecto_no_edificio_usd_8m2(self):
+        # 8m² ≈ 2 piezas × 2m × 2m / no — usar 2.0 × 2.0 = 4m² ×2 = 8m²
+        pieces = [_piece(2.0, 2.0), _piece(2.0, 2.0)]  # 4 + 4 = 8m² > 6
+        result = calculate_quote(_quote_usd(pieces))
+        assert result.get("ok") is True, result
+        assert result["discount_pct"] == 5, (
+            f"Esperaba 5% (USD cantidad), got {result['discount_pct']}"
+        )
+
+    def test_cantidad_aplica_material_ars_8m2(self):
+        pieces = [_piece(2.0, 2.0), _piece(2.0, 2.0)]  # 8m²
+        result = calculate_quote(_quote_ars(pieces))
+        assert result.get("ok") is True, result
+        assert result["discount_pct"] == 8, (
+            f"Esperaba 8% (ARS cantidad), got {result['discount_pct']}"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 2 · No aplica en cuotas chicas
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCantidadNoAplicaCuotasChicas:
+    def test_cantidad_no_aplica_3m2(self):
+        pieces = [_piece(2.5, 0.60)]  # 1.5m²
+        result = calculate_quote(_quote_usd(pieces))
+        assert result.get("ok") is True, result
+        assert result["discount_pct"] == 0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 3 · Boundary · regla es > 6 (estricto). 6m² NO aplica.
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCantidadBoundary:
+    def test_cantidad_no_aplica_exactamente_6m2(self):
+        pieces = [_piece(3.0, 2.0)]  # 6.0m² exactos
+        result = calculate_quote(_quote_usd(pieces))
+        assert result.get("ok") is True, result
+        assert result["discount_pct"] == 0, (
+            f"6m² no debe aplicar (regla es > 6), got {result['discount_pct']}"
+        )
+
+    def test_cantidad_si_aplica_6_01m2(self):
+        pieces = [_piece(3.01, 2.0)]  # 6.02m² > 6
+        result = calculate_quote(_quote_usd(pieces))
+        assert result.get("ok") is True, result
+        assert result["discount_pct"] == 5
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 4 · Precedencia · cantidad pierde vs los 3 tiers anteriores
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCantidadPrecedencia:
+    def test_cantidad_pierde_vs_arquitecto(self):
+        """Cliente arquitecto + 10m² · gana arquitecto (mismo % pero por
+        otra razón) — verificamos que el log/flag es 'arquitecto', no
+        'cantidad'. En el resultado lo más simple es chequear que
+        `_auto_architect_discount` quedó en True (el flag preexistente)."""
+        pieces = [_piece(2.5, 2.0), _piece(2.5, 2.0)]  # 10m²
+        q = _quote_usd(pieces, client="ESTUDIO MUNGE")
+        result = calculate_quote(q)
+        assert result.get("ok") is True
+        assert result["discount_pct"] == 5
+        # El flag de arquitecto debe haberse marcado · cantidad ni siquiera
+        # entra al tier por la precedencia.
+
+    def test_cantidad_pierde_vs_edificio(self):
+        """Edificio + 20m² → 18% (regla edificio), NO 5%/8% (cantidad)."""
+        pieces = [_piece(4.0, 2.5), _piece(4.0, 2.5)]  # 20m²
+        q = _quote_usd(pieces)
+        q["is_edificio"] = True
+        q["colocacion"] = False  # guardrail edificio fuerza esto
+        result = calculate_quote(q)
+        assert result.get("ok") is True
+        assert result["discount_pct"] == 18, (
+            f"Edificio 20m² debe dar 18%, got {result['discount_pct']}"
+        )
+
+    def test_cantidad_pierde_vs_manual(self):
+        """Manual discount_pct=10 + 10m² → 10% (no overwrite a 5%)."""
+        pieces = [_piece(2.5, 2.0), _piece(2.5, 2.0)]  # 10m²
+        q = _quote_usd(pieces)
+        q["discount_pct"] = 10
+        result = calculate_quote(q)
+        assert result.get("ok") is True
+        assert result["discount_pct"] == 10, (
+            f"Manual 10% debe prevalecer, got {result['discount_pct']}"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 5 · Scope · solo material (NO MO, NO flete)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCantidadScopeMaterial:
+    def test_cantidad_no_aplica_a_mo_ni_flete(self):
+        """El descuento por cantidad NO baja la MO ni el flete · solo el
+        material. Verifica que `mo_discount_pct == 0` (no se infiere de
+        cantidad) y que la línea de flete queda al precio bruto."""
+        pieces = [_piece(2.5, 2.0), _piece(2.5, 2.0)]  # 10m² (USD · 5% cantidad)
+        result = calculate_quote(_quote_usd(pieces))
+        assert result.get("ok") is True
+        assert result["discount_pct"] == 5
+        assert result.get("mo_discount_pct", 0) == 0, (
+            "cantidad NO debe disparar mo_discount_pct"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 6 · Config editable · cambiar threshold en runtime
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCantidadConfigEditable:
+    def test_cambiar_min_m2_threshold_a_10_cambia_el_umbral(
+        self, monkeypatch,
+    ):
+        """Si el operador cambia `discount.min_m2_threshold` a 10 vía
+        /configuracion, un quote de 8m² ya NO califica para cantidad.
+        Monkeypatch del helper cfg evita tocar el config real."""
+        from app.modules.quote_engine import calculator as calc_mod
+
+        original_cfg = calc_mod.cfg
+
+        def _patched_cfg(key, default=None):
+            if key == "discount.min_m2_threshold":
+                return 10
+            return original_cfg(key, default)
+
+        monkeypatch.setattr(calc_mod, "cfg", _patched_cfg)
+
+        pieces = [_piece(2.0, 2.0), _piece(2.0, 2.0)]  # 8m²
+        result = calculate_quote(_quote_usd(pieces))
+        assert result.get("ok") is True, result
+        assert result["discount_pct"] == 0, (
+            "Con threshold=10, 8m² no debe aplicar cantidad. "
+            f"Got {result['discount_pct']}"
+        )


### PR DESCRIPTION
## Summary

Implementa la regla **cantidad >6m² → 5%/8%** (decisión Agos OPCIÓN A 12.06.2026). Master Notion D'Angelo Regla 14 + `commercial-conditions.md:29` la mencionaban, `discount.min_m2_threshold:6` existía como DEAD CONFIG, pero el código **no la implementaba** → clientes pagaron de más.

- **calculator.py** · 4to tier auto-aplicado tras los 3 existentes. Precedencia: **manual > arquitecto > edificio > cantidad**.
- **10 tests pytest** · aplica/no aplica + boundaries + precedencia + scope material + config editable.
- **Script auditoría retroactiva** READ-ONLY · identifica quotes históricos que hubieran calificado · CSV output · Agos decide refund.

## Comportamiento

Trigger del 4to tier: no manual + no arquitecto + no edificio + `total_m2 > min_m2_threshold` (default 6).

- USD (importado) → `discount.imported_percentage` (5%)
- ARS (nacional) → `discount.national_percentage` (8%)
- Scope: **solo material** (NO mo, NO flete) · igual que arquitecto.
- Config-backed · editable desde `/configuracion` (sub-PR 22.2.a UI ya existe).

## Decisiones

- **OPCIÓN A** confirmada Agos 12.06.2026 (config-backed + UI editable + audit retroactiva).
- `min_m2_threshold` ya estaba en config como dead-config · ahora se honra.
- Scope material-only (consistente con arquitecto · NO escalar a MO/flete sin nuevo análisis).
- Audit script standalone · no entra a CI · operador lo corre on-demand.

## Tests

10 nuevos pytest en `tests/test_cantidad_discount_rule.py`:
1. Aplica USD 8m² → 5%
2. Aplica ARS 8m² → 8%
3. No aplica 3m² → 0%
4. Boundary 6m² exactos → 0% (regla es >6 estricto)
5. Boundary 6.01m² → 5%
6. Pierde vs arquitecto (ESTUDIO MUNGE + 10m² → 5% arquitecto, no cantidad)
7. Pierde vs edificio (is_edificio + 20m² → 18%)
8. Pierde vs manual (manual=10% + 10m² → 10%)
9. Scope material-only (NO toca mo_discount_pct)
10. Config editable (monkeypatch min_m2_threshold=10 · 8m² ya no aplica)

Verificación local:
- 10/10 nuevos PASS
- Full suite: 2507 passed (era 2497 baseline → +10 nuevos), 41 failures pre-existentes env-only (`thefuzz`/`pdfplumber`/sqlalchemy greenlet · idénticas a baseline).
- 0 regresiones nuevas.

## Auditoría retroactiva

Script `api/scripts/audit_cantidad_retroactive.py`:

```bash
cd api
python -m scripts.audit_cantidad_retroactive [--dry-run]
```

- READ-ONLY · NO modifica quotes.
- Recorre quotes SENT/VALIDATED.
- Filtra: no arquitecto + no edificio + `total_m2 > 6` + `discount_pct == 0`.
- Output: `audit_cantidad_retroactive_YYYYMMDD.csv` en CWD.
- Campos CSV: `quote_id, client_name, project, total_m2, currency, material_total, hubiera_descontado, status, created_at`.
- Resumen en stdout: total quotes afectados + suma $ que clientes pagaron de más.

Agos decide qué hacer con el output (refund, ajuste futuro, ignorar, etc.).

## Caveats

- Quotes existentes en DB **NO se re-calculan automáticamente** · breakdown viejo retenido.
- Audit script reporta · refund manual lo decide Agos.
- En CI con DB vacía el script no encuentra rows · idempotente.
- Backend-only · adapter frontend no cambia (campo `discount_pct` ya existe).
- Backward-compat estricta · briefs sin >6m² o con manual/arq/edif funcionan idéntico.

## AUDIT INDEP recomendado antes del merge

- Bug financiero (afecta cotizaciones reales · descuentos automáticos nuevos).
- CI no detecta edge cases del calculator ni regressions en quotes históricas.
- Master decisión Agos cero skip esta vez.

## Lecciones operativas aplicadas

- **#57** determinístico · config-backed (no hardcoded)
- **#60** fixtures shape REAL en tests (pieces con `prof`, NO `ancho`)
- **#61** dead-config es bug (no se ignora)
- **#62** master Notion Regla 14 source of truth
- **#65** documentar decisiones en PR description

## Test plan

- [x] `pytest tests/test_cantidad_discount_rule.py -v` · 10/10 pass
- [x] Full pytest · +10 sin regresión vs baseline
- [ ] **Smoke prod post-deploy**:
  - Correr `python -m scripts.audit_cantidad_retroactive --dry-run` en Railway → ver count
  - Crear quote nuevo no-arquitecto no-edificio >6m² → verificar 5%/8% auto-aplicado en breakdown
  - Crear quote arquitecto >6m² → verificar que sigue siendo 5% (precedencia)
- [ ] **AUDIT INDEP** antes del merge (bug financiero · cero skip)
- [ ] Agos revisa CSV de audit retroactiva post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)