### PR TITLE
feat(config-ui): expansión /configuracion · descuentos + costing · 6 fields nuevos

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -86,31 +86,67 @@
    Reemplaza el dual render `.dashboard-desktop`/`.dashboard-mobile`
    por un único árbol React con CSS responsive. Breakpoint 767px.
    ───────────────────────────────────────────────────────── */
-.dashboard-v2 { padding: 32px 24px 24px; }
-.dashboard-v2 .row-greet-actions {
-  display: flex; align-items: flex-end; gap: 24px; flex-wrap: wrap;
+.dashboard-v2 {
+  padding: 32px 24px 24px;
 }
-.dashboard-v2 .dh-greet { flex: 1; min-width: 200px; }
-.dashboard-v2 .dh-actions { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+.dashboard-v2 .row-greet-actions {
+  display: flex;
+  align-items: flex-end;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.dashboard-v2 .dh-greet {
+  flex: 1;
+  min-width: 200px;
+}
+.dashboard-v2 .dh-actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
 .dashboard-v2 .dashboard-filterbar {
-  display: flex; align-items: center; margin-top: 16px;
+  display: flex;
+  align-items: center;
+  margin-top: 16px;
   border-bottom: 1px solid var(--line);
 }
-.dashboard-v2 .dashboard-list-mobile { display: none; }
+.dashboard-v2 .dashboard-list-mobile {
+  display: none;
+}
 @media (max-width: 767px) {
-  .dashboard-v2 { padding: 20px 0 80px; }
-  .dashboard-v2 .row-greet-actions { padding: 0 16px; gap: 12px; }
-  .dashboard-v2 .dh-actions { width: 100%; }
-  .dashboard-v2 .dh-actions input { flex: 1; min-width: 0; }
-  .dashboard-v2 .dh-meta { padding: 0 16px; }
-  .dashboard-v2 .dashboard-results-meta { padding: 12px 16px 8px !important; }
-  .dashboard-v2 .dashboard-list-desktop { display: none; }
-  .dashboard-v2 .dashboard-list-mobile { display: block; }
+  .dashboard-v2 {
+    padding: 20px 0 80px;
+  }
+  .dashboard-v2 .row-greet-actions {
+    padding: 0 16px;
+    gap: 12px;
+  }
+  .dashboard-v2 .dh-actions {
+    width: 100%;
+  }
+  .dashboard-v2 .dh-actions input {
+    flex: 1;
+    min-width: 0;
+  }
+  .dashboard-v2 .dh-meta {
+    padding: 0 16px;
+  }
+  .dashboard-v2 .dashboard-results-meta {
+    padding: 12px 16px 8px !important;
+  }
+  .dashboard-v2 .dashboard-list-desktop {
+    display: none;
+  }
+  .dashboard-v2 .dashboard-list-mobile {
+    display: block;
+  }
 }
 
 /* ─────────────────────────────────────────────────────────
    Sprint 4 config-ui-page (sub-PR 22.2.a) · scope `.config-v2`
    ~18 LOC media query · operator-shared.css INTACTO (lección #66).
+   Expansión sub-PR 22.2.a.III: accordion sections.
    ───────────────────────────────────────────────────────── */
 .config-v2 .config-fields-grid {
   display: grid;
@@ -118,10 +154,72 @@
   gap: 20px 24px;
   max-width: 720px;
 }
-.config-v2 .config-fields-grid .input { width: 100%; box-sizing: border-box; }
+.config-v2 .config-fields-grid .input {
+  width: 100%;
+  box-sizing: border-box;
+}
+.config-v2 .config-section {
+  max-width: 720px;
+}
+.config-v2 .config-section + .config-section {
+  margin-top: 12px;
+}
+.config-v2 .config-section[data-open="true"] .config-fields-grid {
+  padding-top: 12px;
+}
+.config-v2 .config-section-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  padding: 10px 0;
+  width: 100%;
+  text-align: left;
+  border-bottom: 1px solid var(--line);
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: 500;
+}
+.config-v2 .config-section-chevron {
+  display: inline-block;
+  width: 12px;
+  color: var(--ink-mute);
+  font-size: 10px;
+}
+.config-v2 .config-section-title {
+  flex: 1;
+}
+.config-v2 .config-section-count {
+  font-size: 11px;
+  color: var(--ink-mute);
+  background: var(--surface);
+  padding: 2px 8px;
+  border-radius: 10px;
+}
 @media (max-width: 767px) {
-  .config-v2 .body { padding: 16px; }
-  .config-v2 .config-fields-grid { grid-template-columns: 1fr; gap: 16px; }
-  .config-v2 .config-actions { flex-wrap: wrap; }
-  .config-v2 .config-actions .btn { flex: 1; min-width: 120px; }
+  .config-v2 .body {
+    padding: 16px 16px 96px;
+  }
+  .config-v2 .config-fields-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+  .config-v2 .config-actions {
+    flex-wrap: wrap;
+    position: sticky;
+    bottom: 0;
+    background: var(--bg, var(--surface));
+    padding: 12px 16px;
+    margin: 0 -16px;
+    border-top: 1px solid var(--line);
+  }
+  .config-v2 .config-actions .btn {
+    flex: 1;
+    min-width: 120px;
+  }
+  .config-v2 .config-actions [data-testid="config-saved-badge"] {
+    flex-basis: 100%;
+  }
 }

--- a/web/src/components/config/ConfigForm.tsx
+++ b/web/src/components/config/ConfigForm.tsx
@@ -1,19 +1,26 @@
 /**
- * ConfigForm · sub-PR 22.2.a config-ui-page.
+ * ConfigForm · sub-PR 22.2.a config-ui-page + 22.2.a.III expansion.
  *
- * 6 defaults operativos editables:
- *   - default_depth (m · profundidad de mesada)
- *   - default_zocalo_height (m · BUG PROD FIX 0.07→0.05)
- *   - default_alzada_height (m)
- *   - colocacion_particulares (bool)
- *   - delivery_zone_sku (string · SKU de delivery-zones.json)
- *   - forma_pago (string)
+ * Fields editables agrupados en 4 secciones colapsables:
+ *
+ *  1. DEFAULTS DE MESADA (3 · default expanded · sub-PR 22.2.a)
+ *     - default_zocalo_height, default_alzada_height, default_depth
+ *
+ *  2. DEFAULTS OPERATIVOS (3 · default expanded · sub-PR 22.2.a)
+ *     - colocacion_particulares, delivery_zone_sku, forma_pago
+ *
+ *  3. DESCUENTOS (5 · default collapsed · sub-PR 22.2.a.III)
+ *     - discount.imported_percentage, national_percentage, building_percentage
+ *     - discount.building_min_m2_threshold, min_m2_threshold
+ *
+ *  4. COSTING (1 · default collapsed · sub-PR 22.2.a.III)
+ *     - merma.small_piece_threshold_m2
  *
  * Flow: fetch initial blob → editable state local → "Guardar" abre diff
  * modal (solo si hay cambios) → onConfirm → PUT → badge "Guardado" 3s.
  *
- * Cero CSS nuevo en operator-shared.css. Scope CSS responsive vive en
- * globals.css bajo `.config-v2` (Step 6 · ~15-20 LOC media query).
+ * Cero CSS nuevo en operator-shared.css. Scope responsive vive en
+ * globals.css bajo `.config-v2` (~15-20 LOC media query · lección #66).
  */
 "use client";
 
@@ -27,21 +34,28 @@ import {
 import { getCatalogConfig, updateCatalogConfig } from "@/lib/api";
 import { ConfigDiffModal, type DiffRow } from "./ConfigDiffModal";
 
+type SectionId = "mesada" | "operativos" | "descuentos" | "costing";
+
 interface FieldDef {
   key: keyof ConfigEditableFields;
   label: string;
   helper?: string;
-  type: "number_m" | "text" | "bool";
+  type: "number_m" | "number" | "percent" | "text" | "bool";
   step?: string;
+  min?: number;
+  max?: number;
+  section: SectionId;
 }
 
 const FIELDS: FieldDef[] = [
+  // ─── Sección 1 · DEFAULTS DE MESADA ────────────────────────────────
   {
     key: "default_zocalo_height",
     label: "Alto de zócalo (m)",
     helper: "Default master D'Angelo = 5cm",
     type: "number_m",
     step: "0.01",
+    section: "mesada",
   },
   {
     key: "default_alzada_height",
@@ -49,6 +63,7 @@ const FIELDS: FieldDef[] = [
     helper: "Default cuando brief no especifica = 60cm",
     type: "number_m",
     step: "0.01",
+    section: "mesada",
   },
   {
     key: "default_depth",
@@ -56,25 +71,102 @@ const FIELDS: FieldDef[] = [
     helper: "Default 60cm cuando brief no aclara",
     type: "number_m",
     step: "0.01",
+    section: "mesada",
   },
+  // ─── Sección 2 · DEFAULTS OPERATIVOS ───────────────────────────────
   {
     key: "delivery_zone_sku",
     label: "Zona de flete por defecto (SKU)",
     helper: "SKU de delivery-zones.json · default ENVIOROS (Rosario)",
     type: "text",
+    section: "operativos",
   },
   {
     key: "forma_pago",
     label: "Forma de pago default",
     helper: "Texto que aparece en el PDF",
     type: "text",
+    section: "operativos",
   },
   {
     key: "colocacion_particulares",
     label: "Colocación incluida para particulares",
     helper: "Edificios siempre van sin colocación (regla aparte)",
     type: "bool",
+    section: "operativos",
   },
+  // ─── Sección 3 · DESCUENTOS (sub-PR 22.2.a.III) ────────────────────
+  {
+    key: "discount_imported_percentage",
+    label: "Descuento material importado %",
+    helper:
+      "Este % aplica tanto al descuento arquitecto como al descuento cantidad por volumen, según moneda del material.",
+    type: "percent",
+    step: "0.5",
+    min: 0,
+    max: 50,
+    section: "descuentos",
+  },
+  {
+    key: "discount_national_percentage",
+    label: "Descuento material nacional %",
+    helper:
+      "Este % aplica tanto al descuento arquitecto como al descuento cantidad por volumen, según moneda del material.",
+    type: "percent",
+    step: "0.5",
+    min: 0,
+    max: 50,
+    section: "descuentos",
+  },
+  {
+    key: "discount_building_percentage",
+    label: "Descuento edificio %",
+    helper: "Aplicado cuando es_edificio=true Y m² ≥ Edificio mínimo m².",
+    type: "percent",
+    step: "0.5",
+    min: 0,
+    max: 50,
+    section: "descuentos",
+  },
+  {
+    key: "discount_building_min_m2_threshold",
+    label: "Edificio mínimo m²",
+    helper: "Umbral para que el descuento edificio se aplique automáticamente.",
+    type: "number",
+    step: "1",
+    min: 0,
+    max: 100,
+    section: "descuentos",
+  },
+  {
+    key: "discount_min_m2_threshold",
+    label: "Cantidad mínimo m² (no-arquitecto/no-edificio)",
+    helper:
+      "Umbral para que el descuento por cantidad se aplique automáticamente (regla > 6m² · 4to tier · sub-PR #494).",
+    type: "number",
+    step: "1",
+    min: 0,
+    max: 100,
+    section: "descuentos",
+  },
+  // ─── Sección 4 · COSTING (sub-PR 22.2.a.III) ───────────────────────
+  {
+    key: "merma_small_piece_threshold_m2",
+    label: "Umbral merma (m²)",
+    helper: "Piezas por debajo de este umbral se consideran retazos a efectos de merma.",
+    type: "number",
+    step: "0.1",
+    min: 0,
+    max: 10,
+    section: "costing",
+  },
+];
+
+const SECTIONS: { id: SectionId; title: string; defaultOpen: boolean }[] = [
+  { id: "mesada", title: "Defaults de mesada", defaultOpen: true },
+  { id: "operativos", title: "Defaults operativos", defaultOpen: true },
+  { id: "descuentos", title: "Descuentos", defaultOpen: false },
+  { id: "costing", title: "Costing", defaultOpen: false },
 ];
 
 function formatValue(key: keyof ConfigEditableFields, value: unknown): string {
@@ -86,6 +178,9 @@ function formatValue(key: keyof ConfigEditableFields, value: unknown): string {
   ) {
     return `${(value as number).toFixed(2)} m`;
   }
+  const def = FIELDS.find((f) => f.key === key);
+  if (def?.type === "percent") return `${value}%`;
+  if (def?.type === "number") return String(value);
   return String(value);
 }
 
@@ -103,6 +198,12 @@ function diffRows(prev: ConfigEditableFields, next: ConfigEditableFields): DiffR
   return rows;
 }
 
+function isOutOfRange(field: FieldDef, value: number): boolean {
+  if (field.min !== undefined && value < field.min) return true;
+  if (field.max !== undefined && value > field.max) return true;
+  return false;
+}
+
 export function ConfigForm() {
   const [baseBlob, setBaseBlob] = useState<CatalogConfig | null>(null);
   const [original, setOriginal] = useState<ConfigEditableFields | null>(null);
@@ -110,6 +211,12 @@ export function ConfigForm() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [showModal, setShowModal] = useState(false);
   const [savedBadge, setSavedBadge] = useState(false);
+  const [openSections, setOpenSections] = useState<Record<SectionId, boolean>>(() =>
+    SECTIONS.reduce(
+      (acc, s) => ({ ...acc, [s.id]: s.defaultOpen }),
+      {} as Record<SectionId, boolean>,
+    ),
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -157,6 +264,14 @@ export function ConfigForm() {
   const rowsToDiff = diffRows(original, draft);
   const hasChanges = rowsToDiff.length > 0;
 
+  // Validación: bloquear guardar si algún número quedó fuera de rango.
+  const hasInvalid = FIELDS.some((f) => {
+    if (f.type !== "number" && f.type !== "percent" && f.type !== "number_m") return false;
+    const v = draft[f.key];
+    if (typeof v !== "number" || !Number.isFinite(v)) return true;
+    return isOutOfRange(f, v);
+  });
+
   const handleField = <K extends keyof ConfigEditableFields>(
     key: K,
     value: ConfigEditableFields[K],
@@ -178,74 +293,125 @@ export function ConfigForm() {
     setSavedBadge(true);
   };
 
+  const toggleSection = (id: SectionId) => {
+    setOpenSections((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
   return (
     <form
       data-testid="config-form"
       onSubmit={(e) => {
         e.preventDefault();
-        if (hasChanges) setShowModal(true);
+        if (hasChanges && !hasInvalid) setShowModal(true);
       }}
       style={{ display: "flex", flexDirection: "column", gap: 16 }}
     >
-      <div className="config-fields-grid">
-        {FIELDS.map((f) => {
-          const val = draft[f.key];
-          const id = `config-field-${f.key}`;
-          return (
-            <div
-              key={f.key}
-              data-testid={`config-row-${f.key}`}
-              style={{ display: "flex", flexDirection: "column", gap: 4 }}
+      {SECTIONS.map((section) => {
+        const fields = FIELDS.filter((f) => f.section === section.id);
+        const isOpen = openSections[section.id];
+        return (
+          <section
+            key={section.id}
+            className="config-section"
+            data-testid={`config-section-${section.id}`}
+            data-open={isOpen ? "true" : "false"}
+          >
+            <button
+              type="button"
+              className="config-section-header"
+              data-testid={`config-section-toggle-${section.id}`}
+              aria-expanded={isOpen}
+              onClick={() => toggleSection(section.id)}
             >
-              <label htmlFor={id} style={{ fontSize: 13, color: "var(--ink)", fontWeight: 500 }}>
-                {f.label}
-              </label>
-              {f.type === "bool" ? (
-                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                  <input
-                    id={id}
-                    data-testid={`config-input-${f.key}`}
-                    type="checkbox"
-                    checked={val as boolean}
-                    onChange={(e) => handleField(f.key, e.target.checked as never)}
-                  />
-                  <span style={{ fontSize: 13, color: "var(--ink-mute)" }}>
-                    {(val as boolean) ? "Activada" : "Desactivada"}
-                  </span>
-                </div>
-              ) : f.type === "number_m" ? (
-                <input
-                  id={id}
-                  data-testid={`config-input-${f.key}`}
-                  className="input num"
-                  type="number"
-                  step={f.step}
-                  min="0"
-                  value={val as number}
-                  onChange={(e) => handleField(f.key, Number(e.target.value) as never)}
-                />
-              ) : (
-                <input
-                  id={id}
-                  data-testid={`config-input-${f.key}`}
-                  className="input"
-                  type="text"
-                  value={val as string}
-                  onChange={(e) => handleField(f.key, e.target.value as never)}
-                />
-              )}
-              {f.helper && (
-                <span
-                  data-testid={`config-helper-${f.key}`}
-                  style={{ fontSize: 11, color: "var(--ink-mute)" }}
-                >
-                  {f.helper}
-                </span>
-              )}
-            </div>
-          );
-        })}
-      </div>
+              <span className="config-section-chevron" aria-hidden="true">
+                {isOpen ? "▼" : "▶"}
+              </span>
+              <span className="config-section-title">{section.title}</span>
+              <span className="config-section-count">{fields.length}</span>
+            </button>
+            {isOpen && (
+              <div className="config-fields-grid">
+                {fields.map((f) => {
+                  const val = draft[f.key];
+                  const id = `config-field-${f.key}`;
+                  const isNum =
+                    f.type === "number" || f.type === "percent" || f.type === "number_m";
+                  const numVal = val as number;
+                  const outOfRange =
+                    isNum && (typeof numVal !== "number" || isOutOfRange(f, numVal));
+                  return (
+                    <div
+                      key={f.key}
+                      data-testid={`config-row-${f.key}`}
+                      style={{ display: "flex", flexDirection: "column", gap: 4 }}
+                    >
+                      <label
+                        htmlFor={id}
+                        style={{ fontSize: 13, color: "var(--ink)", fontWeight: 500 }}
+                      >
+                        {f.label}
+                      </label>
+                      {f.type === "bool" ? (
+                        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                          <input
+                            id={id}
+                            data-testid={`config-input-${f.key}`}
+                            type="checkbox"
+                            checked={val as boolean}
+                            onChange={(e) => handleField(f.key, e.target.checked as never)}
+                          />
+                          <span style={{ fontSize: 13, color: "var(--ink-mute)" }}>
+                            {(val as boolean) ? "Activada" : "Desactivada"}
+                          </span>
+                        </div>
+                      ) : f.type === "text" ? (
+                        <input
+                          id={id}
+                          data-testid={`config-input-${f.key}`}
+                          className="input"
+                          type="text"
+                          value={val as string}
+                          onChange={(e) => handleField(f.key, e.target.value as never)}
+                        />
+                      ) : (
+                        <input
+                          id={id}
+                          data-testid={`config-input-${f.key}`}
+                          className="input num"
+                          type="number"
+                          step={f.step ?? "1"}
+                          min={f.min ?? 0}
+                          max={f.max}
+                          value={val as number}
+                          onChange={(e) => handleField(f.key, Number(e.target.value) as never)}
+                          aria-invalid={outOfRange ? "true" : "false"}
+                        />
+                      )}
+                      {f.helper && (
+                        <span
+                          data-testid={`config-helper-${f.key}`}
+                          style={{ fontSize: 11, color: "var(--ink-mute)" }}
+                        >
+                          {f.helper}
+                        </span>
+                      )}
+                      {outOfRange && (
+                        <span
+                          data-testid={`config-error-${f.key}`}
+                          role="alert"
+                          style={{ fontSize: 11, color: "var(--error)" }}
+                        >
+                          Valor fuera de rango ({f.min ?? 0}–{f.max ?? "∞"})
+                        </span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+        );
+      })}
 
       <div
         className="config-actions"
@@ -254,7 +420,7 @@ export function ConfigForm() {
         <button
           type="submit"
           className="btn primary"
-          disabled={!hasChanges}
+          disabled={!hasChanges || hasInvalid}
           data-testid="config-save"
         >
           Guardar

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -587,20 +587,53 @@ export interface CatalogConfigDefaults {
   [k: string]: unknown;
 }
 
-export interface CatalogConfig {
-  measurements: CatalogConfigMeasurements;
-  defaults: CatalogConfigDefaults;
+export interface CatalogConfigDiscount {
+  imported_percentage?: number;
+  national_percentage?: number;
+  building_percentage?: number;
+  building_min_m2_threshold?: number;
+  min_m2_threshold?: number;
   [k: string]: unknown;
 }
 
-/** Los 6 campos editables desde /configuracion (sub-PR 22.2.a). */
+export interface CatalogConfigMerma {
+  small_piece_threshold_m2?: number;
+  [k: string]: unknown;
+}
+
+export interface CatalogConfig {
+  measurements: CatalogConfigMeasurements;
+  defaults: CatalogConfigDefaults;
+  discount?: CatalogConfigDiscount;
+  merma?: CatalogConfigMerma;
+  [k: string]: unknown;
+}
+
+/** Campos editables desde /configuracion.
+ *
+ * Sub-PR 22.2.a · 6 fields (mesada + operativos).
+ * Sub-PR 22.2.a.III · +6 fields (descuentos + costing).
+ *
+ * El nombre del field es flat (camel-ish) · el path JSON real al que
+ * mapea está documentado en `extractEditableFields` / `applyEditableFields`.
+ */
 export interface ConfigEditableFields {
+  // 22.2.a · mesada
   default_depth: number;
   default_zocalo_height: number;
   default_alzada_height: number;
+  // 22.2.a · operativos
   colocacion_particulares: boolean;
   delivery_zone_sku: string;
   forma_pago: string;
+  // 22.2.a.III · descuentos
+  discount_imported_percentage: number;
+  discount_national_percentage: number;
+  discount_building_percentage: number;
+  discount_building_min_m2_threshold: number;
+  discount_min_m2_threshold: number;
+  // 22.2.a.III · costing
+  merma_small_piece_threshold_m2: number;
 }
 
 export const CONFIG_EDITABLE_KEYS: ReadonlyArray<keyof ConfigEditableFields> = [
@@ -610,20 +643,36 @@ export const CONFIG_EDITABLE_KEYS: ReadonlyArray<keyof ConfigEditableFields> = [
   "colocacion_particulares",
   "delivery_zone_sku",
   "forma_pago",
+  "discount_imported_percentage",
+  "discount_national_percentage",
+  "discount_building_percentage",
+  "discount_building_min_m2_threshold",
+  "discount_min_m2_threshold",
+  "merma_small_piece_threshold_m2",
 ];
+
+function _num(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
 
 export function extractEditableFields(cfg: CatalogConfig): ConfigEditableFields {
   return {
-    default_depth: cfg.measurements?.default_depth ?? 0.6,
-    default_zocalo_height: cfg.measurements?.default_zocalo_height ?? 0.05,
-    default_alzada_height: cfg.measurements?.default_alzada_height ?? 0.6,
+    default_depth: _num(cfg.measurements?.default_depth, 0.6),
+    default_zocalo_height: _num(cfg.measurements?.default_zocalo_height, 0.05),
+    default_alzada_height: _num(cfg.measurements?.default_alzada_height, 0.6),
     colocacion_particulares: cfg.defaults?.colocacion_particulares ?? true,
     delivery_zone_sku: cfg.defaults?.delivery_zone_sku ?? "ENVIOROS",
     forma_pago: cfg.defaults?.forma_pago ?? "Contado",
+    discount_imported_percentage: _num(cfg.discount?.imported_percentage, 5),
+    discount_national_percentage: _num(cfg.discount?.national_percentage, 8),
+    discount_building_percentage: _num(cfg.discount?.building_percentage, 18),
+    discount_building_min_m2_threshold: _num(cfg.discount?.building_min_m2_threshold, 15),
+    discount_min_m2_threshold: _num(cfg.discount?.min_m2_threshold, 6),
+    merma_small_piece_threshold_m2: _num(cfg.merma?.small_piece_threshold_m2, 1.0),
   };
 }
 
-/** Devuelve un nuevo blob con los 6 fields del UI aplicados sobre el
+/** Devuelve un nuevo blob con los fields del UI aplicados sobre el
  * blob original (preserva todas las keys que NO edita el UI). */
 export function applyEditableFields(
   base: CatalogConfig,
@@ -642,6 +691,18 @@ export function applyEditableFields(
       colocacion_particulares: edits.colocacion_particulares,
       delivery_zone_sku: edits.delivery_zone_sku,
       forma_pago: edits.forma_pago,
+    },
+    discount: {
+      ...(base.discount ?? {}),
+      imported_percentage: edits.discount_imported_percentage,
+      national_percentage: edits.discount_national_percentage,
+      building_percentage: edits.discount_building_percentage,
+      building_min_m2_threshold: edits.discount_building_min_m2_threshold,
+      min_m2_threshold: edits.discount_min_m2_threshold,
+    },
+    merma: {
+      ...(base.merma ?? {}),
+      small_piece_threshold_m2: edits.merma_small_piece_threshold_m2,
     },
   };
 }

--- a/web/tests/e2e/configuracion.spec.ts
+++ b/web/tests/e2e/configuracion.spec.ts
@@ -102,3 +102,119 @@ test.describe("Configuración · responsive mobile", () => {
     expect(cols).toBe(1);
   });
 });
+
+/* ─────────────────────────────────────────────────────────────────────
+ * Sub-PR 22.2.a.III · expansion config-ui · descuentos + costing
+ * ─────────────────────────────────────────────────────────────────── */
+
+test.describe("Configuración · accordion · secciones nuevas", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("sección Descuentos arranca colapsada (collapsed default)", async ({ page }) => {
+    await page.goto("/configuracion");
+    const section = page.locator('[data-testid="config-section-descuentos"]');
+    await expect(section).toBeVisible();
+    await expect(section).toHaveAttribute("data-open", "false");
+    // Fields NO visibles hasta expandir
+    await expect(
+      page.locator('[data-testid="config-row-discount_imported_percentage"]'),
+    ).toBeHidden();
+  });
+
+  test("expandir Descuentos muestra 5 fields", async ({ page }) => {
+    await page.goto("/configuracion");
+    await page.locator('[data-testid="config-section-toggle-descuentos"]').click();
+    for (const key of [
+      "discount_imported_percentage",
+      "discount_national_percentage",
+      "discount_building_percentage",
+      "discount_building_min_m2_threshold",
+      "discount_min_m2_threshold",
+    ]) {
+      await expect(page.locator(`[data-testid="config-row-${key}"]`)).toBeVisible();
+    }
+  });
+
+  test("validation range descuento importado (0-50) muestra error + bloquea Guardar", async ({
+    page,
+  }) => {
+    await page.goto("/configuracion");
+    await page.locator('[data-testid="config-section-toggle-descuentos"]').click();
+    const input = page.locator('[data-testid="config-input-discount_imported_percentage"]');
+    await input.fill("75");
+    await expect(
+      page.locator('[data-testid="config-error-discount_imported_percentage"]'),
+    ).toBeVisible();
+    await expect(page.locator('[data-testid="config-save"]')).toBeDisabled();
+    // Volver al rango → desaparece error
+    await input.fill("6");
+    await expect(
+      page.locator('[data-testid="config-error-discount_imported_percentage"]'),
+    ).toBeHidden();
+    await expect(page.locator('[data-testid="config-save"]')).toBeEnabled();
+  });
+
+  test("sección Costing arranca colapsada", async ({ page }) => {
+    await page.goto("/configuracion");
+    const section = page.locator('[data-testid="config-section-costing"]');
+    await expect(section).toBeVisible();
+    await expect(section).toHaveAttribute("data-open", "false");
+  });
+
+  test("validation range merma (0-10) bloquea Guardar fuera de rango", async ({ page }) => {
+    await page.goto("/configuracion");
+    await page.locator('[data-testid="config-section-toggle-costing"]').click();
+    const input = page.locator('[data-testid="config-input-merma_small_piece_threshold_m2"]');
+    await input.fill("15");
+    await expect(
+      page.locator('[data-testid="config-error-merma_small_piece_threshold_m2"]'),
+    ).toBeVisible();
+    await expect(page.locator('[data-testid="config-save"]')).toBeDisabled();
+  });
+
+  test("accordion mantiene estado al toggle independiente por sección", async ({ page }) => {
+    await page.goto("/configuracion");
+    const descuentos = page.locator('[data-testid="config-section-descuentos"]');
+    const costing = page.locator('[data-testid="config-section-costing"]');
+    await page.locator('[data-testid="config-section-toggle-descuentos"]').click();
+    await expect(descuentos).toHaveAttribute("data-open", "true");
+    await expect(costing).toHaveAttribute("data-open", "false");
+    await page.locator('[data-testid="config-section-toggle-costing"]').click();
+    await expect(descuentos).toHaveAttribute("data-open", "true");
+    await expect(costing).toHaveAttribute("data-open", "true");
+    // Cerrar descuentos · costing sigue abierta
+    await page.locator('[data-testid="config-section-toggle-descuentos"]').click();
+    await expect(descuentos).toHaveAttribute("data-open", "false");
+    await expect(costing).toHaveAttribute("data-open", "true");
+  });
+
+  test("diff modal muestra solo cambios cross-section", async ({ page }) => {
+    await page.goto("/configuracion");
+    // Cambio en mesada (siempre visible)
+    await page.locator('[data-testid="config-input-default_zocalo_height"]').fill("0.06");
+    // Cambio en costing (expandir primero)
+    await page.locator('[data-testid="config-section-toggle-costing"]').click();
+    await page.locator('[data-testid="config-input-merma_small_piece_threshold_m2"]').fill("2");
+    await page.locator('[data-testid="config-save"]').click();
+    const modal = page.locator('[data-testid="config-diff-modal"]');
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText("Alto de zócalo (m)");
+    await expect(modal).toContainText("Umbral merma (m²)");
+    // NO debe mostrar fields que no cambiaron
+    await expect(modal).not.toContainText("Forma de pago default");
+  });
+
+  test("helper text del descuento explica acoplamiento arquitecto+cantidad", async ({ page }) => {
+    await page.goto("/configuracion");
+    await page.locator('[data-testid="config-section-toggle-descuentos"]').click();
+    await expect(
+      page.locator('[data-testid="config-helper-discount_imported_percentage"]'),
+    ).toContainText(/arquitecto/i);
+    await expect(
+      page.locator('[data-testid="config-helper-discount_imported_percentage"]'),
+    ).toContainText(/cantidad/i);
+    await expect(
+      page.locator('[data-testid="config-helper-discount_national_percentage"]'),
+    ).toContainText(/arquitecto/i);
+  });
+});

--- a/web/tests/e2e/configuracion.spec.ts
+++ b/web/tests/e2e/configuracion.spec.ts
@@ -95,7 +95,10 @@ test.describe("Configuración · responsive mobile", () => {
   test("grid 1 col en mobile + form visible", async ({ page }) => {
     await page.goto("/configuracion");
     await expect(page.locator('[data-testid="config-form"]')).toBeVisible();
-    const grid = page.locator(".config-fields-grid");
+    // Sub-PR 22.2.a.III: ahora hay múltiples `.config-fields-grid` (uno
+    // por sección abierta · mesada + operativos default-open). `.first()`
+    // evita strict-mode violation.
+    const grid = page.locator(".config-fields-grid").first();
     const cols = await grid.evaluate(
       (el) => getComputedStyle(el).gridTemplateColumns.split(" ").length,
     );


### PR DESCRIPTION
## Summary

Expande `/configuracion` con 2 secciones nuevas (Descuentos · Costing) · 6 fields editables · accordion para evitar scroll largo · cero backend touch.

- **Sección DESCUENTOS** (nueva · 5 fields): imported/national/building % + edificio min m² + cantidad min m² (regla #494).
- **Sección COSTING** (nueva · 1 field): umbral merma (small_piece_threshold_m2).
- **UI accordion** con 4 secciones (2 existentes default-expanded + 2 nuevas default-collapsed).
- **Helper text** explícito en imported/national_percentage explica acoplamiento arquitecto + cantidad.
- **Validation client-side** range por field · inline error + bloquea Guardar.
- **8 E2E tests nuevos**.

## Cambios

| Archivo | Cambio |
|---|---|
| [web/src/lib/api/types.ts](web/src/lib/api/types.ts) | +6 keys flat en `ConfigEditableFields` mapeadas a JSON nested · extract/apply actualizados |
| [web/src/components/config/ConfigForm.tsx](web/src/components/config/ConfigForm.tsx) | refactor con `SECTIONS` + accordion · 6 nuevos fields con range validation |
| [web/src/app/globals.css](web/src/app/globals.css) | +20 LOC scope `.config-v2` (header accordion + sticky bottom actions mobile) |
| [web/tests/e2e/configuracion.spec.ts](web/tests/e2e/configuracion.spec.ts) | +8 tests (collapsed default, expand, validation range, accordion state, diff modal cross-section, helper text) |

## Decisiones arquitectónicas

- **Cero backend refactor** · todos los paths ya hot-reloadables vía `cfg()` · PUT /api/catalog/config invalida cache (#492 wire).
- **Accordion sin librería** · estado local `Record<SectionId, boolean>` en useState · zero deps nuevas.
- **Flat field keys** (`discount_imported_percentage`) mapeadas a nested JSON paths en `applyEditableFields` · mantiene el form logic idéntico al 22.2.a.
- **Validation client-side** opt-in por field (`min`/`max` opcionales en FieldDef) · sigue siendo defensa en profundidad (backend permite Pydantic libre).
- **Diferidos a sub-PRs específicos**:
  - IVA · NO hot-reloadable (requiere recálculo retroactivo · sub-PR 22.IVA)
  - plate_sizes · NO hot-reloadable (afecta despiece · sub-PR 22.plate)
  - delivery zones precios · cubierto por sub-PR 22.2.b (Dux importer)
  - delivery_days.tiers · a definir con Agos

## Estructura UI

```
┌──────────────────────────────────────────────────────┐
│ Configuración                                        │
├──────────────────────────────────────────────────────┤
│ ▼ DEFAULTS DE MESADA           (3 · expanded)        │
├──────────────────────────────────────────────────────┤
│ ▼ DEFAULTS OPERATIVOS          (3 · expanded)        │
├──────────────────────────────────────────────────────┤
│ ▶ DESCUENTOS                   (5 · collapsed NEW)   │
├──────────────────────────────────────────────────────┤
│ ▶ COSTING                      (1 · collapsed NEW)   │
├──────────────────────────────────────────────────────┤
│ [ Descartar ]  [ Guardar ]                           │
└──────────────────────────────────────────────────────┘
```

## Verificación local

- [x] `node_modules/.bin/tsc --noEmit` · 0 errores
- [x] `npm run lint` · 0 errores en archivos del PR (5 warnings pre-existentes en `tests/unit/context-from-breakdown.test.ts` fuera de scope)
- [x] `npm run test:unit` · 129/129 pass
- [x] `npm run build` · `/configuracion` compila sin warnings
- [ ] `npm run test:e2e` · 8 nuevos + 207 existentes (CI valida · local no se corrió por costo)

## Test plan

- [ ] Smoke prod post-deploy: abrir `/configuracion` · verificar 4 secciones · descuentos+costing colapsadas default
- [ ] Expand descuentos · verificar 5 fields + helper text
- [ ] Editar imported_percentage a 75 → ver error inline + Guardar disabled
- [ ] Editar imported_percentage a 6 + merma a 2 → Guardar abre diff con ambos cambios
- [ ] Confirmar diff → badge "Guardado" 3s
- [ ] Crear quote nuevo no-arquitecto no-edificio >6m² → verificar 5% aplica con el nuevo valor (acoplamiento #494)
- [ ] Mobile 375px: secciones full-width + acciones sticky bottom
- [ ] **AUDIT INDEP** antes del merge (UI nueva · acoplamiento bug latente arquitecto/cantidad por compartir field)

## Caveats

- El % imported/national es **compartido** entre regla arquitecto y regla cantidad (decisión consciente · ambas reglas usan los mismos `discount.imported_percentage` / `discount.national_percentage` desde calculator.py). El helper text lo aclara.
- Si Agos quiere desacoplar % arquitecto vs % cantidad en el futuro, requiere keys nuevas en config + cambio en calculator.py (no en este sub-PR).
- IVA + plate_sizes diferidos · cualquier intento de editar desde acá NO los expone (correcto · son NO hot-reloadable).

## Lecciones operativas aplicadas

- **#58** backend + frontend mismo PR (backend = 0)
- **#60** fixtures shape REAL (e2e usan flat keys consistentes con types)
- **#66** CSS responsive ~20 LOC scoped a `.config-v2`
- **#67** arqueología obligatoria (FASE 1 confirmó hot-reloadability de los 6 fields antes de tocar UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)