### PR TITLE
feat(catalogo): UI completa · viewer + Dux importer + backup restore (22.2.b)

### DIFF
--- a/api/app/modules/catalog/import_parser.py
+++ b/api/app/modules/catalog/import_parser.py
@@ -149,7 +149,20 @@ def _read_xlsx(data: bytes) -> tuple[list[str], list[list]]:
 
 
 def _read_csv(data: bytes) -> tuple[list[str], list[list]]:
-    text = data.decode("utf-8-sig")  # Handle BOM
+    # Dux exporta UTF-8 normalmente, pero los CSV guardados desde Excel en
+    # Windows AR vienen en latin-1 (cp1252) y rompían el decode. Fallback
+    # explícito + mensaje user-friendly si ninguno de los dos sirve.
+    try:
+        text = data.decode("utf-8-sig")  # Handle BOM
+    except UnicodeDecodeError:
+        try:
+            text = data.decode("latin-1")
+            logging.warning("[import] CSV usó encoding latin-1 fallback (no UTF-8)")
+        except UnicodeDecodeError:
+            raise ValueError(
+                "No se pudo leer el archivo: encoding no soportado. "
+                "Guardá el CSV como UTF-8 y volvé a subirlo."
+            )
     reader = csv.reader(io.StringIO(text))
     all_rows = list(reader)
     if not all_rows:

--- a/api/tests/test_backup_restore.py
+++ b/api/tests/test_backup_restore.py
@@ -1,0 +1,67 @@
+"""Ciclo completo backup → restore · sub-PR 22.2.b.
+
+test_import_endpoints.py cubre apply→backup y restore-404; acá cubrimos el
+ROUND-TRIP real: seed → apply (cambia precio + backup v1) → restore →
+contenido vuelve a v1 + se crea un backup de seguridad pre-restore.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def _servicios_csv(price: str) -> bytes:
+    rows = [
+        ["Código", "Producto", "Precio de Venta", "Ultima Modificacion", "Precio de Venta($)", "Precio De Venta Con IVA($)"],
+        ["ANAFE", "AGUJERO ANAFE", price, "09/04/2026", price, "0"],
+    ]
+    return "\n".join(",".join(str(c) for c in r) for r in rows).encode("utf-8")
+
+
+class TestBackupRestoreRoundTrip:
+    @pytest.mark.asyncio
+    async def test_full_cycle_restores_previous_content(self, client):
+        # 1. Seed labor con un precio conocido (v1).
+        seed = [{"sku": "ANAFE", "name": "AGUJERO ANAFE", "price_ars": 1000, "currency": "ARS", "price_includes_vat": False}]
+        r = await client.put("/api/catalog/labor", json={"content": seed})
+        assert r.status_code == 200, r.text
+
+        # 2. Apply: sube ANAFE a 40000 → backea v1, deja v2.
+        r = await client.post(
+            "/api/catalog/import-apply",
+            files={"file": ("dux_v2.csv", _servicios_csv("40000"), "text/csv")},
+            data={"catalogs": json.dumps(["labor"]), "include_new": "false", "source_file": "dux_v2.csv"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["ok"]
+
+        # v2 activo: ANAFE = 40000
+        cur = await client.get("/api/catalog/labor")
+        anafe = next(i for i in cur.json() if i["sku"] == "ANAFE")
+        assert anafe["price_ars"] == 40000
+
+        # 3. Listar backups → tomar el más reciente (el de v1).
+        b = await client.get("/api/catalog/backups/labor")
+        assert b.status_code == 200
+        backups = b.json()
+        assert len(backups) >= 1
+        backup_id = backups[0]["id"]
+
+        # 4. Restaurar.
+        r = await client.post(f"/api/catalog/backups/{backup_id}/restore")
+        assert r.status_code == 200, r.text
+        assert r.json()["ok"]
+        assert r.json()["catalog"] == "labor"
+
+        # 5. Contenido vuelve a v1 (ANAFE = 1000).
+        cur = await client.get("/api/catalog/labor")
+        anafe = next(i for i in cur.json() if i["sku"] == "ANAFE")
+        assert anafe["price_ars"] == 1000
+
+        # 6. Safety net: se creó un backup pre-restore del estado v2.
+        b2 = await client.get("/api/catalog/backups/labor")
+        assert len(b2.json()) > len(backups)
+        assert any(
+            "pre-restore" in (bk.get("source_file") or "") for bk in b2.json()
+        )

--- a/api/tests/test_catalog_endpoints.py
+++ b/api/tests/test_catalog_endpoints.py
@@ -1,0 +1,56 @@
+"""Tests de los endpoints de listado/lectura de catálogos · sub-PR 22.2.b.
+
+Cubre los gaps que NO tocaba test_import_endpoints.py (que cubre import +
+backups): GET /api/catalog/ (lista con metadata), GET /api/catalog/{name}
+(200 + 404) y PUT /api/catalog/{name} (403 catálogo no permitido).
+
+DB de test vacía → _load_from_db cae a los JSON reales de api/catalog/.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+class TestListCatalogs:
+    @pytest.mark.asyncio
+    async def test_list_returns_metadata_per_catalog(self, client):
+        r = await client.get("/api/catalog/")
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert isinstance(data, list)
+        assert len(data) >= 1
+        for entry in data:
+            assert set(entry.keys()) >= {"name", "item_count", "last_updated"}
+            assert isinstance(entry["item_count"], int)
+
+    @pytest.mark.asyncio
+    async def test_list_includes_known_catalogs(self, client):
+        r = await client.get("/api/catalog/")
+        names = {e["name"] for e in r.json()}
+        # Catálogos seedeados desde archivo
+        assert "labor" in names
+        assert "materials-silestone" in names
+
+
+class TestGetCatalog:
+    @pytest.mark.asyncio
+    async def test_get_existing_catalog_returns_content(self, client):
+        r = await client.get("/api/catalog/labor")
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert isinstance(data, (list, dict))
+
+    @pytest.mark.asyncio
+    async def test_get_unknown_catalog_returns_404(self, client):
+        r = await client.get("/api/catalog/no-existe-este-catalogo")
+        assert r.status_code == 404
+
+
+class TestUpdateCatalogGuard:
+    @pytest.mark.asyncio
+    async def test_put_disallowed_catalog_returns_403(self, client):
+        r = await client.put(
+            "/api/catalog/catalogo-prohibido",
+            json={"content": [{"sku": "X", "price_ars": 1}]},
+        )
+        assert r.status_code == 403

--- a/api/tests/test_dux_encoding.py
+++ b/api/tests/test_dux_encoding.py
@@ -1,0 +1,51 @@
+"""Tests del fallback de encoding del parser CSV · sub-PR 22.2.b (Bug 1).
+
+Antes: `_read_csv` asumía utf-8-sig → los CSV guardados desde Excel en
+Windows AR (latin-1 / cp1252) rompían con UnicodeDecodeError → 500/400 sin
+mensaje claro. Ahora: fallback explícito a latin-1 + ValueError
+user-friendly si ninguno sirve (rama defensiva · latin-1 decodifica todo).
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.modules.catalog.import_parser import _read_csv
+
+
+HEADER = "Código,Producto,Precio de Venta"
+
+
+class TestCsvEncodingFallback:
+    def test_utf8_sig_with_bom(self):
+        raw = ("﻿" + HEADER + "\nSKU1,Mañana,100").encode("utf-8")
+        headers, rows = _read_csv(raw)
+        # El BOM no debe quedar pegado a la primera columna
+        assert headers[0].strip("﻿") == "Código"
+        assert rows[0][1] == "Mañana"
+
+    def test_latin1_fallback(self):
+        # "Código" / "Mañana" en latin-1 → bytes inválidos para utf-8-sig
+        raw = (HEADER + "\nSKU1,Mañana,100").encode("latin-1")
+        with pytest.raises(UnicodeDecodeError):
+            raw.decode("utf-8-sig")
+        # El parser debe sobrevivir vía fallback latin-1
+        headers, rows = _read_csv(raw)
+        assert "Producto" in headers
+        assert rows[0][0] == "SKU1"
+        assert rows[0][1] == "Mañana"
+
+
+class TestCsvEncodingFallbackEndpoint:
+    @pytest.mark.asyncio
+    async def test_preview_accepts_latin1_csv(self, client):
+        """End-to-end: un CSV latin-1 ya no rompe el import-preview."""
+        body = (
+            "Código,Producto,Precio de Venta\n"
+            "COLOCACION,COLOCACIÓN ESPECIAL,49698.65\n"
+        ).encode("latin-1")
+        r = await client.post(
+            "/api/catalog/import-preview",
+            files={"file": ("dux_latin1.csv", body, "text/csv")},
+        )
+        assert r.status_code == 200, r.text
+        assert "catalogs" in r.json()

--- a/web/src/app/(chrome)/catalogo/[name]/page.tsx
+++ b/web/src/app/(chrome)/catalogo/[name]/page.tsx
@@ -1,0 +1,27 @@
+/**
+ * Catálogo · viewer · sub-PR 22.2.b catalogo-and-dux-importer-ui.
+ *
+ * Viewer JSON read-only + versiones anteriores (backups) con restore.
+ * SIN editor manual (decisión Agos · Marina usa Dux import para precios
+ * masivos). Fetch en el component cliente.
+ */
+import Link from "next/link";
+import { CatalogViewer } from "@/components/catalog/CatalogViewer";
+
+export default function CatalogoViewerPage({ params }: { params: { name: string } }) {
+  const name = decodeURIComponent(params.name);
+  return (
+    <div className="catalogo-v2">
+      <div className="topbar">
+        <div className="crumbs">
+          <Link href="/catalogo">Catálogo</Link>
+          <span className="sep">/</span>
+          <span className="now mono">{name}</span>
+        </div>
+      </div>
+      <div className="body" data-testid="catalogo-viewer-page">
+        <CatalogViewer name={name} />
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(chrome)/catalogo/import/page.tsx
+++ b/web/src/app/(chrome)/catalogo/import/page.tsx
@@ -1,0 +1,26 @@
+/**
+ * Catálogo · import Dux · sub-PR 22.2.b catalogo-and-dux-importer-ui.
+ *
+ * Full page del importador Dux · 3 estados (upload → preview → apply).
+ * El backend genera backups automáticos al aplicar (safety net). Toda la
+ * lógica vive en el component cliente (multipart + estado de máquina).
+ */
+import Link from "next/link";
+import { CatalogImport } from "@/components/catalog/CatalogImport";
+
+export default function CatalogoImportPage() {
+  return (
+    <div className="catalogo-v2">
+      <div className="topbar">
+        <div className="crumbs">
+          <Link href="/catalogo">Catálogo</Link>
+          <span className="sep">/</span>
+          <span className="now">Importar desde Dux</span>
+        </div>
+      </div>
+      <div className="body" data-testid="catalogo-import-page">
+        <CatalogImport />
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(chrome)/catalogo/page.tsx
+++ b/web/src/app/(chrome)/catalogo/page.tsx
@@ -1,24 +1,40 @@
 /**
- * Catálogo · placeholder · Sprint 4 sidebar-and-navigation-fix.
+ * Catálogo · lista · sub-PR 22.2.b catalogo-and-dux-importer-ui.
  *
- * Cierra ruta 404 que el item del Sidebar generaba. Backend ya expone
- * `GET /api/catalog` con los 15 JSONs de materiales/MO/sinks. Sub-PR
- * posterior construye la vista de gestión.
+ * Reemplaza el placeholder (#490) por la lista real de los 14 catálogos
+ * importables + config. Fetch + search + sort viven en el component
+ * cliente (los catálogos son cross-quote · no necesitan SSR aggressive,
+ * mismo criterio que /configuracion).
+ *
+ * Scope CSS: `.catalogo-v2` wrapper · ver globals.css · operator-shared.css
+ * INTACTO.
  */
+import Link from "next/link";
+import { CatalogList } from "@/components/catalog/CatalogList";
+
 export default function CatalogoPage() {
   return (
-    <>
+    <div className="catalogo-v2">
       <div className="topbar">
         <div className="crumbs">
           <span className="now">Catálogo</span>
         </div>
+        <Link href="/catalogo/import" className="btn primary" data-testid="catalog-import-cta">
+          Importar desde Dux
+        </Link>
       </div>
-      <div className="body" data-testid="catalogo-placeholder">
-        <p>Próximamente · UI de gestión de catálogos.</p>
-        <p style={{ color: "var(--ink-mute)", fontSize: 12, marginTop: 8 }}>
-          Backend ya expone <code>GET /api/catalog</code>. Sub-PR posterior construye la vista.
-        </p>
+      <div className="body" data-testid="catalogo-page">
+        <div className="col">
+          <div className="section-head">
+            <h2>Catálogos</h2>
+            <span className="meta">
+              Precios sin IVA · fuente de verdad del cálculo. Para actualizar precios masivos usá
+              Importar desde Dux.
+            </span>
+          </div>
+          <CatalogList />
+        </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -125,3 +125,113 @@
   .config-v2 .config-actions { flex-wrap: wrap; }
   .config-v2 .config-actions .btn { flex: 1; min-width: 120px; }
 }
+
+/* ─── Catálogo · viewer + Dux importer (sub-PR 22.2.b) ───────────────
+   Todo scoped bajo .catalogo-v2 · operator-shared.css INTACTO. Reusa
+   .modal-backdrop / .btn / .input / .topbar / .body / .col de shared. */
+.catalogo-v2 .topbar { justify-content: space-between; align-items: center; }
+.catalogo-v2 .crumbs .sep { color: var(--ink-mute); margin: 0 6px; }
+
+/* Lista */
+.catalogo-v2 .catalog-toolbar { display: flex; gap: 12px; margin-bottom: 16px; }
+.catalogo-v2 .catalog-toolbar .input { flex: 1; min-width: 0; }
+.catalogo-v2 .catalog-toolbar select.input { flex: 0 0 auto; max-width: 260px; }
+.catalogo-v2 .catalog-rows { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.catalogo-v2 .catalog-row {
+  display: grid; grid-template-columns: 1fr auto auto; gap: 16px; align-items: center;
+  padding: 12px 14px; border: 1px solid var(--line); border-radius: 10px;
+  background: var(--bg-card); text-decoration: none; color: var(--ink); transition: border-color 120ms;
+}
+.catalogo-v2 .catalog-row:hover { border-color: var(--line-strong); }
+.catalogo-v2 .catalog-row-name { font-size: 13px; }
+.catalogo-v2 .catalog-row-count { font-size: 12px; color: var(--ink-soft); }
+.catalogo-v2 .catalog-row-updated { font-size: 11px; white-space: nowrap; }
+
+/* Viewer */
+.catalogo-v2 .catalog-viewer-grid {
+  display: grid; grid-template-columns: 1fr 320px; gap: 20px; align-items: start; margin-top: 12px;
+}
+.catalogo-v2 .catalog-viewer-grid h3 { font-size: 13px; color: var(--ink-soft); margin: 0 0 8px; }
+.catalogo-v2 .catalog-json {
+  background: var(--bg-muted); border: 1px solid var(--line); border-radius: 10px;
+  padding: 14px; font-size: 12px; line-height: 1.5; max-height: 60vh; overflow: auto; margin: 0;
+  white-space: pre; color: var(--ink-soft);
+}
+.catalogo-v2 .backup-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.catalogo-v2 .backup-row {
+  border: 1px solid var(--line); border-radius: 10px; padding: 10px 12px;
+  display: flex; flex-direction: column; gap: 4px; background: var(--bg-card);
+}
+.catalogo-v2 .backup-row-main { display: flex; justify-content: space-between; gap: 8px; font-size: 12px; }
+.catalogo-v2 .backup-source { color: var(--ink-mute); font-size: 11px; }
+.catalogo-v2 .backup-row .btn { align-self: flex-start; margin-top: 4px; }
+
+/* Toast */
+.catalogo-v2 .catalog-toast {
+  position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
+  background: var(--bg-card); border: 1px solid var(--line-strong); border-radius: 10px;
+  padding: 12px 18px; font-size: 13px; z-index: 120; box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+}
+
+/* Import · dropzone */
+.catalogo-v2 .import-dropzone {
+  border: 1.5px dashed var(--line-strong); border-radius: 12px; padding: 36px 20px;
+  text-align: center; cursor: pointer; color: var(--ink-soft); background: var(--bg-muted);
+  transition: border-color 120ms, background 120ms;
+}
+.catalogo-v2 .import-dropzone.over { border-color: var(--accent); background: var(--bg-card); }
+.catalogo-v2 .import-spinner { padding: 32px 0; color: var(--ink-soft); }
+
+/* Banners */
+.catalogo-v2 .banner { border-radius: 10px; padding: 12px 14px; font-size: 13px; margin: 12px 0; border: 1px solid; }
+.catalogo-v2 .banner.err { color: var(--error); border-color: oklch(from var(--error) l c h / 0.4); background: oklch(from var(--error) l c h / 0.08); }
+.catalogo-v2 .banner.warn { color: var(--warn); border-color: oklch(from var(--warn) l c h / 0.4); background: oklch(from var(--warn) l c h / 0.08); }
+.catalogo-v2 .import-warnings { margin: 8px 0; padding-left: 18px; }
+
+/* Import · tabs */
+.catalogo-v2 .import-tabs { display: flex; flex-wrap: wrap; gap: 8px; margin: 12px 0; }
+.catalogo-v2 .import-tab {
+  display: flex; align-items: center; gap: 8px; padding: 8px 10px;
+  border: 1px solid var(--line); border-radius: 10px; background: var(--bg-card);
+}
+.catalogo-v2 .import-tab.active { border-color: var(--accent); }
+.catalogo-v2 .import-tab button { background: none; border: none; color: var(--ink); cursor: pointer; text-align: left; display: flex; flex-direction: column; gap: 2px; font: inherit; }
+.catalogo-v2 .import-tab button .meta { font-size: 11px; }
+
+/* Import · diff table */
+.catalogo-v2 .diff-counters { display: flex; flex-wrap: wrap; gap: 6px; margin: 8px 0 12px; }
+.catalogo-v2 .diff-badge { font-size: 11px; padding: 3px 8px; border-radius: 999px; border: 1px solid var(--line); color: var(--ink-mute); }
+.catalogo-v2 .diff-badge.updated { color: var(--warn); border-color: oklch(from var(--warn) l c h / 0.4); }
+.catalogo-v2 .diff-badge.new { color: var(--ok); border-color: oklch(from var(--ok) l c h / 0.4); }
+.catalogo-v2 .diff-badge.zero { color: var(--error); border-color: oklch(from var(--error) l c h / 0.4); }
+.catalogo-v2 .diff-badge.normalized { color: var(--accent); border-color: oklch(from var(--accent) l c h / 0.4); }
+.catalogo-v2 .diff-table details { margin: 8px 0; }
+.catalogo-v2 .diff-table summary { cursor: pointer; font-size: 13px; color: var(--ink-soft); }
+.catalogo-v2 .diff-table table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 12px; }
+.catalogo-v2 .diff-table th, .catalogo-v2 .diff-table td { text-align: left; padding: 5px 8px; border-bottom: 1px solid var(--line-soft); }
+.catalogo-v2 .diff-table th { color: var(--ink-mute); font-weight: 500; }
+.catalogo-v2 .diff-table tr.row-warn td { color: var(--warn); }
+.catalogo-v2 .import-results { list-style: none; margin: 12px 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.catalogo-v2 .import-result-row { display: flex; flex-direction: column; gap: 2px; padding: 10px 12px; border: 1px solid var(--line); border-radius: 10px; background: var(--bg-card); }
+
+/* Modal card (reusa .modal-backdrop de operator-shared) */
+.catalogo-v2 .modal-card {
+  width: 460px; max-width: calc(100vw - 32px); background: var(--bg-card);
+  border: 1px solid var(--line-strong); border-radius: 12px; padding: 20px;
+  box-shadow: 0 16px 48px rgba(0,0,0,0.6);
+}
+.catalogo-v2 .modal-card h3 { margin: 0 0 10px; font-size: 15px; }
+.catalogo-v2 .modal-card p { font-size: 13px; color: var(--ink-soft); margin: 0 0 16px; }
+.catalogo-v2 .modal-actions { display: flex; gap: 8px; justify-content: flex-end; }
+
+/* Responsive (lección 22.1.b · single layout) */
+@media (max-width: 767px) {
+  .catalogo-v2 .body { padding: 16px; }
+  .catalogo-v2 .topbar { flex-wrap: wrap; gap: 8px; }
+  .catalogo-v2 .catalog-toolbar { flex-direction: column; }
+  .catalogo-v2 .catalog-toolbar select.input { max-width: none; }
+  .catalogo-v2 .catalog-row { grid-template-columns: 1fr; gap: 4px; }
+  .catalogo-v2 .catalog-viewer-grid { grid-template-columns: 1fr; }
+  .catalogo-v2 .import-tabs { flex-direction: column; }
+  .catalogo-v2 .diff-table { overflow-x: auto; }
+}

--- a/web/src/components/catalog/CatalogImport.tsx
+++ b/web/src/components/catalog/CatalogImport.tsx
@@ -1,0 +1,582 @@
+/**
+ * CatalogImport · sub-PR 22.2.b · importador Dux full-page (3 estados).
+ *
+ *   A. upload   → drag-drop + validación client (ext/size/MIME) → preview
+ *   B. preview  → diff por catálogo (tabs · counters · tabla expandible),
+ *                 selección de catálogos + include_new → apply
+ *   C. success  → stats por catálogo + links al viewer · "Importar otro"
+ *
+ * iva_warning: banner GLOBAL (decisión 22.2.b · el backend solo emite flag
+ * global · si está activo el backend RECHAZA el apply → deshabilitamos el
+ * botón y explicamos). Bug encoding latin-1 se arregla en el backend.
+ */
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { importApply, importPreview } from "@/lib/api";
+import { ApiError } from "@/lib/api/types";
+import type { CatalogDiff, ImportApplyResponse, ImportPreview } from "@/lib/api/types";
+
+const VALID_EXT = [".xls", ".xlsx", ".csv"];
+const VALID_MIME = [
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.ms-excel",
+  "text/csv",
+  "", // algunos browsers no setean MIME para .csv → permitir y validar por extensión
+];
+const MAX_BYTES = 50 * 1024 * 1024; // 50 MB · backend NO valida tamaño (mitigación client-side)
+
+type Phase =
+  | { kind: "upload" }
+  | { kind: "analyzing" }
+  | { kind: "preview"; preview: ImportPreview }
+  | { kind: "applying" }
+  | { kind: "success"; result: ImportApplyResponse };
+
+function validateFile(file: File): string | null {
+  const lower = file.name.toLowerCase();
+  if (!VALID_EXT.some((e) => lower.endsWith(e))) {
+    return `Extensión no soportada. Usá ${VALID_EXT.join(", ")}.`;
+  }
+  if (file.size > MAX_BYTES) {
+    return `El archivo supera 50 MB (${(file.size / 1024 / 1024).toFixed(1)} MB).`;
+  }
+  if (file.type && !VALID_MIME.includes(file.type)) {
+    return `Tipo de archivo inesperado (${file.type}). Exportá como Excel o CSV desde Dux.`;
+  }
+  return null;
+}
+
+export function CatalogImport() {
+  const [phase, setPhase] = useState<Phase>({ kind: "upload" });
+  const [file, setFile] = useState<File | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [apiError, setApiError] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const [slow, setSlow] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [includeNew, setIncludeNew] = useState(true);
+  const [activeTab, setActiveTab] = useState<string | null>(null);
+  const [confirmApply, setConfirmApply] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Banner "siendo procesado" si analyzing tarda >10s.
+  useEffect(() => {
+    if (phase.kind !== "analyzing" && phase.kind !== "applying") {
+      setSlow(false);
+      return;
+    }
+    const t = setTimeout(() => setSlow(true), 10_000);
+    return () => clearTimeout(t);
+  }, [phase.kind]);
+
+  const acceptFile = (f: File) => {
+    setApiError(null);
+    const err = validateFile(f);
+    if (err) {
+      setValidationError(err);
+      setFile(null);
+      return;
+    }
+    setValidationError(null);
+    setFile(f);
+  };
+
+  const runPreview = async () => {
+    if (!file) return;
+    setApiError(null);
+    setPhase({ kind: "analyzing" });
+    try {
+      const preview = await importPreview(file);
+      const catNames = Object.keys(preview.catalogs);
+      // Preselección: todos los catálogos afectados (el operador deselecciona).
+      setSelected(new Set(catNames));
+      setActiveTab(catNames[0] ?? null);
+      setPhase({ kind: "preview", preview });
+    } catch (err) {
+      setApiError(err instanceof ApiError ? err.message : "No se pudo analizar el archivo.");
+      setPhase({ kind: "upload" });
+    }
+  };
+
+  const runApply = async (preview: ImportPreview) => {
+    if (!file) return;
+    setConfirmApply(false);
+    setApiError(null);
+    setPhase({ kind: "applying" });
+    try {
+      const result = await importApply({
+        file,
+        catalogs: Array.from(selected),
+        includeNew,
+        sourceFile: file.name,
+      });
+      setPhase({ kind: "success", result });
+    } catch (err) {
+      setApiError(err instanceof ApiError ? err.message : "No se pudo aplicar la importación.");
+      setPhase({ kind: "preview", preview });
+    }
+  };
+
+  const reset = () => {
+    setPhase({ kind: "upload" });
+    setFile(null);
+    setValidationError(null);
+    setApiError(null);
+    setSelected(new Set());
+    setIncludeNew(true);
+    setActiveTab(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  return (
+    <div className="catalog-import" data-testid="catalog-import">
+      {apiError && (
+        <div className="banner err" role="alert" data-testid="import-api-error">
+          {apiError}
+        </div>
+      )}
+
+      {(phase.kind === "upload" || phase.kind === "analyzing") && (
+        <UploadState
+          phase={phase.kind}
+          file={file}
+          dragOver={dragOver}
+          slow={slow}
+          validationError={validationError}
+          fileInputRef={fileInputRef}
+          onDragOver={setDragOver}
+          onPick={acceptFile}
+          onSubmit={runPreview}
+        />
+      )}
+
+      {phase.kind === "preview" && (
+        <PreviewState
+          preview={phase.preview}
+          selected={selected}
+          includeNew={includeNew}
+          activeTab={activeTab}
+          onToggleCatalog={(name) =>
+            setSelected((prev) => {
+              const next = new Set(prev);
+              if (next.has(name)) next.delete(name);
+              else next.add(name);
+              return next;
+            })
+          }
+          onIncludeNew={setIncludeNew}
+          onTab={setActiveTab}
+          onApply={() => setConfirmApply(true)}
+        />
+      )}
+
+      {phase.kind === "applying" && (
+        <div className="import-spinner" data-testid="import-applying">
+          <p>Aplicando importación…</p>
+          {slow && <p className="meta">Se generan backups automáticos · puede tardar unos segundos.</p>}
+        </div>
+      )}
+
+      {phase.kind === "success" && <SuccessState result={phase.result} onAnother={reset} />}
+
+      {confirmApply && phase.kind === "preview" && (
+        <div className="modal-backdrop" role="dialog" aria-modal="true" data-testid="apply-confirm">
+          <div className="modal-card">
+            <h3>Confirmar importación</h3>
+            <p>
+              Vas a actualizar <strong>{selected.size}</strong>{" "}
+              {selected.size === 1 ? "catálogo" : "catálogos"}. Se genera un backup automático de cada
+              uno antes de aplicar.
+            </p>
+            <div className="modal-actions">
+              <button
+                type="button"
+                className="btn ghost"
+                onClick={() => setConfirmApply(false)}
+                data-testid="apply-cancel"
+              >
+                Cancelar
+              </button>
+              <button
+                type="button"
+                className="btn primary"
+                onClick={() => runApply(phase.preview)}
+                data-testid="apply-confirm-yes"
+              >
+                Aplicar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Estado A · upload ────────────────────────────────────────────── */
+
+function UploadState({
+  phase,
+  file,
+  dragOver,
+  slow,
+  validationError,
+  fileInputRef,
+  onDragOver,
+  onPick,
+  onSubmit,
+}: {
+  phase: "upload" | "analyzing";
+  file: File | null;
+  dragOver: boolean;
+  slow: boolean;
+  validationError: string | null;
+  fileInputRef: React.RefObject<HTMLInputElement>;
+  onDragOver: (v: boolean) => void;
+  onPick: (f: File) => void;
+  onSubmit: () => void;
+}) {
+  if (phase === "analyzing") {
+    return (
+      <div className="import-spinner" data-testid="import-analyzing">
+        <p>Analizando archivo…</p>
+        {slow && (
+          <p className="meta" data-testid="import-slow-banner">
+            El archivo está siendo procesado · puede tardar unos segundos.
+          </p>
+        )}
+      </div>
+    );
+  }
+  return (
+    <div className="col">
+      <div className="section-head">
+        <h2>Importar desde Dux</h2>
+        <span className="meta">
+          Subí el export de Dux (.xls, .xlsx o .csv). Vas a poder revisar los cambios antes de
+          aplicarlos. Los ítems con precio $0 se omiten y los faltantes nunca se borran.
+        </span>
+      </div>
+
+      <div
+        className={`import-dropzone${dragOver ? " over" : ""}`}
+        data-testid="import-dropzone"
+        onDragOver={(e) => {
+          e.preventDefault();
+          onDragOver(true);
+        }}
+        onDragLeave={() => onDragOver(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          onDragOver(false);
+          const f = e.dataTransfer.files?.[0];
+          if (f) onPick(f);
+        }}
+        onClick={() => fileInputRef.current?.click()}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") fileInputRef.current?.click();
+        }}
+      >
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".xls,.xlsx,.csv"
+          data-testid="import-file-input"
+          style={{ display: "none" }}
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) onPick(f);
+          }}
+        />
+        {file ? (
+          <p data-testid="import-file-name">
+            <strong className="mono">{file.name}</strong> · {(file.size / 1024).toFixed(0)} KB
+          </p>
+        ) : (
+          <p>Arrastrá el archivo acá o hacé click para elegirlo.</p>
+        )}
+      </div>
+
+      {validationError && (
+        <div className="banner err" role="alert" data-testid="import-validation-error">
+          {validationError}
+        </div>
+      )}
+
+      <div className="config-actions" style={{ marginTop: 8 }}>
+        <button
+          type="button"
+          className="btn primary"
+          disabled={!file}
+          onClick={onSubmit}
+          data-testid="import-analyze-btn"
+        >
+          Analizar archivo
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ── Estado B · preview ───────────────────────────────────────────── */
+
+function counts(diff: CatalogDiff) {
+  return {
+    updated: diff.updated.length,
+    normalized: diff.normalized.length,
+    new: diff.new.length,
+    missing: diff.missing.length,
+    zero_price: diff.zero_price.length,
+    unchanged: diff.unchanged,
+  };
+}
+
+function PreviewState({
+  preview,
+  selected,
+  includeNew,
+  activeTab,
+  onToggleCatalog,
+  onIncludeNew,
+  onTab,
+  onApply,
+}: {
+  preview: ImportPreview;
+  selected: Set<string>;
+  includeNew: boolean;
+  activeTab: string | null;
+  onToggleCatalog: (name: string) => void;
+  onIncludeNew: (v: boolean) => void;
+  onTab: (name: string) => void;
+  onApply: () => void;
+}) {
+  const catNames = Object.keys(preview.catalogs);
+  const active = activeTab && preview.catalogs[activeTab] ? preview.catalogs[activeTab] : null;
+  const applyBlocked = preview.iva_warning || selected.size === 0;
+
+  return (
+    <div className="col" data-testid="import-preview">
+      <div className="section-head">
+        <h2>Revisar cambios</h2>
+        <span className="meta">
+          {preview.total_items} ítems leídos · formato {preview.format} · {catNames.length}{" "}
+          {catNames.length === 1 ? "catálogo afectado" : "catálogos afectados"}
+        </span>
+      </div>
+
+      {preview.iva_warning && (
+        <div className="banner err" role="alert" data-testid="import-iva-warning">
+          El archivo solo trae columna de precio <strong>CON IVA</strong>. No se puede importar sin
+          confirmar la conversión a precio sin IVA. Re-exportá desde Dux incluyendo la columna de
+          precio sin IVA.
+        </div>
+      )}
+      {preview.currency_mismatch && (
+        <div className="banner warn" role="alert" data-testid="import-currency-warning">
+          La moneda del archivo difiere de la del catálogo en al menos un catálogo. Se usa la moneda
+          del catálogo para comparar.
+        </div>
+      )}
+      {preview.warnings.length > 0 && (
+        <ul className="import-warnings" data-testid="import-warnings">
+          {preview.warnings.map((w, i) => (
+            <li key={i} className="meta">
+              {w}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="import-tabs" data-testid="import-tabs" role="tablist">
+        {catNames.map((name) => {
+          const c = counts(preview.catalogs[name]);
+          return (
+            <div key={name} className={`import-tab${activeTab === name ? " active" : ""}`}>
+              <input
+                type="checkbox"
+                checked={selected.has(name)}
+                onChange={() => onToggleCatalog(name)}
+                data-testid={`catalog-select-${name}`}
+                aria-label={`Incluir ${name}`}
+              />
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeTab === name}
+                onClick={() => onTab(name)}
+                data-testid={`catalog-tab-${name}`}
+              >
+                <span className="mono">{name}</span>
+                <span className="meta">
+                  {c.updated} act · {c.new} nuevos · {c.zero_price} en $0
+                </span>
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {active && <DiffTable diff={active} />}
+
+      <label className="include-new" style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <input
+          type="checkbox"
+          checked={includeNew}
+          onChange={(e) => onIncludeNew(e.target.checked)}
+          data-testid="include-new"
+        />
+        <span>Agregar ítems nuevos (no presentes hoy en el catálogo)</span>
+      </label>
+
+      <div className="config-actions" style={{ marginTop: 8 }}>
+        <button
+          type="button"
+          className="btn primary"
+          disabled={applyBlocked}
+          onClick={onApply}
+          data-testid="import-apply-btn"
+        >
+          Aplicar a {selected.size} {selected.size === 1 ? "catálogo" : "catálogos"}
+        </button>
+        {preview.iva_warning && (
+          <span className="meta" style={{ color: "var(--error)" }}>
+            Importación bloqueada por la columna CON IVA.
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DiffTable({ diff }: { diff: CatalogDiff }) {
+  const c = counts(diff);
+  return (
+    <div className="diff-table" data-testid={`diff-table-${diff.catalog}`}>
+      <div className="diff-counters">
+        <span className="diff-badge updated">{c.updated} actualizados</span>
+        <span className="diff-badge normalized">{c.normalized} normalizados</span>
+        <span className="diff-badge new">{c.new} nuevos</span>
+        <span className="diff-badge zero">{c.zero_price} en $0 (omitidos)</span>
+        <span className="diff-badge missing">{c.missing} faltantes (no se borran)</span>
+        <span className="diff-badge unchanged">{c.unchanged} sin cambios</span>
+      </div>
+
+      {diff.updated.length > 0 && (
+        <details open>
+          <summary>Actualizados ({diff.updated.length})</summary>
+          <table>
+            <thead>
+              <tr>
+                <th>SKU</th>
+                <th>Nombre</th>
+                <th>Antes</th>
+                <th>Después</th>
+                <th>Δ%</th>
+              </tr>
+            </thead>
+            <tbody>
+              {diff.updated.map((u) => (
+                <tr key={u.sku} className={Math.abs(u.change_pct) > 30 ? "row-warn" : ""}>
+                  <td className="mono">{u.sku}</td>
+                  <td>{u.name}</td>
+                  <td>{u.old_price}</td>
+                  <td>{u.new_price}</td>
+                  <td>{u.change_pct > 0 ? `+${u.change_pct}` : u.change_pct}%</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </details>
+      )}
+
+      {diff.new.length > 0 && (
+        <details>
+          <summary>Nuevos ({diff.new.length})</summary>
+          <table>
+            <thead>
+              <tr>
+                <th>SKU</th>
+                <th>Nombre</th>
+                <th>Precio</th>
+              </tr>
+            </thead>
+            <tbody>
+              {diff.new.map((n) => (
+                <tr key={n.sku}>
+                  <td className="mono">{n.sku}</td>
+                  <td>{n.name}</td>
+                  <td>{n.price}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </details>
+      )}
+
+      {diff.zero_price.length > 0 && (
+        <details>
+          <summary>Precio $0 — omitidos ({diff.zero_price.length})</summary>
+          <ul>
+            {diff.zero_price.map((z) => (
+              <li key={z.sku} className="mono">
+                {z.sku} · {z.name}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
+}
+
+/* ── Estado C · success ───────────────────────────────────────────── */
+
+function SuccessState({
+  result,
+  onAnother,
+}: {
+  result: ImportApplyResponse;
+  onAnother: () => void;
+}) {
+  const entries = Object.entries(result.results);
+  return (
+    <div className="col" data-testid="import-success">
+      <div className="section-head">
+        <h2>Importación aplicada</h2>
+        <span className="meta">
+          Archivo {result.source_file} · se generó un backup por catálogo antes de aplicar.
+        </span>
+      </div>
+
+      <ul className="import-results">
+        {entries.map(([name, r]) => (
+          <li key={name} className="import-result-row" data-testid={`import-result-${name}`}>
+            <Link href={`/catalogo/${encodeURIComponent(name)}`} className="mono">
+              {name}
+            </Link>
+            {r.ok ? (
+              <span className="meta">
+                {r.updated ?? 0} actualizados · {r.normalized ?? 0} normalizados · {r.added ?? 0}{" "}
+                nuevos · {r.skipped_zero ?? 0} en $0 omitidos
+              </span>
+            ) : (
+              <span className="meta" style={{ color: "var(--error)" }}>
+                {r.error}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      <div className="config-actions" style={{ marginTop: 8 }}>
+        <button type="button" className="btn ghost" onClick={onAnother} data-testid="import-another">
+          Importar otro
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/catalog/CatalogList.tsx
+++ b/web/src/components/catalog/CatalogList.tsx
@@ -1,0 +1,141 @@
+/**
+ * CatalogList · sub-PR 22.2.b · lista de catálogos con search + sort.
+ *
+ * Fetch client-side (GET /api/catalog/ vía api layer · mock/real switch).
+ * Orden default por categoría: materiales → granito → servicios → config.
+ * Click en fila → /catalogo/[name].
+ */
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { listCatalogs } from "@/lib/api";
+import type { CatalogMeta } from "@/lib/api/types";
+
+type SortKey = "default" | "name" | "item_count" | "last_updated";
+
+/** materiales(0) → granito(1) → servicios(2) → config/otros(3). */
+function categoryRank(name: string): number {
+  if (name.startsWith("materials-granito")) return 1;
+  if (name.startsWith("materials-")) return 0;
+  if (["labor", "delivery-zones", "sinks"].includes(name)) return 2;
+  return 3;
+}
+
+/** dd/mm/yyyy → epoch para ordenar; null/inválido → 0. */
+function parseUpdated(s: string | null): number {
+  if (!s) return 0;
+  const m = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(s);
+  if (!m) return 0;
+  return new Date(Number(m[3]), Number(m[2]) - 1, Number(m[1])).getTime();
+}
+
+export function CatalogList() {
+  const [catalogs, setCatalogs] = useState<CatalogMeta[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<SortKey>("default");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await listCatalogs();
+        if (!cancelled) setCatalogs(data);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Error desconocido");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const visible = useMemo(() => {
+    if (!catalogs) return [];
+    const q = query.trim().toLowerCase();
+    const filtered = q ? catalogs.filter((c) => c.name.toLowerCase().includes(q)) : catalogs;
+    const sorted = [...filtered];
+    sorted.sort((a, b) => {
+      switch (sort) {
+        case "name":
+          return a.name.localeCompare(b.name);
+        case "item_count":
+          return b.item_count - a.item_count;
+        case "last_updated":
+          return parseUpdated(b.last_updated) - parseUpdated(a.last_updated);
+        default:
+          return categoryRank(a.name) - categoryRank(b.name) || a.name.localeCompare(b.name);
+      }
+    });
+    return sorted;
+  }, [catalogs, query, sort]);
+
+  if (error) {
+    return (
+      <div data-testid="catalog-list-error" role="alert" style={{ color: "var(--error)" }}>
+        No pude cargar los catálogos: {error}
+      </div>
+    );
+  }
+
+  if (!catalogs) {
+    return (
+      <div data-testid="catalog-list-loading" style={{ color: "var(--ink-mute)" }}>
+        Cargando catálogos…
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="catalog-list">
+      <div className="catalog-toolbar">
+        <input
+          className="input"
+          type="search"
+          placeholder="Buscar catálogo…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          data-testid="catalog-search"
+          aria-label="Buscar catálogo"
+        />
+        <select
+          className="input"
+          value={sort}
+          onChange={(e) => setSort(e.target.value as SortKey)}
+          data-testid="catalog-sort"
+          aria-label="Ordenar catálogos"
+        >
+          <option value="default">Orden por categoría</option>
+          <option value="name">Nombre (A→Z)</option>
+          <option value="item_count">Ítems (mayor primero)</option>
+          <option value="last_updated">Actualización (reciente primero)</option>
+        </select>
+      </div>
+
+      {visible.length === 0 ? (
+        <p data-testid="catalog-list-empty" style={{ color: "var(--ink-mute)", marginTop: 12 }}>
+          No hay catálogos que coincidan con “{query}”.
+        </p>
+      ) : (
+        <ul className="catalog-rows" data-testid="catalog-rows">
+          {visible.map((c) => (
+            <li key={c.name}>
+              <Link
+                href={`/catalogo/${encodeURIComponent(c.name)}`}
+                className="catalog-row"
+                data-testid={`catalog-row-${c.name}`}
+              >
+                <span className="catalog-row-name mono">{c.name}</span>
+                <span className="catalog-row-count">{c.item_count} ítems</span>
+                <span className="catalog-row-updated meta">
+                  {c.last_updated ? `Act. ${c.last_updated}` : "—"}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/catalog/CatalogViewer.tsx
+++ b/web/src/components/catalog/CatalogViewer.tsx
@@ -1,0 +1,223 @@
+/**
+ * CatalogViewer · sub-PR 22.2.b · viewer JSON read-only + backups + restore.
+ *
+ * GET /api/catalog/{name} → JSON crudo (read-only · sin editor manual).
+ * GET /api/catalog/backups/{name} → últimas 20 versiones · cada una
+ * restaurable (POST /backups/{id}/restore · el backend auto-backupea el
+ * estado actual antes de restaurar · safety net).
+ */
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { getCatalog, listBackups, restoreBackup } from "@/lib/api";
+import type { CatalogBackup } from "@/lib/api/types";
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return "—";
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return iso;
+  const diffMs = Date.now() - t;
+  const day = 86_400_000;
+  if (diffMs < 0) return new Date(iso).toLocaleString();
+  if (diffMs < day) return "hoy";
+  const days = Math.floor(diffMs / day);
+  if (days === 1) return "ayer";
+  if (days < 30) return `hace ${days} días`;
+  const months = Math.floor(days / 30);
+  return months === 1 ? "hace 1 mes" : `hace ${months} meses`;
+}
+
+function statsSummary(stats: CatalogBackup["stats"]): string {
+  if (!stats) return "";
+  const obj = typeof stats === "string" ? safeParse(stats) : stats;
+  if (!obj) return typeof stats === "string" ? stats : "";
+  const parts: string[] = [];
+  if (typeof obj.items_before === "number") parts.push(`${obj.items_before} ítems`);
+  if (typeof obj.updated === "number") parts.push(`${obj.updated} actualizados`);
+  if (typeof obj.new === "number") parts.push(`${obj.new} nuevos`);
+  if (typeof obj.reason === "string") parts.push(obj.reason);
+  return parts.join(" · ");
+}
+
+function safeParse(s: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(s) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function deriveMeta(content: unknown): { count: number; lastUpdated: string | null } {
+  const items = Array.isArray(content)
+    ? content
+    : content && typeof content === "object" && Array.isArray((content as { items?: unknown }).items)
+      ? ((content as { items: unknown[] }).items)
+      : [];
+  const first = items[0] as { last_updated?: string } | undefined;
+  return {
+    count: Array.isArray(content) ? content.length : items.length || 1,
+    lastUpdated: first?.last_updated ?? null,
+  };
+}
+
+export function CatalogViewer({ name }: { name: string }) {
+  const [content, setContent] = useState<unknown>(null);
+  const [backups, setBackups] = useState<CatalogBackup[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmId, setConfirmId] = useState<number | null>(null);
+  const [restoring, setRestoring] = useState(false);
+  const [toast, setToast] = useState<{ kind: "ok" | "err"; msg: string } | null>(null);
+
+  const load = useCallback(async () => {
+    const [c, b] = await Promise.all([getCatalog(name), listBackups(name)]);
+    setContent(c);
+    setBackups(b);
+  }, [name]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        await load();
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Error desconocido");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [load]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(null), 4000);
+    return () => clearTimeout(t);
+  }, [toast]);
+
+  const handleRestore = async (id: number) => {
+    setRestoring(true);
+    try {
+      await restoreBackup(id);
+      setConfirmId(null);
+      await load();
+      setToast({ kind: "ok", msg: `Catálogo restaurado desde backup #${id}.` });
+    } catch (err) {
+      setConfirmId(null);
+      setToast({ kind: "err", msg: err instanceof Error ? err.message : "Falló la restauración." });
+    } finally {
+      setRestoring(false);
+    }
+  };
+
+  if (error) {
+    return (
+      <div data-testid="catalog-viewer-error" role="alert" style={{ color: "var(--error)" }}>
+        No pude cargar el catálogo: {error}
+      </div>
+    );
+  }
+
+  if (content === null || backups === null) {
+    return (
+      <div data-testid="catalog-viewer-loading" style={{ color: "var(--ink-mute)" }}>
+        Cargando catálogo…
+      </div>
+    );
+  }
+
+  const meta = deriveMeta(content);
+
+  return (
+    <div className="catalog-viewer">
+      <div className="section-head">
+        <h2 className="mono">{name}</h2>
+        <span className="meta">
+          {meta.count} ítems{meta.lastUpdated ? ` · última actualización ${meta.lastUpdated}` : ""}
+        </span>
+      </div>
+
+      <div className="catalog-viewer-grid">
+        <section className="catalog-json-pane">
+          <h3>Contenido</h3>
+          <pre className="catalog-json" data-testid="catalog-json">
+            {JSON.stringify(content, null, 2)}
+          </pre>
+        </section>
+
+        <aside className="catalog-backups-pane">
+          <h3>Versiones anteriores</h3>
+          {backups.length === 0 ? (
+            <p data-testid="backup-list-empty" style={{ color: "var(--ink-mute)", fontSize: 13 }}>
+              Sin backups todavía. Se generan automáticamente al importar o restaurar.
+            </p>
+          ) : (
+            <ul className="backup-list" data-testid="backup-list">
+              {backups.map((b) => (
+                <li key={b.id} className="backup-row" data-testid={`backup-row-${b.id}`}>
+                  <div className="backup-row-main">
+                    <span className="backup-when">{formatRelative(b.created_at)}</span>
+                    <span className="backup-source mono">{b.source_file ?? "—"}</span>
+                  </div>
+                  {statsSummary(b.stats) && (
+                    <span className="backup-stats meta">{statsSummary(b.stats)}</span>
+                  )}
+                  <button
+                    type="button"
+                    className="btn ghost"
+                    data-testid={`backup-restore-${b.id}`}
+                    onClick={() => setConfirmId(b.id)}
+                  >
+                    Restaurar
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </aside>
+      </div>
+
+      {confirmId !== null && (
+        <div className="modal-backdrop" role="dialog" aria-modal="true" data-testid="restore-confirm">
+          <div className="modal-card">
+            <h3>Restaurar backup #{confirmId}</h3>
+            <p>
+              Vas a reemplazar el contenido actual de <strong className="mono">{name}</strong> por el
+              de este backup. Se genera un backup automático del estado actual antes de restaurar.
+            </p>
+            <div className="modal-actions">
+              <button
+                type="button"
+                className="btn ghost"
+                onClick={() => setConfirmId(null)}
+                disabled={restoring}
+                data-testid="restore-cancel"
+              >
+                Cancelar
+              </button>
+              <button
+                type="button"
+                className="btn primary"
+                onClick={() => handleRestore(confirmId)}
+                disabled={restoring}
+                data-testid="restore-confirm-yes"
+              >
+                {restoring ? "Restaurando…" : "Restaurar"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {toast && (
+        <div
+          className="catalog-toast"
+          role="status"
+          data-testid="catalog-toast"
+          style={{ color: toast.kind === "ok" ? "var(--ok, #4ade80)" : "var(--error)" }}
+        >
+          {toast.msg}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -62,6 +62,16 @@ export const triggerPdfV2Generation = mocks.triggerPdfV2Generation;
 /* ─── Audit trail copy · Sprint 4 audit-trail-copy ────────────────── */
 export const getAuditLog = USE_REAL_API ? real.getAuditLog : mocks.getAuditLog;
 
+/* ─── Catálogo · viewer + Dux importer + backups · sub-PR 22.2.b ───
+   Los 8 endpoints catalog mapean limpio a REST → wire real con el flag
+   activo · mocks deterministas en CI/dev. */
+export const listCatalogs = USE_REAL_API ? real.listCatalogs : mocks.listCatalogs;
+export const getCatalog = USE_REAL_API ? real.getCatalog : mocks.getCatalog;
+export const listBackups = USE_REAL_API ? real.listBackups : mocks.listBackups;
+export const restoreBackup = USE_REAL_API ? real.restoreBackup : mocks.restoreBackup;
+export const importPreview = USE_REAL_API ? real.importPreview : mocks.importPreview;
+export const importApply = USE_REAL_API ? real.importApply : mocks.importApply;
+
 /* ─── Catalog config · sub-PR 22.2.a config-ui-page ──────────────── */
 export const getCatalogConfig = USE_REAL_API ? real.getCatalogConfig : mocks.getCatalogConfig;
 export const updateCatalogConfig = USE_REAL_API

--- a/web/src/lib/api/mocks.ts
+++ b/web/src/lib/api/mocks.ts
@@ -1263,3 +1263,159 @@ export async function updateCatalogConfig(
 export function _resetCatalogConfigStore(): void {
   _catalogConfigStore = structuredClone(_catalogConfigDefaults);
 }
+
+/* ─── Catálogo · viewer + Dux importer + backups (sub-PR 22.2.b) ──────
+   Mocks deterministas para CI/dev (modo mock · sin NEXT_PUBLIC_API_URL).
+   Espejan el shape del backend. El importPreview varía por nombre de
+   archivo para que los e2e ejerciten el banner iva_warning y el diff. */
+
+import type {
+  CatalogBackup,
+  CatalogContent,
+  CatalogMeta,
+  ImportApplyResponse,
+  ImportPreview,
+  RestoreBackupResponse,
+} from "./types";
+
+const _catalogMetaMock: readonly CatalogMeta[] = [
+  { name: "materials-silestone", item_count: 24, last_updated: "04/11/2025" },
+  { name: "materials-purastone", item_count: 18, last_updated: "08/01/2026" },
+  { name: "materials-dekton", item_count: 20, last_updated: "08/09/2025" },
+  { name: "materials-neolith", item_count: 15, last_updated: "08/09/2025" },
+  { name: "materials-puraprima", item_count: 12, last_updated: "29/09/2025" },
+  { name: "materials-laminatto", item_count: 10, last_updated: "02/12/2025" },
+  { name: "materials-granito-nacional", item_count: 30, last_updated: "05/02/2026" },
+  { name: "materials-granito-importado", item_count: 22, last_updated: "08/09/2025" },
+  { name: "materials-marmol", item_count: 16, last_updated: "08/09/2025" },
+  { name: "labor", item_count: 8, last_updated: "25/03/2026" },
+  { name: "delivery-zones", item_count: 32, last_updated: "15/12/2025" },
+  { name: "sinks", item_count: 14, last_updated: "31/10/2025" },
+  { name: "architects", item_count: 8, last_updated: null },
+  { name: "config", item_count: 1, last_updated: null },
+];
+
+export async function listCatalogs(): Promise<CatalogMeta[]> {
+  return structuredClone(_catalogMetaMock) as CatalogMeta[];
+}
+
+export async function getCatalog(name: string): Promise<CatalogContent> {
+  if (name === "config") return structuredClone(_catalogConfigStore);
+  // Lista representativa de ítems para el viewer.
+  const currency = name === "labor" || name.includes("nacional") ? "ARS" : "USD";
+  const field = currency === "ARS" ? "price_ars" : "price_usd";
+  return [
+    { sku: "SKU001", name: `${name} · item 1`, [field]: 12500, currency, price_includes_vat: false, last_updated: "04/11/2025" },
+    { sku: "SKU002", name: `${name} · item 2`, [field]: 18900, currency, price_includes_vat: false, last_updated: "04/11/2025" },
+    { sku: "SKU003", name: `${name} · item 3`, [field]: 9300, currency, price_includes_vat: false, last_updated: "04/11/2025" },
+  ];
+}
+
+const _backupsMock: Record<number, { catalog_name: string } & CatalogBackup> = {
+  101: {
+    id: 101,
+    catalog_name: "materials-silestone",
+    created_at: "2026-05-20T14:32:00",
+    source_file: "dux_materials_2026-05.xlsx",
+    stats: { items_before: 24, updated: 6, new: 2 },
+  },
+  102: {
+    id: 102,
+    catalog_name: "materials-silestone",
+    created_at: "2026-04-02T09:10:00",
+    source_file: "dux_materials_2026-04.xlsx",
+    stats: { items_before: 22, updated: 4, new: 0 },
+  },
+};
+
+export async function listBackups(name: string): Promise<CatalogBackup[]> {
+  return Object.values(_backupsMock)
+    .filter((b) => b.catalog_name === name)
+    .map(({ catalog_name: _c, ...rest }) => structuredClone(rest));
+}
+
+export async function restoreBackup(backupId: number): Promise<RestoreBackupResponse> {
+  const b = _backupsMock[backupId];
+  return {
+    ok: true,
+    catalog: b?.catalog_name ?? "materials-silestone",
+    restored_from_backup: backupId,
+  };
+}
+
+export async function importPreview(file: File): Promise<ImportPreview> {
+  // El nombre del archivo dispara el flag global iva_warning (e2e del banner).
+  const ivaWarning = /iva/i.test(file.name);
+  return {
+    format: "dux_materials",
+    total_items: 28,
+    iva_warning: ivaWarning,
+    currency_mismatch: false,
+    warnings: ivaWarning
+      ? ["El archivo solo tiene columna de precio CON IVA."]
+      : ["SKU 'SIL-999': cambio de precio +42.0% (100 → 142)"],
+    catalogs: {
+      "materials-silestone": {
+        catalog: "materials-silestone",
+        currency: "USD",
+        file_currency: "USD",
+        price_field: "price_usd",
+        updated: [
+          { sku: "SIL-001", name: "Silestone Blanco", old_price: 120, new_price: 135, change_pct: 12.5 },
+          { sku: "SIL-999", name: "Silestone Negro", old_price: 100, new_price: 142, change_pct: 42.0 },
+        ],
+        normalized: [{ sku: "SIL-010", name: "Silestone Gris", old_price: 99.999, new_price: 100.0 }],
+        new: [{ sku: "SIL-200", name: "Silestone Arena", price: 155 }],
+        missing: [{ sku: "SIL-050", name: "Silestone Marfil", price: 110 }],
+        zero_price: [{ sku: "SIL-300", name: "Silestone Demo" }],
+        unchanged: 19,
+        warnings: ["SKU 'SIL-999': cambio de precio +42.0% (100 → 142)"],
+        total_in_file: 23,
+        total_in_catalog: 24,
+      },
+      "materials-dekton": {
+        catalog: "materials-dekton",
+        currency: "USD",
+        file_currency: "USD",
+        price_field: "price_usd",
+        updated: [{ sku: "DEK-001", name: "Dekton Aura", old_price: 200, new_price: 210, change_pct: 5.0 }],
+        normalized: [],
+        new: [],
+        missing: [],
+        zero_price: [],
+        unchanged: 19,
+        warnings: [],
+        total_in_file: 20,
+        total_in_catalog: 20,
+      },
+    },
+    unmatched: [{ sku: "XYZ-001", name: "Item sin catálogo", price: 50 }],
+  };
+}
+
+export async function importApply(input: {
+  file: File;
+  catalogs: string[];
+  includeNew: boolean;
+  sourceFile: string;
+}): Promise<ImportApplyResponse> {
+  const results: ImportApplyResponse["results"] = {};
+  for (const cat of input.catalogs) {
+    if (cat === "materials-silestone") {
+      results[cat] = {
+        ok: true,
+        updated: 2,
+        normalized: 1,
+        added: input.includeNew ? 1 : 0,
+        skipped_zero: 1,
+      };
+    } else {
+      results[cat] = { ok: true, updated: 1, normalized: 0, added: 0, skipped_zero: 0 };
+    }
+  }
+  return {
+    ok: true,
+    results,
+    source_file: input.sourceFile || input.file.name,
+  };
+}

--- a/web/src/lib/api/real.ts
+++ b/web/src/lib/api/real.ts
@@ -603,3 +603,157 @@ export async function updateCatalogConfig(
   }
   return (await response.json()) as { ok: boolean; catalog: string };
 }
+
+/* ─── Catálogo · viewer + Dux importer + backups (sub-PR 22.2.b) ──────
+   Wire directo contra los 8 endpoints de catalog/router.py. Mismo patrón
+   que getCatalogConfig: apiFetch + bearerToken opcional (SSR) + ApiError
+   con code semántico. Los multipart (import) NO setean Content-Type (el
+   browser lo arma con el boundary). */
+
+import type {
+  CatalogBackup,
+  CatalogContent,
+  CatalogMeta,
+  ImportApplyResponse,
+  ImportPreview,
+  RestoreBackupResponse,
+} from "./types";
+
+type AuthOpts = { signal?: AbortSignal; bearerToken?: string | null };
+
+export async function listCatalogs(options?: AuthOpts): Promise<CatalogMeta[]> {
+  const { signal, bearerToken } = options ?? {};
+  const response = await apiFetch(`/api/catalog/`, { signal, bearerToken }, 15_000);
+  if (!response.ok) {
+    throw new ApiError(
+      "CATALOG_LIST_FAILED",
+      `GET /api/catalog/ falló (${response.status})`,
+      response.status,
+    );
+  }
+  return (await response.json()) as CatalogMeta[];
+}
+
+export async function getCatalog(
+  name: string,
+  options?: AuthOpts,
+): Promise<CatalogContent> {
+  const { signal, bearerToken } = options ?? {};
+  const response = await apiFetch(
+    `/api/catalog/${encodeURIComponent(name)}`,
+    { signal, bearerToken },
+    15_000,
+  );
+  if (!response.ok) {
+    throw new ApiError(
+      response.status === 404 ? "CATALOG_NOT_FOUND" : "CATALOG_LOAD_FAILED",
+      `GET /api/catalog/${name} falló (${response.status})`,
+      response.status,
+    );
+  }
+  return (await response.json()) as CatalogContent;
+}
+
+export async function listBackups(
+  name: string,
+  options?: AuthOpts,
+): Promise<CatalogBackup[]> {
+  const { signal, bearerToken } = options ?? {};
+  const response = await apiFetch(
+    `/api/catalog/backups/${encodeURIComponent(name)}`,
+    { signal, bearerToken },
+    15_000,
+  );
+  if (!response.ok) {
+    throw new ApiError(
+      "BACKUPS_LIST_FAILED",
+      `GET /api/catalog/backups/${name} falló (${response.status})`,
+      response.status,
+    );
+  }
+  return (await response.json()) as CatalogBackup[];
+}
+
+export async function restoreBackup(
+  backupId: number,
+  options?: AuthOpts,
+): Promise<RestoreBackupResponse> {
+  const { signal, bearerToken } = options ?? {};
+  const response = await apiFetch(
+    `/api/catalog/backups/${backupId}/restore`,
+    { method: "POST", signal, bearerToken },
+    20_000,
+  );
+  if (!response.ok) {
+    throw new ApiError(
+      response.status === 404 ? "BACKUP_NOT_FOUND" : "RESTORE_FAILED",
+      `POST /api/catalog/backups/${backupId}/restore falló (${response.status})`,
+      response.status,
+    );
+  }
+  return (await response.json()) as RestoreBackupResponse;
+}
+
+/** Lee `detail` del error 400 del backend (mensajes user-friendly de
+    encoding/formato) y lo propaga como mensaje del ApiError. */
+async function _errorDetail(response: Response, fallback: string): Promise<string> {
+  try {
+    const body = (await response.json()) as { detail?: string };
+    return body.detail || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export async function importPreview(
+  file: File,
+  options?: AuthOpts,
+): Promise<ImportPreview> {
+  const { signal, bearerToken } = options ?? {};
+  const form = new FormData();
+  form.append("file", file);
+  // Parser sincrónico sin timeout backend → damos 60s holgados (caveat PR).
+  const response = await apiFetch(
+    `/api/catalog/import-preview`,
+    { method: "POST", body: form, signal, bearerToken },
+    60_000,
+  );
+  if (!response.ok) {
+    throw new ApiError(
+      "IMPORT_PREVIEW_FAILED",
+      await _errorDetail(response, `import-preview falló (${response.status})`),
+      response.status,
+    );
+  }
+  return (await response.json()) as ImportPreview;
+}
+
+export async function importApply(
+  input: {
+    file: File;
+    catalogs: string[];
+    includeNew: boolean;
+    sourceFile: string;
+  },
+  options?: AuthOpts,
+): Promise<ImportApplyResponse> {
+  const { signal, bearerToken } = options ?? {};
+  const form = new FormData();
+  form.append("file", input.file);
+  form.append("catalogs", JSON.stringify(input.catalogs));
+  form.append("include_new", String(input.includeNew));
+  form.append("source_file", input.sourceFile);
+  const response = await apiFetch(
+    `/api/catalog/import-apply`,
+    { method: "POST", body: form, signal, bearerToken },
+    60_000,
+  );
+  if (!response.ok) {
+    throw new ApiError(
+      "IMPORT_APPLY_FAILED",
+      await _errorDetail(response, `import-apply falló (${response.status})`),
+      response.status,
+    );
+  }
+  return (await response.json()) as ImportApplyResponse;
+}

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -645,3 +645,115 @@ export function applyEditableFields(
     },
   };
 }
+
+/* ─── Catálogo · viewer + Dux importer + backups (sub-PR 22.2.b) ──────
+   Shapes espejados 1:1 del backend (api/app/modules/catalog/router.py +
+   import_parser.py). El diff `unchanged` es un COUNT (int), no lista. */
+
+/** Metadata por catálogo (GET /api/catalog/). */
+export interface CatalogMeta {
+  name: string;
+  item_count: number;
+  last_updated: string | null;
+}
+
+/** Contenido crudo de un catálogo (GET /api/catalog/{name}) — lista de
+    ítems o blob (config). El viewer lo muestra read-only. */
+export type CatalogContent = unknown;
+
+/** Backup de un catálogo (GET /api/catalog/backups/{name}). */
+export interface CatalogBackup {
+  id: number;
+  created_at: string | null;
+  source_file: string | null;
+  /** stats serializado por el backend — shape libre (items_before, updated, new...). */
+  stats: Record<string, unknown> | string | null;
+}
+
+/* ── Diff de import (POST /api/catalog/import-preview) ── */
+
+export interface ImportUpdatedItem {
+  sku: string;
+  name: string;
+  old_price: number;
+  new_price: number;
+  change_pct: number;
+}
+
+export interface ImportNormalizedItem {
+  sku: string;
+  name: string;
+  old_price: number;
+  new_price: number;
+}
+
+export interface ImportNewItem {
+  sku: string;
+  name: string;
+  price: number;
+}
+
+export interface ImportMissingItem {
+  sku: string;
+  name: string;
+  price: number;
+}
+
+export interface ImportZeroPriceItem {
+  sku: string;
+  name: string;
+}
+
+/** Diff por catálogo dentro del preview. */
+export interface CatalogDiff {
+  catalog: string;
+  currency: string;
+  file_currency: string;
+  price_field: string;
+  updated: ImportUpdatedItem[];
+  normalized: ImportNormalizedItem[];
+  new: ImportNewItem[];
+  missing: ImportMissingItem[];
+  zero_price: ImportZeroPriceItem[];
+  /** COUNT (no lista) de ítems sin cambios. */
+  unchanged: number;
+  warnings: string[];
+  total_in_file: number;
+  total_in_catalog: number;
+}
+
+/** Respuesta de POST /api/catalog/import-preview. */
+export interface ImportPreview {
+  format: string;
+  total_items: number;
+  catalogs: Record<string, CatalogDiff>;
+  unmatched: ImportNewItem[];
+  /** Flag GLOBAL — banner único (decisión 22.2.b · backend solo emite global). */
+  iva_warning: boolean;
+  currency_mismatch: boolean;
+  warnings: string[];
+}
+
+/** Resultado por catálogo dentro de import-apply. */
+export interface ImportApplyResult {
+  ok: boolean;
+  updated?: number;
+  normalized?: number;
+  added?: number;
+  skipped_zero?: number;
+  error?: string;
+}
+
+/** Respuesta de POST /api/catalog/import-apply. */
+export interface ImportApplyResponse {
+  ok: boolean;
+  results: Record<string, ImportApplyResult>;
+  source_file: string;
+}
+
+/** Respuesta de POST /api/catalog/backups/{id}/restore. */
+export interface RestoreBackupResponse {
+  ok: boolean;
+  catalog: string;
+  restored_from_backup: number;
+}

--- a/web/tests/e2e/catalogo-import.spec.ts
+++ b/web/tests/e2e/catalogo-import.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * E2E /catalogo/import · sub-PR 22.2.b · importador Dux 3 estados.
+ *
+ * upload → preview (diff + counts + selección) → apply success. Modo mock:
+ * mocks.importPreview/importApply son deterministas; el nombre del archivo
+ * dispara el banner GLOBAL iva_warning (decisión 22.2.b).
+ */
+import { expect, test } from "@playwright/test";
+
+const CSV = {
+  name: "dux_materials.csv",
+  mimeType: "text/csv",
+  buffer: Buffer.from("codigo,descripcion,precio de venta\nSIL-001,Silestone,135\n"),
+};
+
+const CSV_IVA = {
+  name: "dux_con_iva.csv",
+  mimeType: "text/csv",
+  buffer: Buffer.from("codigo,descripcion,precio con iva\nSIL-001,Silestone,163\n"),
+};
+
+test.describe("Import Dux · upload → preview → apply", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("upload muestra preview con counts por catálogo", async ({ page }) => {
+    await page.goto("/catalogo/import");
+    await expect(page.locator('[data-testid="catalogo-import-page"]')).toBeVisible();
+    await page.locator('[data-testid="import-file-input"]').setInputFiles(CSV);
+    await page.locator('[data-testid="import-analyze-btn"]').click();
+    await expect(page.locator('[data-testid="import-preview"]')).toBeVisible();
+    // 2 catálogos afectados (silestone + dekton)
+    await expect(page.locator('[data-testid="catalog-tab-materials-silestone"]')).toBeVisible();
+    await expect(page.locator('[data-testid="catalog-tab-materials-dekton"]')).toBeVisible();
+    // counts del diff de silestone
+    await expect(page.locator('[data-testid="diff-table-materials-silestone"]')).toContainText(
+      "2 actualizados",
+    );
+    await expect(page.locator('[data-testid="diff-table-materials-silestone"]')).toContainText(
+      "1 nuevos",
+    );
+  });
+
+  test("deseleccionar un catálogo baja el contador del botón aplicar", async ({ page }) => {
+    await page.goto("/catalogo/import");
+    await page.locator('[data-testid="import-file-input"]').setInputFiles(CSV);
+    await page.locator('[data-testid="import-analyze-btn"]').click();
+    await expect(page.locator('[data-testid="import-apply-btn"]')).toContainText("2 catálogos");
+    await page.locator('[data-testid="catalog-select-materials-dekton"]').uncheck();
+    await expect(page.locator('[data-testid="import-apply-btn"]')).toContainText("1 catálogo");
+  });
+
+  test("apply → confirm → success con resultados y link al viewer", async ({ page }) => {
+    await page.goto("/catalogo/import");
+    await page.locator('[data-testid="import-file-input"]').setInputFiles(CSV);
+    await page.locator('[data-testid="import-analyze-btn"]').click();
+    await page.locator('[data-testid="import-apply-btn"]').click();
+    await expect(page.locator('[data-testid="apply-confirm"]')).toBeVisible();
+    await page.locator('[data-testid="apply-confirm-yes"]').click();
+    await expect(page.locator('[data-testid="import-success"]')).toBeVisible();
+    await expect(page.locator('[data-testid="import-result-materials-silestone"]')).toContainText(
+      "actualizados",
+    );
+    await expect(page.locator('[data-testid="import-another"]')).toBeVisible();
+  });
+});
+
+test.describe("Import Dux · iva_warning banner global", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("archivo con columna CON IVA → banner global + apply bloqueado", async ({ page }) => {
+    await page.goto("/catalogo/import");
+    await page.locator('[data-testid="import-file-input"]').setInputFiles(CSV_IVA);
+    await page.locator('[data-testid="import-analyze-btn"]').click();
+    await expect(page.locator('[data-testid="import-iva-warning"]')).toBeVisible();
+    await expect(page.locator('[data-testid="import-apply-btn"]')).toBeDisabled();
+  });
+});
+
+test.describe("Import Dux · validación client", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("extensión no soportada → error de validación, sin analizar", async ({ page }) => {
+    await page.goto("/catalogo/import");
+    await page.locator('[data-testid="import-file-input"]').setInputFiles({
+      name: "datos.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("%PDF-1.4"),
+    });
+    await expect(page.locator('[data-testid="import-validation-error"]')).toBeVisible();
+    await expect(page.locator('[data-testid="import-analyze-btn"]')).toBeDisabled();
+  });
+});

--- a/web/tests/e2e/catalogo.spec.ts
+++ b/web/tests/e2e/catalogo.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * E2E /catalogo · sub-PR 22.2.b catalogo-and-dux-importer-ui.
+ *
+ * Lista (search + sort + navegación) + viewer (JSON read-only + backups +
+ * restore) + responsive. Modo mock (sin NEXT_PUBLIC_API_URL · mocks.ts).
+ */
+import { expect, test } from "@playwright/test";
+
+test.describe("Catálogo · lista", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("renderea los 14 catálogos + topbar + CTA import", async ({ page }) => {
+    await page.goto("/catalogo");
+    await expect(page.locator('[data-testid="catalogo-page"]')).toBeVisible();
+    await expect(page.locator(".topbar .crumbs .now")).toContainText("Catálogo");
+    await expect(page.locator('[data-testid="catalog-import-cta"]')).toBeVisible();
+    const rows = page.locator('[data-testid="catalog-rows"] > li');
+    await expect(rows).toHaveCount(14);
+  });
+
+  test("search filtra por nombre", async ({ page }) => {
+    await page.goto("/catalogo");
+    await page.locator('[data-testid="catalog-search"]').fill("silestone");
+    const rows = page.locator('[data-testid="catalog-rows"] > li');
+    await expect(rows).toHaveCount(1);
+    await expect(page.locator('[data-testid="catalog-row-materials-silestone"]')).toBeVisible();
+  });
+
+  test("click en fila navega al viewer", async ({ page }) => {
+    await page.goto("/catalogo");
+    await page.locator('[data-testid="catalog-row-materials-silestone"]').click();
+    await page.waitForURL("**/catalogo/materials-silestone");
+    await expect(page.locator('[data-testid="catalogo-viewer-page"]')).toBeVisible();
+  });
+});
+
+test.describe("Catálogo · viewer + backups", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("muestra JSON read-only + lista de backups", async ({ page }) => {
+    await page.goto("/catalogo/materials-silestone");
+    await expect(page.locator('[data-testid="catalog-json"]')).toBeVisible();
+    await expect(page.locator('[data-testid="catalog-json"]')).toContainText("SKU001");
+    await expect(page.locator('[data-testid="backup-list"]')).toBeVisible();
+    await expect(page.locator('[data-testid="backup-row-101"]')).toBeVisible();
+  });
+
+  test("restore pide confirmación y muestra toast de éxito", async ({ page }) => {
+    await page.goto("/catalogo/materials-silestone");
+    await page.locator('[data-testid="backup-restore-101"]').click();
+    await expect(page.locator('[data-testid="restore-confirm"]')).toBeVisible();
+    await page.locator('[data-testid="restore-confirm-yes"]').click();
+    const toast = page.locator('[data-testid="catalog-toast"]');
+    await expect(toast).toBeVisible();
+    await expect(toast).toContainText("restaurado");
+  });
+});
+
+test.describe("Catálogo · responsive mobile", () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test("viewer grid colapsa a 1 columna en mobile", async ({ page }) => {
+    await page.goto("/catalogo/materials-silestone");
+    await expect(page.locator('[data-testid="catalog-json"]')).toBeVisible();
+    const grid = page.locator(".catalog-viewer-grid");
+    const cols = await grid.evaluate(
+      (el) => getComputedStyle(el).gridTemplateColumns.split(" ").length,
+    );
+    expect(cols).toBe(1);
+  });
+});

--- a/web/tests/e2e/sidebar-navigation.spec.ts
+++ b/web/tests/e2e/sidebar-navigation.spec.ts
@@ -31,11 +31,13 @@ test.describe("Sidebar presente en chrome global", () => {
 });
 
 test.describe("Items del Sidebar navegan (Next Link nativo)", () => {
-  test("click Catálogo navega a /catalogo · renderea placeholder", async ({ page }) => {
+  test("click Catálogo navega a /catalogo · renderea lista real", async ({ page }) => {
+    // Sub-PR 22.2.b catalogo-and-dux-importer-ui reemplazó el placeholder
+    // por la lista real (`catalogo-page`). Antes: catalogo-placeholder.
     await page.goto("/");
     await page.locator('[data-testid="sidebar-nav-catalogo"]').click();
     await page.waitForURL("**/catalogo");
-    await expect(page.locator('[data-testid="catalogo-placeholder"]')).toBeVisible();
+    await expect(page.locator('[data-testid="catalogo-page"]')).toBeVisible();
     await expect(page.locator(".crumbs .now")).toContainText("Catálogo");
   });
 


### PR DESCRIPTION
## Sub-PR 22.2.b · catálogo + Dux importer UI completo

Cierra deuda de ~1.5 meses: el backend de catálogos (8 endpoints + parser Dux + tablas DB) está listo desde mayo pero sin UI.

### ⚠️ Correcciones a la FASE 1 (premisas desactualizadas vs main `0ea4e2e`)
La FASE 1 asumía cosas que ya no aplican contra el main actual — verificado y ajustado:
- **"Borrar 4 componentes legacy"** → **no-op**: ya fueron borrados en `b18c62b` (el dir `web/src/components/catalog/` no existía).
- **"Reusar `api.ts:811-951` (8 funciones)"** → **no aplicaba**: `api.ts` ya no existe; el frontend se refactorizó a `web/src/lib/api/` (mock/real split). **Se construyó** la capa wire desde cero (real + mocks + types + index).
- **Backend 8 endpoints** → ✅ correcto, reales.

### Páginas nuevas
- **`/catalogo`** · lista de 14 catálogos + config · search + sort (categoría/nombre/ítems/actualización) · click → viewer
- **`/catalogo/[name]`** · viewer JSON **read-only** (sin editor manual · decisión Agos) + versiones anteriores (backups) con **restore** confirmable + toast
- **`/catalogo/import`** · importador Dux full-page · 3 estados (upload → preview → apply) · validación client (ext/size/MIME) · diff por catálogo (tabs + counters + tabla expandible) · selección + `include_new` · confirm modal

### Capa API (`web/src/lib/api/` · mock + real + types + index · gate `USE_REAL_API`)
`listCatalogs` · `getCatalog` · `listBackups` · `restoreBackup` · `importPreview` · `importApply`. Mocks deterministas para CI/dev (modo mock sin `NEXT_PUBLIC_API_URL`).

### Bug latente cerrado (backend · SOLO este fix · cero feature creep)
- **Encoding latin-1 fallback** en `import_parser._read_csv` (`api/.../import_parser.py:152`): los CSV exportados desde Excel en Windows AR (cp1252) rompían con `UnicodeDecodeError`. Ahora: `utf-8-sig` → fallback `latin-1` → `ValueError` user-friendly. Test unit + endpoint.

### Decisiones arquitectónicas
- **iva_warning = banner GLOBAL** (Opción 1, decisión Javi): el backend solo emite un flag global; per-catálogo requeriría cambiar el contrato del backend (feature, no bug). Queda como follow-up **22.iva-warning-per-catalog**. Si el flag está activo, el backend rechaza el apply → el botón se deshabilita y se explica.
- **Sin editor JSON manual** (Marina usa Dux import para precios masivos).
- **Restore con safety-net**: el backend auto-backupea el estado actual antes de restaurar (ya implementado).
- **Estado C (success)** muestra stats por catálogo + links al viewer (el endpoint `import-apply` NO devuelve ids de backup, así que no se listan ahí; se ven en `/catalogo/[name]`).

### Fix test stale (lección #492)
`sidebar-navigation.spec.ts` aserteaba `catalogo-placeholder`; este PR lo reemplaza por la lista real (`catalogo-page`). Actualizado a `catalogo-page` (mismo patrón que el fix de configuración en #492). Grep de testids corrido antes del push.

### CSS
Todo scoped bajo `.catalogo-v2` en `globals.css` · **`operator-shared.css` INTACTO** · responsive `<768px` (lección 22.1.b · single layout).

### Tests
- **Backend** (gaps no cubiertos por `test_import_*` existentes): `test_catalog_endpoints.py` (list / get / 404 / 403), `test_dux_encoding.py` (latin-1 fallback unit + endpoint), `test_backup_restore.py` (round-trip apply→restore + safety backup).
- **E2E**: `catalogo.spec.ts` (lista/search/nav · viewer/backups/restore · responsive), `catalogo-import.spec.ts` (upload→preview→apply · iva banner global · validación client).

### Verificación
- `typecheck` ✅ · `lint` ✅ (0 errores · 5 warnings prettier pre-existentes del #489) · `build` ✅
- **e2e: 229 passed** (+11 nuevos) · 0 fallas reales (1 flaky pre-existente en paso-5, pasa en retry)
- backend: 9 tests nuevos verde + suites import/catalog verde (las fallas de quote-engine en local son pre-existentes en main `0ea4e2e` · entorno sin `pdfplumber` y evals LLM-dependent)

### Caveats / follow-ups
- `catalog_backups` sin rotación (cron de retención · follow-up)
- parser sincrónico sin timeout backend (mitigado con validación client + 60s timeout)
- iva_warning per-catálogo → sub-PR 22.iva-warning
- Background jobs si Dux manda >50K items (Celery · futuro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)