### PR TITLE
feat(pdf-wire): cierra MVP loop · /generate full breakdown + Bug 1/2 fix + frontend real wire

### DIFF
--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -1422,23 +1422,21 @@ async def generate_quote_documents(quote_id: str, db: AsyncSession = Depends(get
     if not bd:
         raise HTTPException(status_code=400, detail="Este presupuesto no tiene datos de cálculo (quote_breakdown)")
 
-    # Build doc_data from breakdown (same structure as quote_engine/router.py)
-    doc_data = {
-        "client_name": bd.get("client_name", quote.client_name),
-        "project": bd.get("project", quote.project),
-        "date": bd.get("date", ""),
-        "delivery_days": bd.get("delivery_days", ""),
-        "material_name": bd.get("material_name", quote.material or ""),
-        "material_m2": bd.get("material_m2", 0),
-        "material_price_unit": bd.get("material_price_unit", 0),
-        "material_currency": bd.get("material_currency", "USD"),
-        "discount_pct": bd.get("discount_pct", 0),
-        "sectors": bd.get("sectors", []),
-        "sinks": bd.get("sinks", []),
-        "mo_items": bd.get("mo_items", []),
-        "total_ars": bd.get("total_ars", 0),
-        "total_usd": bd.get("total_usd", 0),
-    }
+    # Sub-PR paso-5-pdf-real-wire: copia full breakdown como /validate y
+    # /regenerate. Antes este endpoint copiaba 14 keys a mano · faltaban
+    # sobrante_m2/total, mo_discount_pct/amount, has_m2_override, is_edificio,
+    # thickness_mm, notes, material_total_bruto · el PDF no renderea bloques
+    # cuando faltan. `dict(bd)` cierra el gap en una línea (FASE 1 mapeo).
+    doc_data = dict(bd)
+    # Fallbacks defensivos para breakdowns legacy sin estos top-level fields.
+    doc_data.setdefault("client_name", quote.client_name)
+    doc_data.setdefault("project", quote.project)
+    doc_data.setdefault("date", "")
+    doc_data.setdefault("material_name", quote.material or "")
+    # Notes vienen del Quote DB (no del breakdown) · cierra deuda PR #439.
+    # El operador puede editar notas después del cálculo · el breakdown
+    # podría tener una versión vieja o no tenerlas.
+    doc_data["notes"] = quote.notes
 
     # Generate PDF + Excel
     doc_result = await generate_documents(quote_id, doc_data)

--- a/api/app/modules/agent/tools/document_tool.py
+++ b/api/app/modules/agent/tools/document_tool.py
@@ -142,6 +142,32 @@ _M2_OVERRIDE_FOOTNOTE = (
 )
 
 
+def _read_material_bruto(data: dict, mat_m2: float, mat_price: float) -> int:
+    """Lee el `material_total_bruto` del breakdown (sub-PR paso-5-pdf-real-wire
+    fix Bug 1 · descuento aplicado 2× en edificio PDF + Excel).
+
+    Precedencia:
+    1. `material_total_bruto` explícito (calculator post-fix · pre-descuento).
+    2. `material_total` legacy (calculator pre-fix · POST-descuento) →
+       derivar bruto: `net / (1 - discount_pct/100)`.
+    3. Recalcular desde `mat_m2 * mat_price` (último recurso).
+
+    Backward compat: quotes generados antes del fix tienen `material_total`
+    como NET. La derivación los normaliza al BRUTO esperado. Si `discount_pct`
+    es 0 o falta, los 3 paths coinciden.
+    """
+    bruto = data.get("material_total_bruto")
+    if bruto is not None:
+        return int(round(bruto))
+    net = data.get("material_total")
+    if net is not None:
+        pct = float(data.get("discount_pct") or 0)
+        if pct > 0 and pct < 100:
+            return int(round(net / (1 - pct / 100)))
+        return int(round(net))
+    return int(round(mat_m2 * mat_price))
+
+
 def _pdf_has_m2_override(data: dict) -> bool:
     """Return True if the renderer should show the Planilla-de-Cómputo footnote.
 
@@ -262,6 +288,21 @@ def _strip_duplicate_dims_in_labels(quote_data: dict) -> None:
 async def generate_documents(quote_id: str, quote_data: dict) -> dict:
     """Generate PDF and Excel for a quote."""
     try:
+        # Sub-PR paso-5-pdf-real-wire: log warning si faltan campos críticos
+        # del breakdown · ayuda a detectar quotes con breakdowns parciales
+        # antes de que el operador descubra que el PDF salió incompleto.
+        _required_pdf_fields = (
+            "client_name", "project", "material_name",
+            "material_m2", "material_currency",
+            "total_ars", "total_usd",
+        )
+        _missing = [f for f in _required_pdf_fields if f not in quote_data]
+        if _missing:
+            logging.warning(
+                f"[PDF] quote {quote_id} missing top-level breakdown fields: "
+                f"{_missing} · el PDF puede renderear vacío/incorrecto."
+            )
+
         # PR #48 — strip defensivo de dimensiones duplicadas en piece labels.
         # Aplica acá (entry point de render) para que /regenerate también
         # limpie breakdowns legacy que tienen labels duplicados guardados.
@@ -853,7 +894,11 @@ def _generate_edificio_pdf(pdf_path: Path, data: dict) -> None:
     pdf.ln(2)
 
     # Material row
-    mat_total_bruto = data.get("material_total") or round(mat_m2 * mat_price)
+    # Sub-PR paso-5-pdf-real-wire · Bug 1 fix: leer BRUTO via helper.
+    # Antes: `data.get("material_total") or recalc` → `material_total` es
+    # NET post-descuento (calculator.py:1915) → el bloque "Descuento N%"
+    # más abajo restaba sobre un valor ya descontado · double-discount.
+    mat_total_bruto = _read_material_bruto(data, mat_m2, mat_price)
     _mat_display = f"{mat_name} - {thickness}mm ESPESOR" if not _re.search(r'\d+[Mm][Mm]', mat_name) else mat_name
 
     f = row_fill()
@@ -1093,8 +1138,9 @@ def _generate_edificio_excel(excel_path: Path, data: dict) -> None:
     ws["F22"].alignment = right_align
 
     # Row 23: Material (PDF: bold 9pt)
+    # Sub-PR paso-5-pdf-real-wire · Bug 1 fix idem _generate_edificio_pdf:871.
     _mat_display = f"{mat_name} - {thickness}mm ESPESOR" if not _re.search(r'\d+[Mm][Mm]', mat_name) else mat_name
-    mat_total_bruto = data.get("material_total") or round(mat_m2 * mat_price)
+    mat_total_bruto = _read_material_bruto(data, mat_m2, mat_price)
 
     apply_zebra(23)
     ws.merge_cells("A23:C23")

--- a/api/app/modules/quote_engine/calculator.py
+++ b/api/app/modules/quote_engine/calculator.py
@@ -1912,6 +1912,14 @@ def calculate_quote(input_data: dict) -> dict:
         "material_price_unit": price_unit,
         "material_price_base": price_base,
         "material_currency": currency,
+        # Sub-PR paso-5-pdf-real-wire: dual key para cerrar Bug 1 (descuento
+        # aplicado 2× en resumen-obra PDF + Excel renderers).
+        # - `material_total_bruto` = pre-descuento (source of truth para
+        #   renderers que muestran un "Descuento N%" separado).
+        # - `material_total` = post-descuento (mantiene shape histórico
+        #   consumido por UI /contexto, comparison PDF, breakdown adapters).
+        # Si discount_pct == 0, ambos coinciden.
+        "material_total_bruto": material_total,
         "material_total": material_total_net,
         "discount_pct": discount_pct,
         "discount_amount": discount_amount,

--- a/api/scripts/audit_pdf_discount_double_count.py
+++ b/api/scripts/audit_pdf_discount_double_count.py
@@ -1,0 +1,194 @@
+"""Auditoría retroactiva · sub-PR paso-5-pdf-real-wire (Bug 1).
+
+Identifica quotes en status SENT/VALIDATED que pudieron haber sido
+afectados por el Bug 1 (descuento de material aplicado 2× en PDFs
+edificio + Excel renderers). El bug aplicaba cuando:
+
+  1. El quote tenía `discount_pct > 0`.
+  2. El PDF generado era edificio (Edificio PDF) o el Excel renderer
+     consumía `material_total` como bruto, cuando en realidad era NET
+     post-descuento (calculator.py:1915 guarda NET).
+  3. El renderer aplicaba descuento de nuevo sobre el NET → cliente
+     recibía un PDF con un descuento mayor del que correspondía →
+     facturó MENOS de lo que correspondía cobrar (D'Angelo pierde).
+
+Fórmula del exceso descontado (lo que faltó cobrar):
+
+    Calculator guardaba: net = bruto × (1 - p)
+    PDF mostraba: net × (1 - p) = bruto × (1 - p)²
+    Esperado: net (es decir, bruto × (1 - p))
+
+    Exceso = net - bruto × (1 - p)² = net - net × (1 - p) = net × p
+    O equivalente: bruto × p × (1 - p)
+
+READ-ONLY · NO modifica ningún quote · solo reporta. Agos decide qué
+hacer con el output (refacturar, ignorar, etc.).
+
+Output: `audit_pdf_discount_double_count_YYYYMMDD.csv`.
+
+Uso:
+    cd api
+    python -m scripts.audit_pdf_discount_double_count [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.models.quote import Quote, QuoteStatus
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger(__name__)
+
+
+def _safe_float(value, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _extract_metrics(quote: Quote) -> dict | None:
+    """Extrae métricas del breakdown · None si quote no clasifica."""
+    bd = quote.quote_breakdown
+    if not isinstance(bd, dict):
+        return None
+    discount_pct = _safe_float(bd.get("discount_pct"))
+    if discount_pct <= 0:
+        return None
+    # `material_total` del breakdown legacy (calculator guarda NET).
+    # Si ya tiene `material_total_bruto` (post-fix), el quote fue
+    # generado con la corrección · NO califica para audit retro.
+    if "material_total_bruto" in bd:
+        return None
+    material_total_net = _safe_float(bd.get("material_total"))
+    if material_total_net <= 0:
+        return None
+    is_edificio = bool(bd.get("is_edificio"))
+    if not is_edificio:
+        # El Bug 1 solo afecta a edificio PDF y al Excel del flujo
+        # standard (que también pasa por _generate_excel · línea 1112).
+        # El standard `_generate_pdf` NO tenía el bug (recalculaba
+        # bruto desde m² × precio).
+        # Para conservar el universo afectable, incluimos NO-edificio
+        # si el quote tiene Excel generado (asumimos que sí, todos
+        # los quotes lo generan).
+        pass
+    return {
+        "discount_pct": discount_pct,
+        "material_total_net": material_total_net,
+        "currency": (bd.get("material_currency") or "ARS").upper(),
+        "is_edificio": is_edificio,
+        "total_m2": _safe_float(bd.get("material_m2")),
+    }
+
+
+def _calc_exceso(metrics: dict) -> int:
+    """Exceso descontado = material_total_net × discount_pct/100."""
+    p = metrics["discount_pct"] / 100.0
+    return int(round(metrics["material_total_net"] * p))
+
+
+def audit(*, dry_run: bool = False) -> int:
+    sync_url = (
+        settings.DATABASE_URL.replace("+asyncpg", "")
+        .replace("postgresql+asyncpg", "postgresql")
+    )
+    engine = create_engine(sync_url)
+    log.info(
+        "Audit Bug 1 PDF discount double-count · universo: SENT + VALIDATED · "
+        "discount_pct > 0 · breakdown legacy sin `material_total_bruto`",
+    )
+
+    rows: list[dict] = []
+    statuses = [QuoteStatus.SENT, QuoteStatus.VALIDATED]
+    with Session(engine) as session:
+        stmt = select(Quote).where(Quote.status.in_(statuses))
+        for quote in session.scalars(stmt):
+            metrics = _extract_metrics(quote)
+            if metrics is None:
+                continue
+            exceso = _calc_exceso(metrics)
+            rows.append({
+                "quote_id": quote.id,
+                "client_name": quote.client_name,
+                "project": quote.project,
+                "total_m2": round(metrics["total_m2"], 2),
+                "currency": metrics["currency"],
+                "discount_pct": metrics["discount_pct"],
+                "material_total_net": int(metrics["material_total_net"]),
+                "exceso_descontado": exceso,
+                "is_edificio": metrics["is_edificio"],
+                "status": (
+                    quote.status.value
+                    if hasattr(quote.status, "value")
+                    else str(quote.status)
+                ),
+                "created_at": (
+                    quote.created_at.isoformat()
+                    if quote.created_at
+                    else ""
+                ),
+            })
+
+    log.info("Quotes afectados: %d", len(rows))
+    total_exceso = sum(r["exceso_descontado"] for r in rows)
+    log.info(
+        "Total $ exceso descontado (cliente pagó MENOS de lo que debía): %s",
+        total_exceso,
+    )
+
+    # Top 5 por exceso.
+    top5 = sorted(rows, key=lambda r: r["exceso_descontado"], reverse=True)[:5]
+    log.info("Top 5 quotes por exceso descontado:")
+    for r in top5:
+        log.info(
+            "  - %s · %s · %s$ · %s · %s",
+            r["quote_id"],
+            r["client_name"],
+            r["exceso_descontado"],
+            r["currency"],
+            r["status"],
+        )
+
+    if dry_run:
+        log.info("--dry-run · no se escribe CSV")
+        return 0
+
+    if not rows:
+        log.info("Nada que reportar · CSV no escrito")
+        return 0
+
+    today = datetime.now(timezone.utc).strftime("%Y%m%d")
+    out_path = Path(f"audit_pdf_discount_double_count_{today}.csv")
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+    log.info("CSV escrito · %s (%d rows)", out_path.resolve(), len(rows))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Solo imprime resumen · no escribe CSV.",
+    )
+    args = parser.parse_args()
+    return audit(dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/api/scripts/audit_pdf_discount_double_count.py
+++ b/api/scripts/audit_pdf_discount_double_count.py
@@ -76,14 +76,20 @@ def _extract_metrics(quote: Quote) -> dict | None:
         return None
     is_edificio = bool(bd.get("is_edificio"))
     if not is_edificio:
-        # El Bug 1 solo afecta a edificio PDF y al Excel del flujo
-        # standard (que también pasa por _generate_excel · línea 1112).
-        # El standard `_generate_pdf` NO tenía el bug (recalculaba
-        # bruto desde m² × precio).
-        # Para conservar el universo afectable, incluimos NO-edificio
-        # si el quote tiene Excel generado (asumimos que sí, todos
-        # los quotes lo generan).
-        pass
+        # Bug 1 fue EXCLUSIVO de los renderers edificio:
+        # - `_generate_edificio_pdf` (document_tool.py:871 · pre-fix leía
+        #   `material_total` legacy NET y restaba descuento de nuevo).
+        # - `_generate_edificio_excel` (line 1112 · mismo patrón).
+        #
+        # Los renderers standard NUNCA tuvieron el bug: ambos recalculan
+        # bruto desde `m² × precio` ignorando `material_total` del breakdown:
+        # - `_generate_pdf` standard (~1415): `round(mat_m2 * mat_price)`.
+        # - `_generate_excel` standard (~1798): `round(mat_m2 * mat_price)`.
+        #
+        # Incluir quotes NO-edificio inflaría el universo con falsos
+        # positivos y generaría plata fantasma si Agos re-factura sobre
+        # el CSV. Hallazgo audit indep · fix bloqueante pre-merge.
+        return None
     return {
         "discount_pct": discount_pct,
         "material_total_net": material_total_net,

--- a/api/tests/test_pdf_generate_wire.py
+++ b/api/tests/test_pdf_generate_wire.py
@@ -1,0 +1,284 @@
+"""Sub-PR paso-5-pdf-real-wire · tests del wire end-to-end del PDF.
+
+Cubre los 3 bugs cerrados + el wire de `/generate` que ahora copia full
+breakdown en vez de los 14 campos manuales del pre-fix:
+
+  1. Wire `/generate` propaga full breakdown (sobrante, mo_discount,
+     has_m2_override, is_edificio, notes).
+  2. Bug 1: descuento de material se aplica UNA sola vez en edificio PDF.
+  3. Bug 2: `material_total_bruto` override manual respetado (default explícito).
+  4. Snapshot real-flow: input del calculator real → PDF → assertions.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.modules.agent.tools.document_tool import (
+    _read_material_bruto,
+    _generate_edificio_pdf,
+    _generate_pdf,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Helpers · extracción de texto del PDF generado.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _pdf_to_text(pdf_path: Path) -> str:
+    """Extrae texto del PDF usando `pdftotext` (poppler · ya está en CI).
+    Fallback a None si no está disponible · marca skip en el test."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["pdftotext", str(pdf_path), "-"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        return result.stdout
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pytest.skip("pdftotext (poppler) no disponible en este env")
+
+
+OUTPUT_DIR = Path(__file__).parent.parent / "output" / "test-pdf-wire"
+
+
+@pytest.fixture(autouse=True)
+def _ensure_output_dir(tmp_path_factory):
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fixture · breakdown mínimo edificio con shape REAL del calculator
+# (post-PR paso-5-pdf-real-wire · incluye `material_total_bruto`).
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _edificio_breakdown(
+    *,
+    discount_pct: float = 0,
+    material_total_bruto: int | None = None,
+    material_total: int | None = None,
+) -> dict:
+    """Breakdown mínimo para `_generate_edificio_pdf`. `material_total_bruto`
+    es el campo nuevo (post-fix); `material_total` el legacy (NET)."""
+    bruto = 100_000  # 100k USD bruto
+    pct = discount_pct
+    net = round(bruto * (1 - pct / 100))
+    return {
+        "client_name": "Cliente Test",
+        "project": "Test Edificio",
+        "date": "01.06.2026",
+        "delivery_days": "30 dias",
+        "material_name": "Test Material",
+        "thickness_mm": 20,
+        "material_m2": 50.0,
+        "material_price_unit": 2000,
+        "material_currency": "USD",
+        "material_total_bruto": material_total_bruto if material_total_bruto is not None else bruto,
+        "material_total": material_total if material_total is not None else net,
+        "discount_pct": pct,
+        "discount_amount": bruto - net,
+        "sectors": [{"label": "Sector A", "pieces": ["1.5 × 0.6 Mesada"]}],
+        "sinks": [],
+        "mo_items": [],
+        "total_ars": 0,
+        "total_usd": 0,
+        "is_edificio": True,
+        "show_mo": False,
+        "grand_total_text": "USD 100.000",
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 1 · `_read_material_bruto` helper · precedencia + backward compat.
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestReadMaterialBruto:
+    def test_lee_material_total_bruto_explicito(self):
+        data = {"material_total_bruto": 80_000, "material_total": 76_000, "discount_pct": 5}
+        assert _read_material_bruto(data, 50.0, 2000) == 80_000
+
+    def test_deriva_bruto_de_net_legacy_con_descuento(self):
+        # Breakdown legacy: solo material_total (NET) + discount_pct.
+        # Helper deriva bruto = net / (1 - pct/100).
+        data = {"material_total": 95_000, "discount_pct": 5}
+        # 95000 / 0.95 = 100000
+        assert _read_material_bruto(data, 50.0, 2000) == 100_000
+
+    def test_legacy_sin_descuento_usa_material_total_directo(self):
+        data = {"material_total": 100_000, "discount_pct": 0}
+        assert _read_material_bruto(data, 50.0, 2000) == 100_000
+
+    def test_recalcula_desde_m2_x_price_si_ambos_ausentes(self):
+        data = {"discount_pct": 0}
+        assert _read_material_bruto(data, 50.0, 2000) == 100_000
+
+    def test_override_manual_cero_se_respeta_no_fallback(self):
+        """Bug 2 regression: si `material_total_bruto=0` explícito (override
+        a precio gratis · raro pero válido), el helper devuelve 0 · NO cae
+        al fallback `m2*price` por evaluación truthy del `or`."""
+        data = {"material_total_bruto": 0, "discount_pct": 0}
+        assert _read_material_bruto(data, 50.0, 2000) == 0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 2 · Bug 1 regression · descuento aplicado UNA sola vez en edificio.
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestEdificioPdfDescuentoUnaSolaVez:
+    def test_edificio_pdf_con_descuento_15pct_no_aplica_doble(self, tmp_path):
+        """Quote edificio con discount_pct=15 · material bruto 100k.
+        PDF debe mostrar:
+          - bloque material: $100.000 (bruto)
+          - bloque descuento: −$15.000 (15% sobre 100k)
+        NO debe mostrar $85.000 → −$12.750 (15% sobre 85k · double-count)."""
+        bd = _edificio_breakdown(discount_pct=15)
+        out = tmp_path / "edificio.pdf"
+        _generate_edificio_pdf(out, bd)
+        text = _pdf_to_text(out)
+        # Bruto $100.000 visible (algún format).
+        assert "100.000" in text or "100,000" in text or "100000" in text, (
+            "Esperaba bruto $100.000 en el PDF"
+        )
+        # Descuento $15.000 (15% de 100k · NO 12.750 de 85k).
+        assert "15.000" in text or "15,000" in text, (
+            "Esperaba descuento $15.000 (Bug 1 fix · 15% sobre bruto, NO sobre net)"
+        )
+        # Anti-regresión: 12.750 sería el descuento double-count.
+        assert "12.750" not in text and "12,750" not in text, (
+            "Detectado descuento double-count $12.750 (15% de 85k)"
+        )
+
+    def test_edificio_pdf_legacy_breakdown_sin_bruto_se_deriva(self, tmp_path):
+        """Backward compat: si el breakdown viene de un quote pre-fix
+        (solo `material_total` NET + `discount_pct`), el helper deriva el
+        bruto correctamente · el PDF renderea como si el fix siempre hubiera estado."""
+        bd = _edificio_breakdown(discount_pct=10)
+        # Simular legacy: borrar material_total_bruto.
+        bd.pop("material_total_bruto", None)
+        # material_total ya es NET (90k de 100k bruto).
+        assert bd["material_total"] == 90_000
+        out = tmp_path / "edificio_legacy.pdf"
+        _generate_edificio_pdf(out, bd)
+        text = _pdf_to_text(out)
+        # Bruto derivado: 90k / 0.9 = 100k.
+        assert "100.000" in text or "100,000" in text
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 3 · Wire /generate propaga campos críticos (sobrante, notes, etc).
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestGenerateWirePropagaFullBreakdown:
+    def test_standard_pdf_renderea_notes_cuando_quote_tiene(self, tmp_path):
+        """PR #439 (deuda cerrada en este sub-PR): `quote.notes` se inyecta
+        en doc_data["notes"] antes de generate_documents · el PDF lo
+        renderea como bloque NOTAS al final."""
+        bd = {
+            "client_name": "Cliente Test",
+            "project": "Cocina",
+            "date": "01.06.2026",
+            "delivery_days": "30 dias",
+            "material_name": "Test Material",
+            "thickness_mm": 20,
+            "material_m2": 5.0,
+            "material_price_unit": 2000,
+            "material_currency": "USD",
+            "material_total_bruto": 10_000,
+            "material_total": 10_000,
+            "discount_pct": 0,
+            "sectors": [{"label": "Cocina", "pieces": ["2.0 × 0.6 Mesada"]}],
+            "sinks": [],
+            "mo_items": [],
+            "total_ars": 0,
+            "total_usd": 10_000,
+            "notes": "Cliente prefiere entrega los sábados",
+        }
+        out = tmp_path / "with_notes.pdf"
+        _generate_pdf(out, bd)
+        text = _pdf_to_text(out)
+        assert "sábados" in text or "sabados" in text, (
+            "PR #439 deuda: notes del quote no llegan al PDF"
+        )
+
+    def test_standard_pdf_renderea_sobrante_cuando_presente(self, tmp_path):
+        """Sobrante (merma del calculator) renderea bloque separado.
+        Antes de este sub-PR, `/generate` no propagaba sobrante_m2 ni
+        sobrante_total al doc_data · el bloque no aparecía."""
+        bd = {
+            "client_name": "Cliente Sobrante",
+            "project": "Cocina",
+            "date": "01.06.2026",
+            "delivery_days": "30 dias",
+            "material_name": "Test Material",
+            "thickness_mm": 20,
+            "material_m2": 5.0,
+            "material_price_unit": 2000,
+            "material_currency": "USD",
+            "material_total_bruto": 10_000,
+            "material_total": 10_000,
+            "discount_pct": 0,
+            "sectors": [{"label": "Cocina", "pieces": ["2.0 × 0.6 Mesada"]}],
+            "sinks": [],
+            "mo_items": [],
+            "sobrante_m2": 1.5,
+            "sobrante_total": 3_000,
+            "total_ars": 0,
+            "total_usd": 13_000,
+        }
+        out = tmp_path / "with_sobrante.pdf"
+        _generate_pdf(out, bd)
+        text = _pdf_to_text(out)
+        text_lower = text.lower()
+        assert "sobrante" in text_lower or "merma" in text_lower, (
+            "Sobrante no renderea · el wire de /generate no propagó sobrante_m2/total"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 4 · Snapshot real-flow · calculator → PDF.
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestPdfSnapshotRealFlow:
+    def test_calculator_output_se_renderea_sin_crashear(self, tmp_path):
+        """Cierra el gap del docstring de test_pdf_snapshots.py (líneas 8-14):
+        los snapshots existentes usan fixtures manuales replicadas del
+        frontend mock, NO del calculator real. Este test usa el output
+        REAL del calculator como input al PDF · si calculator y PDF
+        divergen en shape, falla acá (no en producción)."""
+        from app.modules.quote_engine.calculator import calculate_quote
+
+        result = calculate_quote({
+            "client_name": "Cliente Snapshot",
+            "project": "Cocina test",
+            "material": "Blanco Paloma",
+            "catalog": "materials-purastone",
+            "sku": "PALOMA",
+            "pieces": [
+                {"largo": 1.5, "prof": 0.60, "descripcion": "Mesada"},
+            ],
+            "localidad": "Rosario",
+            "colocacion": True,
+            "pileta": "empotrada_cliente",
+            "plazo": "30 dias",
+        })
+        assert result.get("ok") is True, result
+        # Sub-PR paso-5-pdf-real-wire: confirmar que el field nuevo está.
+        assert "material_total_bruto" in result, (
+            "calculator no expone `material_total_bruto` · fix Step 2 incompleto"
+        )
+        # PDF debe renderear sin crashear con el output real del calculator.
+        out = tmp_path / "real_flow.pdf"
+        _generate_pdf(out, result)
+        assert out.exists() and out.stat().st_size > 1000, (
+            "PDF generado vacío o corrupto a partir del calculator output"
+        )

--- a/web/src/app/quotes/[id]/pdf/page.tsx
+++ b/web/src/app/quotes/[id]/pdf/page.tsx
@@ -36,13 +36,18 @@ export default async function PdfPage({ params }: { params: { id: string } }) {
   // Sprint 4 paso-5-d-revision-v2 (mockup 21) · sufijo `-REVISING` SSR-seedea
   // el estado D · cargamos el diff data en paralelo cuando matchea.
   const isRevising = params.id.endsWith("-REVISING");
+  // Sub-PR paso-5-pdf-real-wire: `getPdfGeneratedInfo` ahora pasa por real
+  // wire (GET /api/quotes/{id} con extracción de pdf_url/excel_url). Sin
+  // bearer en SSR el real wire falla con 401. El `-GENERATED`/`-REVISING`
+  // suffix sigue funcionando en mocks (cero cambio de E2E) porque mocks
+  // ignora el token.
   const [metaR, calcR, ctxR, traceR, piecesR, genR, diffR] = await Promise.allSettled([
     getQuoteMetadata(params.id, { bearerToken }),
     getCalculationForQuote(params.id),
     getContextForQuote(params.id),
     getPdfTrace(params.id),
     listPiecesForQuote(params.id),
-    getPdfGeneratedInfo(params.id),
+    getPdfGeneratedInfo(params.id, { bearerToken }),
     isRevising ? getPdfV2DiffData(params.id) : Promise.resolve(null),
   ]);
 
@@ -70,8 +75,7 @@ export default async function PdfPage({ params }: { params: { id: string } }) {
   // Fix-up #1: piezas para sub-filas row-piece + tipologia para campo
   // "Proyecto" del grid cliente (template HTML del backend).
   const pieces = piecesR.status === "fulfilled" ? piecesR.value.pieces : [];
-  const proyecto =
-    (ctx?.tipologia?.value && String(ctx.tipologia.value)) || quote.client || "";
+  const proyecto = (ctx?.tipologia?.value && String(ctx.tipologia.value)) || quote.client || "";
 
   // Sprint 4 paso-5 · `pdfDateIso` calculado server-side y pasado como
   // string al client → evita hydration mismatch por `new Date()` corriendo
@@ -81,13 +85,10 @@ export default async function PdfPage({ params }: { params: { id: string } }) {
   // que es determinístico.
   const pdfDateIso = new Date().toISOString();
 
-  const initialGenerated =
-    genR.status === "fulfilled" && genR.value !== null ? genR.value : null;
+  const initialGenerated = genR.status === "fulfilled" && genR.value !== null ? genR.value : null;
 
   const initialDiffData =
-    isRevising && diffR.status === "fulfilled" && diffR.value !== null
-      ? diffR.value
-      : null;
+    isRevising && diffR.status === "fulfilled" && diffR.value !== null ? diffR.value : null;
 
   return (
     <PdfView

--- a/web/src/components/pdf/PdfConfirmModal.tsx
+++ b/web/src/components/pdf/PdfConfirmModal.tsx
@@ -23,6 +23,42 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { ApiError } from "@/lib/api/types";
+
+/** Sub-PR paso-5-pdf-real-wire · mapeo de códigos de error backend a
+ * mensajes user-friendly en español. El adapter `_mapPdfError` en
+ * `real.ts` traduce el status + detail a un `code` semántico; acá lo
+ * usamos para mostrar el mensaje correcto en el banner del modal.
+ *
+ * Códigos cubiertos:
+ * - PDF_TIMEOUT       · backend lento o uvicorn saturado.
+ * - DRIVE_QUOTA       · Drive sin espacio.
+ * - BREAKDOWN_MISSING · quote sin paso 2 procesado.
+ * - QUOTE_NOT_FOUND   · 404 puro (quote borrado entre el load y el click).
+ * - PDF_NO_URL        · backend devuelve ok=true pero sin pdf_url (bug raro).
+ * - PDF_GENERIC       · cualquier otro · usa el mensaje del backend.
+ */
+function _friendlyMessage(err: unknown): string {
+  if (err instanceof ApiError) {
+    switch (err.code) {
+      case "PDF_TIMEOUT":
+        return "La generación está tardando más de lo normal. Probá de nuevo en unos segundos.";
+      case "DRIVE_QUOTA":
+        return "El almacenamiento de Drive está al límite. Avisale al admin antes de reintentar.";
+      case "BREAKDOWN_MISSING":
+        return "Falta procesar el contexto del quote. Volvé al paso anterior y confirmá los datos antes de generar.";
+      case "QUOTE_NOT_FOUND":
+        return "No encontramos este presupuesto · puede haber sido borrado en otro tab.";
+      case "PDF_NO_URL":
+        return "Algo raro pasó · el backend confirmó pero no devolvió el archivo. Reintentá.";
+      case "PDF_GENERIC":
+      default:
+        return err.message || "No se pudo generar el presupuesto.";
+    }
+  }
+  if (err instanceof Error) return err.message;
+  return "No se pudo generar el presupuesto.";
+}
 
 interface Props {
   pdfFilename: string;
@@ -55,7 +91,7 @@ export function PdfConfirmModal({ pdfFilename, xlsxFilename, onCancel, onConfirm
       await onConfirm();
       // Caller cierra el modal en success (transición a estado C).
     } catch (err) {
-      setErrorMsg(err instanceof Error ? err.message : "No se pudo generar el presupuesto.");
+      setErrorMsg(_friendlyMessage(err));
       setLoading(false);
     }
   };

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -51,13 +51,23 @@ export const getAuditSnapshot = mocks.getAuditSnapshot;
 /* ─── Paso 5 PDF · Sprint 4 paso-5-pdf-preview · mockup 18 ── */
 export const getPdfTrace = mocks.getPdfTrace;
 
-/* ─── Paso 5 estado C · Sprint 4 paso-5-c-generado · mockup 20 ── */
-export const triggerPdfGeneration = mocks.triggerPdfGeneration;
-export const getPdfGeneratedInfo = mocks.getPdfGeneratedInfo;
+/* ─── Paso 5 estado C · Sprint 4 paso-5-c-generado · mockup 20
+   Wire real con sub-PR paso-5-pdf-real-wire · cierra el MVP loop. */
+export const triggerPdfGeneration = USE_REAL_API
+  ? real.triggerPdfGeneration
+  : mocks.triggerPdfGeneration;
+export const getPdfGeneratedInfo = USE_REAL_API
+  ? real.getPdfGeneratedInfo
+  : mocks.getPdfGeneratedInfo;
 
-/* ─── Paso 5 estado D · Sprint 4 paso-5-d-revision-v2 · mockup 21 ── */
+/* ─── Paso 5 estado D · Sprint 4 paso-5-d-revision-v2 · mockup 21
+   `triggerPdfV2Generation` wirea contra POST /quotes/{id}/regenerate.
+   `getPdfV2DiffData` SIGUE en mock · backend no expone diff v1 vs v2
+   todavía (sub-PR posterior `paso-5-v2-diff-real`). */
 export const getPdfV2DiffData = mocks.getPdfV2DiffData;
-export const triggerPdfV2Generation = mocks.triggerPdfV2Generation;
+export const triggerPdfV2Generation = USE_REAL_API
+  ? real.triggerPdfV2Generation
+  : mocks.triggerPdfV2Generation;
 
 /* ─── Audit trail copy · Sprint 4 audit-trail-copy ────────────────── */
 export const getAuditLog = USE_REAL_API ? real.getAuditLog : mocks.getAuditLog;

--- a/web/src/lib/api/real.ts
+++ b/web/src/lib/api/real.ts
@@ -634,10 +634,7 @@ export async function listCatalogs(options?: AuthOpts): Promise<CatalogMeta[]> {
   return (await response.json()) as CatalogMeta[];
 }
 
-export async function getCatalog(
-  name: string,
-  options?: AuthOpts,
-): Promise<CatalogContent> {
+export async function getCatalog(name: string, options?: AuthOpts): Promise<CatalogContent> {
   const { signal, bearerToken } = options ?? {};
   const response = await apiFetch(
     `/api/catalog/${encodeURIComponent(name)}`,
@@ -654,10 +651,7 @@ export async function getCatalog(
   return (await response.json()) as CatalogContent;
 }
 
-export async function listBackups(
-  name: string,
-  options?: AuthOpts,
-): Promise<CatalogBackup[]> {
+export async function listBackups(name: string, options?: AuthOpts): Promise<CatalogBackup[]> {
   const { signal, bearerToken } = options ?? {};
   const response = await apiFetch(
     `/api/catalog/backups/${encodeURIComponent(name)}`,
@@ -705,10 +699,7 @@ async function _errorDetail(response: Response, fallback: string): Promise<strin
   }
 }
 
-export async function importPreview(
-  file: File,
-  options?: AuthOpts,
-): Promise<ImportPreview> {
+export async function importPreview(file: File, options?: AuthOpts): Promise<ImportPreview> {
   const { signal, bearerToken } = options ?? {};
   const form = new FormData();
   form.append("file", file);
@@ -756,4 +747,194 @@ export async function importApply(
     );
   }
   return (await response.json()) as ImportApplyResponse;
+}
+
+/* ─── PDF real wire · sub-PR paso-5-pdf-real-wire ─────────────────────
+   POST /api/quotes/{id}/generate    → PdfGeneratedInfo (gen v1)
+   POST /api/quotes/{id}/regenerate  → PdfGeneratedInfo (gen v2 / refresh)
+   GET  /api/quotes/{id}             → PdfGeneratedInfo | null (SSR estado C)
+   getPdfV2DiffData queda en MOCK · no hay endpoint backend equivalente
+   (mockup 21 paso-5-d-revision-v2 · sub-PR posterior abre el endpoint).
+
+   Adapter de shape: backend devuelve `{ok, pdf_url, excel_url, drive_url}`
+   snake_case + sin metadatos UI (pdfSizeKb, generatedBy, traceId, etc).
+   El adapter mapea camelCase y degrada lo faltante a "—" o defaults
+   conservadores (timestamp current). El UI ya muestra "—" cuando los
+   placeholders aparecen (pattern de getQuoteMetadata real).
+
+   Error mapping: el backend solo expone status code + detail string. El
+   handler `_mapPdfError` traduce a codes UI-friendly (PDF_TIMEOUT,
+   DRIVE_QUOTA, BREAKDOWN_MISSING, GENERIC) para que el modal renderee
+   mensajes en español específicos.
+*/
+
+import type { PdfGeneratedInfo } from "./types";
+
+interface RealGenerateResponse {
+  ok?: boolean;
+  pdf_url?: string | null;
+  excel_url?: string | null;
+  drive_url?: string | null;
+  drive_file_id?: string | null;
+  error?: string | null;
+  detail?: string | null;
+}
+
+interface RealQuoteWithDocs {
+  id: string;
+  pdf_url?: string | null;
+  excel_url?: string | null;
+  drive_url?: string | null;
+  drive_file_id?: string | null;
+  updated_at?: string | null;
+  client_name?: string | null;
+  [key: string]: unknown;
+}
+
+// EM_DASH legacy del adapter de listQuotes (línea 91) es `as number` para
+// degradar m². Acá usamos string puro · campos faltantes del backend se
+// renderean como "—" en el UI sin cast.
+const EM_DASH_STR = "—";
+
+function _displayTimestamp(iso: string): string {
+  try {
+    const d = new Date(iso);
+    const dd = String(d.getDate()).padStart(2, "0");
+    const mm = String(d.getMonth() + 1).padStart(2, "0");
+    const yyyy = d.getFullYear();
+    const hh = String(d.getHours()).padStart(2, "0");
+    const min = String(d.getMinutes()).padStart(2, "0");
+    return `${dd}.${mm}.${yyyy} ${hh}:${min}`;
+  } catch {
+    return EM_DASH_STR;
+  }
+}
+
+function _adaptToPdfInfo(
+  raw: RealGenerateResponse | RealQuoteWithDocs,
+  fallbackIso?: string,
+): PdfGeneratedInfo | null {
+  const pdfUrl = raw.pdf_url ?? "";
+  if (!pdfUrl) return null;
+  const generatedAtIso =
+    ("updated_at" in raw && typeof raw.updated_at === "string" ? raw.updated_at : fallbackIso) ??
+    new Date().toISOString();
+  return {
+    pdfUrl,
+    excelUrl: raw.excel_url ?? "",
+    driveUrl: raw.drive_url ?? "",
+    driveFolderPath: EM_DASH_STR,
+    pdfSizeKb: 0,
+    excelSizeKb: 0,
+    generatedAtIso,
+    generatedAtDisplay: _displayTimestamp(generatedAtIso),
+    generatedBy: EM_DASH_STR,
+    traceId: EM_DASH_STR,
+    driveId: raw.drive_file_id ?? EM_DASH_STR,
+  };
+}
+
+async function _readErrorBody(response: Response): Promise<string> {
+  try {
+    const data = await response.json();
+    if (typeof data?.detail === "string") return data.detail;
+    if (typeof data?.error === "string") return data.error;
+  } catch {
+    /* response no es JSON · cae al statusText */
+  }
+  return response.statusText || `HTTP ${response.status}`;
+}
+
+/** Mapea el status + detail del backend a un code UI-friendly. El modal
+ * `PdfConfirmModal` consume el `code` para mostrar mensaje en español
+ * específico (PDF_TIMEOUT → "está tardando...", BREAKDOWN_MISSING →
+ * "falta procesar el contexto", etc). */
+function _mapPdfError(status: number, detail: string): { code: string; message: string } {
+  const lower = detail.toLowerCase();
+  if (status === 504 || lower.includes("timeout")) {
+    return { code: "PDF_TIMEOUT", message: detail };
+  }
+  if (
+    lower.includes("drive") &&
+    (lower.includes("quota") || lower.includes("límite") || lower.includes("limite"))
+  ) {
+    return { code: "DRIVE_QUOTA", message: detail };
+  }
+  if (
+    status === 400 &&
+    (lower.includes("quote_breakdown") ||
+      lower.includes("datos de cálculo") ||
+      lower.includes("datos de calculo"))
+  ) {
+    return { code: "BREAKDOWN_MISSING", message: detail };
+  }
+  if (status === 404) {
+    return { code: "QUOTE_NOT_FOUND", message: detail };
+  }
+  return { code: "PDF_GENERIC", message: detail };
+}
+
+async function _doGenerateRequest(
+  path: string,
+  options?: { signal?: AbortSignal; bearerToken?: string | null },
+): Promise<PdfGeneratedInfo> {
+  const { signal, bearerToken } = options ?? {};
+  const response = await apiFetch(
+    path,
+    { method: "POST", signal, bearerToken },
+    90_000, // PDF + Drive upload puede tardar
+  );
+  if (!response.ok) {
+    const detail = await _readErrorBody(response);
+    const { code, message } = _mapPdfError(response.status, detail);
+    throw new ApiError(code, message, response.status);
+  }
+  const data = (await response.json()) as RealGenerateResponse;
+  if (!data.ok) {
+    const { code, message } = _mapPdfError(500, data.error ?? "Error desconocido");
+    throw new ApiError(code, message, 500);
+  }
+  const adapted = _adaptToPdfInfo(data);
+  if (!adapted) {
+    throw new ApiError("PDF_NO_URL", "El backend respondió ok pero sin pdf_url", 500);
+  }
+  return adapted;
+}
+
+export async function triggerPdfGeneration(
+  quoteId: string,
+  options?: { signal?: AbortSignal; bearerToken?: string | null },
+): Promise<PdfGeneratedInfo> {
+  return _doGenerateRequest(`/api/quotes/${encodeURIComponent(quoteId)}/generate`, options);
+}
+
+export async function triggerPdfV2Generation(
+  quoteId: string,
+  options?: { signal?: AbortSignal; bearerToken?: string | null },
+): Promise<PdfGeneratedInfo> {
+  // /regenerate refresca PDF sin recalcular · semánticamente v2 (cambios
+  // editoriales del operador sin tocar números del calculator).
+  return _doGenerateRequest(`/api/quotes/${encodeURIComponent(quoteId)}/regenerate`, options);
+}
+
+export async function getPdfGeneratedInfo(
+  quoteId: string,
+  options?: { signal?: AbortSignal; bearerToken?: string | null },
+): Promise<PdfGeneratedInfo | null> {
+  const { signal, bearerToken } = options ?? {};
+  const response = await apiFetch(
+    `/api/quotes/${encodeURIComponent(quoteId)}`,
+    { signal, bearerToken },
+    20_000,
+  );
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    throw new ApiError(
+      "PDF_INFO_LOAD_FAILED",
+      `GET /api/quotes/{id} falló (${response.status})`,
+      response.status,
+    );
+  }
+  const quote = (await response.json()) as RealQuoteWithDocs;
+  return _adaptToPdfInfo(quote);
 }

--- a/web/tests/e2e/paso-5-pdf-real-wire.spec.ts
+++ b/web/tests/e2e/paso-5-pdf-real-wire.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * E2E paso-5-pdf-real-wire · PDF generation wireado al backend Railway.
+ *
+ * Gated: solo corre cuando `NEXT_PUBLIC_API_URL` está seteado · default
+ * CI arranca sin env var, así que estos tests se SKIPEAN y los 4 specs
+ * existentes (paso-5-*.spec.ts) siguen siendo el cover por defecto via
+ * mocks deterministas.
+ *
+ * Estrategia (idem brief-upload-real.spec.ts): aún con env var seteada
+ * NO dependemos del backend Railway vivo · interceptamos los endpoints
+ * con `page.route()` y simulamos respuestas para verificar:
+ *   - El gate `USE_REAL_API` del index.ts efectivamente swap-eó al wire real
+ *   - El POST /quotes/{id}/generate se dispara con bearer correcto
+ *   - Estado A → C transition post-success
+ *   - Error mapping (BREAKDOWN_MISSING, DRIVE_QUOTA, PDF_TIMEOUT) renderea
+ *     mensaje específico en español, no el detail crudo del backend.
+ *
+ * Para correr contra Railway REAL: `NEXT_PUBLIC_API_URL=https://...`
+ * y quitar los `page.route()` interceptors.
+ */
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+const HAS_API_URL = !!process.env.NEXT_PUBLIC_API_URL;
+test.skip(
+  !HAS_API_URL,
+  "paso-5-pdf-real-wire requiere NEXT_PUBLIC_API_URL · default CI corre mocks",
+);
+
+test.describe.configure({ mode: "serial" });
+
+const BACKEND_BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+function generateRoute(quoteId: string) {
+  return `${BACKEND_BASE}/api/quotes/${quoteId}/generate`;
+}
+
+function quoteDetailRoute(quoteId: string) {
+  return `${BACKEND_BASE}/api/quotes/${quoteId}`;
+}
+
+/** Mockea GET /quotes/{id} (necesario para SSR del estado inicial · el
+ * adapter espera Quote con `pdf_url`/`excel_url`). Default sin pdf_url
+ * → estado A (sin generar). */
+async function mockQuoteDetail(page: Page, quoteId: string, withPdf: boolean = false) {
+  await page.route(quoteDetailRoute(quoteId), async (route: Route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: quoteId,
+        client_name: "Cliente Test",
+        project: "Cocina test",
+        material: "Blanco Paloma",
+        status: withPdf ? "sent" : "draft",
+        pdf_url: withPdf ? "https://drive.google.com/file/test-pdf" : null,
+        excel_url: withPdf ? "https://drive.google.com/file/test-xlsx" : null,
+        drive_url: withPdf ? "https://drive.google.com/folder/test-folder" : null,
+        drive_file_id: withPdf ? "abc123" : null,
+        updated_at: "2026-06-14T18:42:00Z",
+        quote_breakdown: { client_name: "Cliente Test" },
+      }),
+    });
+  });
+}
+
+test("real wire · POST /generate retorna 200 + pdf_url → estado C visible con file rows", async ({
+  page,
+}) => {
+  const quoteId = "real-pdf-001";
+  await mockQuoteDetail(page, quoteId, false);
+  await page.route(generateRoute(quoteId), async (route: Route) => {
+    if (route.request().method() !== "POST") return route.fallback();
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        pdf_url: "https://drive.google.com/file/real-pdf",
+        excel_url: "https://drive.google.com/file/real-xlsx",
+        drive_url: "https://drive.google.com/folder/real-folder",
+        drive_file_id: "real-abc-123",
+      }),
+    });
+  });
+
+  await page.goto(`/quotes/${quoteId}/pdf`);
+  await page.locator('[data-testid="generate-pdf"]').click();
+  await page.locator('[data-testid="modal-confirm"]').click();
+  // Estado C visible · sidebar generated con file rows.
+  await expect(page.locator('[data-testid="pdf-state-c-sidebar"]')).toBeVisible({
+    timeout: 10_000,
+  });
+});
+
+test("real wire · 400 BREAKDOWN_MISSING → modal renderea mensaje español específico", async ({
+  page,
+}) => {
+  const quoteId = "real-pdf-002";
+  await mockQuoteDetail(page, quoteId, false);
+  await page.route(generateRoute(quoteId), async (route: Route) => {
+    if (route.request().method() !== "POST") return route.fallback();
+    return route.fulfill({
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({
+        detail: "Este presupuesto no tiene datos de cálculo (quote_breakdown)",
+      }),
+    });
+  });
+
+  await page.goto(`/quotes/${quoteId}/pdf`);
+  await page.locator('[data-testid="generate-pdf"]').click();
+  await page.locator('[data-testid="modal-confirm"]').click();
+  const banner = page.locator('[data-testid="modal-error-banner"]');
+  await expect(banner).toBeVisible({ timeout: 10_000 });
+  await expect(banner).toContainText(/falta procesar el contexto/i);
+  // El botón "Reintentar" debe quedar habilitado para reintento.
+  await expect(page.locator('[data-testid="modal-confirm"]')).toBeEnabled();
+});
+
+test("real wire · descarga usa pdf_url real del backend (window.open con URL exacta)", async ({
+  page,
+  context,
+}) => {
+  const quoteId = "real-pdf-003";
+  const expectedPdfUrl = "https://drive.google.com/file/expected-pdf-url";
+  // GET pre-poblado · estado C ya seedeado desde SSR.
+  await mockQuoteDetail(page, quoteId, true);
+  await page.route(quoteDetailRoute(quoteId), async (route: Route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: quoteId,
+        client_name: "Cliente Download",
+        project: "Test",
+        material: "Test",
+        status: "sent",
+        pdf_url: expectedPdfUrl,
+        excel_url: "https://drive.google.com/file/excel-url",
+        drive_url: "https://drive.google.com/folder/test",
+        drive_file_id: "dl-123",
+        updated_at: "2026-06-14T18:42:00Z",
+        quote_breakdown: { client_name: "Cliente Download" },
+      }),
+    });
+  });
+
+  await page.goto(`/quotes/${quoteId}/pdf`);
+  // Click descarga PDF · capturamos la nueva pestaña.
+  const popupPromise = context.waitForEvent("page", { timeout: 10_000 });
+  await page.locator('[data-testid="download-pdf-row"]').click();
+  const popup = await popupPromise;
+  expect(popup.url()).toBe(expectedPdfUrl);
+});


### PR DESCRIPTION
## Summary · Sprint 4 paso 10 · cierra el MVP loop

Sub-PR final del MVP: **brief → contexto → despiece → cálculo → PDF con datos reales**. Backend + frontend + 3 bug fixes financieros + auditoría retroactiva.

🚨 **AUDIT INDEPENDIENTE OBLIGATORIO ANTES DEL MERGE** 🚨

- **Bug financiero (Bug 1)**: puede haber afectado quotes de edificio reales · cliente pagó menos de lo que correspondía.
- **Tamaño**: ~600 LOC tocando backend + frontend + calculator.
- **Cierra MVP loop**: primer wire end-to-end PDF real · regresión silente == operador entera por el cliente.

## Parte 1 · Wire del PDF

[api/app/modules/agent/router.py:1426](api/app/modules/agent/router.py:1426) · `/quotes/{id}/generate` reemplaza dict manual de 14 campos por `dict(bd)` (patrón de `/validate` y `/regenerate`) + `doc_data["notes"] = quote.notes` (cierra deuda PR #439). Propaga **9 campos** que antes no llegaban al PDF: `sobrante_m2`, `sobrante_total`, `mo_discount_pct/amount`, `has_m2_override`, `is_edificio`, `thickness_mm`, `notes`, `material_total_bruto`.

[document_tool.py:262](api/app/modules/agent/tools/document_tool.py:262) · logging warning si faltan campos críticos del breakdown · detección proactiva.

## Parte 2 · Frontend real wire

[web/src/lib/api/real.ts](web/src/lib/api/real.ts) · +165 LOC · 3 funciones nuevas (`triggerPdfGeneration`, `triggerPdfV2Generation`, `getPdfGeneratedInfo`). Adapter shape backend (snake_case + sin metadatos UI) → `PdfGeneratedInfo` (camelCase + fields degradados a "—"). Error mapping `_mapPdfError` traduce status + detail a 6 códigos (`PDF_TIMEOUT`, `DRIVE_QUOTA`, `BREAKDOWN_MISSING`, `QUOTE_NOT_FOUND`, `PDF_NO_URL`, `PDF_GENERIC`).

[web/src/lib/api/index.ts:55-65](web/src/lib/api/index.ts:55) · gate `USE_REAL_API` para las 3 nuevas. **`getPdfV2DiffData` sigue en mock** · no hay endpoint backend para v1 vs v2 diff (sub-PR follow-up `paso-5-v2-diff-real`).

[PdfConfirmModal.tsx](web/src/components/pdf/PdfConfirmModal.tsx) · `_friendlyMessage(err)` mapea `ApiError.code` a mensaje en español específico (no muestra el detail crudo del backend).

[quotes/[id]/pdf/page.tsx](web/src/app/quotes/[id]/pdf/page.tsx) · `getPdfGeneratedInfo(id, { bearerToken })` pasa token SSR · sin él el real wire falla 401.

## Parte 3 · Bugs financieros (3)

### Bug 1 · descuento aplicado 2× en edificio PDF + Excel

- **Síntoma**: PDFs de edificio mostraban el descuento aplicado dos veces · cliente pagaba MENOS de lo que correspondía. Standard `_generate_pdf` (línea 1415) NO tenía el bug (recalculaba bruto directo desde `m² × precio`).
- **Causa**: [document_tool.py:871](api/app/modules/agent/tools/document_tool.py:871) y [:1112](api/app/modules/agent/tools/document_tool.py:1112) leían `data.get("material_total")` esperando bruto · pero `calculator.py:1915` guardaba `material_total` como NET (post-descuento). Al restar descuento de nuevo → double-discount.
- **Fix**:
  - [calculator.py:1915](api/app/modules/quote_engine/calculator.py:1915) ahora expone `material_total_bruto` (pre-descuento) junto con `material_total` (NET · backward compat).
  - [document_tool.py:`_read_material_bruto`](api/app/modules/agent/tools/document_tool.py) helper nuevo · lee bruto con fallback derivable de NET legacy (`net / (1 - pct/100)`) con guards.
  - Ambos sitios afectados ([871 y 1112](api/app/modules/agent/tools/document_tool.py:871)) pasan a usar el helper.

### Bug 2 · `material_total` como fallback (no source of truth)

- Cerrado implícitamente por `_read_material_bruto` · usa `is not None` (no `or` truthy) · override manual a $0 se respeta.

### Bug 3 · notes del quote no llegan al PDF (deuda PR #439)

- Cerrado en Parte 1 (`doc_data["notes"] = quote.notes`).

## Parte 4 · Auditoría retroactiva Bug 1

[api/scripts/audit_pdf_discount_double_count.py](api/scripts/audit_pdf_discount_double_count.py) · READ-ONLY · identifica quotes SENT/VALIDATED con `discount_pct > 0` + breakdown legacy sin `material_total_bruto` · estima exceso descontado · CSV output + síntesis stdout (count, total $, top 5 por exceso).

```bash
cd api
python -m scripts.audit_pdf_discount_double_count [--dry-run]
```

Agos decide qué hacer con el output (refacturar, ignorar, comunicar). Sub-PR follow-up potencial: `audit_pdf_discount_double_count_retro_action`.

## Tests nuevos

### Backend · 10 tests pytest ([test_pdf_generate_wire.py](api/tests/test_pdf_generate_wire.py))
1. `_read_material_bruto` lee bruto explícito
2. ` ` deriva bruto de net legacy + discount_pct
3. ` ` legacy sin descuento usa material_total directo
4. ` ` recalcula desde m²×price si ambos ausentes
5. ` ` override manual 0 se respeta (Bug 2 regression)
6. Edificio PDF descuento 15% una sola vez (NO 12.75% double-count)
7. Edificio legacy breakdown sin bruto se deriva correctamente
8. Standard PDF renderea notes cuando quote tiene
9. Standard PDF renderea sobrante cuando presente
10. Snapshot real-flow: `calculator.calculate_quote()` → PDF sin crash (cierra gap del docstring `test_pdf_snapshots.py:8-14`)

### Frontend · 3 E2E ([paso-5-pdf-real-wire.spec.ts](web/tests/e2e/paso-5-pdf-real-wire.spec.ts))
- Gated por `NEXT_PUBLIC_API_URL` (skip en CI default · 4 specs `paso-5-*.spec.ts` mock siguen cubriendo)
- Pattern `page.route()` interceptor (idem `brief-upload-real.spec.ts`):
  1. Happy path: POST `/generate` 200 → estado C visible con file rows
  2. Error 400 BREAKDOWN_MISSING → modal renderea "Falta procesar el contexto del quote..."
  3. Descarga usa `pdf_url` real del backend (window.open con URL exacta)

## Verificación local

- [x] `pytest tests/test_pdf_generate_wire.py` · 10/10 pass
- [x] Full pytest · 2526 passed (+10 nuevos) · 41 env-only fails idénticas a baseline · 0 regresiones nuevas
- [x] `tsc --noEmit` · 0 errores
- [x] `npm run lint` · 0 errores en archivos del PR
- [x] `npm run test:unit` · 129/129 pass
- [x] `npm run build` · OK

## Test plan post-deploy

- [ ] Smoke prod: crear quote nuevo edificio con descuento 15% · descargar PDF · verificar **descuento aplicado UNA sola vez** (NO 12.75% double-count)
- [ ] Verificar bloque NOTAS aparece en PDF si `Quote.notes` está poblado
- [ ] Verificar bloque SOBRANTE aparece si `breakdown.sobrante_m2 > 0`
- [ ] Correr `python -m scripts.audit_pdf_discount_double_count --dry-run` en Railway → ver síntesis · Agos decide
- [ ] Setear `NEXT_PUBLIC_API_URL` en Vercel preview → verificar que `triggerPdfGeneration` real dispara `/generate` (no mock)
- [ ] Verificar error BREAKDOWN_MISSING en modal muestra mensaje español (no detail crudo del backend)
- [ ] **AUDIT INDEPENDIENTE** antes del merge

## Caveats

- Quotes existentes en draft retienen breakdown viejo · re-disparar `/generate` los regenera con el wire nuevo, pero usan el `material_total` NET viejo (helper deriva bruto · regression guard cubierto en test 7).
- E2E real-wire skipea sin `NEXT_PUBLIC_API_URL` · default CI corre mocks (cero cambio de specs existentes).
- `getPdfV2DiffData` sigue en mock · no hay endpoint backend para v1 vs v2 diff · sub-PR follow-up `paso-5-v2-diff-real`.
- El standard `_generate_pdf` (línea 1415) NO tenía el bug · quotes residenciales no-edificio NO están en el universo del audit.

## Lecciones operativas aplicadas

- **#57** determinístico cross-domain (mismo discount field unifica calculator + PDF)
- **#58** backend + frontend mismo PR
- **#60** fixtures shape REAL (snapshot real-flow test cierra gap docstring)
- **#61** bugs son bugs (Bug 1 financiero · no deuda técnica)
- **#65** documentar decisiones (material_total NET vs bruto explicado in-code)
- **#67** arqueología obligatoria · FASE 1 reveló premisa stale del test_pdf_snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)