### PR TITLE
feat(dashboard): ocultar id crudo + tag de canal web/operador

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -333,3 +333,44 @@
   .catalogo-v2 .import-tabs { flex-direction: column; }
   .catalogo-v2 .diff-table { overflow-x: auto; }
 }
+
+/* ─── SourceTag · chip de canal (web / operador) en la lista del dashboard.
+   Reemplaza el id crudo. Sobrio: mono micro + hairline · diferenciado por
+   label + peso (web filled / operador outline) · NO usa --accent (IA) ni
+   --human (púrpura) para no pisar la semántica de provenance. */
+.source-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  font-weight: 500;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  line-height: 1;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  color: var(--ink-mute);
+  white-space: nowrap;
+}
+.source-tag::before {
+  content: "";
+  width: 4.5px;
+  height: 4.5px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.7;
+}
+/* web = incoming/externo · un punto más de presencia (filled) para que
+   Marina lo distinga al escanear. */
+.source-tag.web {
+  background: var(--bg-muted);
+  border-color: var(--line-strong);
+  color: var(--ink-soft);
+}
+/* operador = carga interna · outline neutral. */
+.source-tag.operator {
+  background: transparent;
+  color: var(--ink-mute);
+}

--- a/web/src/components/dashboard/QuoteListItem.tsx
+++ b/web/src/components/dashboard/QuoteListItem.tsx
@@ -6,7 +6,8 @@
 import Link from "next/link";
 import type { DashboardQuote } from "@/lib/api";
 import { StatusChip } from "./StatusChip";
-import { formatAmount, formatM2 } from "./format";
+import { SourceTag } from "./SourceTag";
+import { formatAmount, formatM2, resolveQuoteSource } from "./format";
 
 export function QuoteListItem({ quote }: { quote: DashboardQuote }) {
   return (
@@ -26,12 +27,7 @@ export function QuoteListItem({ quote }: { quote: DashboardQuote }) {
       }}
     >
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-        <span
-          className="font-mono"
-          style={{ fontSize: 10, color: "var(--ink-mute)", letterSpacing: "0.4px" }}
-        >
-          {quote.id}
-        </span>
+        <SourceTag source={resolveQuoteSource(quote)} />
         <StatusChip status={quote.status} />
       </div>
       <div style={{ fontSize: 14, color: "var(--ink)" }}>{quote.client}</div>

--- a/web/src/components/dashboard/QuoteTable.tsx
+++ b/web/src/components/dashboard/QuoteTable.tsx
@@ -9,7 +9,8 @@
 import Link from "next/link";
 import type { DashboardQuote } from "@/lib/api";
 import { StatusChip } from "./StatusChip";
-import { formatAmount, formatM2 } from "./format";
+import { SourceTag } from "./SourceTag";
+import { formatAmount, formatM2, resolveQuoteSource } from "./format";
 
 interface Props {
   quotes: DashboardQuote[];
@@ -63,10 +64,10 @@ export function QuoteTable({ quotes, loading }: Props) {
                 style={{ display: "block", color: "inherit" }}
                 data-testid={`quote-link-${q.id}`}
               >
-                <div className="font-mono" style={{ fontSize: 11, color: "var(--ink-mute)" }}>
-                  {q.id}
+                <div>{q.client}</div>
+                <div style={{ marginTop: 4 }}>
+                  <SourceTag source={resolveQuoteSource(q)} />
                 </div>
-                <div style={{ marginTop: 2 }}>{q.client}</div>
               </Link>
             </td>
             <td>{q.material}</td>

--- a/web/src/components/dashboard/SourceTag.tsx
+++ b/web/src/components/dashboard/SourceTag.tsx
@@ -1,0 +1,30 @@
+/**
+ * SourceTag · chip de canal de origen (web / operador) para la lista del
+ * dashboard. Reemplaza el id crudo (UUID `web-…`) que quedaba feo en la
+ * lista. Sobrio a propósito: mono micro + hairline, diferenciado por label
+ * + peso (web = filled, operador = outline). NO usa `--accent` (reservado a
+ * IA) ni `--human` (púrpura) para no romper la semántica de provenance.
+ */
+import type { DashboardSource } from "@/lib/mocks/dashboardDataset";
+
+const LABEL: Record<DashboardSource, string> = {
+  web: "Web",
+  operator: "Operador",
+};
+
+const TITLE: Record<DashboardSource, string> = {
+  web: "Generado por el cliente desde la web",
+  operator: "Cargado por el operador",
+};
+
+export function SourceTag({ source }: { source: DashboardSource }) {
+  return (
+    <span
+      className={`source-tag ${source}`}
+      data-testid={`source-tag-${source}`}
+      title={TITLE[source]}
+    >
+      {LABEL[source]}
+    </span>
+  );
+}

--- a/web/src/components/dashboard/format.ts
+++ b/web/src/components/dashboard/format.ts
@@ -6,6 +6,7 @@
  *   - USD: `USD 1.538` (espacio, separador miles con punto)
  *   - m²:  `6,50 m²` (coma decimal · 2 decimales)
  */
+import type { DashboardSource } from "@/lib/mocks/dashboardDataset";
 
 export function formatARS(value: number): string {
   return `$${value.toLocaleString("es-AR", { maximumFractionDigits: 0 })}`;
@@ -24,4 +25,17 @@ export function formatM2(value: number): string {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   })} m²`;
+}
+
+/**
+ * Resuelve el canal de origen del presupuesto. Preferimos el campo
+ * autoritativo `source` (Quote.source del backend); si falta (mocks legacy
+ * o respuestas viejas) caemos al prefijo del id (`web-*` = web pública).
+ */
+export function resolveQuoteSource(quote: {
+  source?: DashboardSource;
+  id: string;
+}): DashboardSource {
+  if (quote.source === "web" || quote.source === "operator") return quote.source;
+  return quote.id.startsWith("web-") ? "web" : "operator";
 }

--- a/web/src/lib/api/real.ts
+++ b/web/src/lib/api/real.ts
@@ -81,6 +81,7 @@ interface RealQuoteListItem {
   total_usd: number | null;
   status: string;
   created_at: string;
+  source?: string | null;
 }
 
 function adaptStatus(s: string): DashboardStatus {
@@ -95,6 +96,9 @@ function adaptListItem(item: RealQuoteListItem): DashboardQuote {
   const amount = currency === "USD" ? (item.total_usd ?? 0) : (item.total_ars ?? 0);
   return {
     id: item.id,
+    // Quote.source del backend ("web" | "operator"). Si el backend no lo
+    // manda, resolveQuoteSource cae al prefijo del id (`web-*`).
+    source: item.source === "web" ? "web" : item.source === "operator" ? "operator" : undefined,
     client: item.client_name || "Cliente sin identificar",
     clientFull: item.client_name || item.project || "—",
     material: item.material || "—",

--- a/web/src/lib/mocks/dashboardDataset.ts
+++ b/web/src/lib/mocks/dashboardDataset.ts
@@ -13,9 +13,14 @@
 
 export type DashboardStatus = "draft" | "sent" | "expired" | "lost";
 export type DashboardCurrency = "ARS" | "USD";
+/** Canal de origen · "web" = generado por el cliente desde la web pública
+ * (id `web-*`, Quote.source="web") · "operator" = cargado por Marina.
+ * Opcional: legacy/mocks sin el campo se derivan del prefijo del id. */
+export type DashboardSource = "web" | "operator";
 
 export interface DashboardQuote {
   readonly id: string;
+  readonly source?: DashboardSource;
   readonly client: string;
   readonly clientFull: string;
   readonly material: string;
@@ -44,6 +49,7 @@ export const DASHBOARD_QUOTES: ReadonlyArray<DashboardQuote> = [
   // ─── ENVIADO (12) ─────────────────────────────────────────────────────
   {
     id: "PRES-2026-018",
+    source: "operator",
     client: "Cueto-Heredia",
     clientFull: "Estudio Cueto-Heredia · cocina Belgrano",
     material: "Granito Negro Brasil",
@@ -58,6 +64,7 @@ export const DASHBOARD_QUOTES: ReadonlyArray<DashboardQuote> = [
   },
   {
     id: "PRES-2026-017",
+    source: "web",
     client: "Familia Pereyra",
     clientFull: "Familia Pereyra · cocina U + isla",
     material: "Silestone Blanco Norte",

--- a/web/tests/e2e/dashboard.spec.ts
+++ b/web/tests/e2e/dashboard.spec.ts
@@ -194,6 +194,34 @@ test.describe("Regression · scope eliminado (KPIs + aside)", () => {
   });
 });
 
+test.describe("SourceTag · canal web/operador + id oculto", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("el id crudo ya NO se muestra en la fila de la lista", async ({ page }) => {
+    await page.goto("/");
+    const row = page.locator('[data-testid="quote-row-PRES-2026-018"]');
+    await expect(row).toContainText("Cueto-Heredia");
+    // El id (UUID `web-…` en prod, PRES-* en mock) ya no se renderiza como texto.
+    await expect(row).not.toContainText("PRES-2026-018");
+  });
+
+  test("tag 'Web' en quote source=web · tag 'Operador' en source=operator", async ({ page }) => {
+    await page.goto("/");
+    // PRES-2026-017 (Pereyra) tiene source: "web" en el dataset.
+    await expect(
+      page
+        .locator('[data-testid="quote-row-PRES-2026-017"]')
+        .locator('[data-testid="source-tag-web"]'),
+    ).toBeVisible();
+    // PRES-2026-018 (Cueto-Heredia) tiene source: "operator".
+    await expect(
+      page
+        .locator('[data-testid="quote-row-PRES-2026-018"]')
+        .locator('[data-testid="source-tag-operator"]'),
+    ).toContainText("Operador");
+  });
+});
+
 test.describe("Mobile · responsive single layout", () => {
   test.use({ viewport: { width: 375, height: 812 } });
 


### PR DESCRIPTION
## Qué resuelve

En la lista de presupuestos el id crudo (UUID `web-d3890e51-56ba-41f1-…`) quedaba feo y ruidoso. Además no había forma de distinguir de un vistazo los presupuestos que llegan **desde la web** vs los que carga **el operador**.

## Cambios

**1 · Se quita el id crudo de la lista** (desktop `QuoteTable` + mobile `QuoteListItem`). El nombre del cliente pasa a ser el identificador primario. El id sigue vivo en el `href` y los `data-testid` → navegación y tests intactos.

**2 · `<SourceTag>` — chip de canal `Web` / `Operador`:**
- Diseño sobrio (mono micro + hairline pill), diferenciado por **label + peso** (web = filled, operador = outline).
- **No usa `--accent`** (reservado a IA per handoff) ni `--human` (púrpura) → no pisa la semántica IA/humano del producto. Solo tokens neutrales (`--ink-mute`/`--ink-soft`/`--bg-muted`/`--line`).
- Ocupa el lugar que tenía el id, así la altura de fila no cambia.

**3 · Fuente del canal — campo autoritativo + fallback:**
- `resolveQuoteSource()` prefiere `Quote.source` (`"web"`/`"operator"`, **ya expuesto** por `GET /api/quotes` vía `QuoteListResponse.source`).
- Si falta, cae al prefijo del id (`web-*` = web). Cubre quotes legacy y mocks.
- `real.ts` mapea `source` del backend; el dataset mock marca 2 quotes (017=web, 018=operator) para showcase + cobertura e2e.

## Scope
- CSS nuevo scoped bajo `.source-tag` en `globals.css` · **`operator-shared.css` INTACTO**.
- **Cero backend** (el campo `source` ya existía y ya se devolvía).
- 8 archivos, +132/-11.

## Verificación
- typecheck ✅ · lint ✅ (0 errores · 5 warnings prettier pre-existentes del #489) · build ✅
- **dashboard e2e 24/24** incluidos 2 nuevos: (a) el id crudo ya no se muestra en la fila, (b) tag `Web` en source=web + `Operador` en source=operator. Verificado en navegador real.

## Para tu sign-off visual
El **Vercel preview** de este PR renderiza el branch con datos reales — ahí ves los tags `Web`/`Operador` y la lista sin el UUID. Si querés ajustar el wording (`Web`/`Operador`) o el peso visual del chip, lo cambio en un toque.

🤖 Generated with [Claude Code](https://claude.com/claude-code)