### PR TITLE
fix(quote): denormaliza client_name desde el breakdown en GET /quotes/{id}

### DIFF
--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -306,12 +306,75 @@ def _compute_pdf_outdated(quote: Quote) -> tuple[bool, Optional[datetime]]:
     return pdf_outdated, last_pdf_ts
 
 
+def _client_name_from_breakdown(bd: dict | None) -> str | None:
+    """Extrae el nombre del cliente desde el `quote_breakdown`.
+
+    El wizard (brief → contexto → despiece) guarda el cliente extraído SOLO
+    dentro del JSON `quote_breakdown` (en `verified_context_analysis` /
+    `context_analysis_pending`), nunca en la columna denormalizada
+    `Quote.client_name`. Por eso el header (`GET /quotes/{id}`) y el dashboard
+    (que filtra drafts con `client_name` vacío) no veían el nombre y caían al
+    fallback `Presupuesto {uuid}`.
+
+    Replica la MISMA precedencia que el adapter del frontend
+    (`web/src/lib/api/adapters/context-from-breakdown.ts`):
+
+      1. entry "Cliente" en `data_known`/`assumptions` de `verified_*`
+      2. ídem en `context_analysis_pending`
+      3. `_brief_analysis_raw.client_name` (verified → pending → top-level)
+
+    Devuelve `None` si no hay nombre utilizable.
+    """
+    if not isinstance(bd, dict):
+        return None
+
+    verified = bd.get("verified_context_analysis")
+    pending = bd.get("context_analysis_pending")
+
+    def _find_entry(analysis: object, field_name: str) -> str | None:
+        if not isinstance(analysis, dict):
+            return None
+        for bucket in ("data_known", "assumptions"):
+            for entry in analysis.get(bucket) or []:
+                if isinstance(entry, dict) and entry.get("field") == field_name:
+                    val = (entry.get("value") or "").strip()
+                    if val:
+                        return val
+        return None
+
+    name = _find_entry(verified, "Cliente") or _find_entry(pending, "Cliente")
+    if name:
+        return name
+
+    for source in (verified, pending, bd):
+        raw = source.get("_brief_analysis_raw") if isinstance(source, dict) else None
+        if isinstance(raw, dict):
+            raw_name = (raw.get("client_name") or "").strip() if raw.get("client_name") else ""
+            if raw_name:
+                return raw_name
+
+    return None
+
+
 @router.get("/quotes/{quote_id}")
 async def get_quote(quote_id: str, db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(Quote).where(Quote.id == quote_id))
     quote = result.scalar_one_or_none()
     if not quote:
         raise HTTPException(status_code=404, detail="Presupuesto no encontrado")
+
+    # Lazy denormalization — si la fila no tiene `client_name` pero el
+    # `quote_breakdown` ya lo extrajo (caso típico del wizard), lo copiamos a
+    # la columna y persistimos una sola vez. Así el header deja de mostrar
+    # "Presupuesto {uuid}" y el quote aparece/agrupa en el dashboard. Mismo
+    # patrón de cache lazy que `email_draft`. Idempotente: corre solo mientras
+    # `client_name` esté vacío.
+    if not (quote.client_name or "").strip():
+        derived = _client_name_from_breakdown(quote.quote_breakdown)
+        if derived:
+            quote.client_name = derived[:500]
+            await db.commit()
+            await db.refresh(quote)
 
     # PR #442 — computar pdf_outdated antes de armar el response.
     pdf_outdated, pdf_generated_at = _compute_pdf_outdated(quote)

--- a/api/tests/test_quote_client_denormalize.py
+++ b/api/tests/test_quote_client_denormalize.py
@@ -1,0 +1,116 @@
+"""Tests · `GET /api/quotes/{id}` denormaliza `client_name` desde el breakdown.
+
+Bug: el wizard (brief → contexto → despiece) guarda el cliente extraído SOLO
+dentro de `quote_breakdown`, nunca en la columna `Quote.client_name`. El header
+y el dashboard leen la columna → mostraban "Presupuesto {uuid}" y el draft
+quedaba oculto del listado (que filtra `client_name != ""`).
+
+Fix: `get_quote` copia el nombre del breakdown a la columna (lazy, una vez) con
+la MISMA precedencia que el adapter del frontend
+(`web/src/lib/api/adapters/context-from-breakdown.ts`).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.models.quote import Quote, QuoteStatus
+
+
+async def _seed(db_session, quote_id: str, *, client_name: str = "", breakdown=None):
+    db_session.add(
+        Quote(
+            id=quote_id,
+            client_name=client_name,
+            project="",
+            messages=[],
+            status=QuoteStatus.DRAFT,
+            quote_breakdown=breakdown,
+        )
+    )
+    await db_session.commit()
+
+
+def _bd_with(field_value=None, *, raw_client=None, bucket="data_known", analysis_key="context_analysis_pending"):
+    """Construye un breakdown con shape REAL del backend."""
+    analysis: dict = {}
+    if field_value is not None:
+        analysis[bucket] = [{"field": "Cliente", "value": field_value, "source": "brief"}]
+    if raw_client is not None:
+        analysis["_brief_analysis_raw"] = {"client_name": raw_client}
+    return {analysis_key: analysis}
+
+
+@pytest.mark.asyncio
+async def test_denormaliza_desde_data_known_pending(client, db_session):
+    qid = str(uuid.uuid4())
+    await _seed(db_session, qid, client_name="", breakdown=_bd_with("Juan Pérez"))
+
+    resp = await client.get(f"/api/quotes/{qid}")
+    assert resp.status_code == 200
+    assert resp.json()["client_name"] == "Juan Pérez"
+
+    # Persistido en la fila (dashboard ahora lo incluye/agrupa).
+    refreshed = await db_session.get(Quote, qid)
+    await db_session.refresh(refreshed)
+    assert refreshed.client_name == "Juan Pérez"
+
+
+@pytest.mark.asyncio
+async def test_verified_tiene_precedencia_sobre_pending(client, db_session):
+    qid = str(uuid.uuid4())
+    bd = {
+        "verified_context_analysis": {
+            "data_known": [{"field": "Cliente", "value": "Cliente Verificado", "source": "brief"}],
+        },
+        "context_analysis_pending": {
+            "data_known": [{"field": "Cliente", "value": "Cliente Pending", "source": "brief"}],
+        },
+    }
+    await _seed(db_session, qid, client_name="", breakdown=bd)
+
+    resp = await client.get(f"/api/quotes/{qid}")
+    assert resp.json()["client_name"] == "Cliente Verificado"
+
+
+@pytest.mark.asyncio
+async def test_fallback_a_brief_analysis_raw(client, db_session):
+    qid = str(uuid.uuid4())
+    # Sin entry "Cliente" → cae al _brief_analysis_raw.client_name.
+    await _seed(db_session, qid, client_name="", breakdown=_bd_with(None, raw_client="Erica Bernardi"))
+
+    resp = await client.get(f"/api/quotes/{qid}")
+    assert resp.json()["client_name"] == "Erica Bernardi"
+
+
+@pytest.mark.asyncio
+async def test_no_pisa_client_name_existente(client, db_session):
+    qid = str(uuid.uuid4())
+    # La columna ya tiene un valor → NO se sobrescribe con el breakdown.
+    await _seed(db_session, qid, client_name="Nombre Canónico", breakdown=_bd_with("Otro Nombre"))
+
+    resp = await client.get(f"/api/quotes/{qid}")
+    assert resp.json()["client_name"] == "Nombre Canónico"
+
+
+@pytest.mark.asyncio
+async def test_sin_breakdown_no_crashea_queda_vacio(client, db_session):
+    qid = str(uuid.uuid4())
+    await _seed(db_session, qid, client_name="", breakdown=None)
+
+    resp = await client.get(f"/api/quotes/{qid}")
+    assert resp.status_code == 200
+    assert resp.json()["client_name"] == ""
+
+
+@pytest.mark.asyncio
+async def test_breakdown_sin_cliente_queda_vacio(client, db_session):
+    qid = str(uuid.uuid4())
+    # Breakdown existe pero sin "Cliente" ni raw.client_name.
+    bd = {"context_analysis_pending": {"data_known": [{"field": "Material", "value": "Granito", "source": "brief"}]}}
+    await _seed(db_session, qid, client_name="", breakdown=bd)
+
+    resp = await client.get(f"/api/quotes/{qid}")
+    assert resp.status_code == 200
+    assert resp.json()["client_name"] == ""


### PR DESCRIPTION
## Problema

El header del presupuesto mostraba `Presupuesto 1a96a288` (prefijo del UUID) en vez del nombre del cliente, aun cuando el brief contenía claramente `Cliente: Juan Pérez`.

### Causa raíz

El wizard (brief → contexto → despiece) guarda el cliente extraído **solo dentro del JSON `quote_breakdown`** (`verified_context_analysis` / `context_analysis_pending`), **nunca en la columna denormalizada `Quote.client_name`**. Los flujos `context-analysis` y `context-confirmed` persisten solo `messages` y `quote_breakdown` — cero write-back a `client_name`.

- El header (`Qhead` → `getQuoteDisplayName`) lee `Quote.client_name` vía `GET /quotes/{id}` → vacío → cae al fallback `Presupuesto {uuid}`.
- El dashboard **excluye** drafts con `client_name` vacío (`Quote.client_name != ""`), así que estos quotes ni aparecían/agrupaban.

## Fix

Lazy denormalization en `get_quote`: si la fila no tiene `client_name` pero el breakdown ya lo extrajo, copia el nombre a la columna y persiste **una sola vez** (mismo patrón de cache lazy que `email_draft`).

El helper `_client_name_from_breakdown` replica la **misma precedencia** que el adapter del frontend (`context-from-breakdown.ts`):
1. entry `"Cliente"` en `data_known`/`assumptions` de `verified_context_analysis`
2. ídem en `context_analysis_pending`
3. `_brief_analysis_raw.client_name` (verified → pending → top-level)

Idempotente · no pisa un `client_name` ya seteado · choke point único que arregla **header + visibilidad/agrupación en dashboard + quotes ya existentes al recargar**.

## Tests

6 casos nuevos en `api/tests/test_quote_client_denormalize.py`:
- denormaliza desde `data_known`/pending
- precedencia `verified` > `pending`
- fallback a `_brief_analysis_raw`
- no pisa `client_name` existente
- sin breakdown → no crashea, queda vacío
- breakdown sin cliente → queda vacío

✅ 6/6 verdes · 52 tests de endpoints relacionados verdes · backend-only, cero frontend touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)