### PR TITLE
fix(zocalo): unificar default_zocalo_height a measurements.* (bug 7cm financiero)

### DIFF
--- a/api/app/modules/agent/agent.py
+++ b/api/app/modules/agent/agent.py
@@ -566,9 +566,12 @@ async def _run_dual_read(
             # Construir y emitir context_analysis
             try:
                 from app.modules.quote_engine.context_analyzer import build_context_analysis
-                from app.modules.agent.tools.catalog_tool import get_ai_config as _get_ai
                 _cfg_defaults = {
-                    "default_zocalo_height": (_get_ai() or {}).get("default_zocalo_height", 0.07),
+                    # sprint-4/zocalo-config-unification: leer del MISMO bloque
+                    # (measurements.*) que edita /configuracion (#492). Antes leía
+                    # de ai_engine.* vía get_ai_config → la key no existe ahí →
+                    # caía SIEMPRE al fallback 0.07 (bug financiero · sobre-cobro).
+                    "default_zocalo_height": _cfg("measurements.default_zocalo_height", 0.05),
                     "default_payment": "Contado",
                     "default_delivery_days": "30 días",
                 }
@@ -2918,12 +2921,12 @@ class AgentService:
                             from app.modules.quote_engine.context_analyzer import (
                                 build_context_analysis,
                             )
-                            from app.modules.agent.tools.catalog_tool import (
-                                get_ai_config as _get_ai_tp,
-                            )
                             _cfg_tp = {
-                                "default_zocalo_height": (_get_ai_tp() or {}).get(
-                                    "default_zocalo_height", 0.07
+                                # sprint-4/zocalo-config-unification: idem site 1 ·
+                                # leer measurements.* (bloque que edita /configuracion),
+                                # no ai_engine.* · fallback master D'Angelo 0.05 (5cm).
+                                "default_zocalo_height": _cfg(
+                                    "measurements.default_zocalo_height", 0.05
                                 ),
                                 "default_payment": "Contado",
                                 "default_delivery_days": "30 días",

--- a/api/app/modules/quote_engine/dual_reader.py
+++ b/api/app/modules/quote_engine/dual_reader.py
@@ -27,8 +27,11 @@ from app.core.company_config import get as _cfg
 def _default_zocalo_alto() -> float:
     """PR #57 — leer alto zócalo default desde catalog/config.json en vez
     de hardcodear. Permite que el operador lo edite desde el panel de
-    Configuración web sin redeploy."""
-    return _cfg("measurements.default_zocalo_height", 0.07)
+    Configuración web sin redeploy.
+
+    sprint-4/zocalo-config-unification: fallback corregido 0.07 → 0.05
+    (default master D'Angelo · mismo root-cause que agent.py:571/2925)."""
+    return _cfg("measurements.default_zocalo_height", 0.05)
 
 logger = logging.getLogger(__name__)
 

--- a/api/scripts/audit_zocalo_7cm_retroactive.py
+++ b/api/scripts/audit_zocalo_7cm_retroactive.py
@@ -1,0 +1,179 @@
+"""Auditoría retroactiva · sprint-4/zocalo-config-unification (bug zócalo 7cm).
+
+Identifica quotes que pudieron quedar afectados por el bug del zócalo de 7cm:
+el agent leía `default_zocalo_height` del bloque `ai_engine.*` (donde la key
+no existe) → caía SIEMPRE al fallback hardcodeado 0.07 → cuando el brief NO
+especificaba alto de zócalo, se aplicaron 7cm en vez del default master 5cm.
+Sobre-cobro ≈ 40% en el m² del zócalo (material; la MO de zócalo, si aplica,
+se reporta aparte como nota · NO se suma al diff por defecto).
+
+HEURÍSTICA de detección (read-only · no hay forma 100% de saber si el brief
+especificó zócalo desde el breakdown):
+  - Se escanean los labels de piezas del breakdown (`sectors[].pieces[]`)
+    buscando zócalos (`"<ml>ML X <alto> ZOC"`).
+  - Se marca AFECTADO si algún zócalo tiene alto == 0.07 (fingerprint del
+    fallback · el master es 0.05 · 7cm explícito en brief es raro).
+  - Cada fila queda para revisión manual de Javi/Agos antes de cualquier
+    acción comercial (la columna `nota_heuristica` lo recuerda).
+
+Fórmula del exceso (material):
+    extra_m2 = sum(ml_zocalo) × (0.07 − 0.05)
+    diff_financiero = round(extra_m2 × material_price_unit)   [en la moneda del quote]
+
+READ-ONLY · solo SELECT · NO modifica NADA en la DB. `--dry-run` imprime
+resumen sin escribir CSV.
+
+Uso:
+    cd api
+    python -m scripts.audit_zocalo_7cm_retroactive --dry-run
+    python -m scripts.audit_zocalo_7cm_retroactive --since 2026-04-01
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.models.quote import Quote, QuoteStatus
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger(__name__)
+
+DEFAULT_SINCE = "2026-04-01"  # repo init · pre-agent no existe nada
+MASTER_ZOCALO = 0.05
+BUG_ZOCALO = 0.07
+
+# Label de zócalo del calculator: f"{largo:.2f}ML X {dim2:.2f} ZOC"
+_ZOC_RE = re.compile(r"(\d+(?:\.\d+)?)\s*ML\s*X\s*(\d+\.\d+)\s*ZOC", re.IGNORECASE)
+
+
+def _iter_piece_labels(bd: dict):
+    """Yield los labels de pieza (string) de todos los sectores del breakdown."""
+    for sector in bd.get("sectors") or []:
+        for piece in sector.get("pieces") or []:
+            if isinstance(piece, str):
+                yield piece
+            elif isinstance(piece, dict):
+                yield str(piece.get("label", ""))
+
+
+def _extract_zocalos_7cm(bd: dict) -> list[tuple[float, float]]:
+    """Devuelve [(ml, alto)] de zócalos con alto == 0.07 (fingerprint del bug)."""
+    found = []
+    for label in _iter_piece_labels(bd):
+        for m in _ZOC_RE.finditer(label):
+            ml = float(m.group(1))
+            alto = round(float(m.group(2)), 2)
+            if alto == BUG_ZOCALO:
+                found.append((ml, alto))
+    return found
+
+
+def _pdf_emitido(quote: Quote) -> tuple[bool, str]:
+    """(emitido_al_cliente, fecha_emision_iso) · best-effort."""
+    emitido = quote.status == QuoteStatus.SENT or bool(quote.pdf_url) or bool(quote.drive_pdf_url)
+    fecha = ""
+    ro = quote.resumen_obra if isinstance(quote.resumen_obra, dict) else None
+    if ro and ro.get("generated_at"):
+        fecha = str(ro["generated_at"])
+    return emitido, fecha
+
+
+def audit(*, since: str, dry_run: bool) -> int:
+    sync_url = settings.DATABASE_URL.replace("+asyncpg", "").replace("postgresql+asyncpg", "postgresql")
+    cutoff = datetime.fromisoformat(since).replace(tzinfo=timezone.utc)
+    engine = create_engine(sync_url)
+    log.info(
+        "Audit zócalo 7cm · universo: created_at >= %s · zócalos con alto==0.07 "
+        "(fingerprint del fallback) · READ-ONLY", since,
+    )
+
+    rows: list[dict] = []
+    with Session(engine) as session:
+        stmt = select(Quote).where(Quote.created_at >= cutoff)
+        for quote in session.scalars(stmt):
+            bd = quote.quote_breakdown
+            if not isinstance(bd, dict):
+                continue
+            zocs = _extract_zocalos_7cm(bd)
+            if not zocs:
+                continue
+            total_ml = round(sum(ml for ml, _ in zocs), 2)
+            if total_ml <= 0:
+                continue
+            price_unit = float(bd.get("material_price_unit") or 0)
+            currency = (bd.get("material_currency") or "ARS").upper()
+            m2_zocalo = round(total_ml * BUG_ZOCALO, 2)
+            extra_m2 = total_ml * (BUG_ZOCALO - MASTER_ZOCALO)
+            diff_financiero = int(round(extra_m2 * price_unit))
+            monto_total = quote.total_usd if currency == "USD" else quote.total_ars
+            emitido, fecha_emision = _pdf_emitido(quote)
+            rows.append({
+                "quote_id": quote.id,
+                "client_name": quote.client_name,
+                "project": quote.project,
+                "fecha_creacion": quote.created_at.isoformat() if quote.created_at else "",
+                "fecha_emision_pdf": fecha_emision,
+                "status": quote.status.value if hasattr(quote.status, "value") else str(quote.status),
+                "pdf_emitido_cliente": "SI" if emitido else "no",
+                "currency": currency,
+                "monto_total": int(monto_total) if monto_total else 0,
+                "ml_zocalo_total": total_ml,
+                "m2_zocalo": m2_zocalo,
+                "diff_financiero_material": diff_financiero,
+                "nota_heuristica": "Revisar brief: confirmar que NO especificaba alto de zócalo antes de refacturar",
+            })
+
+    rows.sort(key=lambda r: r["diff_financiero_material"], reverse=True)
+    total_diff = sum(r["diff_financiero_material"] for r in rows)
+    emitidos = [r for r in rows if r["pdf_emitido_cliente"] == "SI"]
+
+    log.info("Quotes afectados (heurística): %d · de los cuales emitidos al cliente: %d",
+             len(rows), len(emitidos))
+    by_cur: dict[str, int] = {}
+    for r in rows:
+        by_cur[r["currency"]] = by_cur.get(r["currency"], 0) + r["diff_financiero_material"]
+    for cur, tot in by_cur.items():
+        log.info("  Exceso material total %s: %s", cur, tot)
+    log.info("Top 5 por exceso:")
+    for r in rows[:5]:
+        log.info("  - %s · %s · %s %s · %s", r["quote_id"], r["client_name"],
+                 r["diff_financiero_material"], r["currency"], r["status"])
+
+    if dry_run:
+        log.info("--dry-run · no se escribe CSV (total_diff acumulado mixto: %s)", total_diff)
+        return 0
+    if not rows:
+        log.info("Nada que reportar · CSV no escrito")
+        return 0
+
+    today = datetime.now(timezone.utc).strftime("%Y%m%d")
+    out_path = Path(f"audit_zocalo_7cm_{today}.csv")
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+    log.info("CSV escrito · %s (%d rows)", out_path.resolve(), len(rows))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--since", default=DEFAULT_SINCE, help=f"Cutoff created_at (default {DEFAULT_SINCE})")
+    parser.add_argument("--dry-run", action="store_true", help="Solo resumen · no escribe CSV.")
+    args = parser.parse_args()
+    return audit(since=args.since, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/api/tests/test_zocalo_config_unification.py
+++ b/api/tests/test_zocalo_config_unification.py
@@ -1,0 +1,88 @@
+"""sprint-4/zocalo-config-unification · regresión del bug del zócalo 7cm.
+
+Bug (FASE 1): el agent leía `default_zocalo_height` del bloque `ai_engine.*`
+del config (vía get_ai_config) en vez de `measurements.*` → la key no existía
+ahí → caía SIEMPRE al fallback hardcodeado 0.07 (7cm). El default master
+D'Angelo es 0.05 (5cm). Sobre-cobro ~40% en m² de zócalo (material + MO).
+
+Fix: agent.py:571/2925 + dual_reader.py:31 leen `_cfg("measurements.
+default_zocalo_height", 0.05)`.
+
+Estos tests cubren los DOS consumidores del valor:
+  1. `dual_reader._default_zocalo_alto()` (fallback corregido 0.07→0.05).
+  2. `context_analyzer._build_assumptions()` (consume el `config_defaults`
+     que el agent ahora arma con measurements.default_zocalo_height).
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.modules.quote_engine import dual_reader
+from app.modules.quote_engine.context_analyzer import _build_assumptions
+
+
+def _zocalo_assumption(assumptions: list[dict]) -> dict | None:
+    return next((a for a in assumptions if "Trasero por tramo" in str(a.get("value", ""))), None)
+
+
+# ── dual_reader._default_zocalo_alto · fallback corregido ──────────────────
+
+class TestDualReaderDefaultZocalo:
+    def test_usa_valor_de_config(self, monkeypatch):
+        monkeypatch.setattr(
+            dual_reader, "_cfg",
+            lambda key, default=None: 0.05 if key == "measurements.default_zocalo_height" else default,
+        )
+        assert dual_reader._default_zocalo_alto() == 0.05
+
+    def test_respeta_config_editable_distinto(self, monkeypatch):
+        monkeypatch.setattr(
+            dual_reader, "_cfg",
+            lambda key, default=None: 0.08 if key == "measurements.default_zocalo_height" else default,
+        )
+        assert dual_reader._default_zocalo_alto() == 0.08
+
+    def test_fallback_es_005_no_007(self, monkeypatch):
+        # Config sin la key (null/ausente) → devuelve el default que pasa la
+        # función. Verifica que ese default ahora es 0.05 (no el viejo 0.07).
+        monkeypatch.setattr(dual_reader, "_cfg", lambda key, default=None: default)
+        assert dual_reader._default_zocalo_alto() == 0.05
+
+
+# ── context_analyzer · consumer del config_defaults del agent ──────────────
+
+class TestContextAssumptionsZocalo:
+    def test_sin_alto_brief_usa_default_005(self):
+        """Brief pide zócalo pero no especifica alto · config=0.05 → 5cm."""
+        out = _build_assumptions(
+            analysis={"zocalos": "yes"},
+            quote=None,
+            dual_result={},
+            config_defaults={"default_zocalo_height": 0.05},
+        )
+        z = _zocalo_assumption(out)
+        assert z is not None, out
+        assert "5 cm" in z["value"]
+        assert "7 cm" not in z["value"]
+
+    def test_sin_alto_brief_respeta_config_editable_008(self):
+        """Operador editó measurements a 0.08 en /configuracion → 8cm."""
+        out = _build_assumptions(
+            analysis={"zocalos": "yes"},
+            quote=None,
+            dual_result={},
+            config_defaults={"default_zocalo_height": 0.08},
+        )
+        z = _zocalo_assumption(out)
+        assert z is not None and "8 cm" in z["value"]
+
+    def test_alto_explicito_en_brief_ignora_config(self):
+        """Brief dice 'zócalo 6cm' → respeta el brief, ignora el default."""
+        out = _build_assumptions(
+            analysis={"zocalos": "yes", "zocalos_alto_cm": 6},
+            quote=None,
+            dual_result={},
+            config_defaults={"default_zocalo_height": 0.05},
+        )
+        z = _zocalo_assumption(out)
+        assert z is not None and "6 cm" in z["value"]


### PR DESCRIPTION
## Bug

Confirmado en `SYSTEM-ARCHITECTURE-AUDIT-15.06.2026.md` (quote `1a96a288`): para un brief de particular **sin zócalo especificado**, Valentina aplicaba **7cm** en vez del default master D'Angelo de **5cm** → sobre-cobro ~40% en el m² del zócalo (material + MO). El campo `measurements.default_zocalo_height` en `/configuracion` (#492) estaba correcto en 0.05, pero el agent no lo leía.

## Reporte FASE 1 (findings)

| # | Hallazgo |
|---|---|
| A | `agent.py` tenía **2** refs (`571`, `2925`), ambas fallback `0.07` |
| B | También `dual_reader.py:31` (fuente correcta, fallback `0.07`) · `text_parser.py:27` ya correcto (`0.05`) · `context_analyzer.py:272` fallback OK pero recibía el `config_defaults` que el agent armaba con 0.07 |
| C | **Bug DOBLE** (ver lección abajo) |
| D | `_ai_config_cache` (de `get_ai_config`) **no** se invalida en el PUT de config → pero el fix mueve la lectura a `_cfg`/company_config (sí invalidado) → **Escenario B** |
| E | Deuda separada: string cosmético `agent.py:2411`, invalidación `_ai_config_cache` |

## Escenario aplicado: **B** (quirúrgico)

`agent.py:571` + `:2925` + `dual_reader.py:31` → `_cfg("measurements.default_zocalo_height", 0.05)`. Mismo patrón/cache que `text_parser.py:23-27` (`company_config`, ya invalidado por el PUT de `/configuracion`). **No se tocó el catalog router PUT.** Imports muertos `get_ai_config as _get_ai/_get_ai_tp` eliminados.

## 🔑 Lección operativa (finding C)

> Bug doble · `agent.py` no solo tenía fallback hardcodeado 0.07, sino que leía del bloque `ai_engine.*` del config en lugar de `measurements.*`. El fix de #492 sobre `measurements.*` nunca llegó al agent porque el agent miraba otro bloque. Lección: cuando un fix de config UI cierra un bug financiero pero el síntoma persiste en producción, verificar que el código consumidor lea del mismo bloque del config donde se hizo el fix.

## Tests

`api/tests/test_zocalo_config_unification.py` (6, todos verde):
- `dual_reader._default_zocalo_alto()` → usa config (0.05 / 0.08) · fallback **0.05 no 0.07**.
- `context_analyzer._build_assumptions()` (consumer del `config_defaults` del agent): brief sin alto + config 0.05 → 5cm · config 0.08 → 8cm · brief con alto explícito (6cm) → respeta brief.

Suites relacionadas (dual_reader, pending_questions, config_endpoint, card_editor, plan_anchor): **234 passed**, cero regresión. No había tests que asertaran el default=7cm (los `0.07` en tests son inputs explícitos de fixtures, no el fallback).

## Script audit retroactivo (READ-ONLY · no se ejecuta acá)

`api/scripts/audit_zocalo_7cm_retroactive.py` — `--since 2026-04-01` · `--dry-run` · solo SELECT, **no modifica nada**. Identifica quotes con zócalos a 0.07 (fingerprint del fallback), calcula `diff_financiero = sum(ml) × 0.02 × material_price_unit`, marca emitidos al cliente (status=sent) vs draft, suma el impacto por moneda. **Javi lo corre manualmente** cuando defina el mensaje para Agos.

**Magnitud estimada** (por quote): cocina típica ~4 ml de zócalo a USD 600/m² → exceso material ≈ 4 × 0.02 × 600 = **USD 48/quote** (+ MO). Total agregado: pendiente de correr el script contra la DB de prod.

## Scope / verificación
- Solo `.py`: `agent.py` + `dual_reader.py` (in-scope) + test + script. **Cero archivos frontend**, `operator-shared.css` byte-identical, sin middleware, sin catalog router PUT.
- Sintaxis OK · tests verde.

## Caveat (NO regresión nueva)
Multi-worker gunicorn: cada worker tiene cache module-level propio · la invalidación del PUT solo afecta al worker que lo recibe · los demás refrescan en unos segundos (badge ya presente en UI #492). Comportamiento aceptado Sprint 4.

## Follow-ups (deuda, sub-PRs separados)
- `agent.py:2411` string cosmético "0.07 m" en mensaje de ayuda.
- Invalidar `_ai_config_cache` en el PUT de config (toggles `ai_engine.*` editados por UI no refrescan hasta restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)