### PR TITLE
fix(zocalo): path interactivo pending-questions lee config (fast-follow #501)

### DIFF
--- a/api/app/modules/quote_engine/pending_questions.py
+++ b/api/app/modules/quote_engine/pending_questions.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from app.core.company_config import get as _cfg
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Brief matchers (keyword detection sobre el texto libre del operador)
 # ─────────────────────────────────────────────────────────────────────────────
@@ -570,6 +572,12 @@ def _detect_zocalos_question(brief: str, dual_result: dict) -> dict | None:
     if has_zocalos_in_card:
         return None
 
+    # sprint-4/zocalo-pending-questions-fix: el alto default sale del config
+    # editable (/configuracion · measurements.default_zocalo_height), NO
+    # hardcodeado. Antes 0.07 fijo → ignoraba el config + sobre-cobro 40%
+    # (fast-follow del audit de #501 · el path interactivo no se había unificado).
+    _alto_default = _cfg("measurements.default_zocalo_height", 0.05)
+    _alto_cm = int(round(_alto_default * 100))
     return {
         "id": "zocalos",
         "label": "Zócalos",
@@ -581,8 +589,8 @@ def _detect_zocalos_question(brief: str, dual_result: dict) -> dict | None:
         "options": [
             {
                 "value": "default_trasero",
-                "label": "Sí — trasero por tramo, 7cm (default)",
-                "apply": {"mode": "trasero_default", "alto_m": 0.07},
+                "label": f"Sí — trasero por tramo, {_alto_cm}cm (default)",
+                "apply": {"mode": "trasero_default", "alto_m": _alto_default},
             },
             {
                 "value": "custom",
@@ -680,7 +688,7 @@ def detect_pending_questions(
 # Answer applicator — materializa las respuestas del operador en el card
 # ─────────────────────────────────────────────────────────────────────────────
 
-def apply_zocalos_answer(dual_result: dict, answer: dict, default_alto_m: float = 0.07) -> dict:
+def apply_zocalos_answer(dual_result: dict, answer: dict, default_alto_m: float | None = None) -> dict:
     """Dada la respuesta del operador a la pregunta de zócalos, agrega
     los zócalos determinísticamente al card.
 
@@ -689,8 +697,12 @@ def apply_zocalos_answer(dual_result: dict, answer: dict, default_alto_m: float 
       "id": "zocalos",
       "value": "default_trasero" | "custom" | "no",
       "detail": "texto libre si value == custom" (opcional),
-      "alto_m": 0.07 (opcional, override del default),
+      "alto_m": 0.05 (opcional, override del default),
     }
+
+    sprint-4/zocalo-pending-questions-fix: `default_alto_m=None` → se lee del
+    config editable (measurements.default_zocalo_height, default master 0.05).
+    Antes era 0.07 fijo → ignoraba /configuracion + sobre-cobro 40%.
 
     Muta y devuelve dual_result in-place.
     """
@@ -701,6 +713,8 @@ def apply_zocalos_answer(dual_result: dict, answer: dict, default_alto_m: float 
         # nada que agregar
         return dual_result
 
+    if default_alto_m is None:
+        default_alto_m = _cfg("measurements.default_zocalo_height", 0.05)
     alto = float(answer.get("alto_m") or default_alto_m)
     for sector in dual_result.get("sectores") or []:
         for tramo in sector.get("tramos") or []:

--- a/api/tests/test_pending_questions.py
+++ b/api/tests/test_pending_questions.py
@@ -119,7 +119,10 @@ class TestApplyZocalosAnswer:
         assert len(t1_z) == 1
         assert t1_z[0]["lado"] == "trasero"
         assert t1_z[0]["ml"] == 2.05
-        assert t1_z[0]["alto_m"] == 0.07
+        # sprint-4/zocalo-pending-questions-fix: el default ahora sale del
+        # config (measurements.default_zocalo_height=0.05 · master D'Angelo),
+        # no del 0.07 hardcodeado.
+        assert t1_z[0]["alto_m"] == 0.05
         assert t1_z[0]["source"] == "brief_rule"
         assert len(t2_z) == 1
         assert t2_z[0]["ml"] == 2.95

--- a/api/tests/test_zocalo_config_unification.py
+++ b/api/tests/test_zocalo_config_unification.py
@@ -86,3 +86,75 @@ class TestContextAssumptionsZocalo:
         )
         z = _zocalo_assumption(out)
         assert z is not None and "6 cm" in z["value"]
+
+
+# ── pending_questions (path INTERACTIVO) · fast-follow audit #501 ───────────
+# El audit independiente de #501 detectó que el path interactivo seguía
+# hardcodeando 7cm (pending_questions.py:585 opción default + :683 apply).
+# Es probablemente el path MÁS frecuente (cualquier brief sin zócalo dispara
+# la pregunta). Estos tests cierran ese gap.
+
+from app.modules.quote_engine import pending_questions
+from app.modules.quote_engine.pending_questions import (
+    _detect_zocalos_question,
+    apply_zocalos_answer,
+)
+
+
+def _dr_un_tramo() -> dict:
+    """dual_result mínimo · 1 sector / 1 tramo / sin zócalos (dispara la pregunta)."""
+    return {
+        "sectores": [
+            {
+                "tipo": "cocina",
+                "tramos": [
+                    {"largo_m": {"valor": 2.05, "status": "CONFIRMADO"}, "zocalos": []},
+                ],
+            }
+        ]
+    }
+
+
+class TestPendingQuestionInteractivo:
+    def test_pregunta_default_usa_config_005_no_007(self, monkeypatch):
+        monkeypatch.setattr(
+            pending_questions, "_cfg",
+            lambda key, default=None: 0.05 if key == "measurements.default_zocalo_height" else default,
+        )
+        q = _detect_zocalos_question("", _dr_un_tramo())
+        assert q is not None
+        opt = next(o for o in q["options"] if o["value"] == "default_trasero")
+        assert "5cm" in opt["label"] and "7cm" not in opt["label"]
+        assert opt["apply"]["alto_m"] == 0.05
+
+    def test_pregunta_default_respeta_config_editable_008(self, monkeypatch):
+        monkeypatch.setattr(
+            pending_questions, "_cfg",
+            lambda key, default=None: 0.08 if key == "measurements.default_zocalo_height" else default,
+        )
+        q = _detect_zocalos_question("", _dr_un_tramo())
+        opt = next(o for o in q["options"] if o["value"] == "default_trasero")
+        assert "8cm" in opt["label"]
+        assert opt["apply"]["alto_m"] == 0.08
+
+
+class TestApplyZocalosAnswer:
+    def test_sin_default_explicito_lee_config_005(self, monkeypatch):
+        monkeypatch.setattr(
+            pending_questions, "_cfg",
+            lambda key, default=None: 0.05 if key == "measurements.default_zocalo_height" else default,
+        )
+        dr = apply_zocalos_answer(_dr_un_tramo(), {"id": "zocalos", "value": "default_trasero"})
+        z = dr["sectores"][0]["tramos"][0]["zocalos"][0]
+        assert z["alto_m"] == 0.05
+
+    def test_alto_m_explicito_en_answer_gana(self, monkeypatch):
+        monkeypatch.setattr(
+            pending_questions, "_cfg",
+            lambda key, default=None: 0.05 if key == "measurements.default_zocalo_height" else default,
+        )
+        dr = apply_zocalos_answer(
+            _dr_un_tramo(), {"id": "zocalos", "value": "default_trasero", "alto_m": 0.10}
+        )
+        z = dr["sectores"][0]["tramos"][0]["zocalos"][0]
+        assert z["alto_m"] == 0.10


### PR DESCRIPTION
## Motivación

**Fast-follow del audit independiente de #501.** El audit detectó que la unificación del zócalo a `measurements.*` quedó **incompleta**: PR #501 acotó el fix a `agent.py` + `dual_reader.py`, pero el **path interactivo** de pending-questions —exactamente el escenario "brief sin zócalo especificado"— seguía hardcodeando **7cm** e ignorando el config editable de `/configuracion`.

Esto es lo que vale el audit independiente: la sesión 1 (autor de #501) no lo vio porque el prompt scopeó a `agent.py`; la sesión 2 sin contexto previo trazó los call sites y destapó el path interactivo.

## 🚨 Hipótesis de magnitud (importante para Agos)

`pending_questions` es **probablemente el path MÁS frecuente**: cualquier brief sin zócalo explícito dispara la pregunta interactiva, cuya opción default aplicaba 7cm. Si se confirma, la **magnitud retroactiva del bug es bastante mayor** que la estimación inicial de ~USD 48/quote del #501. El script de audit de #501 ya captura estos quotes (ver abajo), así que la cifra final saldrá de correrlo.

## Sitios corregidos (FASE 1 ya trazada por el audit)

- **`pending_questions.py:585`** — la opción default era un dict estático `"trasero por tramo, 7cm (default)"` con `alto_m: 0.07`. Ahora el **label + `apply.alto_m`** se arman dinámicamente desde `_cfg("measurements.default_zocalo_height", 0.05)` al construir la pregunta (el copy muestra el alto real del config: "trasero por tramo, Xcm").
- **`pending_questions.py:683`** — `apply_zocalos_answer(..., default_alto_m: float = 0.07)` → `default_alto_m: float | None = None`; si `None`, lee del config al ejecutar.
- Import `from app.core.company_config import get as _cfg`.

**Caller activo** (`pending_questions.py:1183`) llama sin `default_alto_m` y el frontend no envía `alto_m` → antes gobernaba el 0.07 hardcodeado; ahora gobierna el config (master 0.05).

## Tests

- `test_zocalo_config_unification.py` **+4**: pregunta default usa config 0.05 (no 0.07) · respeta editable 0.08 · `apply_zocalos_answer` sin `default_alto_m` lee config 0.05 · `alto_m` explícito en el answer gana.
- `test_pending_questions.py`: `test_default_trasero_adds_zocalo_per_tramo` actualizado **0.07 → 0.05** (asertaba el default buggy; ahora lee config). **98 passed** en la suite combinada.
- 1 failure pre-existente (`test_five_fixes::test_anafe_qty_2_doubles_mo_quantity`, dominio anafe/MO) — **confirmado en main limpio `4cc51ab`**, ajeno a este PR.

## Sin nuevo script audit
El script `audit_zocalo_7cm_retroactive.py` de #501 **ya cubre** este path: la heurística matchea `alto==0.07` en `quote_breakdown` sin discriminar qué código produjo el fallback.

## Scope
Solo `pending_questions.py` + tests. **Cero frontend, cero middleware, `operator-shared.css` byte-identical.** Escenario B (sin tocar catalog router PUT · `_cfg`/company_config ya invalidado por el PUT de config).

## Estado
**FASE 5 sin merge.** Listo para audit independiente nuevo (mismo patrón que #501).

🤖 Generated with [Claude Code](https://claude.com/claude-code)