### PR TITLE
fix(zocalo): editor manual de card lee config · CIERRE saga zócalo (fast-follow #502)

### DIFF
--- a/api/app/modules/agent/card_editor.py
+++ b/api/app/modules/agent/card_editor.py
@@ -20,6 +20,7 @@ from typing import Any
 import anthropic
 
 from app.core.config import settings
+from app.core.company_config import get as _cfg
 
 logger = logging.getLogger(__name__)
 
@@ -235,7 +236,11 @@ def apply_card_patch(dr: dict, ops: list[dict]) -> tuple[dict, list[str], list[s
                 t.setdefault("zocalos", []).append({
                     "lado": op.get("lado", "trasero"),
                     "ml": float(op.get("ml", 0) or 0),
-                    "alto_m": float(op.get("alto_m", 0.07) or 0.07),
+                    # sprint-4/zocalo-card-editor-fix (cierre saga · fast-follow
+                    # audit #502): default del alto desde config editable, no 0.07
+                    # hardcodeado. `or` preserva el comportamiento previo (0 o
+                    # ausente → default · un zócalo de 0cm no es válido).
+                    "alto_m": float(op.get("alto_m") or _cfg("measurements.default_zocalo_height", 0.05)),
                     "status": "CONFIRMADO",
                     "opus_ml": None,
                     "sonnet_ml": None,

--- a/api/tests/test_zocalo_config_unification.py
+++ b/api/tests/test_zocalo_config_unification.py
@@ -158,3 +158,59 @@ class TestApplyZocalosAnswer:
         )
         z = dr["sectores"][0]["tramos"][0]["zocalos"][0]
         assert z["alto_m"] == 0.10
+
+
+# ── card_editor (path EDICIÓN MANUAL) · cierre saga · fast-follow audit #502 ─
+# Cuarto y último sitio del bug 7cm: la op add_zocalo del editor manual de
+# card (card_editor.py:238) defaulteaba a 0.07 hardcodeado e ignoraba el
+# config. Detectado por el barrido amplio (grep del VALOR, no de la función).
+
+from app.modules.agent import card_editor
+from app.modules.agent.card_editor import apply_card_patch
+
+
+def _card_un_tramo_sin_zocalo() -> dict:
+    return {
+        "sectores": [
+            {"id": "cocina", "tipo": "L", "tramos": [
+                {"id": "t1", "largo_m": {"valor": 1.61}, "zocalos": []},
+            ]},
+        ],
+    }
+
+
+def _add_zocalo_op(**extra) -> dict:
+    return {"op": "add_zocalo", "sector_id": "cocina", "tramo_id": "t1",
+            "lado": "trasero", "ml": 1.61, **extra}
+
+
+class TestCardEditorAddZocalo:
+    def test_sin_alto_m_usa_config_005(self, monkeypatch):
+        monkeypatch.setattr(
+            card_editor, "_cfg",
+            lambda key, default=None: 0.05 if key == "measurements.default_zocalo_height" else default,
+        )
+        patched, _applied, _errors = apply_card_patch(_card_un_tramo_sin_zocalo(), [_add_zocalo_op()])
+        z = patched["sectores"][0]["tramos"][0]["zocalos"][0]
+        assert z["alto_m"] == 0.05
+
+    def test_alto_m_explicito_008_ignora_config(self, monkeypatch):
+        monkeypatch.setattr(
+            card_editor, "_cfg",
+            lambda key, default=None: 0.05 if key == "measurements.default_zocalo_height" else default,
+        )
+        patched, _a, _e = apply_card_patch(_card_un_tramo_sin_zocalo(), [_add_zocalo_op(alto_m=0.08)])
+        z = patched["sectores"][0]["tramos"][0]["zocalos"][0]
+        assert z["alto_m"] == 0.08
+
+    def test_alto_m_cero_cae_al_config(self, monkeypatch):
+        # Comportamiento documentado: un zócalo de 0cm de alto no es válido ·
+        # 0 (falsy) se trata como "no especificado" → default del config.
+        # Preserva la semántica `or` previa (antes 0 → 0.07; ahora 0 → config).
+        monkeypatch.setattr(
+            card_editor, "_cfg",
+            lambda key, default=None: 0.05 if key == "measurements.default_zocalo_height" else default,
+        )
+        patched, _a, _e = apply_card_patch(_card_un_tramo_sin_zocalo(), [_add_zocalo_op(alto_m=0)])
+        z = patched["sectores"][0]["tramos"][0]["zocalos"][0]
+        assert z["alto_m"] == 0.05


### PR DESCRIPTION
## Motivación · cierre de saga

**Fast-follow del audit independiente de #502**, que con el barrido amplio (lección #74 refinada: grep del **valor** hardcodeado, no de los callers de una función) destapó el **cuarto y último** sitio del bug del zócalo 7cm.

Saga completa:
- #501 → `agent.py` (2 sitios) + `dual_reader.py` — leían del bloque equivocado / fallback 0.07.
- #502 → `pending_questions.py` (path interactivo) — 7cm hardcodeado en la pregunta.
- **#503 (este) → `card_editor.py` (path edición manual de card)** — último sitio.

## Sitio corregido

`card_editor.py:238` (op `add_zocalo` del editor manual):
```python
# antes
"alto_m": float(op.get("alto_m", 0.07) or 0.07),
# ahora
"alto_m": float(op.get("alto_m") or _cfg("measurements.default_zocalo_height", 0.05)),
```
+ import `from app.core.company_config import get as _cfg`. Caller vivo: `apply_card_patch` (`card_editor.py:215`) ← `agent.py:2434`.

**Caso `alto_m == 0`:** se mantiene la semántica `or` previa (0 = no especificado → default del config). Un zócalo de 0cm de alto no es físicamente válido, así que 0 cae al default — igual que antes (solo cambia la fuente del default de 0.07 a config 0.05). Documentado en test.

## 🏁 CIERRE DE SAGA · barrido amplio confirmado

```
grep -rn "0.07" app/modules/quote_engine app/modules/agent
```
→ **CERO `0.07` de zócalo en código vivo.** Todo lo restante es comentario, docstring de ejemplo, o el string cosmético `agent.py:2414` — ninguno produce alto de zócalo en cálculo. La saga zócalo queda cerrada con este PR.

## Tests
`test_zocalo_config_unification.py` **+3**: `add_zocalo` sin `alto_m` → config 0.05 · con `alto_m=0.08` → respeta (config ignorada) · con `alto_m=0` → cae al config (comportamiento documentado). **170 passed** en la suite combinada (zócalo + card_editor + pending_questions). El `test_add_zocalo` existente pasa intacto (usa `alto_m` explícito).

## Sin nuevo script audit
El `audit_zocalo_7cm_retroactive.py` de #501 ya cubre los 3 paths: la heurística matchea `alto==0.07` en `quote_breakdown` sin discriminar qué código lo produjo.

## Scope
Solo `card_editor.py` + tests. **Cero frontend, cero middleware, `operator-shared.css` byte-identical.**

## Deuda separada (NO en este PR · observaciones del audit #502)
- `visual_quote_builder.py` `backsplash_height_m=0.075` — **otra dimensión** (backsplash 7.5cm), no zócalo.
- `agent.py:2414` string cosmético "0.07 m" en mensaje de ayuda (deuda ya conocida).

## Estado
**FASE 5 sin merge.** Listo para audit independiente nuevo (mismo patrón que #501/#502). El criterio de cierre fue el barrido amplio limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)