### PR TITLE
fix(zocalo): prompt del extractor no sesga a 7cm · CIERRE FINAL saga (fast-follow #503)

### DIFF
--- a/api/app/modules/agent/card_editor.py
+++ b/api/app/modules/agent/card_editor.py
@@ -2,7 +2,7 @@
 
 Flujo:
     1. Operador sube plano → dual_read emite card
-    2. Sin confirmar, escribe en chat: "te falto un zócalo 0.5 × 0.07 en tramo 2"
+    2. Sin confirmar, escribe en chat: "te faltó un zócalo trasero de 0.5 ml en tramo 2"
     3. `is_card_modification_message()` detecta por keywords
     4. `extract_card_patch()` llama a Claude para parsear el texto → ops JSON
     5. `apply_card_patch()` aplica las ops al dict del dual_read_result
@@ -72,7 +72,7 @@ detectado automáticamente. Devolvé JSON con las operaciones a aplicar.
 Operaciones válidas:
 - add_zocalo: {"op": "add_zocalo", "sector_id": "X", "tramo_id": "Y",
               "lado": "trasero|lateral_izq|lateral_der|frontal|<custom>",
-              "ml": <number>, "alto_m": <number>}
+              "ml": <number>, "alto_m": <number, OPCIONAL>}
 - remove_zocalo: {"op": "remove_zocalo", "sector_id": "X", "tramo_id": "Y",
                   "lado": "<lado>"}
 - edit_zocalo_ml: {"op": "edit_zocalo_ml", "sector_id": "X", "tramo_id": "Y",
@@ -92,15 +92,18 @@ Reglas:
 - Si el operador dice "tramo 2" o "segundo tramo" → mapeá al tramo_id
   por posición (primer tramo = tramos[0], segundo = tramos[1], etc.).
 - Si el operador dice medidas en cm, convertilas a m (50 cm → 0.50).
+- ALTO DEL ZÓCALO: si el operador NO especifica el alto, OMITÍ el campo
+  `alto_m` por completo. El sistema aplica el default configurable de la
+  marmolería. NUNCA inventes ni asumas un alto cuando el operador no lo dijo.
 - Si no hay suficiente info para una op concreta, devolvé operación
   `ask_operator` con el campo faltante:
   {"op": "ask_operator", "reason": "..."}
 
 Devolvé SOLO JSON. Si son múltiples ops, array. Sin texto extra.
-Ejemplo de output:
+Ejemplo de output (zócalo sin alto especificado → SIN `alto_m`):
 ```json
 [{"op": "add_zocalo", "sector_id": "cocina", "tramo_id": "tramo_2",
-  "lado": "trasero", "ml": 0.5, "alto_m": 0.07}]
+  "lado": "trasero", "ml": 0.5}]
 ```
 """
 

--- a/api/tests/test_zocalo_config_unification.py
+++ b/api/tests/test_zocalo_config_unification.py
@@ -214,3 +214,24 @@ class TestCardEditorAddZocalo:
         patched, _a, _e = apply_card_patch(_card_un_tramo_sin_zocalo(), [_add_zocalo_op(alto_m=0)])
         z = patched["sectores"][0]["tramos"][0]["zocalos"][0]
         assert z["alto_m"] == 0.05
+
+
+# ── capa de INFERENCIA LLM (prompt del extractor) · CIERRE FINAL saga zócalo ─
+# Quinto sitio (audit #503): el ejemplo de _EXTRACTOR_SYSTEM mostraba
+# alto_m: 0.07 → sesgaba al LLM a emitir 0.07 explícito, que gana sobre el
+# default config en apply_card_patch → bypassa el fix de #503. Este guard
+# blinda el prompt contra regresión.
+
+from app.modules.agent.card_editor import _EXTRACTOR_SYSTEM
+
+
+class TestExtractorPromptNoZocalo007:
+    def test_prompt_no_contiene_007(self):
+        # Regresión: ningún 0.07 (ni el ejemplo) que sesgue al modelo.
+        assert "0.07" not in _EXTRACTOR_SYSTEM
+
+    def test_prompt_instruye_omitir_alto_si_no_especificado(self):
+        # El prompt debe decirle al modelo que omita alto_m cuando el
+        # operador no lo especifica (así gobierna el default del config).
+        assert "alto_m" in _EXTRACTOR_SYSTEM
+        assert "OMIT" in _EXTRACTOR_SYSTEM.upper()


### PR DESCRIPTION
## Motivación · cierre final de la saga

**Fast-follow del audit de #503**, que con el barrido amplio del valor destapó el **quinto y último** sitio — esta vez en la **capa de inferencia LLM**, no en la determinista.

El path de edición manual de card tiene 2 mitades:
- `extract_card_patch` — el LLM parsea texto libre → ops JSON.
- `apply_card_patch` — aplica las ops (#503 ya la corrigió: lee config).

El sesgo vivía en la **primera mitad**: el ejemplo de output de `_EXTRACTOR_SYSTEM` (system prompt, enviado al LLM en `card_editor.py:148`) mostraba `"alto_m": 0.07`. Eso podía hacer que el modelo emitiera `alto_m: 0.07` **explícito** cuando el operador no especificaba alto → y un valor explícito **gana** sobre el default config en `apply_card_patch` → re-introducía 7cm y **bypassaba el fix de #503**. El patrón "un nivel más profundo" que cazó cada audit de la saga.

## Cambios (`_EXTRACTOR_SYSTEM`)
- **Ejemplo de output:** quitado `alto_m: 0.07` → ahora muestra `add_zocalo` **sin** `alto_m` (el caso "no especificado", que es el canónico).
- **Spec de `add_zocalo`:** `alto_m` marcado `OPCIONAL`.
- **Regla nueva:** *"si el operador NO especifica el alto, OMITÍ `alto_m` · el sistema aplica el default configurable · NUNCA inventes ni asumas un alto"*. No se nombra ningún número, para no primear al modelo.
- **Docstring stale (línea 5):** ejemplo "0.5 × 0.07" → "trasero de 0.5 ml".

## Test de regresión (blindaje)
- `assert "0.07" not in _EXTRACTOR_SYSTEM` — garantiza que ningún 0.07 (ni en ejemplos ni en reglas) vuelva a sesgar al modelo.
- `assert` que el prompt instruye omitir `alto_m`.
- **172 passed** en la suite combinada (zócalo + card_editor + pending_questions).

## 🏁 Saga zócalo — cierre completo
| Capa | Estado | PR |
|---|---|---|
| Determinista · `agent.py` + `dual_reader.py` | ✅ | #501 |
| Determinista · `pending_questions.py` (interactivo) | ✅ | #502 |
| Determinista · `card_editor.py` `apply_card_patch` (manual) | ✅ | #503 |
| **Inferencia LLM · `_EXTRACTOR_SYSTEM` (input manual)** | ✅ | **#504 (este)** |

Barrido amplio: **cero `0.07` de zócalo en código vivo NI en prompts**. Tras este merge, la saga queda cerrada en ambas capas.

## Scope
Solo `card_editor.py` (prompt + docstring) + tests. **Cero frontend, cero middleware, `operator-shared.css` byte-identical.** Sin script audit nuevo (el de #501 cubre la detección retroactiva).

## Deuda separada (no zócalo)
- `visual_quote_builder.py` `backsplash_height_m=0.075` (otra dimensión).
- `agent.py:2414` string cosmético "0.07 m" (deuda conocida).

## Estado
**FASE 5 sin merge.** Listo para el audit independiente final de la saga.

🤖 Generated with [Claude Code](https://claude.com/claude-code)