### PR TITLE
feat(routing): /quotes/[id]/brief redirige a /contexto · cierra loop sin escape

### DIFF
--- a/web/src/app/quotes/[id]/brief/page.tsx
+++ b/web/src/app/quotes/[id]/brief/page.tsx
@@ -1,18 +1,15 @@
 /**
- * Paso 1 · Brief — placeholder.
+ * Paso 1 · Brief — redirect a Paso 2 · Contexto.
  *
- * Implementación real (drag & drop de plano, brief libre, extracción
- * IA) en sub-PR `sprint-2/paso-1-brief-upload`.
+ * La ruta persiste como safety net. El step `brief` sigue declarado en
+ * `STEPS` (canonicalQuote.ts) para preservar la semántica del Stepper.
  */
-export default function BriefPage() {
-  return (
-    <div className="col placeholder-section">
-      <h2 className="font-serif italic" style={{ marginBottom: 8 }}>
-        Paso 1 · Brief
-      </h2>
-      <p className="font-serif italic text-ink-soft">
-        Placeholder. Implementación viene en sprint-2/paso-1-brief-upload.
-      </p>
-    </div>
-  );
+import { redirect } from "next/navigation";
+
+interface Props {
+  params: { id: string };
+}
+
+export default function BriefPage({ params }: Props) {
+  redirect(`/quotes/${params.id}/contexto`);
 }

--- a/web/src/components/despiece/DespieceEmptyState.tsx
+++ b/web/src/components/despiece/DespieceEmptyState.tsx
@@ -43,7 +43,7 @@ export function DespieceEmptyState({ onProcessWithAI, onCompleteManual }: Props)
             Subí el brief, el plano, o ambos. <em>Valentina</em> identifica las piezas y propone el
             despiece completo. Después editás lo que quieras.
           </div>
-          <div className="meta">→ vuelve al paso 1 · procesa con IA</div>
+          <div className="meta">→ revisá el contexto y reintentá</div>
         </div>
 
         <div

--- a/web/src/components/despiece/DespieceView.tsx
+++ b/web/src/components/despiece/DespieceView.tsx
@@ -184,7 +184,7 @@ export function DespieceView({ quoteId }: Props) {
           </div>
         </div>
         <DespieceEmptyState
-          onProcessWithAI={() => router.push(`/quotes/${quoteId}/brief`)}
+          onProcessWithAI={() => router.push(`/quotes/${quoteId}/contexto`)}
           onCompleteManual={() => setManualMode(true)}
         />
       </div>

--- a/web/tests/e2e/smoke.spec.ts
+++ b/web/tests/e2e/smoke.spec.ts
@@ -18,28 +18,9 @@ test("/ home muestra dashboard con saludo Marina + CTA Nuevo presupuesto", async
   await expect(page.locator('[data-testid="cta-new-quote"]')).toBeVisible();
 });
 
-test("chrome shell renderea en /quotes/[id]/brief", async ({ page }) => {
+test("/quotes/[id]/brief redirige a /contexto", async ({ page }) => {
   await page.goto("/quotes/PRES-2026-018/brief");
-
-  // Sidebar visible con brand
-  await expect(page.locator(".sidebar")).toBeVisible();
-  await expect(page.locator(".sidebar .brand")).toContainText("D'Angelo Operator");
-
-  // Topbar visible con breadcrumb del quote
-  await expect(page.locator(".topbar")).toBeVisible();
-  await expect(page.locator(".topbar .crumbs .now")).toContainText("PRES-2026-018");
-  await expect(page.locator(".topbar .crumbs .now")).toContainText("Cueto-Heredia");
-
-  // Status chip · PRES-018 está en status "sent" en DASHBOARD_QUOTES
-  await expect(page.locator(".status-chip.sent")).toBeVisible();
-
-  // Qhead muestra cliente canon (DASHBOARD_QUOTES: PRES-018 = Cueto-Heredia · Granito Negro Brasil)
-  await expect(page.locator(".qhead h1")).toContainText("Cueto-Heredia");
-  await expect(page.locator(".qhead .sub")).toContainText("Negro Brasil");
-
-  // Stepper presente con 5 pasos y paso 1 activo
-  await expect(page.locator(".stepper")).toHaveAttribute("data-current-step", "brief");
-  await expect(page.locator('.stepper .step[data-step="brief"]')).toHaveClass(/now/);
+  await page.waitForURL(/\/quotes\/PRES-2026-018\/contexto/, { timeout: 5000 });
 });
 
 test("stepper se actualiza al navegar entre rutas", async ({ page }) => {


### PR DESCRIPTION
## Summary

Cierra el **loop sin escape** del despiece: Marina caía al placeholder de paso 1 (`/quotes/[id]/brief`) cuando entraba al despiece sin haber hecho upload, sin botón de vuelta. Placeholder desde el sub-PR #457 (Sprint 2), nunca completado. Identificado como gap arquitectónico en SYSTEM-ARCHITECTURE-AUDIT-15.06.2026.

**Decisión Javi 15.06.2026 (forward-only)**: la ruta NO se elimina · se convierte en redirect server-side a `/contexto` para preservar la semántica del `Stepper` sin tocar `STEPS`.

## Cambios

| Archivo | Cambio |
|---|---|
| `web/src/app/quotes/[id]/brief/page.tsx` | placeholder → `redirect(\`/quotes/\${params.id}/contexto\`)` server-side (`next/navigation`) |
| `web/src/components/despiece/DespieceView.tsx:187` | `router.push('/brief')` → `router.push('/contexto')` (evita bounce) |
| `web/src/components/despiece/DespieceEmptyState.tsx:46` | copy del CTA: \"→ vuelve al paso 1 · procesa con IA\" → \"→ revisá el contexto y reintentá\" |
| `web/tests/e2e/smoke.spec.ts:21-23` | test verifica redirect (`waitForURL`) en lugar de chrome shell sobre placeholder |

**4 files changed, 15 insertions(+), 37 deletions(-)**

## Reporte FASE 1 (read-only · referencias destapadas)

| Iter | Query | Hits relevantes |
|---|---|---|
| 1 | `ls quotes/[id]/brief/` + `cat page.tsx` | placeholder 527 bytes confirmado |
| 2 | strings literal `/brief` en código | **cero** (sólo template literal en DespieceView) |
| 3 | botón \"Procesar con Valentina\" | 3 ocurrencias · solo 1 es scope (DespieceEmptyState) |
| 4 | nav programática a `/brief` | 1 callsite: `DespieceView.tsx:187` |
| 5 | tests E2E con `/brief` | `smoke.spec.ts:21-43` (test full) + `:50` (assertion lateral en otro test) |
| 6 | `DespieceEmptyState` | encontrado · recibe callbacks como props |

### ⚠️ Gap arquitectónico no contemplado en el plan original (resuelto)
`brief` está hardcodeado como **paso 1 canónico** en `web/src/lib/mocks/canonicalQuote.ts:46-52` (`STEPS`). Eliminar la ruta hubiera dejado el Stepper apuntando a 404 desde cualquier quote en paso 2-5. La decisión de mantener la ruta como redirect server-side cierra este gap sin tocar STEPS.

## Algoritmo del redirect

```tsx
import { redirect } from \"next/navigation\";

interface Props { params: { id: string }; }

export default function BriefPage({ params }: Props) {
  redirect(\`/quotes/\${params.id}/contexto\`);
}
```

- Server Component (sin \"use client\")
- Next.js 14.2.29 · `params` sincrónico
- 307 Temporary Redirect (status estándar de `redirect()`)
- Preserva el `id` de la quote actual (sin perder contexto del cliente)

## Verificación local

- **TypeCheck**: `npx tsc --noEmit` sin errores
- **Preview server** (dev mode):
  ```
  GET /quotes/PRES-2026-018/brief    → 307
  GET /quotes/PRES-2026-018/contexto → 200
  Final URL: /quotes/PRES-2026-018/contexto
  ```
  Redirect confirmado en vivo.

## Scope confirmado

- ✅ Cero archivos backend modificados
- ✅ Cero archivos `.py`
- ✅ `operator-shared.css` byte-identical
- ✅ Sin tocar `STEPS` ni `Stepper.tsx`
- ✅ Stepper line 50 del test (assertion lateral sobre `step[data-step=\"brief\"]`) sigue válida

## Test plan

- [x] TypeCheck verde
- [x] Preview server confirma 307 redirect + URL final
- [ ] CI E2E pasa el test actualizado de smoke
- [ ] Validación visual Javi: empty state del despiece → click \"Procesar con Valentina\" → llega a `/contexto`
- [ ] Validación de copy del CTA (ajustable pre-merge si Javi prefiere otra redacción)

🤖 Generated with [Claude Code](https://claude.com/claude-code)