### PR TITLE
feat(routing): /quotes/[id]/brief redirige a /contexto · cierra loop sin escape

### DIFF
--- a/web/src/app/quotes/[id]/brief/page.tsx
+++ b/web/src/app/quotes/[id]/brief/page.tsx
@@ -1,18 +1,15 @@
 /**
- * Paso 1 · Brief — placeholder.
+ * Paso 1 · Brief — redirect a Paso 2 · Contexto.
  *
- * Implementación real (drag & drop de plano, brief libre, extracción
- * IA) en sub-PR `sprint-2/paso-1-brief-upload`.
+ * La ruta persiste como safety net. El step `brief` sigue declarado en
+ * `STEPS` (canonicalQuote.ts) para preservar la semántica del Stepper.
  */
-export default function BriefPage() {
-  return (
-    <div className="col placeholder-section">
-      <h2 className="font-serif italic" style={{ marginBottom: 8 }}>
-        Paso 1 · Brief
-      </h2>
-      <p className="font-serif italic text-ink-soft">
-        Placeholder. Implementación viene en sprint-2/paso-1-brief-upload.
-      </p>
-    </div>
-  );
+import { redirect } from "next/navigation";
+
+interface Props {
+  params: { id: string };
+}
+
+export default function BriefPage({ params }: Props) {
+  redirect(`/quotes/${params.id}/contexto`);
 }

--- a/web/src/components/despiece/DespieceEmptyState.tsx
+++ b/web/src/components/despiece/DespieceEmptyState.tsx
@@ -43,7 +43,7 @@ export function DespieceEmptyState({ onProcessWithAI, onCompleteManual }: Props)
             Subí el brief, el plano, o ambos. <em>Valentina</em> identifica las piezas y propone el
             despiece completo. Después editás lo que quieras.
           </div>
-          <div className="meta">→ vuelve al paso 1 · procesa con IA</div>
+          <div className="meta">→ revisá el contexto y reintentá</div>
         </div>
 
         <div

--- a/web/src/components/despiece/DespieceView.tsx
+++ b/web/src/components/despiece/DespieceView.tsx
@@ -184,7 +184,7 @@ export function DespieceView({ quoteId }: Props) {
           </div>
         </div>
         <DespieceEmptyState
-          onProcessWithAI={() => router.push(`/quotes/${quoteId}/brief`)}
+          onProcessWithAI={() => router.push(`/quotes/${quoteId}/contexto`)}
           onCompleteManual={() => setManualMode(true)}
         />
       </div>

--- a/web/tests/e2e/smoke.spec.ts
+++ b/web/tests/e2e/smoke.spec.ts
@@ -18,28 +18,9 @@ test("/ home muestra dashboard con saludo Marina + CTA Nuevo presupuesto", async
   await expect(page.locator('[data-testid="cta-new-quote"]')).toBeVisible();
 });
 
-test("chrome shell renderea en /quotes/[id]/brief", async ({ page }) => {
+test("/quotes/[id]/brief redirige a /contexto", async ({ page }) => {
   await page.goto("/quotes/PRES-2026-018/brief");
-
-  // Sidebar visible con brand
-  await expect(page.locator(".sidebar")).toBeVisible();
-  await expect(page.locator(".sidebar .brand")).toContainText("D'Angelo Operator");
-
-  // Topbar visible con breadcrumb del quote
-  await expect(page.locator(".topbar")).toBeVisible();
-  await expect(page.locator(".topbar .crumbs .now")).toContainText("PRES-2026-018");
-  await expect(page.locator(".topbar .crumbs .now")).toContainText("Cueto-Heredia");
-
-  // Status chip · PRES-018 está en status "sent" en DASHBOARD_QUOTES
-  await expect(page.locator(".status-chip.sent")).toBeVisible();
-
-  // Qhead muestra cliente canon (DASHBOARD_QUOTES: PRES-018 = Cueto-Heredia · Granito Negro Brasil)
-  await expect(page.locator(".qhead h1")).toContainText("Cueto-Heredia");
-  await expect(page.locator(".qhead .sub")).toContainText("Negro Brasil");
-
-  // Stepper presente con 5 pasos y paso 1 activo
-  await expect(page.locator(".stepper")).toHaveAttribute("data-current-step", "brief");
-  await expect(page.locator('.stepper .step[data-step="brief"]')).toHaveClass(/now/);
+  await page.waitForURL(/\/quotes\/PRES-2026-018\/contexto/, { timeout: 5000 });
 });
 
 test("stepper se actualiza al navegar entre rutas", async ({ page }) => {


### PR DESCRIPTION
**Recovery PR** — reemplaza al [PR #507](https://github.com/javi10823/ia-agent-quote-marble-operator/pull/507) que se auto-cerró por race condition en cleanup. Mismo contenido, rebased sobre `main` actual (incluye #506).

## Summary

Cierra el **loop sin escape** del despiece: Marina caía al placeholder de paso 1 (`/quotes/[id]/brief`) cuando entraba al despiece sin haber hecho upload, sin botón de vuelta. Placeholder desde el sub-PR #457 (Sprint 2), nunca completado.

**Decisión Javi 15.06.2026 (forward-only)**: la ruta NO se elimina · se convierte en redirect server-side a `/contexto` para preservar la semántica del `Stepper` sin tocar `STEPS`.

## Cambios

| Archivo | Cambio |
|---|---|
| `web/src/app/quotes/[id]/brief/page.tsx` | placeholder → `redirect()` server-side a `/quotes/${id}/contexto` |
| `web/src/components/despiece/DespieceView.tsx:187` | `router.push('/brief')` → `router.push('/contexto')` (evita bounce) |
| `web/src/components/despiece/DespieceEmptyState.tsx:46` | copy ajustado: "→ revisá el contexto y reintentá" |
| `web/tests/e2e/smoke.spec.ts:21-23` | test verifica redirect con `waitForURL` |

**4 files changed, 15 insertions(+), 37 deletions(-)**

## Verificación local

- TypeCheck verde
- Preview server: `GET /brief → 307 → /contexto` confirmado en vivo
- CI del PR original (mismo contenido, pre-rebase) ya había pasado verde: backend / typecheck / unit-tests / lint / build / e2e-tests / Vercel

## Scope

- ✅ Cero backend, cero `.py`
- ✅ Sin tocar `STEPS` ni `Stepper.tsx`
- ✅ `operator-shared.css` byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)