### PR TITLE
fix(chrome): scroll vertical en /configuracion y /catalogo (páginas wrapped)

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -399,3 +399,41 @@
   background: transparent;
   color: var(--ink-mute);
 }
+
+/* ─────────────────────────────────────────────────────────
+   Sprint 4 config-scroll-fix · scroll vertical en páginas wrapped
+   del route-group (chrome) · operator-shared.css INTACTO (lección #66).
+
+   El layout fijo a viewport (Sprint 1.5 · operator-shared.css) asume que
+   `.body` es hijo DIRECTO de `.main`: `.main` es grid de 4 filas
+   (auto auto auto 1fr) para topbar/qhead/stepper/body de /quotes, y solo
+   `.main > .body` recibe overflow-y:auto. Las páginas /configuracion y
+   /catalogo envuelven topbar+body en un único `<div .config-v2/.catalogo-v2>`,
+   así que:
+     1) ese wrapper cae en la fila 1 (auto = altura de contenido) y desborda
+        `.page` (height:100vh; overflow:hidden) → recorta sin scroll.
+     2) `.body` es NIETO de `.main` → el selector `.main > .body` no matchea
+        → no hay scroll interno.
+   (/clientes usa Fragment, así que su `.body` sí es hijo directo y se salva.)
+
+   Fix: el wrapper llena `.main` (fila 1fr), se vuelve grid auto/1fr (topbar
+   fijo + body flexible), y el `.body` recupera el scroll interno. Scoped a
+   los dos wrappers afectados · NO toca la lógica del accordion.
+   ───────────────────────────────────────────────────────── */
+@media (min-width: 1024px) {
+  body:not([data-print]):not([data-mobile]) .main:has(> .config-v2),
+  body:not([data-print]):not([data-mobile]) .main:has(> .catalogo-v2) {
+    grid-template-rows: 1fr;
+  }
+  body:not([data-print]):not([data-mobile]) .config-v2,
+  body:not([data-print]):not([data-mobile]) .catalogo-v2 {
+    min-height: 0;
+    display: grid;
+    grid-template-rows: auto 1fr;
+  }
+  body:not([data-print]):not([data-mobile]) .config-v2 > .body,
+  body:not([data-print]):not([data-mobile]) .catalogo-v2 > .body {
+    min-height: 0;
+    overflow-y: auto;
+  }
+}


### PR DESCRIPTION
## Contexto

Bug UI reportado (reporte Chrome 15.06.2026 + screenshot Javi 15.06.2026): en `/configuracion` el contenido del accordion (PR #495) excede el viewport pero el **scroll vertical está bloqueado** — Marina no puede acceder a los campos inferiores.

> **Hallazgo FASE 1:** el barrido destapó que **`/catalogo` tiene el mismo defecto** (recorta 147px de contenido). La premisa inicial de que catalogo "scrolleaba bien" era incorrecta. Por eso este PR — manteniendo el nombre de branch `sprint-4/config-scroll-fix` — **cubre ambas páginas**, cerrando el bug de clase en un PR en vez de dejar un fast-follow para catalogo.

## Causa raíz

El layout fijo a viewport (Sprint 1.5, `operator-shared.css`) en desktop (`@media min-width:1024px`) asume que `.body` es **hijo directo de `.main`**:
```css
.page { height:100vh; overflow:hidden; }
.main { display:grid; grid-template-rows: auto auto auto 1fr; }  /* topbar/qhead/stepper/body de /quotes */
.main > .body { overflow-y:auto; min-height:0; }                 /* SOLO hijo directo scrollea */
```
`/configuracion` y `/catalogo` envuelven `topbar + body` en un único `<div className="config-v2">` / `"catalogo-v2">`. Resultado:
1. El wrapper es el **único hijo** de `.main` → cae en la fila 1 (`auto` = altura de contenido) → desborda `.page` (`overflow:hidden`) → **recorta sin scroll**.
2. `.body` es **nieto** de `.main` → el selector `.main > .body` no matchea → no hay scroll interno.

`/clientes` usa un **Fragment** (`<>`), así que su `.body` sí es hijo directo y se salva (por eso no se reportó). `/quotes/*` tiene 4 hijos directos → body en la fila `1fr` → siempre scrolleó bien.

## Solución

CSS **scoped en `globals.css`** (dentro de un `@media min-width:1024px`), `operator-shared.css` **INTACTO** (lección #66):
```css
.main:has(> .config-v2), .main:has(> .catalogo-v2) { grid-template-rows: 1fr; }
.config-v2, .catalogo-v2 { min-height:0; display:grid; grid-template-rows:auto 1fr; }
.config-v2 > .body, .catalogo-v2 > .body { min-height:0; overflow-y:auto; }
```
(con prefijos `body:not([data-print]):not([data-mobile])` para igualar especificidad/scope de las reglas existentes)

El wrapper pasa a llenar `.main` (fila `1fr`), se vuelve grid `auto 1fr` (topbar fijo + body flexible), y el `.body` recupera el scroll interno. Usa `:has()` (ya presente en el codebase, líneas 110 y 3486 de operator-shared.css). **No toca la lógica del accordion.**

## Verificación visual en vivo (dev server @ 1440×900 · target Marina)

| Página | Antes | Después |
|--------|-------|---------|
| `/configuracion` | `gridRows: 946px 0px 0px 0px` · recorta 46px · sin scroll | `gridRows: 900px` · body `overflow:auto` scrolleable · `pageClips: 0` ✅ |
| `/catalogo` | `gridRows: 1047px 0px 0px 0px` · recorta 147px | body scrolleable (scrollTop 147) · `pageClips: 0` ✅ |
| `/clientes` | Fragment · ok | sin cambios (mis reglas no aplican) ✅ |
| `/quotes/[id]/contexto` | grid 4 filas · ok | sin cambios (`56px 124.5px 50px 669.5px`) ✅ |

- Accordion sigue colapsable (data-open toggle true→false verificado) ✅
- **Cero scroll horizontal** nuevo en las 4 páginas ✅
- Consola sin errores ✅

*(Screenshots de `/configuracion` y `/catalogo` scrolleados al fondo capturados durante la verificación — bottom content accesible en ambas.)*

## Scope

- ✅ Solo `web/src/app/globals.css` (+38 LOC) · cero `.py` · `operator-shared.css` byte-identical
- ✅ No toca componente del accordion · solo CSS del wrapper
- No aplica magnitud retroactiva (cambio UX puro)

## Lección #74 aplicada
Barrido amplio FASE 1 (no solo el archivo reportado) destapó que catalogo tenía el mismo defecto → bug de clase cerrado en **1 PR** en vez de config-fix + fast-follow catalogo.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)