### PR TITLE
feat(despiece): wire real listPiecesForQuote + handler botón confirmar contexto

### DIFF
--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -30,6 +30,9 @@ from app.modules.agent.schemas import (
     QuoteStatusUpdate,
     QuotePatchRequest,
     DeriveMaterialRequest,
+    PieceListResponse,
+    PieceSchema,
+    PieceOptionsSchema,
 )
 
 router = APIRouter(tags=["agent"])
@@ -356,6 +359,92 @@ def _client_name_from_breakdown(bd: dict | None) -> str | None:
     return None
 
 
+def _field_valor(field: object) -> float | None:
+    """Extrae `.valor` de un FieldValue (shape `{valor, opus, sonnet, status}`
+    usado por `dual_read_result`), o asume un número plano. None si no se
+    puede extraer."""
+    if field is None:
+        return None
+    if isinstance(field, dict):
+        v = field.get("valor")
+        try:
+            return float(v) if v is not None else None
+        except (TypeError, ValueError):
+            return None
+    if isinstance(field, (int, float)):
+        return float(field)
+    return None
+
+
+def _serialize_dual_read_to_pieces(dual_read: dict | None) -> list[dict]:
+    """Convierte `dual_read_result.sectores[].tramos[]` a lista de `Piece`
+    dicts en el shape que espera el frontend `useDespiece` hook.
+
+    Sub-PR despiece-real-wire · cierra deuda de mocks → real backend.
+    `verified_derived_pieces` ya no se persiste (PR #386), todo vive en
+    `dual_read_result` post-confirm via `apply_answers` + merges.
+
+    Cada tramo (mesada) emite 1 `Piece` de tipo "encimera". Cada zócalo del
+    tramo emite 1 `Piece` adicional de tipo "zocalo". `_manual:true` del
+    tramo se traduce a `origin="EDITADO"` (operador puede haber tocado);
+    sin flag, `origin="IA"`. `_manual:true` NO se expone al frontend.
+    """
+    pieces: list[dict] = []
+    sectores = (dual_read or {}).get("sectores") or []
+    for sector in sectores:
+        tramos = sector.get("tramos") or []
+        for tramo in tramos:
+            largo_m = _field_valor(tramo.get("largo_m"))
+            ancho_m = _field_valor(tramo.get("ancho_m"))
+            if largo_m is None or ancho_m is None:
+                continue
+            quantity_raw = tramo.get("quantity") or 1
+            try:
+                quantity = max(1, int(quantity_raw))
+            except (TypeError, ValueError):
+                quantity = 1
+            tramo_id = str(tramo.get("id") or f"t{len(pieces) + 1}")
+            pieces.append({
+                "id": tramo_id,
+                "type": "encimera",
+                "label": str(tramo.get("descripcion") or "Mesada"),
+                "width_mm": round(largo_m * 1000, 2),
+                "depth_mm": round(ancho_m * 1000, 2),
+                "quantity": quantity,
+                "options": {},
+                "origin": "EDITADO" if tramo.get("_manual") else "IA",
+                "edited": False,
+            })
+            for idx, z in enumerate(tramo.get("zocalos") or []):
+                ml = z.get("ml")
+                alto_m = z.get("alto_m")
+                if ml is None or alto_m is None:
+                    continue
+                try:
+                    ml_f = float(ml)
+                    alto_f = float(alto_m)
+                except (TypeError, ValueError):
+                    continue
+                z_quantity_raw = z.get("quantity") or 1
+                try:
+                    z_quantity = max(1, int(z_quantity_raw))
+                except (TypeError, ValueError):
+                    z_quantity = 1
+                lado = str(z.get("lado") or "").strip() or "trasero"
+                pieces.append({
+                    "id": f"{tramo_id}-z{idx + 1}",
+                    "type": "zocalo",
+                    "label": f"Zócalo {lado}",
+                    "width_mm": round(ml_f * 1000, 2),
+                    "depth_mm": round(alto_f * 1000, 2),
+                    "quantity": z_quantity,
+                    "options": {},
+                    "origin": "IA",
+                    "edited": False,
+                })
+    return pieces
+
+
 def _phone_email_from_breakdown(bd: dict | None) -> tuple[str | None, str | None]:
     """Extrae phone + email desde el `_brief_analysis_raw` del breakdown JSON.
 
@@ -431,6 +520,52 @@ async def get_quote(quote_id: str, db: AsyncSession = Depends(get_db)):
         return response_dict
 
     return response
+
+
+# ── DESPIECE PIECES (read-only · sub-PR despiece-real-wire) ─────────────────
+
+@router.get("/quotes/{quote_id}/pieces", response_model=PieceListResponse)
+async def list_pieces_for_quote(quote_id: str, db: AsyncSession = Depends(get_db)):
+    """Lista piezas del despiece desde el `quote_breakdown.dual_read_result`.
+
+    Cierra el gap del frontend `useDespiece` hook que consumía 100% mocks.
+    Source único: `dual_read_result.sectores[].tramos[]` (pre o post-confirm
+    del operador · `verified_derived_pieces` ya no se persiste · PR #386).
+
+    Las 4 mutaciones (update/add/delete/regenerate) siguen mock-only · sub-PR
+    siguiente las migra al modelo agentic via /chat (no CRUD plano).
+    """
+    result = await db.execute(select(Quote).where(Quote.id == quote_id))
+    quote = result.scalar_one_or_none()
+    if not quote:
+        raise HTTPException(status_code=404, detail="quote_not_found")
+
+    breakdown = quote.quote_breakdown or {}
+    dual_read = breakdown.get("dual_read_result")
+
+    if not dual_read:
+        return PieceListResponse(
+            pieces=[],
+            status="pending",
+            timeline=[],
+            warnings=[],
+        )
+
+    pieces = _serialize_dual_read_to_pieces(dual_read)
+    if not pieces:
+        return PieceListResponse(
+            pieces=[],
+            status="failed",
+            timeline=[],
+            warnings=["Valentina no detectó piezas en este despiece"],
+        )
+
+    return PieceListResponse(
+        pieces=[PieceSchema(**p) for p in pieces],
+        status="done",
+        timeline=[],
+        warnings=[],
+    )
 
 
 # ── COMPARE QUOTES ───────────────────────────────────────────────────────────

--- a/api/app/modules/agent/schemas.py
+++ b/api/app/modules/agent/schemas.py
@@ -215,3 +215,41 @@ class AuditLogResponse(BaseModel):
     tools_used: list[AuditLogToolUsage] = Field(default_factory=list)
     quote_breakdown: Optional[dict] = None
     errors: list[AuditLogEventItem] = Field(default_factory=list)
+
+
+# ── PieceList REST · sub-PR sprint-4/despiece-real-wire ──────────────────
+# Cierra el gap del frontend `useDespiece` hook que usaba 100% mocks. Sólo
+# `listPiecesForQuote` se cablea real en este sub-PR; las 4 mutaciones
+# (update/add/delete/regenerate) siguen mock-only hasta sub-PR siguiente
+# que migre al modelo agentic via /chat (no CRUD plano).
+# Shape mirroreado del frontend `web/src/lib/api/types.ts:172-212`.
+
+
+class PieceOptionsSchema(BaseModel):
+    pileta: Optional[dict] = None
+    anafe: bool = False
+    tomas: Optional[int] = None
+    alzada: bool = False
+    regrueso_mm: Optional[int] = None
+
+
+class PieceSchema(BaseModel):
+    id: str
+    type: str  # "encimera" | "zocalo" | "alzada" | "frente" | "isla" | string
+    label: str
+    sublabel: Optional[str] = None
+    width_mm: float
+    depth_mm: float
+    quantity: int = 1
+    options: PieceOptionsSchema = Field(default_factory=PieceOptionsSchema)
+    origin: str = "IA"  # "IA" | "EDITADO" | "AGREGADO_MANUAL"
+    confidence: Optional[float] = None
+    extracted_from: Optional[str] = None
+    edited: bool = False
+
+
+class PieceListResponse(BaseModel):
+    pieces: list[PieceSchema] = Field(default_factory=list)
+    status: str  # "pending" | "inferring" | "done" | "failed"
+    timeline: list = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)

--- a/api/tests/test_pieces_endpoint.py
+++ b/api/tests/test_pieces_endpoint.py
@@ -1,0 +1,276 @@
+"""Tests de `GET /api/quotes/{quote_id}/pieces` · sub-PR despiece-real-wire.
+
+Cobertura:
+- Quote con dual_read_result · tramos + zócalos → serializa al shape Piece
+- Quote sin dual_read_result → status="pending", lista vacía
+- Quote con dual_read_result pero sectores vacíos → status="failed"
+- Quote inexistente → 404
+- Helper _serialize_dual_read_to_pieces · tests unitarios del mapeo
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.modules.agent.router import _serialize_dual_read_to_pieces, _field_valor
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _seed_quote(db_session, quote_id: str, breakdown: dict | None = None):
+    """Inserta una quote draft con el breakdown dado (o None)."""
+    from app.models.quote import Quote, QuoteStatus
+
+    db_session.add(
+        Quote(
+            id=quote_id,
+            client_name="Test Client",
+            project="Cocina test",
+            material="Silestone Blanco Norte",
+            status=QuoteStatus.DRAFT,
+            quote_breakdown=breakdown,
+        )
+    )
+
+
+def _field(valor: float) -> dict:
+    """FieldValue shape usado por dual_read_result."""
+    return {"valor": valor, "opus": None, "sonnet": None, "status": "CONFIRMADO"}
+
+
+# ── Tests del helper de serialización ───────────────────────────────────────
+
+
+class TestFieldValor:
+    def test_extracts_from_dict_shape(self):
+        assert _field_valor({"valor": 2.5}) == 2.5
+
+    def test_extracts_from_plain_number(self):
+        assert _field_valor(1.5) == 1.5
+        assert _field_valor(3) == 3.0
+
+    def test_none_returns_none(self):
+        assert _field_valor(None) is None
+
+    def test_dict_without_valor_returns_none(self):
+        assert _field_valor({"opus": 1.0}) is None
+
+    def test_invalid_valor_returns_none(self):
+        assert _field_valor({"valor": "abc"}) is None
+
+
+class TestSerializeDualRead:
+    def test_empty_dual_read(self):
+        assert _serialize_dual_read_to_pieces({}) == []
+        assert _serialize_dual_read_to_pieces(None) == []
+
+    def test_single_mesada_no_zocalos(self):
+        dr = {
+            "sectores": [{
+                "tramos": [{
+                    "id": "t1",
+                    "descripcion": "Mesada principal",
+                    "largo_m": _field(2.5),
+                    "ancho_m": _field(0.6),
+                    "quantity": 1,
+                    "zocalos": [],
+                }]
+            }]
+        }
+        pieces = _serialize_dual_read_to_pieces(dr)
+        assert len(pieces) == 1
+        p = pieces[0]
+        assert p["id"] == "t1"
+        assert p["type"] == "encimera"
+        assert p["label"] == "Mesada principal"
+        assert p["width_mm"] == 2500.0
+        assert p["depth_mm"] == 600.0
+        assert p["quantity"] == 1
+        assert p["origin"] == "IA"
+
+    def test_mesada_manual_flag_maps_to_editado(self):
+        dr = {
+            "sectores": [{
+                "tramos": [{
+                    "id": "t1",
+                    "descripcion": "Mesada principal",
+                    "largo_m": _field(2.5),
+                    "ancho_m": _field(0.6),
+                    "_manual": True,
+                }]
+            }]
+        }
+        pieces = _serialize_dual_read_to_pieces(dr)
+        assert pieces[0]["origin"] == "EDITADO"
+
+    def test_mesada_with_zocalos_emits_one_piece_per_zocalo(self):
+        dr = {
+            "sectores": [{
+                "tramos": [{
+                    "id": "t1",
+                    "descripcion": "Mesada principal",
+                    "largo_m": _field(2.5),
+                    "ancho_m": _field(0.6),
+                    "zocalos": [
+                        {"lado": "trasero", "ml": 2.5, "alto_m": 0.05, "quantity": 1},
+                        {"lado": "lateral_izq", "ml": 0.6, "alto_m": 0.05, "quantity": 1},
+                    ],
+                }]
+            }]
+        }
+        pieces = _serialize_dual_read_to_pieces(dr)
+        # 1 mesada + 2 zócalos
+        assert len(pieces) == 3
+        assert pieces[0]["type"] == "encimera"
+        assert pieces[1]["type"] == "zocalo"
+        assert pieces[1]["label"] == "Zócalo trasero"
+        assert pieces[1]["width_mm"] == 2500.0
+        assert pieces[1]["depth_mm"] == 50.0
+        assert pieces[2]["label"] == "Zócalo lateral_izq"
+
+    def test_skips_tramos_without_required_dimensions(self):
+        dr = {
+            "sectores": [{
+                "tramos": [
+                    {"id": "t1", "descripcion": "Sin medidas"},  # falta largo/ancho
+                    {
+                        "id": "t2",
+                        "descripcion": "Mesada válida",
+                        "largo_m": _field(2.0),
+                        "ancho_m": _field(0.6),
+                    },
+                ]
+            }]
+        }
+        pieces = _serialize_dual_read_to_pieces(dr)
+        assert len(pieces) == 1
+        assert pieces[0]["id"] == "t2"
+
+    def test_quantity_int_coerced(self):
+        dr = {
+            "sectores": [{
+                "tramos": [{
+                    "id": "t1",
+                    "descripcion": "Mesada",
+                    "largo_m": _field(1.0),
+                    "ancho_m": _field(0.6),
+                    "quantity": "24",
+                }]
+            }]
+        }
+        pieces = _serialize_dual_read_to_pieces(dr)
+        assert pieces[0]["quantity"] == 24
+
+    def test_quantity_invalid_defaults_to_one(self):
+        dr = {
+            "sectores": [{
+                "tramos": [{
+                    "id": "t1",
+                    "descripcion": "Mesada",
+                    "largo_m": _field(1.0),
+                    "ancho_m": _field(0.6),
+                    "quantity": "abc",
+                }]
+            }]
+        }
+        pieces = _serialize_dual_read_to_pieces(dr)
+        assert pieces[0]["quantity"] == 1
+
+
+# ── Tests del endpoint REST ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestListPiecesEndpoint:
+    async def test_404_quote_not_found(self, client):
+        random_id = str(uuid.uuid4())
+        r = await client.get(f"/api/quotes/{random_id}/pieces")
+        assert r.status_code == 404
+        assert r.json()["detail"] == "quote_not_found"
+
+    async def test_pending_when_no_breakdown(self, client, db_session):
+        qid = str(uuid.uuid4())
+        _seed_quote(db_session, qid, breakdown=None)
+        await db_session.commit()
+        r = await client.get(f"/api/quotes/{qid}/pieces")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["pieces"] == []
+        assert data["status"] == "pending"
+
+    async def test_pending_when_breakdown_has_no_dual_read(self, client, db_session):
+        qid = str(uuid.uuid4())
+        _seed_quote(db_session, qid, breakdown={"other_key": "x"})
+        await db_session.commit()
+        r = await client.get(f"/api/quotes/{qid}/pieces")
+        assert r.status_code == 200
+        assert r.json()["status"] == "pending"
+
+    async def test_failed_when_dual_read_has_no_valid_tramos(self, client, db_session):
+        qid = str(uuid.uuid4())
+        _seed_quote(db_session, qid, breakdown={"dual_read_result": {"sectores": []}})
+        await db_session.commit()
+        r = await client.get(f"/api/quotes/{qid}/pieces")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "failed"
+        assert "no detectó piezas" in data["warnings"][0].lower()
+
+    async def test_done_with_real_text_dispiece_shape(self, client, db_session):
+        """Brief solo texto · `parsed_pieces_to_card()` produce este shape."""
+        qid = str(uuid.uuid4())
+        breakdown = {
+            "dual_read_result": {
+                "source": "TEXT",
+                "sectores": [{
+                    "id": "sector_1",
+                    "tipo": "cocina",
+                    "tramos": [
+                        {
+                            "id": "t1",
+                            "descripcion": "Mesada principal",
+                            "largo_m": _field(2.5),
+                            "ancho_m": _field(0.6),
+                            "quantity": 1,
+                            "_manual": True,
+                            "zocalos": [{
+                                "lado": "trasero",
+                                "ml": 2.5,
+                                "alto_m": 0.05,
+                                "quantity": 1,
+                            }],
+                        },
+                        {
+                            "id": "t2",
+                            "descripcion": "Mesada isla",
+                            "largo_m": _field(1.8),
+                            "ancho_m": _field(0.9),
+                            "quantity": 1,
+                            "_manual": True,
+                            "zocalos": [],
+                        },
+                    ],
+                }],
+            }
+        }
+        _seed_quote(db_session, qid, breakdown=breakdown)
+        await db_session.commit()
+
+        r = await client.get(f"/api/quotes/{qid}/pieces")
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["status"] == "done"
+        # 2 mesadas + 1 zócalo
+        assert len(data["pieces"]) == 3
+        labels = [p["label"] for p in data["pieces"]]
+        assert "Mesada principal" in labels
+        assert "Mesada isla" in labels
+        assert "Zócalo trasero" in labels
+        # Origen EDITADO porque tramos tienen _manual=True
+        mesadas = [p for p in data["pieces"] if p["type"] == "encimera"]
+        assert all(p["origin"] == "EDITADO" for p in mesadas)
+        # _manual flag NO se expone al frontend
+        for p in data["pieces"]:
+            assert "_manual" not in p

--- a/web/src/components/contexto/ContextForm.tsx
+++ b/web/src/components/contexto/ContextForm.tsx
@@ -10,8 +10,9 @@
  */
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
-import type { ContextData, ContextResponse } from "@/lib/api";
+import { streamChat, type ContextData, type ContextResponse } from "@/lib/api";
 import { ContextField } from "./ContextField";
 
 export interface FieldDef {
@@ -82,6 +83,35 @@ export function ContextForm({
   chatOpen,
 }: Props) {
   const router = useRouter();
+  const [confirming, setConfirming] = useState(false);
+  const [confirmError, setConfirmError] = useState<string | null>(null);
+
+  // Sub-PR sprint-4/despiece-real-wire · cierra el gap del botón confirmar.
+  // Antes: solo `router.push(/despiece)` · no triggereaba el segundo agent
+  // call · `context_analysis_pending` quedaba sin promover a
+  // `verified_context_analysis` · useDespiece mostraba status="failed".
+  //
+  // Ahora: POST /chat con prefijo `[CONTEXT_CONFIRMED]` (agent.py:1956
+  // ya lo procesa) · drain del SSE para esperar persistencia · DESPUÉS
+  // navegar a /despiece. Payload `{answers: []}` mínimo (text-only no
+  // tiene pending_answers · agent las skip si _is_text_dispiece).
+  async function handleConfirm() {
+    setConfirming(true);
+    setConfirmError(null);
+    try {
+      const payload = JSON.stringify({ answers: [] });
+      const stream = streamChat(quoteId, `[CONTEXT_CONFIRMED]${payload}`, "contexto");
+      const reader = stream.getReader();
+      while (true) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+      router.push(`/quotes/${quoteId}/despiece`);
+    } catch (err) {
+      setConfirmError(err instanceof Error ? err.message : "Error al confirmar contexto");
+      setConfirming(false);
+    }
+  }
 
   return (
     <div className="col" data-testid="context-form" data-state={isDirty ? "B" : "A"}>
@@ -176,10 +206,20 @@ export function ContextForm({
           type="button"
           className="btn primary"
           data-testid="confirm-context"
-          onClick={() => router.push(`/quotes/${quoteId}/despiece`)}
+          onClick={handleConfirm}
+          disabled={confirming}
         >
-          Confirmar y continuar a despiece →
+          {confirming ? "Confirmando…" : "Confirmar y continuar a despiece →"}
         </button>
+        {confirmError && (
+          <div
+            className="error-msg"
+            data-testid="confirm-context-error"
+            style={{ color: "var(--color-error, #c33)", marginTop: 8, fontSize: 13 }}
+          >
+            {confirmError}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -34,7 +34,11 @@ export const getContextForQuote = USE_REAL_API ? real.getContextForQuote : mocks
 export const updateContextForQuote = mocks.updateContextForQuote;
 export const getDashboardKpis = mocks.getDashboardKpis;
 export const getValentinaBriefSummary = mocks.getValentinaBriefSummary;
-export const listPiecesForQuote = mocks.listPiecesForQuote;
+/* Sprint 4 despiece-real-wire · `listPiecesForQuote` wireada contra
+   `GET /api/quotes/{id}/pieces` (backend serializa desde dual_read_result).
+   Las 4 mutaciones siguen mock-only · sub-PR siguiente migra al modelo
+   agentic via /chat. */
+export const listPiecesForQuote = USE_REAL_API ? real.listPiecesForQuote : mocks.listPiecesForQuote;
 export const updatePieceForQuote = mocks.updatePieceForQuote;
 export const addPieceForQuote = mocks.addPieceForQuote;
 export const deletePieceForQuote = mocks.deletePieceForQuote;

--- a/web/src/lib/api/real.ts
+++ b/web/src/lib/api/real.ts
@@ -942,3 +942,29 @@ export async function getPdfGeneratedInfo(
   const quote = (await response.json()) as RealQuoteWithDocs;
   return _adaptToPdfInfo(quote);
 }
+
+
+/* ─── listPiecesForQuote · Sprint 4 despiece-real-wire ───────────────────
+   GET /api/quotes/{id}/pieces · backend serializa desde
+   `quote_breakdown.dual_read_result.sectores[].tramos[]`. Las 4 mutaciones
+   (update/add/delete/regenerate) siguen mock-only hasta sub-PR siguiente. */
+
+import type { PieceList } from "./types";
+
+export async function listPiecesForQuote(
+  quoteId: string,
+  options?: { signal?: AbortSignal },
+): Promise<PieceList> {
+  const response = await apiFetch(
+    `/api/quotes/${encodeURIComponent(quoteId)}/pieces`,
+    { signal: options?.signal },
+  );
+  if (!response.ok) {
+    throw new ApiError(
+      "LIST_PIECES_FAILED",
+      `GET /api/quotes/{id}/pieces ${response.status}`,
+      response.status,
+    );
+  }
+  return (await response.json()) as PieceList;
+}


### PR DESCRIPTION
## Summary

Cierra el **gap visual reportado en validación Chrome 16.06.2026**: brief solo texto producía piezas correctas en `quote_breakdown.dual_read_result` pero el frontend mostraba `status=\"failed\"` porque (a) el botón \"Confirmar y continuar a despiece →\" solo hacía `router.push` sin disparar el segundo agent call, y (b) `useDespiece` hook leía 100% de mocks.

**Opción B confirmada** (scope acotado · 4 mutaciones siguen mock-only para sub-PR siguiente).

## Hallazgos FASE 1

- **Botón actual**: solo `router.push('/despiece')` · cero API call
- **`useDespiece` hook**: lee 100% de mocks (`web/src/lib/api/index.ts:37-41` exporta los 5 desde `mocks`)
- **Mecanismo \"segundo agent call\" real**: NO endpoint REST dedicado · es `POST /chat` con prefijo `[CONTEXT_CONFIRMED]{answers}` (agent.py:1956-2074 lo procesa, persiste `verified_context_analysis`, aplica `merge_derived_pieces` al `dual_read_result`)
- **`verified_derived_pieces` ya NO se persiste** (PR #386 lo eliminó) · todo vive en `dual_read_result` post-confirm
- **Modelo arquitectónico**: frontend asume CRUD REST · backend es agentic vía `/chat`. Las 4 mutaciones (update/add/delete/regenerate) son naturalmente agentic y se difieren a sub-PR siguiente

## Cambios

### Backend (api/)

| Archivo | Cambio |
|---|---|
| `agent/router.py` | `GET /api/quotes/{id}/pieces` nuevo + 2 helpers (`_field_valor`, `_serialize_dual_read_to_pieces`) |
| `agent/schemas.py` | `PieceListResponse` + `PieceSchema` + `PieceOptionsSchema` (shape mirroreado del frontend `types.ts`) |
| `tests/test_pieces_endpoint.py` | 17 tests nuevos · helper unitario + endpoint REST |

**Serialización**: cada tramo del `dual_read_result.sectores[].tramos[]` emite 1 `Piece` (`type=encimera`); cada zócalo del tramo emite 1 `Piece` adicional (`type=zocalo`). `_manual:true` se traduce a `origin=EDITADO` y NO se expone al frontend.

### Frontend (web/)

| Archivo | Cambio |
|---|---|
| `lib/api/real.ts` | `listPiecesForQuote` agregada · fetch via `apiFetch` con credentials:include + 401 handling |
| `lib/api/index.ts:37` | swap `mocks.listPiecesForQuote` → `USE_REAL_API ? real.listPiecesForQuote : mocks.listPiecesForQuote` |
| `components/contexto/ContextForm.tsx` | botón confirmar dispara `streamChat(quoteId, \"[CONTEXT_CONFIRMED]{...}\", \"contexto\")` + drain SSE + router.push · disabled durante el call · error UI inline si falla |

**Las 4 mutaciones (`update/add/delete/regenerate`) siguen mock-only** · sub-PR siguiente las migra al modelo agentic via `/chat`.

## Verificación local

- ✅ Backend: 17/17 tests del slice pieces pass · cero regresiones en suite completa (mismos 15 fails + 2 errors pre-existentes en `evaluation/` + `pdf_snapshots`)
- ✅ Frontend: `npx tsc --noEmit` verde
- ✅ Preview server mock-mode: navegación end-to-end OK (`/contexto` → click confirmar → `/despiece` sin errores · sin console errors)
- ⏳ Verificación real (mock_mode=false con NEXT_PUBLIC_API_URL al backend Railway) → preview Vercel del PR

## Test plan

- [x] 17 tests backend pass (helper + endpoint, 4 escenarios)
- [x] TypeCheck frontend verde
- [x] Preview mock-mode confirma cero rotura del flow existente
- [ ] CI Backend Tests + Web CI verdes
- [ ] Validación visual Chrome end-to-end en preview Vercel · brief solo texto → confirmar contexto → ver piezas reales (Mesada principal + Mesada isla + Zócalo trasero) con dimensiones correctas
- [ ] **Audit independiente OBLIGATORIO** (path crítico MVP · scope mixed backend+frontend)

## Lecciones operativas Ola 1 aplicadas

- **#74 consolidada**: 3 barridos amplios desde FASE 1 (botón + hook + endpoints + 5 funciones API)
- **#74 expansión**: `useDespiece` no era passthrough · era extractor del client API; bajé a leer
- **#75**: tests cubren las 4 variantes (con dual_read, sin breakdown, breakdown sin sectores, 404 inexistente) + roundtrip text-parser real
- **#79**: verify visual mock-mode confirmó cero rotura del flow existente · variante real queda para preview Vercel del PR

## Out of scope (deuda explícita post-merge)

- 4 mutaciones REST (`update/add/delete/regenerate piece`) · sub-PR siguiente migra al modelo agentic via `/chat`
- Validación visual con planos PDF · estrategia brief-texto-primero (lección #76)
- Script audit retroactivo · forward-only (decisión 16.06.2026)
- `_manual:true` filter logic en `DespieceView.tsx` · si el bug visual sigue post-deploy, sub-PR aparte

🤖 Generated with [Claude Code](https://claude.com/claude-code)