### PR TITLE
fix(brief): re-balancear copy del paso 1 para no asumir plano primary

### DIFF
--- a/web/src/components/brief/BriefForm.tsx
+++ b/web/src/components/brief/BriefForm.tsx
@@ -101,11 +101,16 @@ export function BriefForm({
       </>
     );
   } else if (hasMinBrief || hasChips) {
-    helperContent = "Sin plano voy a intentar igual pero será aproximado.";
+    helperContent = (
+      <>
+        Sin plano voy a intentar igual pero será aproximado.{" "}
+        <em>Valentina</em> tarda unos segundos en procesar el brief.
+      </>
+    );
   } else {
     helperContent = (
       <>
-        Necesito al menos el <em>plano en PDF</em> para arrancar. ¿No tenés?{" "}
+        Necesito al menos un brief con medidas o un <em>plano en PDF</em> para arrancar. ¿No tenés?{" "}
         <a
           href="#"
           className="link-inline"
@@ -164,11 +169,10 @@ export function BriefForm({
               "Cuando le des dale, voy a leer el plano, extraer medidas, identificar ambiente y armar el contexto del paso 2. Te aviso si encuentro algo raro."
             ) : (
               <>
-                Soy <em>Valentina</em>. Si me das el plano y un brief — aunque sea informal —
+                Soy <em>Valentina</em>. Si me das un brief con medidas — aunque sea informal —
                 extraigo cliente, ambiente, medidas, material y armo el contexto del paso 2 sola.
                 <br />
                 <br />
-                ¿No tenés plano todavía?{" "}
                 <a
                   href="#"
                   className="link-inline"
@@ -178,7 +182,7 @@ export function BriefForm({
                   }}
                   data-testid="brief-manual-hero-link"
                 >
-                  cargá a mano →
+                  Cargá los datos a mano →
                 </a>
               </>
             )}

--- a/web/tests/e2e/brief-upload.spec.ts
+++ b/web/tests/e2e/brief-upload.spec.ts
@@ -144,7 +144,9 @@ test("Estado A · brief-textarea-wrap con placeholder LITERAL del mockup", async
 test("Estado A · CTA disabled cuando todo vacío + helper LITERAL", async ({ page }) => {
   await page.goto("/quotes/new");
   await expect(page.locator('[data-testid="brief-submit"]')).toBeDisabled();
-  await expect(page.locator('[data-testid="brief-helper"]')).toContainText(/Necesito al menos el/);
+  await expect(page.locator('[data-testid="brief-helper"]')).toContainText(
+    /Necesito al menos un brief/,
+  );
 });
 
 test("Estado A · llenar 3 chips sin PDF habilita CTA (cliente+ambiente)", async ({ page }) => {
@@ -264,10 +266,10 @@ test("Persistencia A↔B · chips llenos en A se mantienen al subir PDF (estado 
   await expect(page.locator('[data-testid="brief-text"]')).toHaveValue("brief preservado");
 });
 
-test("Estado A · h2 LITERAL 'Subí lo que tengas y arranco' + lead con 'cargá a mano →'", async ({
+test("Estado A · h2 LITERAL 'Subí lo que tengas y arranco' + lead con CTA 'Cargá los datos a mano'", async ({
   page,
 }) => {
   await page.goto("/quotes/new");
   await expect(page.locator(".brief-hero h2")).toContainText("Subí lo que tengas y arranco");
-  await expect(page.locator(".brief-hero .lead")).toContainText("cargá a mano");
+  await expect(page.locator(".brief-hero .lead")).toContainText("Cargá los datos a mano");
 });


### PR DESCRIPTION
## Summary

Sub-PR re-scopeado a **copy rebalance puro** (Hipótesis A-modificada confirmada por FASE 1).

FASE 1 confirmó que el flow brief-only **YA está cableado end-to-end** post-#512 · validación visual del operador mostró 3 piezas reales generadas desde texto solo (Mesada principal + Mesada isla + Zócalo trasero). El plan original (rebuild BriefView 3-4 días) era snapshot pre-Sprint 4 · sub-PRs previos (#281, #405-#409, #480, #493, #511, #512) ya hicieron todo el work funcional.

**Tercera vez consecutiva** del patrón \"plan asume gap que no existe\" (post text-parser-agent-integration + paso-1-real original mergeado en #475) · candidata a **lección operativa #82**: verificar empíricamente contra código actual ANTES de implementar, especialmente cuando el plan referencia un snapshot temporal que puede estar obsoleto post-merges.

Absorbe el follow-up `brief-form-copy-rebalance` que estaba agendado aparte · evita fragmentación · cero scope creep · **cero archivos backend**.

## Cambios · 5 sites en `BriefForm.tsx`

| Site | Antes | Después |
|---|---|---|
| Helper text (con brief sin plano) | \"Sin plano voy a intentar igual pero será aproximado.\" | + \"_Valentina_ tarda **unos segundos** en procesar el brief.\" (NO ~12s · datos empíricos #512 mostraron text_parse en 2776ms) |
| Helper text (vacío inicial) | \"Necesito al menos el **plano en PDF** para arrancar\" | \"Necesito al menos un brief con medidas o un **plano en PDF** para arrancar\" |
| Hero lead estado A | \"Si me das el **plano** y un brief — aunque sea informal —\" | \"Si me das un **brief con medidas** — aunque sea informal —\" |
| Hero lead estado A · CTA | \"¿No tenés plano todavía? cargá a mano →\" (pregunta retórica) | \"Cargá los datos a mano →\" (CTA directa · matchea botón del form) |

## NO tocados (legítimos · ya OK)

- Helper con planFile (`line 100`): \"Valentina tarda ~12 segundos en procesar un plano\" · branch con-plano honesto
- Hero lead estado B (`line 164`): branch isStateB=true (operador subió plano)
- Dropzone CTAs (`lines 304, 415`): CTAs legítimos del dropzone + validator
- `BriefProcessing.tsx` (7 menciones): YA condicional según `planName` post-#509

## Tests actualizados

- `brief-upload.spec.ts:147` · assertion regex `/Necesito al menos el/` → `/Necesito al menos un brief/`
- `brief-upload.spec.ts:267-273` · test name + assertion del lead actualizadas al nuevo CTA `Cargá los datos a mano`
- Tests de click del `brief-manual-hero-link` y `brief-manual-helper-link` (lines 221, 227) NO se tocan · asserten click → navigation, no copy text

## Verificación local

- `npx tsc --noEmit` verde
- Skip preview verify mock-mode (decisión Javi · validación visual real va al cierre contra preview Vercel del PR · lección #81 patrón \"validación visual = cierre, NO mid-FASE\")

## Out of scope (explícito)

- Funcionalidad nueva · refactor del flow
- Validación con planos PDF (estrategia brief-texto-primero · lección #76)
- Cambios backend / `.py`
- Audit independiente (frontend puro · cero lógica financiera · cero riesgo)

## Note sobre branch name

El branch original sugerido (`sprint-4/paso-1-real`) ya estaba usado por [PR #475](https://github.com/javi10823/ia-agent-quote-marble-operator/pull/475) (MERGED 2026-06-09) · la branch remota había quedado residual. Renombré a `sprint-4/paso-1-real-copy-rebalance` para reflejar mejor el scope real y evitar confusión cosmética. Cero impacto funcional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)