### PR TITLE
feat(calculation): wire real GET /quotes/{id}/calculation · serializer residential

### DIFF
--- a/api/app/modules/agent/router.py
+++ b/api/app/modules/agent/router.py
@@ -33,6 +33,15 @@ from app.modules.agent.schemas import (
     PieceListResponse,
     PieceSchema,
     PieceOptionsSchema,
+    CalculationResponse,
+    MaterialRowSchema,
+    LaborRowDataSchema,
+    MermaSectionSchema,
+    PiletaSectionSchema,
+    FleteRowSchema,
+    GrandTotalsSchema,
+    GrandTotalsCurrencySchema,
+    DatosPdfDefaultsSchema,
 )
 
 router = APIRouter(tags=["agent"])
@@ -501,6 +510,266 @@ def _extract_calc_pieces_from_dual_read(dual_read: dict | None) -> list[dict]:
     return pieces
 
 
+# ── Calculation serializer helpers · sub-PR calculation-real-wire ────────
+# Convierten el shape backend (`calculate_quote()` return inlined al top-level
+# del `quote_breakdown`) al shape `CalculationResult` del frontend
+# (types.ts:344). PASO 0 EXP-2 confirmó shapes vía Railway query:
+#   - mo_items: [{description, quantity, unit_price, base_price, total}]
+#   - sinks: [{name, quantity, unit_price}]
+#   - merma: {aplica, desperdicio, sobrante_m2, motivo}
+#   - piece_details: [{description, largo, dim2, m2, quantity, override, _is_frentin}]
+
+
+def _format_ars(value: float | int | None) -> str:
+    """Locale es-AR · "$1.234,56" (separador miles "." · decimal ",")."""
+    if value is None:
+        return "—"
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return "—"
+    formatted = f"{v:,.2f}"
+    formatted = formatted.replace(",", "X").replace(".", ",").replace("X", ".")
+    return f"${formatted}"
+
+
+def _format_usd(value: float | int | None) -> str:
+    """Locale es-AR · "USD 1.234"."""
+    if value is None:
+        return "—"
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return "—"
+    formatted = f"{v:,.0f}".replace(",", ".")
+    return f"USD {formatted}"
+
+
+def _format_qty_m2(value: float | int | None) -> str:
+    if value is None:
+        return "—"
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return "—"
+    formatted = f"{v:.2f}".replace(".", ",")
+    return f"{formatted} m²"
+
+
+def _is_flete_item(item: dict) -> bool:
+    """Heurística confirmada PASO 0 EXP-2: el item flete tiene `description`
+    que arranca con "flete" (case-insensitive). Sample real:
+    "Flete + toma medidas ibarlucea"."""
+    desc = (item.get("description") or "").lower().strip()
+    return desc.startswith("flete")
+
+
+def _serialize_residential_calc(breakdown: dict, quote) -> CalculationResponse:
+    """Adapter no trivial · mapea ~7 secciones del shape backend al shape
+    `CalculationResult` del frontend. Solo residential (edificio out-of-scope).
+
+    Shape source confirmado PASO 0 EXP + EXP-2 vs Railway DB.
+    """
+    quote_id = str(quote.id)
+    mo_items = breakdown.get("mo_items") or []
+    sinks = breakdown.get("sinks") or []
+    merma = breakdown.get("merma") or {}
+    material_currency = breakdown.get("material_currency") or "USD"
+    pileta = (breakdown.get("pileta") or "").strip().lower()
+
+    # ── Material section · 1 row + descuento opcional + subtotal ──
+    material_name = breakdown.get("material_name") or "Material"
+    material_m2 = breakdown.get("material_m2") or 0
+    material_total = breakdown.get("material_total") or 0
+    material_total_bruto = breakdown.get("material_total_bruto") or material_total
+    material_price_unit = breakdown.get("material_price_unit") or 0
+    discount_pct = breakdown.get("discount_pct") or 0
+    discount_amount = breakdown.get("discount_amount") or 0
+
+    is_usd = material_currency == "USD"
+    _fmt_money = _format_usd if is_usd else _format_ars
+
+    material_rows: list[MaterialRowSchema] = [
+        MaterialRowSchema(
+            label=material_name,
+            qty=_format_qty_m2(material_m2),
+            unit=f"{material_currency} {int(material_price_unit)}",
+            total=_fmt_money(material_total_bruto),
+        )
+    ]
+    if discount_amount and discount_pct:
+        material_rows.append(
+            MaterialRowSchema(
+                label=f"Descuento {discount_pct}%",
+                qty="",
+                unit="",
+                total="−" + _fmt_money(discount_amount),
+                variant="discount",
+            )
+        )
+    material_subtotal = _fmt_money(material_total)
+
+    # ── Merma section ──
+    if bool(merma.get("aplica")):
+        sobrante_m2 = breakdown.get("sobrante_m2") or 0
+        sobrante_total = breakdown.get("sobrante_total") or 0
+        merma_rows: list[MaterialRowSchema] = []
+        if sobrante_m2 > 0:
+            merma_rows.append(
+                MaterialRowSchema(
+                    label="Sobrante recuperable",
+                    qty=_format_qty_m2(sobrante_m2),
+                    unit="",
+                    total=_fmt_money(sobrante_total),
+                )
+            )
+        merma_section = MermaSectionSchema(
+            status="aplica",
+            chipLabel="APLICA",
+            sub=str(merma.get("motivo") or ""),
+            rows=merma_rows or None,
+        )
+    else:
+        merma_section = MermaSectionSchema(
+            status="na",
+            chipLabel=f"N/A — {merma.get('motivo') or 'sin merma'}",
+        )
+
+    # ── Labor section · mo_items filtrados (skip flete) ──
+    labor_rows: list[LaborRowDataSchema] = []
+    labor_subtotal_total = 0.0
+    for item in mo_items:
+        if not isinstance(item, dict) or _is_flete_item(item):
+            continue
+        item_total = item.get("total") or 0
+        labor_subtotal_total += float(item_total)
+        labor_rows.append(
+            LaborRowDataSchema(
+                sku="MO",
+                label=str(item.get("description") or ""),
+                qty=str(item.get("quantity") or 1),
+                basePrice=_format_ars(item.get("base_price")),
+                iva="×1,21",
+                total=_format_ars(item_total),
+            )
+        )
+    labor_subtotal_str = _format_ars(labor_subtotal_total)
+
+    # ── Flete section · single trip residential ──
+    flete_item = next((it for it in mo_items if isinstance(it, dict) and _is_flete_item(it)), None)
+    localidad = breakdown.get("localidad") or "—"
+    if flete_item:
+        flete_section = FleteRowSchema(
+            zona=str(localidad).title(),
+            qty="1 viaje",
+            basePrice=_format_ars(flete_item.get("base_price")),
+            total=_format_ars(flete_item.get("total")),
+        )
+    else:
+        flete_section = FleteRowSchema(
+            zona=str(localidad).title(),
+            qty="—",
+            basePrice="—",
+            total="—",
+        )
+
+    # ── Piletas section · 3 escenarios por `pileta` value ──
+    if pileta == "empotrada_cliente":
+        piletas_section = PiletaSectionSchema(
+            chipLabel="N/A — pileta empotrada (la trae el cliente)",
+            variant="na",
+        )
+    elif pileta == "empotrada_johnson":
+        if sinks:
+            sink0 = sinks[0]
+            piletas_section = PiletaSectionSchema(
+                chipLabel="APLICA",
+                variant="info",
+                sub=f"{sink0.get('name', '—')} × {sink0.get('quantity', 1)} · {_format_ars(sink0.get('unit_price'))}",
+            )
+        else:
+            piletas_section = PiletaSectionSchema(
+                chipLabel="APLICA",
+                variant="info",
+                sub="Johnson (catálogo)",
+            )
+    elif pileta == "apoyo":
+        piletas_section = PiletaSectionSchema(
+            chipLabel="N/A — pileta de apoyo",
+            variant="na",
+        )
+    else:
+        piletas_section = PiletaSectionSchema(chipLabel="—", variant="na")
+
+    # ── Totals ──
+    total_ars = breakdown.get("total_ars") or 0
+    total_usd = breakdown.get("total_usd") or 0
+    totals = GrandTotalsSchema(
+        ars=GrandTotalsCurrencySchema(value=_format_ars(total_ars), meta="MO + flete (ARS)"),
+        usd=GrandTotalsCurrencySchema(value=_format_usd(total_usd), meta="Material importado (USD)"),
+    )
+
+    # ── DatosPdf defaults · desde columnas Quote + breakdown ──
+    delivery_days = breakdown.get("delivery_days") or "30 días"
+    datos_pdf = DatosPdfDefaultsSchema(
+        plazo=str(delivery_days),
+        anticipoPct="50%",
+        saldo="Contra entrega",
+        envio="Incluye flete" if flete_item else "Retira en taller",
+        notas=str(quote.notes or ""),
+        vigenciaDias="30",
+    )
+
+    # ── Banner summary · pre-rendered string ──
+    n_pieces = len(breakdown.get("piece_details") or [])
+    banner_parts = [
+        f"✓ Calculado",
+        material_name,
+        _format_qty_m2(material_m2),
+        f"{_format_ars(total_ars)} + {_format_usd(total_usd)}",
+    ]
+    if n_pieces:
+        banner_parts.insert(0, f"{n_pieces} piezas")
+    banner_summary = " · ".join(banner_parts)
+
+    return CalculationResponse(
+        quoteId=quote_id,
+        status="ok",
+        bannerSummary=banner_summary,
+        bannerAdjustments=[],
+        material={"rows": [r.model_dump() for r in material_rows], "subtotal": material_subtotal},
+        merma=merma_section,
+        labor={"rows": [r.model_dump() for r in labor_rows], "subtotal": labor_subtotal_str},
+        piletas=piletas_section,
+        flete=flete_section,
+        totals=totals,
+        datosPdf=datos_pdf,
+    )
+
+
+def _pending_calculation_response(quote_id: str, summary: str) -> CalculationResponse:
+    """Empty CalculationResponse para pending / edificio_not_supported."""
+    return CalculationResponse(
+        quoteId=quote_id,
+        status="pending",
+        bannerSummary=summary,
+        bannerAdjustments=[],
+        material={"rows": [], "subtotal": "—"},
+        merma=MermaSectionSchema(status="na", chipLabel="—"),
+        labor={"rows": [], "subtotal": "—"},
+        piletas=PiletaSectionSchema(chipLabel="—", variant="na"),
+        flete=FleteRowSchema(zona="—", qty="—", basePrice="—", total="—"),
+        totals=GrandTotalsSchema(
+            ars=GrandTotalsCurrencySchema(value="—", meta=""),
+            usd=GrandTotalsCurrencySchema(value="—", meta=""),
+        ),
+        datosPdf=DatosPdfDefaultsSchema(
+            plazo="30 días", anticipoPct="50%", saldo="Contra entrega",
+            envio="—", notas="", vigenciaDias="30",
+        ),
+    )
+
+
 def _phone_email_from_breakdown(bd: dict | None) -> tuple[str | None, str | None]:
     """Extrae phone + email desde el `_brief_analysis_raw` del breakdown JSON.
 
@@ -622,6 +891,47 @@ async def list_pieces_for_quote(quote_id: str, db: AsyncSession = Depends(get_db
         timeline=[],
         warnings=[],
     )
+
+
+# ── CALCULATION (read-only display · sub-PR calculation-real-wire) ─────────
+
+@router.get("/quotes/{quote_id}/calculation", response_model=CalculationResponse)
+async def get_calculation_for_quote(quote_id: str, db: AsyncSession = Depends(get_db)):
+    """Serializa `quote_breakdown` al shape `CalculationResult` del frontend.
+
+    Cierra el gap del paso 4 que consumía 100% mocks. Sub-PR scope:
+    - Residential (top-level breakdown.material_*, mo_items, merma, etc.)
+    - Edificio out-of-scope · devuelve status=pending con summary específico
+      (multi-material UI no soportado por `CalculationResult` actual)
+    - Sin cálculo → status=pending
+
+    Helpers de mapeo en `_serialize_residential_calc()` y
+    `_pending_calculation_response()`. `triggerCalculation` y `applyAutoFix`
+    siguen mock-only · sub-PR aparte si Marina los necesita.
+    """
+    result = await db.execute(select(Quote).where(Quote.id == quote_id))
+    quote = result.scalar_one_or_none()
+    if not quote:
+        raise HTTPException(status_code=404, detail="quote_not_found")
+
+    breakdown = quote.quote_breakdown or {}
+
+    # Edificio out-of-scope (multi-material via paso2_calc.calc_results)
+    if breakdown.get("is_edificio") or "paso2_calc" in breakdown:
+        return _pending_calculation_response(
+            str(quote.id),
+            "Cálculo de edificios no disponible en esta vista todavía",
+        )
+
+    # Residential sin cálculo aún
+    if not breakdown.get("material_name") or not breakdown.get("total_ars"):
+        return _pending_calculation_response(
+            str(quote.id),
+            "Cálculo pendiente · esperá a que Valentina termine el paso 3",
+        )
+
+    # Residential con cálculo completo
+    return _serialize_residential_calc(breakdown, quote)
 
 
 # ── COMPARE QUOTES ───────────────────────────────────────────────────────────

--- a/api/app/modules/agent/schemas.py
+++ b/api/app/modules/agent/schemas.py
@@ -253,3 +253,113 @@ class PieceListResponse(BaseModel):
     status: str  # "pending" | "inferring" | "done" | "failed"
     timeline: list = Field(default_factory=list)
     warnings: list[str] = Field(default_factory=list)
+
+
+# ── Calculation Response · sub-PR sprint-4/calculation-real-wire ──────────
+# Cierra el gap del paso 4 que consumía 100% mocks. Solo `getCalculationForQuote`
+# se cablea real en este sub-PR; `triggerCalculation` y `applyAutoFix` siguen
+# mock-only hasta sub-PR siguiente (decisión: trigger ya está cubierto por
+# agent loop · applyAutoFix es caso nicho mockup 08 patch error).
+# Shape mirroreado del frontend `web/src/lib/api/types.ts:267-342` (CalcStatus,
+# MaterialRow, LaborRowData, MermaSection, PiletaSection, FleteRow, GrandTotals,
+# DatosPdfDefaults, ValentinaAdjustment, CalculationResult).
+
+
+class AuditEntrySchema(BaseModel):
+    kind: str  # "SOURCE" | "REGLA" | "CALC" | "IVA" | "SUMA"
+    text: str
+
+
+class MaterialRowSchema(BaseModel):
+    label: str
+    sub: Optional[str] = None
+    qty: str
+    unit: str
+    total: str
+    variant: Optional[str] = None  # "default" | "discount" | "subtotal"
+    audit: Optional[list[AuditEntrySchema]] = None
+
+
+class LaborRowDataSchema(BaseModel):
+    sku: str
+    label: str
+    sub: Optional[str] = None
+    qty: str
+    basePrice: str
+    iva: str
+    total: str
+    audit: Optional[list[AuditEntrySchema]] = None
+
+
+class MermaSobranteToggleSchema(BaseModel):
+    label: str
+    defaultChecked: bool
+
+
+class MermaErrorRowSchema(BaseModel):
+    label: str
+    detail: str
+    fixLabel: str
+
+
+class MermaSectionSchema(BaseModel):
+    status: str  # "na" | "aplica" | "error"
+    chipLabel: str
+    sub: Optional[str] = None
+    rows: Optional[list[MaterialRowSchema]] = None
+    sobranteToggle: Optional[MermaSobranteToggleSchema] = None
+    stockToggle: Optional[MermaSobranteToggleSchema] = None
+    errorRow: Optional[MermaErrorRowSchema] = None
+
+
+class PiletaSectionSchema(BaseModel):
+    chipLabel: str
+    variant: str  # "na" | "info"
+    sub: Optional[str] = None
+
+
+class FleteRowSchema(BaseModel):
+    zona: str
+    qty: str
+    basePrice: str
+    total: str
+    audit: Optional[list[AuditEntrySchema]] = None
+
+
+class GrandTotalsCurrencySchema(BaseModel):
+    value: str
+    meta: str
+
+
+class GrandTotalsSchema(BaseModel):
+    ars: GrandTotalsCurrencySchema
+    usd: GrandTotalsCurrencySchema
+    warnDetail: Optional[str] = None
+
+
+class DatosPdfDefaultsSchema(BaseModel):
+    plazo: str
+    anticipoPct: str
+    saldo: str
+    envio: str
+    notas: str
+    vigenciaDias: str
+
+
+class ValentinaAdjustmentSchema(BaseModel):
+    text: str
+
+
+class CalculationResponse(BaseModel):
+    quoteId: str
+    status: str  # "pending" | "ok" | "error"
+    bannerSummary: str
+    bannerAdjustments: list[ValentinaAdjustmentSchema] = Field(default_factory=list)
+    material: dict  # {"rows": list[MaterialRowSchema], "subtotal": str}
+    merma: MermaSectionSchema
+    labor: dict  # {"rows": list[LaborRowDataSchema], "subtotal": str}
+    piletas: PiletaSectionSchema
+    flete: FleteRowSchema
+    totals: GrandTotalsSchema
+    patchError: Optional[dict] = None
+    datosPdf: DatosPdfDefaultsSchema

--- a/api/tests/test_calculation_endpoint.py
+++ b/api/tests/test_calculation_endpoint.py
@@ -1,0 +1,282 @@
+"""Tests para GET /api/quotes/{id}/calculation · sub-PR calculation-real-wire.
+
+Cobertura:
+- Helper unit tests · _format_ars · _format_usd · _format_qty_m2 · _is_flete_item
+- Endpoint REST · residential complete · residential pending · edificio
+  not_supported · quote 404
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.modules.agent.router import (
+    _format_ars,
+    _format_usd,
+    _format_qty_m2,
+    _is_flete_item,
+    _serialize_residential_calc,
+)
+
+
+# ═══════════════════════════════════════════════════════
+# Helpers · format
+# ═══════════════════════════════════════════════════════
+
+
+class TestFormatHelpers:
+    @pytest.mark.parametrize("value,expected", [
+        (1234.56, "$1.234,56"),
+        (198244, "$198.244,00"),
+        (0, "$0,00"),
+        (None, "—"),
+        ("abc", "—"),
+        (1500000.5, "$1.500.000,50"),
+    ])
+    def test_format_ars(self, value, expected):
+        assert _format_ars(value) == expected
+
+    @pytest.mark.parametrize("value,expected", [
+        (1822, "USD 1.822"),
+        (519, "USD 519"),
+        (0, "USD 0"),
+        (None, "—"),
+        ("xyz", "—"),
+    ])
+    def test_format_usd(self, value, expected):
+        assert _format_usd(value) == expected
+
+    @pytest.mark.parametrize("value,expected", [
+        (2.82, "2,82 m²"),
+        (0.69, "0,69 m²"),
+        (10, "10,00 m²"),
+        (None, "—"),
+    ])
+    def test_format_qty_m2(self, value, expected):
+        assert _format_qty_m2(value) == expected
+
+
+# ═══════════════════════════════════════════════════════
+# Heurística flete
+# ═══════════════════════════════════════════════════════
+
+
+class TestIsFlete:
+    @pytest.mark.parametrize("item,expected", [
+        ({"description": "Flete + toma medidas ibarlucea"}, True),
+        ({"description": "flete rosario"}, True),
+        ({"description": "FLETE × 5"}, True),
+        ({"description": "  Flete extra"}, True),
+        ({"description": "Agujero anafe"}, False),
+        ({"description": "Agujero y pegado pileta"}, False),
+        ({"description": "Colocación"}, False),
+        ({"description": ""}, False),
+        ({"description": None}, False),
+        ({}, False),
+    ])
+    def test_heuristic(self, item, expected):
+        assert _is_flete_item(item) == expected
+
+
+# ═══════════════════════════════════════════════════════
+# Serializer · _serialize_residential_calc
+# ═══════════════════════════════════════════════════════
+
+
+class _FakeQuote:
+    """Quote fake compatible con _serialize_residential_calc."""
+    def __init__(self, quote_id: str, notes: str = ""):
+        self.id = quote_id
+        self.notes = notes
+
+
+def _hugo_zimaro_breakdown() -> dict:
+    """Shape real del breakdown residential confirmado en PASO 0 EXP/EXP-2
+    contra Railway DB · quote 3d09fa0f-24ca-498e-ba83-2caa759ab4ac."""
+    return {
+        "is_edificio": False,
+        "material_name": "SILESTONE BLANCO NORTE",
+        "material_m2": 2.82,
+        "material_total": 1464,
+        "material_total_bruto": 1464,
+        "material_price_unit": 519,
+        "material_price_base": 429.0,
+        "material_currency": "USD",
+        "material_type": "silestone",
+        "discount_pct": 0,
+        "discount_amount": 0,
+        "mo_items": [
+            {"description": "Agujero y pegado pileta", "quantity": 1, "unit_price": 65147, "base_price": 53840.17, "total": 65147},
+            {"description": "Agujero anafe", "quantity": 1, "unit_price": 43097, "base_price": 35617.36, "total": 43097},
+            {"description": "Flete + toma medidas ibarlucea", "quantity": 1, "unit_price": 90000, "base_price": 74380.17, "total": 90000},
+        ],
+        "merma": {
+            "aplica": True,
+            "desperdicio": 1.38,
+            "sobrante_m2": 0.69,
+            "motivo": "Desperdicio 1.38 m² ≥ 1.0 → sobrante 0.69 m²",
+        },
+        "sobrante_m2": 0.69,
+        "sobrante_total": 358,
+        "total_ars": 198244,
+        "total_usd": 1822,
+        "colocacion": False,
+        "anafe": True,
+        "pileta": "empotrada_cliente",
+        "pileta_qty": 1,
+        "sinks": [],
+        "localidad": "ibarlucea",
+        "delivery_days": "30 días",
+        "piece_details": [
+            {"description": "Mesada en L - parte 1", "largo": 2.4, "dim2": 0.6, "m2": 1.44, "quantity": 1},
+        ],
+        "ok": True,
+    }
+
+
+class TestSerializeResidential:
+    def test_hugo_zimaro_residential_full(self):
+        bd = _hugo_zimaro_breakdown()
+        q = _FakeQuote("hugo-test-id", notes="Cliente trae bacha")
+        resp = _serialize_residential_calc(bd, q)
+        assert resp.status == "ok"
+        assert resp.quoteId == "hugo-test-id"
+        # Material
+        assert len(resp.material["rows"]) == 1
+        assert resp.material["rows"][0]["label"] == "SILESTONE BLANCO NORTE"
+        assert resp.material["rows"][0]["qty"] == "2,82 m²"
+        assert resp.material["rows"][0]["unit"] == "USD 519"
+        assert resp.material["subtotal"] == "USD 1.464"
+        # Merma aplica
+        assert resp.merma.status == "aplica"
+        assert resp.merma.chipLabel == "APLICA"
+        assert resp.merma.rows and len(resp.merma.rows) == 1
+        # Labor · 2 rows (skip flete)
+        assert len(resp.labor["rows"]) == 2
+        labels = [r["label"] for r in resp.labor["rows"]]
+        assert "Agujero y pegado pileta" in labels
+        assert "Agujero anafe" in labels
+        # Flete extraído
+        assert resp.flete.zona == "Ibarlucea"
+        assert resp.flete.qty == "1 viaje"
+        assert resp.flete.total == "$90.000,00"
+        # Piletas · empotrada_cliente
+        assert resp.piletas.variant == "na"
+        assert "cliente" in resp.piletas.chipLabel.lower()
+        # Totals
+        assert resp.totals.ars.value == "$198.244,00"
+        assert resp.totals.usd.value == "USD 1.822"
+        # Banner
+        assert "SILESTONE BLANCO NORTE" in resp.bannerSummary
+        assert "2,82 m²" in resp.bannerSummary
+        # DatosPdf
+        assert resp.datosPdf.plazo == "30 días"
+        assert resp.datosPdf.envio == "Incluye flete"
+        assert resp.datosPdf.notas == "Cliente trae bacha"
+
+    def test_merma_no_aplica(self):
+        bd = _hugo_zimaro_breakdown()
+        bd["merma"] = {"aplica": False, "motivo": "Negro Brasil — nunca merma"}
+        q = _FakeQuote("test-no-merma")
+        resp = _serialize_residential_calc(bd, q)
+        assert resp.merma.status == "na"
+        assert "Negro Brasil" in resp.merma.chipLabel
+
+    def test_pileta_johnson_with_sinks(self):
+        bd = _hugo_zimaro_breakdown()
+        bd["pileta"] = "empotrada_johnson"
+        bd["sinks"] = [{"name": "PILETA JOHNSON LUXOR S171", "quantity": 1, "unit_price": 268048}]
+        q = _FakeQuote("test-johnson")
+        resp = _serialize_residential_calc(bd, q)
+        assert resp.piletas.variant == "info"
+        assert "LUXOR" in (resp.piletas.sub or "")
+
+    def test_pileta_apoyo(self):
+        bd = _hugo_zimaro_breakdown()
+        bd["pileta"] = "apoyo"
+        q = _FakeQuote("test-apoyo")
+        resp = _serialize_residential_calc(bd, q)
+        assert resp.piletas.variant == "na"
+        assert "apoyo" in resp.piletas.chipLabel.lower()
+
+    def test_discount_applied(self):
+        bd = _hugo_zimaro_breakdown()
+        bd["discount_pct"] = 5
+        bd["discount_amount"] = 73
+        bd["material_total_bruto"] = 1537
+        bd["material_total"] = 1464
+        q = _FakeQuote("test-discount")
+        resp = _serialize_residential_calc(bd, q)
+        # 2 rows: material + discount
+        assert len(resp.material["rows"]) == 2
+        assert resp.material["rows"][1]["variant"] == "discount"
+        assert "−" in resp.material["rows"][1]["total"]
+
+
+# ═══════════════════════════════════════════════════════
+# Endpoint REST · 4 escenarios
+# ═══════════════════════════════════════════════════════
+
+
+def _seed_quote(db_session, quote_id: str, breakdown: dict | None = None, notes: str = ""):
+    from app.models.quote import Quote, QuoteStatus
+    db_session.add(
+        Quote(
+            id=quote_id,
+            client_name="Test Client",
+            project="Cocina test",
+            material="SILESTONE BLANCO NORTE",
+            status=QuoteStatus.DRAFT,
+            quote_breakdown=breakdown,
+            notes=notes,
+        )
+    )
+
+
+@pytest.mark.asyncio
+class TestCalculationEndpoint:
+    async def test_404_quote_not_found(self, client):
+        random_id = str(uuid.uuid4())
+        r = await client.get(f"/api/quotes/{random_id}/calculation")
+        assert r.status_code == 404
+        assert r.json()["detail"] == "quote_not_found"
+
+    async def test_residential_pending_no_breakdown(self, client, db_session):
+        qid = str(uuid.uuid4())
+        _seed_quote(db_session, qid, breakdown=None)
+        await db_session.commit()
+        r = await client.get(f"/api/quotes/{qid}/calculation")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "pending"
+        assert "Cálculo pendiente" in data["bannerSummary"]
+
+    async def test_edificio_not_supported(self, client, db_session):
+        qid = str(uuid.uuid4())
+        _seed_quote(db_session, qid, breakdown={
+            "is_edificio": True,
+            "paso2_calc": {"calc_results": {"Negro Boreal": {}}},
+        })
+        await db_session.commit()
+        r = await client.get(f"/api/quotes/{qid}/calculation")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "pending"
+        assert "edificios" in data["bannerSummary"].lower()
+
+    async def test_residential_complete(self, client, db_session):
+        qid = str(uuid.uuid4())
+        _seed_quote(db_session, qid, breakdown=_hugo_zimaro_breakdown())
+        await db_session.commit()
+        r = await client.get(f"/api/quotes/{qid}/calculation")
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["status"] == "ok"
+        assert data["quoteId"] == qid
+        assert data["totals"]["ars"]["value"] == "$198.244,00"
+        assert data["totals"]["usd"]["value"] == "USD 1.822"
+        # Material + 2 labor (skip flete) + flete separado
+        assert len(data["material"]["rows"]) == 1
+        assert len(data["labor"]["rows"]) == 2
+        assert data["flete"]["qty"] == "1 viaje"

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -53,8 +53,16 @@ export const getMaterialsList = USE_REAL_API ? real.getMaterialsList : mocks.get
 export const deriveMaterialForQuote = USE_REAL_API ? real.deriveMaterialForQuote : mocks.deriveMaterialForQuote;
 export type { MaterialOption, DeriveMaterialResponse } from "./real";
 
-/* ─── Cálculo (paso 4 · siempre mock · Sprint 4 wire chat-driven) ── */
-export const getCalculationForQuote = mocks.getCalculationForQuote;
+/* ─── Cálculo (paso 4) · Sprint 4 calculation-real-wire ──────────────────
+   getCalculationForQuote: wireada contra GET /api/quotes/{id}/calculation
+   (backend serializa breakdown residential al shape CalculationResult).
+   triggerCalculation y applyAutoFix siguen mock-only · deuda explícita:
+   - triggerCalculation: el cálculo real se dispara via agent loop cuando
+     Marina edita pieces (post-#514). Botón "↻ Re-calcular" es legacy del
+     mockup · sub-PR aparte si Marina pide explícito.
+   - applyAutoFix: caso nicho del mockup 08 patch error · validators
+     post-#506/#511 limpian inconsistencias antes que aparezca. */
+export const getCalculationForQuote = USE_REAL_API ? real.getCalculationForQuote : mocks.getCalculationForQuote;
 export const triggerCalculation = mocks.triggerCalculation;
 export const applyAutoFix = mocks.applyAutoFix;
 

--- a/web/src/lib/api/real.ts
+++ b/web/src/lib/api/real.ts
@@ -1185,3 +1185,30 @@ export async function deriveMaterialForQuote(
   }
   return (await response.json()) as DeriveMaterialResponse;
 }
+
+
+/* ─── getCalculationForQuote · Sprint 4 calculation-real-wire ────────────
+   GET /api/quotes/{id}/calculation · backend serializa `quote_breakdown`
+   al shape `CalculationResult` (residential top-level · edificio out-of-scope
+   con status="pending" + summary específico). `triggerCalculation` y
+   `applyAutoFix` siguen mock-only (deuda explícita · sub-PR aparte). */
+
+import type { CalculationResult } from "./types";
+
+export async function getCalculationForQuote(
+  quoteId: string,
+  options?: { signal?: AbortSignal },
+): Promise<CalculationResult> {
+  const response = await apiFetch(
+    `/api/quotes/${encodeURIComponent(quoteId)}/calculation`,
+    { signal: options?.signal },
+  );
+  if (!response.ok) {
+    throw new ApiError(
+      "GET_CALCULATION_FAILED",
+      `GET /api/quotes/{id}/calculation ${response.status}`,
+      response.status,
+    );
+  }
+  return (await response.json()) as CalculationResult;
+}


### PR DESCRIPTION
## Summary

Primer sub-PR **P0 desbloqueante MVP Ola 3** · cierra el gap del paso 4 que consumía 100% mocks. Backend nuevo `GET /api/quotes/{id}/calculation` serializa `quote_breakdown` residential al shape `CalculationResult` esperado por el frontend `useCalculo` hook.

**Hipótesis A modificada confirmada vía FASE 1** (5ta vez consecutiva del patrón \"plan asume gap más grande del real\" · lección #82 robustecida):
- **Área A** · GET endpoint · gap real · este sub-PR lo cierra ✅
- **Área B** · `triggerCalculation` · cubierto por agent loop ya cableado (Marina edita pieces → agent invoca `calculate_quote` tool → persiste `calc_results` nuevo). **Mock-only · deuda explícita**.
- **Área C** · `applyAutoFix` · caso nicho mockup 08 patch error · validators post-#506/#511 limpian inconsistencias. **Mock-only · deuda explícita**.

## PASO 0 EXP/EXP-2 findings (lección #80 · query Railway DB)

| Hallazgo | Real |
|---|---|
| Shape residential | calculator return **inlined al TOP-LEVEL** del breakdown (NO en key `calc_results` separada como anticipaba el prompt) |
| Shape edificio | wrapper `paso2_calc.calc_results` con **MULTI-MATERIAL** (dict keyed por material name) · UI no soporta · out-of-scope |
| mo_items shape | `{description, quantity, unit_price, base_price, total}` |
| Flete heurística | `description.lower().startswith(\"flete\")` (sample: \"Flete + toma medidas ibarlucea\") |
| sinks shape | `{name, quantity, unit_price}` (vacío para `pileta=\"empotrada_cliente\"`) |

## Cambios

### Backend · `agent/schemas.py` (+~100 líneas)
`CalculationResponse` + 10 sub-schemas mirroreados de `web/src/lib/api/types.ts:267-342`.

### Backend · `agent/router.py` (+~230 líneas)
- 3 helpers de formato locale es-AR: `_format_ars` (`\"$1.234,56\"`), `_format_usd` (`\"USD 1.234\"`), `_format_qty_m2` (`\"2,82 m²\"`)
- `_is_flete_item(item)` heurística confirmada
- `_serialize_residential_calc(breakdown, quote)` adapter no trivial (~180 líneas mapping 7 secciones):
  1. material.rows · 1 row + descuento opcional + subtotal
  2. merma section · directo de breakdown.merma
  3. labor.rows · mo_items filtrados (skip flete)
  4. flete · item separado · zona desde breakdown.localidad
  5. piletas · 3 escenarios (`empotrada_cliente` · `empotrada_johnson` con sinks · `apoyo`)
  6. totals · bi-currency (ARS MO+flete + USD material)
  7. datosPdf · defaults
- `_pending_calculation_response()` para edge cases
- Endpoint `GET /quotes/{quote_id}/calculation` · 3 ramas (404 · edificio_not_supported · residential_pending · residential_complete)

### Backend · `tests/test_calculation_endpoint.py` (nuevo · 34 tests)
- 16 unit tests format helpers (None, \"abc\", 0, valores grandes)
- 10 unit tests `_is_flete_item` (case variants, edge cases)
- 5 unit tests serializer (canonical Hugo Zimaro · merma_no_aplica · pileta_johnson_with_sinks · pileta_apoyo · discount_applied)
- 4 endpoint REST tests (404 · pending · edificio · residential_complete)

### Frontend · `web/src/lib/api/real.ts` (+~25 líneas)
`getCalculationForQuote(quoteId)` fetch via `apiFetch` + 401 handling.

### Frontend · `web/src/lib/api/index.ts:56-66`
Swap `mocks.getCalculationForQuote` → `USE_REAL_API ? real... : mocks...`. `triggerCalculation` y `applyAutoFix` siguen mock-only con comentario explicativo inline.

## Verificación local

- ✅ **34/34 tests slice pass** · cero regresiones
- ✅ `npx tsc --noEmit` verde
- ⏭ Skip preview verify mock-mode (lección #84 · validación visual real va al cierre)

## Test plan (lección #84 · 2 pasos)

- [x] TypeCheck verde
- [x] 34 tests backend pass
- [ ] CI Backend Tests + Web CI verdes
- [ ] **Paso 1 pre-merge** · validación visual UI en preview Vercel · confirmar CalculoView renderea sin crash con mock-mode (Vercel no toca backend)
- [ ] **Paso 2 post-merge** · validación visual end-to-end en production Railway · brief texto + quote Operador completa CON project → /calculo muestra cifras reales del agente · MÚLTIPLES quotes (residential nueva · quote derivada de #515) · formatting locale es-AR sin NaN · sin valores raw (lección #83)

## Out of scope (deuda explícita post-merge)

- Edificio multi-material (sub-PR aparte `calculation-real-wire-edificio` si Marina lo pide)
- `triggerCalculation` y `applyAutoFix` real
- `operator-project-required-fix` (sub-PR follow-up separado)
- Modificación de `calculator.py` (cero scope)

## Audit independiente OBLIGATORIO

Path crítico MVP · backend nuevo + adapter complejo (7 secciones · 230 líneas). Foco específico:
- Mapeo correcto de las 7 secciones
- Formatting locale es-AR sin bugs (separador miles · decimal)
- Heurística flete robusta (case variants)
- Edge cases (sinks vacío · merma.aplica=false · descuento)
- Shape `CalculationResponse` matches `CalculationResult` types.ts

Standby para audit independiente sub-agent post-CI verde + validación visual paso 1 (preview Vercel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)